### PR TITLE
Fix a crash when checking a type of an unbound variable

### DIFF
--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -85,9 +85,9 @@ evalSourceBlock env block = case block of
     ShowPass s -> liftM (const mempty) $ filterOutputs f $ evalModule env m
       where f out = case out of PassInfo s' _ _ | s == s' -> True; _ -> False
     _ -> return ()
-  GetNameType v -> case topSubstEnv env ! v of
-    L val -> tell [TextOut $ pprint (getType val)] >> return mempty
-    _ -> throw UnboundVarErr $ pprint v
+  GetNameType v -> case topSubstEnv env `envLookup` v of
+    Just (L val) -> tell [TextOut $ pprint (getType val)] >> return mempty
+    _            -> throw UnboundVarErr $ pprint v
   IncludeSourceFile fname -> do
     source <- liftIOTop $ readFile fname
     evalSourceBlocks env $ map sbContents $ parseProg source


### PR DESCRIPTION
Previously, executing `:t x` in an enivornment where `x` hasn't been
defined would crash the REPL because `!` errors out when the key is not
in the map. Replacing `!` with a safer lookup function fixes the issue.