### PR TITLE
Fix alias command on readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ or these example programs:
 
  * Build Dex: `make`
  * Run tests: `make tests`
- * Set up alias (e.g. in .bashrc) `alias dex=stack exec dex --`
+ * Set up alias (e.g. in .bashrc) `alias dex="stack exec dex --"`
 
 ## Running
 


### PR DESCRIPTION
Add quotes to the alias command on readme, withuot them most shells would simply alias stack to dex, and not the full command.