### PR TITLE
Solidify dependently typed index spaces

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -291,3 +291,17 @@ fAmb = ()
 >
 >   fEff2 @Int ()
 >   ^^^^^^^^^^^
+
+:p
+    for i:7. sum for j:(Range 0 unboundName). 1.0
+> Error: variable not in scope: unboundName
+
+:p
+    x = "123"
+    for i:7. sum for j:(Range 0 x). 1.0
+> Kind error:
+> Expected: Int
+>   Actual: Str
+>
+>     for i:7. sum for j:(Range 0 x). 1.0
+>              ^^^^

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -195,9 +195,10 @@ instance PrettyLam PiType where
   prettyLam (Pi a (eff,b)) = (p a, p eff <+> p b)
 
 instance Pretty Kind where
-  pretty TyKind     = "Type"
-  pretty MultKind   = "Mult"
-  pretty EffectKind = "Effect"
+  pretty TyKind      = "Type"
+  pretty MultKind    = "Mult"
+  pretty EffectKind  = "Effect"
+  pretty (DepKind t) = pretty t
   pretty k = p $ show k
 
 instance Pretty a => Pretty (VarP a) where

--- a/src/lib/Subst.hs
+++ b/src/lib/Subst.hs
@@ -89,8 +89,7 @@ instance Subst Type where
     Dep v -> case substVar env v of
                Var v' -> Dep v'
                Con (Lit (IntLit i)) -> DepLit i
-               _      -> NoDep  -- TODO: make this an error
-                                -- (need to be stricter about where we put `Dep`)
+               term   -> error $ "Can't lift term into a type: " ++ (pprint term)
     Effect row t -> case t of
       Nothing -> Effect row' Nothing
       Just v  -> substTail row' (recur v)


### PR DESCRIPTION
The previous solutions were pretty hacky, so this patch cleans up a lot
of their shortcomings. In particular we now:
- Make sure the dependent variables are in scope
- Preserve the type while lifting term variables to the type level (aka Dep)
- Do kind checking to ensure that range expressions can only be given Ints
- No longer silently ignore terms that cannot be lifted to the type
  level by pretending they're not there

Co-authored-by: Dougal Maclaurin <dougalm@google.com>