### PR TITLE
Remove color flag from diff as it breaks mac

### DIFF
--- a/misc/check-no-diff
+++ b/misc/check-no-diff
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 tmpdiff=$(mktemp)
-diff --left-column -y --color=always $1 $2 > $tmpdiff \
+diff --left-column -y $1 $2 > $tmpdiff \
        && echo OK || (cat $tmpdiff; false)
 status=$?
 


### PR DESCRIPTION
Annoyingly there is no `diff --color` for mac.
(What a terrible world).

I assume diff works fine without it.
