### PR TITLE
Add IndexRange and start work on inject

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -420,12 +420,12 @@ litArr = [10, 5, 3]
 
 :p
     n = iadd 3 7
-    sum for i:(Range 0 n). 1.0
+    sum for i:(IntRange 0 n). 1.0
 > 10.0
 
 :p
     n = 4
-    sum for i:(Range 0 n). 1.0
+    sum for i:(IntRange 0 n). 1.0
 > 4.0
 
 :p idiv 10 3

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -293,17 +293,17 @@ fAmb = ()
 >   ^^^^^^^^^^^
 
 :p
-    for i:7. sum for j:(Range 0 unboundName). 1.0
+    for i:7. sum for j:(IntRange 0 unboundName). 1.0
 > Error: variable not in scope: unboundName
 
 :p
     x = "123"
-    for i:7. sum for j:(Range 0 x). 1.0
+    for i:7. sum for j:(IntRange 0 x). 1.0
 > Kind error:
 > Expected: Int
 >   Actual: Str
 >
->     for i:7. sum for j:(Range 0 x). 1.0
+>     for i:7. sum for j:(IntRange 0 x). 1.0
 >              ^^^^
 
 :p [1,2,3]@Int
@@ -318,3 +318,18 @@ fAmb = ()
 >
 > :p [1,2,3]@2
 >    ^^^^^^^^^
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:(IdxRange one i). 1.0
+> [0.0, 0.0, 1.0, 2.0]
+
+-- TODO: Fix the kind error!
+:p
+  for i:4. sum for j:(IdxRange 1 i). 1.0
+> [0.0, 0.0, 1.0, 2.0]
+
+-- TODO: Implement a dependent arrow type
+-- :p
+--   zero = asidx @4 0
+--   for i:4. for j:(IdxRange zero i). 1.0

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -75,7 +75,8 @@ instance Pretty Type where
                  _  -> " |" <+> hsep (punctuate "," (map p qs))
     TypeAlias _ _ -> "<type alias>"  -- TODO
     IdxSetLit i -> p i
-    Range a b -> "Range" <+> p a <+> p b
+    IntRange a b -> "(IntRange" <+> p a <+> p b <> ")"
+    IndexRange a b -> "(IndexRange" <+> p a <+> p b <> ")"
     DepLit x  -> "(DepLit" <+> p x <+> ")"
     Dep x  -> "(Dep" <+> p x <+> ")"
     NoDep  -> "NoDep"

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -523,7 +523,8 @@ className = do
 tauTypeAtomic :: Parser Type
 tauTypeAtomic =   parenTy
               <|> liftM (ArrowType NonLin) piType
-              <|> rangeType
+              <|> intRangeType
+              <|> indexRangeType
               <|> liftM Ref (symbol "Ref" >> tauTypeAtomic)
               <|> typeName
               <|> liftM TypeVar typeVar
@@ -538,8 +539,11 @@ tauType = makeExprParser (sc >> tauTypeAtomic) typeOps
               , [InfixR (TabType <$ symbol "=>")]
               , [InfixR arrowType] ]
 
-rangeType :: Parser Type
-rangeType = symbol "Range" >> liftM2 Range dep dep
+intRangeType :: Parser Type
+intRangeType = symbol "IntRange" >> liftM2 IntRange dep dep
+
+indexRangeType :: Parser Type
+indexRangeType = symbol "IdxRange" >> liftM2 IndexRange dep dep
 
 dep :: Parser Dep
 dep =    (do v <- lowerName


### PR DESCRIPTION
Range has been renamed to IntRange (as a restriction on the infinite set
of integers), while restrictions of finite index sets are now possible
using IndexRange. Note that while it can be used in nested for loops,
all such ranges have to be eliminated (e.g. with sum), because we
currently don't support dependent table arrows.

There's also some preliminary work on inject which is currently blocked
on our inability to verify typeclass constraints inside kind inference.