### PR TITLE
Make benchmarks

### DIFF
--- a/benchmarks/numpy-bench.py
+++ b/benchmarks/numpy-bench.py
@@ -4,10 +4,10 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
+from __future__ import print_function
 import time
 import numpy as np
 import sys
-from __future__ import print_function
 
 
 n = int(sys.argv[1])

--- a/makefile
+++ b/makefile
@@ -61,3 +61,4 @@ benchmark:
 	gcc -O3 -ffast-math benchmarks/cbench.c -o benchmarks/bench
 	benchmarks/bench 1000
 	$(dex) script benchmarks/time-tests.dx
+	rm benchmarks/bench

--- a/makefile
+++ b/makefile
@@ -60,3 +60,9 @@ doc/%.html: examples/%.dx
 
 doc/%.css: static/%.css
 	cp $^ $@
+
+benchmark:
+	python benchmarks/numpy-bench.py 1000
+	gcc -O3 -ffast-math benchmarks/cbench.c -o benchmarks/bench
+	benchmarks/bench 1000
+	$(dex) script benchmarks/time-tests.dx


### PR DESCRIPTION
Yeah, this is the last one, sorry.

1. Fixes the position of python's imports, important because it won't run without putting the future import at the top of the file 

2. Adds a benchmark recipe to the makefile, while I understand that right now the benchmarks are just an experiment I believe most people checking Dex out would like to know more or less how it compares with numpy and c. 