### PR TITLE
Fix eta-reduction for NAtomicFor

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -188,3 +188,6 @@ litArr = [10, 5, 3]
 
 :p fold (for i::3. 0.0) $ for i::2. lam c. (for j. c.j + real (asint j))
 > [0.0, 2.0, 4.0]
+
+:p (mat = for i::4 j::4 . asint i; tmp = for i. mat.i.i; tmp)
+> [0, 1, 2, 3]

--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -189,5 +189,5 @@ litArr = [10, 5, 3]
 :p fold (for i::3. 0.0) $ for i::2. lam c. (for j. c.j + real (asint j))
 > [0.0, 2.0, 4.0]
 
-:p (mat = for i::4 j::4 . asint i; tmp = for i. mat.i.i; tmp)
+:p (mat2 = for i::4 j::4 . asint i; tmp = for i. mat2.i.i; tmp)
 > [0, 1, 2, 3]

--- a/src/lib/Normalize.hs
+++ b/src/lib/Normalize.hs
@@ -300,7 +300,7 @@ simplifyAtom atom = case atom of
     refreshBindersRSimp [b] $ \[b'@(i':>_)] -> do
       body' <- simplifyAtom body
       return $ case body' of
-        NGet e (NVar i) | i == i' -> e
+        NGet e (NVar i) | i == i' && not (isin i (freeVars e)) -> e
         _ -> NAtomicFor b' body'
   NLam bs body ->
     refreshBindersRSimp bs $ \bs' -> do


### PR DESCRIPTION
Fix the broken eta-reduction mentioned [here](https://github.com/google-research/dex-lang/issues/8#issuecomment-547697495).

This will incur additional traverses of the AST, however [similar operations](https://github.com/google-research/dex-lang/blob/92a916859befc746fa050e55fb71b733d04d21ea/src/lib/Normalize.hs#L589) seems to have already been used in the pass.