### PR TITLE
Add Particle Swarm Optimizer demo

### DIFF
--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -55,7 +55,6 @@ minimumby sq [-1.0, -0.1, 2.0, 3.0]
 
 ' ## The Optimizer itself.
 ### TODO:
- - Replace `res = optStep inits` with `res = fold inits (for iter::200. optStep)`
  - workout how to pass `nparticles` and `niters` in as a variable
      - Currrently hardcoded as 1000 and 200 respectively
  - workout more compact way to define type sig
@@ -85,11 +84,11 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
     initPs::(1000=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p) 
     initG::(Real, d=>Real) = minimumby fst initPs
     inits = (keyLoop,initG,initPs,initPositions,initVelocities)
-    res = optStep inits
+    res = fold inits (for iter::200. optStep)
     (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
     finalGloc
 
-:p optimize (newKey 1) rosenbrock2 ([-1.0, -1.0],[2.0, 2.0]) (0.2,0.3,0.4)
+:p optimize (newKey 1) rosenbrock2 ([-1.0, -1.0],[2.0, 2.0]) (0.5,0.3,0.4)
 
 
 

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -3,7 +3,7 @@
 ' ## Fitness function
 
 rosenbrock:: Real -> Real -> Real
-rosenbrock x y = sq (1.0 - x) + 10000.0*sq (y - x*x) 
+rosenbrock x y = sq (1.0 - x) + 80.0*sq (y - x*x)
 
 
 ' We write one that uses vector for input
@@ -44,7 +44,7 @@ minby:: A a::Data. (a->Real)->a->a->a
 minby f x y = [x,y].(asidx $ b2i $ (f x) > (f y))
 
 minby sq -1.0 0.5
-minby fst (0.7, 1000.0) (3.0, 12.0)
+minby (asNonLin fst) (0.7, 8.0) (3.0, 12.0)
 
 
 minimumby:: A p q::Data. (q->Real)->(p=>q)->q
@@ -56,9 +56,8 @@ minimumby sq [-1.0, -0.1, 2.0, 3.0]
 ' ## The Optimizer itself.
 ### TODO:
  - workout how to pass `nparticles` and `niters` in as a variable
-     - Currrently hardcoded as 1000 and 200 respectively
+     - Currrently hardcoded as 50 and 140 respectively
  - workout more compact way to define type sig
-
 
 
 optimize:: Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
@@ -68,23 +67,29 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
         gWeight::Real = gRate * rand keyG
         pWeight::Real = pRate * rand keyP
         (gscore, gloc) = gbest
-        plocs = map snd pbests
-        gDirs::(1000=>d=>Real) = for p i. gloc.i - positions.p.i
-        pDirs::(1000=>d=>Real) = for p i. plocs.p.i - positions.p.i
-        newVelocities::(1000=>d=>Real) = for p i. momentum*velocities.p.i + gWeight*gDirs.p.i + pWeight*gDirs.p.i
-        newPositions::(1000=>d=>Real) = for p i. positions.p.i + velocities.p.i
-        newPbests::(1000=>(Real, d=>Real)) = for p. minby fst pbests.p (f newPositions.p, newPositions.p)
-        newGbest::(Real, d=>Real) = minby fst gbest (minimumby fst newPbests)
+        plocs = map (asNonLin snd) pbests
+        gDirs::(50=>d=>Real) =
+            for p i. gloc.i - positions.p.i
+        pDirs::(50=>d=>Real) =
+            for p i. plocs.p.i - positions.p.i
+        newVelocities::(50=>d=>Real) =
+            for p i. momentum*velocities.p.i + gWeight*gDirs.p.i + pWeight*gDirs.p.i
+        newPositions::(50=>d=>Real) =
+            for p i. positions.p.i + velocities.p.i
+        newPbests::(50=>(Real, d=>Real)) =
+            for p. minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
+        newGbest::(Real, d=>Real) =
+            minby (asNonLin fst) gbest (minimumby (asNonLin fst) newPbests)
         (keyNext,newGbest,newPbests,newPositions,newVelocities)
     randInit1 keyI1 = randBounded keyI1 lb ub
-    randInit keyI = for p::1000. randInit1 $ ixkey keyI p
+    randInit keyI = for p::50. randInit1 $ ixkey keyI p
     (keyPos, keyVel, keyLoop) = splitKey3 key
-    initPositions::(1000=>d=>Real) = randInit keyPos
-    initVelocities::(1000=>d=>Real) = randInit keyVel
-    initPs::(1000=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p) 
-    initG::(Real, d=>Real) = minimumby fst initPs
+    initPositions::(50=>d=>Real) = randInit keyPos
+    initVelocities::(50=>d=>Real) = randInit keyVel
+    initPs::(50=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p)
+    initG::(Real, d=>Real) = minimumby (asNonLin fst) initPs
     inits = (keyLoop,initG,initPs,initPositions,initVelocities)
-    res = fold inits (for iter::200. optStep)
+    res = fold inits (for iter::140. optStep)
     (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
     finalGloc
 

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -18,13 +18,16 @@ rosenbrock2 xs =
 ' Min should be at 1.0, 1.0
 
 :p rosenbrock 1.0 1.000
+> 0.0
 
 :p rosenbrock2 [1.0, 1.000]
+> 0.0
 
 :p rosenbrock 1.0 1.02
+> 3.2e-2
 
 :p rosenbrock2 [1.0, 1.02]
-
+> 3.2e-2
 
 
 ' ## Helper functions
@@ -37,31 +40,37 @@ ixkey2 x i = ixkey $ ixkey x i
 
 :p k = newKey 0
    for i::2 j::3. sq $ randn (ixkey2 k i j)
+> [[1.773118, 0.50770324, 7.503997e-2], [1.4671916, 5.4218978e-2, 0.5504309]]
 
-' make a random vector unifornly distrubuted between lb and ub
+
+' make a random vector uniformly distributed between `lb` and `ub`
 
 randBounded:: Key -> (d=>Real)->(d=>Real)->(d=>Real)
 randBounded key lb ub =
     for i. lb.i + ((rand $ ixkey key i) * (ub.i - lb.i))
 
-randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
+:p randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
+> [-0.3510105, 1.4935503]
 
 
 ' ## The Optimizer itself.
-### TODO:
- - workout how to pass `nparticles` and `niters` in as a variable
-     - Currrently hardcoded as 50 and 140 respectively
- - workout more compact way to define type sig
+We have **arguments**:
+ - type explicit, `np::Ix`: number of particles
+ - type explicit, `niter::Ix`: number of iterations
+ - type: `d::Ix`: number of dimensions in the domain of `f`, i.e. the search space.
+ - `f::(d=>Real)->Real`: loss function being minimized.
+ - `(lb,ub)::(d=>Real,d=>Real)`: boundries of the space being searched
+ - `(momentum,gRate,pRate)::(Real,Real,Real)`: PSO hyper-parameters to control exploration vs exploitation.
 
+' **Returns**: the optimal point found with-in the bounds on the input domain of `f`.
 
-
-optimize:: Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
+optimize:: A np::Ix niter::Ix d::Ix. Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
 optimize key f (lb,ub) (momentum,gRate,pRate) =
     optStep (keyL, gbest, pbests,positions,velocities) =
         .. -- prepare stuff for this step
-        newPositions::(50=>d=>Real) = for p i. 
+        newPositions::(np=>d=>Real) = for p i. 
             positions.p.i + velocities.p.i
-        newPbests::(50=>(Real, d=>Real)) = for p. 
+        newPbests::(np=>(Real, d=>Real)) = for p. 
             minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
         newGbest::(Real, d=>Real) =
             minby (asNonLin fst) gbest (minimumby (asNonLin fst) newPbests)
@@ -69,37 +78,71 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
         (keyG, keyP, keyNext) = splitKey3 keyL
         (gscore, gloc) = gbest
         plocs = map (asNonLin snd) pbests
-        gVel::(50=>d=>Real) = for p i.
+        gVel::(np=>d=>Real) = for p i.
             weight = rand $ (ixkey2 keyG p i)
             dir = gloc.i - positions.p.i
             weight * dir
-        pVel::(50=>d=>Real) = for p i. 
+        pVel::(np=>d=>Real) = for p i. 
             weight = rand $ (ixkey2 keyP p i)
             dir = plocs.p.i - positions.p.i
             weight * dir
-        newVelocities::(50=>d=>Real) = for p i.
+        newVelocities::(np=>d=>Real) = for p i.
             momentum*velocities.p.i + gRate*gVel.p.i + pRate*gVel.p.i
         (keyNext,newGbest,newPbests,newPositions,newVelocities)
     .. -- Initialize
     randInit1 keyI1 = randBounded keyI1 lb ub
-    randInit keyI = for p::50. randInit1 $ ixkey keyI p
+    randInit keyI = for p::np. randInit1 $ ixkey keyI p
     (keyPos, keyVel, keyLoop) = splitKey3 key
-    initPositions::(50=>d=>Real) = randInit keyPos
-    initVelocities::(50=>d=>Real) = randInit keyVel
-    initPs::(50=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p)
+    initPositions::(np=>d=>Real) = randInit keyPos
+    initVelocities::(np=>d=>Real) = randInit keyVel
+    initPs::(np=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p)
     initG::(Real, d=>Real) = minimumby (asNonLin fst) initPs
     inits = (keyLoop,initG,initPs,initPositions,initVelocities)
     .. -- Run the loop
-    res = fold inits (for iter::140. optStep)
+    res = fold inits (for iter::niter. optStep)
     (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
     finalGloc
 
+' ---
+Lets see how it goes.  
+Run it for more iterations and result should improve.  
+Which it indeed does.
+
 :p optimize ..
+    @50 .. -- number of particles
+    @10 .. -- number of iterations
     (newKey 0) .. -- random seed
     rosenbrock2 .. -- function to optimize
     ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
     (0.5,0.3,0.4) -- momentum/pRate/gRate
+> [3.7902775, 14.911414]
 
 
+:p optimize ..
+    @50 .. -- number of particles
+    @20 .. -- number of iterations
+    (newKey 0) .. -- random seed
+    rosenbrock2 .. -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+    (0.5,0.3,0.4) -- momentum/pRate/gRate
+> [1.737736, 3.1227164]
+
+:p optimize ..
+    @50 .. -- number of particles
+    @100 .. -- number of iterations
+    (newKey 0) .. -- random seed
+    rosenbrock2 .. -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+    (0.5,0.3,0.4) -- momentum/pRate/gRate
+> [1.0062338, 1.0128839]
+
+:p optimize ..
+    @50 .. -- number of particles
+    @1000 .. -- number of iterations
+    (newKey 0) .. -- random seed
+    rosenbrock2 .. -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+    (0.5,0.3,0.4) -- momentum/pRate/gRate
+> [1.0, 1.0]
 
 ' ---

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -1,0 +1,97 @@
+' # Particle Swarm Optimizer
+
+' ## Fitness function
+
+rosenbrock:: Real -> Real -> Real
+rosenbrock x y = sq (1.0 - x) + 10000.0*sq (y - x*x) 
+
+
+' We write one that uses vector for input
+
+rosenbrock2:: (2=>Real) -> Real
+rosenbrock2 xs =
+  x = xs.(asidx 0)
+  y = xs.(asidx 1)
+  rosenbrock x y
+
+
+' Min should be at 1.0, 1.0
+
+:p rosenbrock 1.0 1.000
+
+:p rosenbrock2 [1.0, 1.000]
+
+:p rosenbrock 1.0 1.02
+
+:p rosenbrock2 [1.0, 1.02]
+
+
+
+' ## Helper functions
+
+' make a random vector unifornly distrubuted between lb and ub
+
+randBounded:: Key -> (d=>Real)->(d=>Real)->(d=>Real)
+randBounded key lb ub =
+    for i. lb.i + ((rand $ ixkey key i) * (ub.i - lb.i))
+
+randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
+
+' minby and minimumby
+' to find the smallest values
+
+minby:: A a::Data. (a->Real)->a->a->a
+minby f x y = [x,y].(asidx $ b2i $ (f x) > (f y))
+
+minby sq -1.0 0.5
+minby fst (0.7, 1000.0) (3.0, 12.0)
+
+
+minimumby:: A p q::Data. (q->Real)->(p=>q)->q
+minimumby f xs = fold xs.(asidx 0) (for i. minby f xs.i)
+
+minimumby sq [-1.0, -0.1, 2.0, 3.0]
+
+
+' ## The Optimizer itself.
+### TODO:
+ - Replace `res = optStep inits` with `res = fold inits (for iter::200. optStep)`
+ - workout how to pass `nparticles` and `niters` in as a variable
+     - Currrently hardcoded as 1000 and 200 respectively
+ - workout more compact way to define type sig
+
+
+
+optimize:: Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
+optimize key f (lb,ub) (momentum,gRate,pRate) =
+    optStep (keyL, gbest, pbests,positions,velocities) =
+        (keyG, keyP, keyNext) = splitKey3 keyL
+        gWeight::Real = gRate * rand keyG
+        pWeight::Real = pRate * rand keyP
+        (gscore, gloc) = gbest
+        plocs = map snd pbests
+        gDirs::(1000=>d=>Real) = for p i. gloc.i - positions.p.i
+        pDirs::(1000=>d=>Real) = for p i. plocs.p.i - positions.p.i
+        newVelocities::(1000=>d=>Real) = for p i. momentum*velocities.p.i + gWeight*gDirs.p.i + pWeight*gDirs.p.i
+        newPositions::(1000=>d=>Real) = for p i. positions.p.i + velocities.p.i
+        newPbests::(1000=>(Real, d=>Real)) = for p. minby fst pbests.p (f newPositions.p, newPositions.p)
+        newGbest::(Real, d=>Real) = minby fst gbest (minimumby fst newPbests)
+        (keyNext,newGbest,newPbests,newPositions,newVelocities)
+    randInit1 keyI1 = randBounded keyI1 lb ub
+    randInit keyI = for p::1000. randInit1 $ ixkey keyI p
+    (keyPos, keyVel, keyLoop) = splitKey3 key
+    initPositions::(1000=>d=>Real) = randInit keyPos
+    initVelocities::(1000=>d=>Real) = randInit keyVel
+    initPs::(1000=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p) 
+    initG::(Real, d=>Real) = minimumby fst initPs
+    inits = (keyLoop,initG,initPs,initPositions,initVelocities)
+    res = optStep inits
+    (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
+    finalGloc
+
+:p optimize (newKey 1) rosenbrock2 ([-1.0, -1.0],[2.0, 2.0]) (0.2,0.3,0.4)
+
+
+
+
+' ---

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -52,6 +52,13 @@ minimumby f xs = fold xs.(asidx 0) (for i. minby f xs.i)
 
 minimumby sq [-1.0, -0.1, 2.0, 3.0]
 
+' ### Rand helpers
+
+ixkey2 :: A n::Ix m::Ix. Key -> n -> m -> Key
+ixkey2 x i = ixkey $ ixkey x i
+
+:p k = newKey 0
+   for i::2 j::3. sq $ randn (ixkey2 k i j)
 
 ' ## The Optimizer itself.
 ### TODO:
@@ -60,27 +67,33 @@ minimumby sq [-1.0, -0.1, 2.0, 3.0]
  - workout more compact way to define type sig
 
 
+
 optimize:: Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
 optimize key f (lb,ub) (momentum,gRate,pRate) =
     optStep (keyL, gbest, pbests,positions,velocities) =
-        (keyG, keyP, keyNext) = splitKey3 keyL
-        gWeight::Real = gRate * rand keyG
-        pWeight::Real = pRate * rand keyP
-        (gscore, gloc) = gbest
-        plocs = map (asNonLin snd) pbests
-        gDirs::(50=>d=>Real) =
-            for p i. gloc.i - positions.p.i
-        pDirs::(50=>d=>Real) =
-            for p i. plocs.p.i - positions.p.i
-        newVelocities::(50=>d=>Real) =
-            for p i. momentum*velocities.p.i + gWeight*gDirs.p.i + pWeight*gDirs.p.i
-        newPositions::(50=>d=>Real) =
-            for p i. positions.p.i + velocities.p.i
-        newPbests::(50=>(Real, d=>Real)) =
-            for p. minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
+        .. -- prepare stuff for this step
+        newPositions::(50=>d=>Real) = for p i. 
+            positions.p.i + velocities.p.i
+        newPbests::(50=>(Real, d=>Real)) = for p. 
+            minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
         newGbest::(Real, d=>Real) =
             minby (asNonLin fst) gbest (minimumby (asNonLin fst) newPbests)
+        .. -- prepare stuff for next step
+        (keyG, keyP, keyNext) = splitKey3 keyL
+        (gscore, gloc) = gbest
+        plocs = map (asNonLin snd) pbests
+        gVel::(50=>d=>Real) = for p i.
+            weight = rand $ (ixkey2 keyG p i)
+            dir = gloc.i - positions.p.i
+            weight * dir
+        pVel::(50=>d=>Real) = for p i. 
+            weight = rand $ (ixkey2 keyP p i)
+            dir = plocs.p.i - positions.p.i
+            weight * dir
+        newVelocities::(50=>d=>Real) = for p i.
+            momentum*velocities.p.i + gRate*gVel.p.i + pRate*gVel.p.i
         (keyNext,newGbest,newPbests,newPositions,newVelocities)
+    .. -- Initialize
     randInit1 keyI1 = randBounded keyI1 lb ub
     randInit keyI = for p::50. randInit1 $ ixkey keyI p
     (keyPos, keyVel, keyLoop) = splitKey3 key
@@ -89,11 +102,16 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
     initPs::(50=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p)
     initG::(Real, d=>Real) = minimumby (asNonLin fst) initPs
     inits = (keyLoop,initG,initPs,initPositions,initVelocities)
+    .. -- Run the loop
     res = fold inits (for iter::140. optStep)
     (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
     finalGloc
 
-:p optimize (newKey 1) rosenbrock2 ([-1.0, -1.0],[2.0, 2.0]) (0.5,0.3,0.4)
+:p optimize ..
+    (newKey 0) .. -- random seed
+    rosenbrock2 .. -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+    (0.5,0.3,0.4) -- momentum/pRate/gRate
 
 
 

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -31,6 +31,12 @@ rosenbrock2 xs =
 
 ' ## Helper functions
 
+minbyfst:: A a::Data. (Real, a)->(Real, a)->(Real, a)
+minbyfst = minby (asNonLin fst)
+
+minimumbyfst:: A n a::Data. (n=>(Real, a))->(Real, a)
+minimumbyfst = minimumby (asNonLin fst)
+
 ' ### Rand helpers
 
 ' make a random vector uniformly distributed between `lb` and `ub`
@@ -41,6 +47,7 @@ randBounded key lb ub =
 
 :p randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
 > [-0.3510105, 1.4935503]
+
 
 
 ' ## The Optimizer itself.
@@ -56,15 +63,13 @@ We have **arguments**:
 
 optimize:: A np::Ix niter::Ix d::Ix. Key->((d=>Real)->Real) -> (d=>Real,d=>Real) -> (Real,Real,Real) -> (d=>Real)
 optimize key f (lb,ub) (momentum,gRate,pRate) =
-    optStep (keyL, gbest, pbests,positions,velocities) =
-        .. -- prepare stuff for this step
+    optStep (keyL, gbest, pbests, positions, velocities) =       
         newPositions::(np=>d=>Real) = for p i.
             positions.p.i + velocities.p.i
         newPbests::(np=>(Real, d=>Real)) = for p.
-            minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
+            minbyfst pbests.p (f newPositions.p, newPositions.p)
         newGbest::(Real, d=>Real) =
-            minby (asNonLin fst) gbest (minimumby (asNonLin fst) newPbests)
-        .. -- prepare stuff for next step
+            minbyfst gbest (minimumbyfst newPbests)
         (keyG, keyP, keyNext) = splitKey3 keyL
         (gscore, gloc) = gbest
         plocs = map (asNonLin snd) pbests
@@ -79,17 +84,15 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
         newVelocities::(np=>d=>Real) = for p i.
             momentum*velocities.p.i + gRate*gVel.p.i + pRate*gVel.p.i
         (keyNext,newGbest,newPbests,newPositions,newVelocities)
-    .. -- Initialize
     randInit1 keyI1 = randBounded keyI1 lb ub
     randInit keyI = for p::np. randInit1 $ ixkey keyI p
     (keyPos, keyVel, keyLoop) = splitKey3 key
     initPositions::(np=>d=>Real) = randInit keyPos
     initVelocities::(np=>d=>Real) = randInit keyVel
     initPs::(np=>(Real, d=>Real)) = for p. (f initPositions.p, initPositions.p)
-    initG::(Real, d=>Real) = minimumby (asNonLin fst) initPs
+    initG::(Real, d=>Real) = minimumbyfst initPs
     inits = (keyLoop,initG,initPs,initPositions,initVelocities)
-    .. -- Run the loop
-    res = fold inits (for iter::niter. optStep)
+    res = fold inits (lam iter::niter. optStep)
     (dc0,(finalGscore, finalGloc),dc1,dc2,dc3) = res
     finalGloc
 
@@ -98,41 +101,45 @@ Lets see how it goes.
 Run it for more iterations and result should improve.
 Which it indeed does.
 
-:p optimize ..
-    @50 .. -- number of particles
-    @10 .. -- number of iterations
-    (newKey 0) .. -- random seed
-    rosenbrock2 .. -- function to optimize
-    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
-    (0.5,0.3,0.4) -- momentum/pRate/gRate
+:p (optimize 
+    @50  -- number of particles
+    @10  -- number of iterations
+    (newKey 0)  -- random seed
+    rosenbrock2  -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0])  -- bounds
+    (0.5,0.3,0.4)  -- momentum/pRate/gRate
+)
 > [3.7902775, 14.911414]
 
 
-:p optimize ..
-    @50 .. -- number of particles
-    @20 .. -- number of iterations
-    (newKey 0) .. -- random seed
-    rosenbrock2 .. -- function to optimize
-    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+:p (optimize 
+    @50  -- number of particles
+    @20  -- number of iterations
+    (newKey 0)  -- random seed
+    rosenbrock2  -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0])  -- bounds
     (0.5,0.3,0.4) -- momentum/pRate/gRate
+)
 > [1.737736, 3.1227164]
 
-:p optimize ..
-    @50 .. -- number of particles
-    @100 .. -- number of iterations
-    (newKey 0) .. -- random seed
-    rosenbrock2 .. -- function to optimize
-    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+:p (optimize 
+    @50  -- number of particles
+    @100  -- number of iterations
+    (newKey 0)  -- random seed
+    rosenbrock2  -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0])  -- bounds
     (0.5,0.3,0.4) -- momentum/pRate/gRate
+)
 > [1.0062338, 1.0128839]
 
-:p optimize ..
-    @50 .. -- number of particles
-    @1000 .. -- number of iterations
-    (newKey 0) .. -- random seed
-    rosenbrock2 .. -- function to optimize
-    ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
+:p (optimize 
+    @50  -- number of particles
+    @1000  -- number of iterations
+    (newKey 0)  -- random seed
+    rosenbrock2  -- function to optimize
+    ([-10.0, -10.0],[20.0, 20.0])  -- bounds
     (0.5,0.3,0.4) -- momentum/pRate/gRate
+)
 > [1.0, 1.0]
 
 ' ---

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -14,7 +14,6 @@ rosenbrock2 xs =
   y = xs.(1@2)
   rosenbrock x y
 
-
 ' Min should be at 1.0, 1.0
 
 :p rosenbrock 1.0 1.000
@@ -33,15 +32,6 @@ rosenbrock2 xs =
 ' ## Helper functions
 
 ' ### Rand helpers
-like `ixkey` but takes 2 index to use as keys
-
-ixkey2 :: A n::Ix m::Ix. Key -> n -> m -> Key
-ixkey2 x i = ixkey $ ixkey x i
-
-:p k = newKey 0
-   for i::2 j::3. sq $ randn (ixkey2 k i j)
-> [[1.773118, 0.50770324, 7.503997e-2], [1.4671916, 5.4218978e-2, 0.5504309]]
-
 
 ' make a random vector uniformly distributed between `lb` and `ub`
 
@@ -68,9 +58,9 @@ optimize:: A np::Ix niter::Ix d::Ix. Key->((d=>Real)->Real) -> (d=>Real,d=>Real)
 optimize key f (lb,ub) (momentum,gRate,pRate) =
     optStep (keyL, gbest, pbests,positions,velocities) =
         .. -- prepare stuff for this step
-        newPositions::(np=>d=>Real) = for p i. 
+        newPositions::(np=>d=>Real) = for p i.
             positions.p.i + velocities.p.i
-        newPbests::(np=>(Real, d=>Real)) = for p. 
+        newPbests::(np=>(Real, d=>Real)) = for p.
             minby (asNonLin fst) pbests.p (f newPositions.p, newPositions.p)
         newGbest::(Real, d=>Real) =
             minby (asNonLin fst) gbest (minimumby (asNonLin fst) newPbests)
@@ -82,7 +72,7 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
             weight = rand $ (ixkey2 keyG p i)
             dir = gloc.i - positions.p.i
             weight * dir
-        pVel::(np=>d=>Real) = for p i. 
+        pVel::(np=>d=>Real) = for p i.
             weight = rand $ (ixkey2 keyP p i)
             dir = plocs.p.i - positions.p.i
             weight * dir
@@ -104,8 +94,8 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
     finalGloc
 
 ' ---
-Lets see how it goes.  
-Run it for more iterations and result should improve.  
+Lets see how it goes.
+Run it for more iterations and result should improve.
 Which it indeed does.
 
 :p optimize ..
@@ -146,3 +136,4 @@ Which it indeed does.
 > [1.0, 1.0]
 
 ' ---
+

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -10,8 +10,8 @@ rosenbrock x y = sq (1.0 - x) + 80.0*sq (y - x*x)
 
 rosenbrock2:: (2=>Real) -> Real
 rosenbrock2 xs =
-  x = xs.(asidx 0)
-  y = xs.(asidx 1)
+  x = xs.(0@2)
+  y = xs.(1@2)
   rosenbrock x y
 
 
@@ -46,20 +46,6 @@ randBounded key lb ub =
 
 randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
 
-' ### minby and minimumby
-to find the smallest values
-
-minby:: A a::Data. (a->Real)->a->a->a
-minby f x y = [x,y].(asidx $ b2i $ (f x) > (f y))
-
-minby sq -1.0 0.5
-minby (asNonLin fst) (0.7, 8.0) (3.0, 12.0)
-
-
-minimumby:: A p q::Data. (q->Real)->(p=>q)->q
-minimumby f xs = fold xs.(asidx 0) (for i. minby f xs.i)
-
-minimumby sq [-1.0, -0.1, 2.0, 3.0]
 
 ' ## The Optimizer itself.
 ### TODO:
@@ -113,7 +99,6 @@ optimize key f (lb,ub) (momentum,gRate,pRate) =
     rosenbrock2 .. -- function to optimize
     ([-10.0, -10.0],[20.0, 20.0]) .. -- bounds
     (0.5,0.3,0.4) -- momentum/pRate/gRate
-
 
 
 

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -29,6 +29,15 @@ rosenbrock2 xs =
 
 ' ## Helper functions
 
+' ### Rand helpers
+like `ixkey` but takes 2 index to use as keys
+
+ixkey2 :: A n::Ix m::Ix. Key -> n -> m -> Key
+ixkey2 x i = ixkey $ ixkey x i
+
+:p k = newKey 0
+   for i::2 j::3. sq $ randn (ixkey2 k i j)
+
 ' make a random vector unifornly distrubuted between lb and ub
 
 randBounded:: Key -> (d=>Real)->(d=>Real)->(d=>Real)
@@ -37,8 +46,8 @@ randBounded key lb ub =
 
 randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
 
-' minby and minimumby
-' to find the smallest values
+' ### minby and minimumby
+to find the smallest values
 
 minby:: A a::Data. (a->Real)->a->a->a
 minby f x y = [x,y].(asidx $ b2i $ (f x) > (f y))
@@ -51,14 +60,6 @@ minimumby:: A p q::Data. (q->Real)->(p=>q)->q
 minimumby f xs = fold xs.(asidx 0) (for i. minby f xs.i)
 
 minimumby sq [-1.0, -0.1, 2.0, 3.0]
-
-' ### Rand helpers
-
-ixkey2 :: A n::Ix m::Ix. Key -> n -> m -> Key
-ixkey2 x i = ixkey $ ixkey x i
-
-:p k = newKey 0
-   for i::2 j::3. sq $ randn (ixkey2 k i j)
 
 ' ## The Optimizer itself.
 ### TODO:

--- a/makefile
+++ b/makefile
@@ -34,7 +34,8 @@ libdex: cbits/libdex.so
 
 example-names = type-tests eval-tests shadow-tests annot-tests linear-tests ad-tests \
                 monad-tests lens-tests include-test mandelbrot mandelbrot pi sierpinsky \
-                regression brownian_motion
+                regression brownian_motion particle-swarm-optimizer
+
 quine-test-targets = $(example-names:%=run-%)
 
 doc-names = $(example-names:%=doc/%.html)


### PR DESCRIPTION
This implements a [Particle Swarm Optimizer](https://en.wikipedia.org/wiki/Particle_swarm_optimization) (PSO).

It's still running into compiler errors though.

```
:p optimize (newKey 1) rosenbrock2 ([-1.0, -1.0],[2.0, 2.0]) (0.5,0.3,0.4)
Compiler bug!
Please report this at github.com/google-research/dex-lang/issues

Not implemented: (afor  p::1000 . 
    newPbests.p.newPbests_2.p)
CallStack (from HasCallStack):
  error, called at src/lib/Imp.hs:105:8 in dex-0.1.0.0-9pQ6aTLha3fLdCjkbXPWRy:Imp
```