### PR TITLE
Fix Travis CI caching

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ cache:
   directories:
   - $HOME/.local/bin
   - $HOME/.stack
-  - $HOME/.stack-work
+  - $TRAVIS_BUILD_DIR/.stack-work
 
 addons:
   apt:


### PR DESCRIPTION
Wrong environment variable was used.  Caches `.stack-work` correctly now.