### PR TITLE
Generalize AsIdx to arbitrary index set types

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -94,7 +94,7 @@ toImpCExpr dests op = case op of
     n' <- typeToSize (varAnn b)
     emitLoop n' $ \i -> do
       let ithDest = tabGetIAtom dests i
-      extendR (b @> asIdx n' i) $ toImpExpr ithDest body
+      extendR (b @> asIdx (varAnn b) i) $ toImpExpr ithDest body
   TabGet x i -> do
     i' <- toImpAtom i >>= fromScalarIAtom
     xs <- toImpAtom x
@@ -184,7 +184,7 @@ makeDest' shape ty = case ty of
     n'  <- lift $ typeToSize n
     liftM (ICon . AFor n) $ makeDest' (shape ++ [n']) b
   RecType r   -> liftM (ICon . RecCon ) $ traverse (makeDest' shape) r
-  IdxSetLit n -> liftM (ICon . AsIdx n) $ makeDest' shape (BaseType IntType)
+  IdxSetLit n -> liftM (ICon . AsIdx (IdxSetLit n)) $ makeDest' shape (BaseType IntType)
   _ -> error $ "Can't lower type to imp: " ++ pprint ty
 
 tabGetIAtom :: IAtom -> IExpr -> IAtom
@@ -245,8 +245,8 @@ toImpDepVal (DepLit i) = return $ ILit $ IntLit i
 copyIAtom :: IAtom -> IAtom -> ImpM ()
 copyIAtom dest src = zipWithM_ copyOrStore (toList dest) (toList src)
 
-asIdx :: IExpr -> IExpr -> IAtom
-asIdx n i = ICon $ AsIdx (fromIInt n) (ILeaf i)
+asIdx :: Type -> IExpr -> IAtom
+asIdx n i = ICon $ AsIdx n (ILeaf i)
 
 -- === Imp embedding ===
 

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -329,7 +329,7 @@ idxLit = do
   n <- uint
   failIf (i < 0 || i >= n) $ "Index out of bounds: "
                                 ++ pprint i ++ " of " ++ pprint n
-  return $ AsIdx n (FPrimExpr $ ConExpr $ Lit $ IntLit i)
+  return $ AsIdx (IdxSetLit n) (FPrimExpr $ ConExpr $ Lit $ IntLit i)
 
 literal :: Parser LitVal
 literal =     numLit

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -150,7 +150,7 @@ valFromPtrs' shape ty = case ty of
   TabType n a -> liftM (Con . AFor n) $ valFromPtrs' (shape ++ [n']) a
     where (IdxSetLit n') = n
   IdxSetLit n -> do
-    liftM (Con . AsIdx n) $ valFromPtrs' shape (BaseType IntType)
+    liftM (Con . AsIdx (IdxSetLit n)) $ valFromPtrs' shape (BaseType IntType)
   _ -> error $ "Not implemented: " ++ pprint ty
 
 type PrimConVal = PrimCon Type Atom LamExpr

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -178,7 +178,12 @@ data PrimCon ty e lam =
         Lit LitVal
       | Lam ty ty lam
       | RecCon (Record e)
-      | AsIdx Int e
+      | AsIdx ty e        -- Construct an index from an expression
+                          -- NOTE: the indices are expected to be zero-based!
+                          -- This means that even though the index space might
+                          -- contain all integers between 5 and 10 (exclusive),
+                          -- the only integers that are valid to be cast to such
+                          -- indices fall into the range of [0, 5).
       | AFor ty e
       | AGet e
       | ArrayRef Array
@@ -663,7 +668,7 @@ instance TraversableExpr PrimCon where
     Lam lin eff lam -> liftA3 Lam (fT lin) (fT eff) (fL lam)
     AFor n e    -> liftA2 AFor (fT n) (fE e)
     AGet e      -> liftA  AGet (fE e)
-    AsIdx n e   -> liftA  (AsIdx n) (fE e)
+    AsIdx n e   -> liftA2 AsIdx (fT n) (fE e)
     RecCon r    -> liftA  RecCon (traverse fE r)
     Todo ty             -> liftA  Todo (fT ty)
     ArrayRef ref        -> pure $ ArrayRef ref

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -576,7 +576,7 @@ traverseConType con eq kindIs _ = case con of
   RecCon r -> return $ RecType r
   AFor n a -> return $ TabType n a
   AGet (ArrayType _ b) -> return $ BaseType b  -- TODO: check shape matches AFor scope
-  AsIdx n e -> eq e (BaseType IntType) >> return (IdxSetLit n)
+  AsIdx n e -> eq e (BaseType IntType) >> return n
   ArrayRef (Array shape b _) -> return $ ArrayType shape b
   Todo ty -> kindIs TyKind ty >> return ty
   _ -> error $ "Unexpected primitive type: " ++ pprint con


### PR DESCRIPTION
Previously the `AsIdx` constructor has taken an `Int` that was implicitly
interpreter as the upper bound for the `IdxSetLit` type. This patch
makes the index set argument explicit, allowing generalization of
`AsIdx` to e.g. `Range`.