### PR TITLE
Fix materializeAtom in simplify pass

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -191,3 +191,6 @@ litArr = [10, 5, 3]
 
 :p (mat2 = for i::4 j::4 . asint i; tmp = for i. mat2.i.i; tmp)
 > [0, 1, 2, 3]
+
+:p (x = [[0, 1], [2, 3]]; xt.i.j = x.j.i; xt)
+> [[0, 2], [1, 3]]

--- a/src/lib/Normalize.hs
+++ b/src/lib/Normalize.hs
@@ -328,14 +328,14 @@ materializeAtom atom = case atom of
     let decl = NLet [v:>ty] atomExpr
     return ((NVar v, [decl]), env')
   _ -> return ((atom, []), mempty)
-  where
-    atomToNExpr :: NAtom -> SimplifyM NExpr
-    atomToNExpr atom = case atom of
-      NAtomicFor b body -> 
-        refreshBindersRSimp [b] $ \[b'] -> do
-          bodyExpr <- atomToNExpr body
-          return (NScan b' [] [] bodyExpr)
-      _ -> return (NAtoms [atom])
+
+atomToNExpr :: NAtom -> SimplifyM NExpr
+atomToNExpr atom = case atom of
+  NAtomicFor b body ->
+    refreshBindersRSimp [b] $ \[b'] -> do
+      bodyExpr <- atomToNExpr body
+      return (NScan b' [] [] bodyExpr)
+  _ -> return (NAtoms [atom])
 
 simplifyDecl :: NDecl -> SimplifyM ([NDecl], SimpEnv)
 simplifyDecl decl = case decl of


### PR DESCRIPTION
The reason for issue #8 might be due to the broken `materializeAtom` function. Currently, it basically eliminates the `NAtomFor` by creating a declaration of `NScan` and returning the bound variable. This is problematic in that it makes the `body` expression of `NAtomFor` out of current context during recursive calls. E.g. `afor i. afor j. x.j.i` becomes `tab = for j. x.j.i; tab_1 = for i. tab; tab_1`, i.e. `for j. x.j.i` is taken outside of context of index variable `i`.

This patch fixes this issue by trying to maintain the nested `NAtomicFor` structure in the generated declaration. It introduces a helper function to recursively transform the atom expression to an `NExpr` and then creates a single declaration for it.