### PR TITLE
Use print() function in both Python 2 and Python 3

### DIFF
--- a/misc/py/dex.py
+++ b/misc/py/dex.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2019 Google LLC
 #
 # Use of this source code is governed by a BSD-style
@@ -29,5 +30,5 @@ def load(fname):
   with open(fname) as f:
     s = f.read()
   top_level_functions = loadSource(s)
-  print top_level_functions
+  print(top_level_functions)
   return DexModule(top_level_functions)

--- a/misc/py/test-dex2jax.py
+++ b/misc/py/test-dex2jax.py
@@ -1,3 +1,4 @@
+from __future__ import print_function
 # Copyright 2019 Google LLC
 #
 # Use of this source code is governed by a BSD-style
@@ -10,4 +11,4 @@ foo = dex.load("foo.dx")
 
 # print foo.addReals(1.0, 2.0)
 
-print foo.f
+print(foo.f)


### PR DESCRIPTION
Legacy __print__ statements are syntax errors in Python 3 but __print()__ function works as expected in both Python 2 and Python 3.