### PR TITLE
Allow arbitrary inclusions and exclusions of index range bounds

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -420,12 +420,12 @@ litArr = [10, 5, 3]
 
 :p
     n = iadd 3 7
-    sum for i:(IntRange 0 n). 1.0
+    sum for i:0...<n. 1.0
 > 10.0
 
 :p
     n = 4
-    sum for i:(IntRange 0 n). 1.0
+    sum for i:0...<n. 1.0
 > 4.0
 
 :p idiv 10 3

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -293,17 +293,17 @@ fAmb = ()
 >   ^^^^^^^^^^^
 
 :p
-    for i:7. sum for j:(IntRange 0 unboundName). 1.0
+    for i:7. sum for j:0...<unboundName. 1.0
 > Error: variable not in scope: unboundName
 
 :p
     x = "123"
-    for i:7. sum for j:(IntRange 0 x). 1.0
+    for i:7. sum for j:0...<x. 1.0
 > Kind error:
 > Expected: Int
 >   Actual: Str
 >
->     for i:7. sum for j:(IntRange 0 x). 1.0
+>     for i:7. sum for j:0...<x. 1.0
 >              ^^^^
 
 :p [1,2,3]@Int
@@ -321,15 +321,15 @@ fAmb = ()
 
 :p
   one = asidx @4 1
-  for i:4. sum for j:(IdxRange one i). 1.0
+  for i:4. sum for j:one..<i. 1.0
 > [0.0, 0.0, 1.0, 2.0]
 
 -- TODO: Fix the kind error!
 :p
-  for i:4. sum for j:(IdxRange 1 i). 1.0
+  for i:4. sum for j:1..<i. 1.0
 > [0.0, 0.0, 1.0, 2.0]
 
 -- TODO: Implement a dependent arrow type
 -- :p
 --   zero = asidx @4 0
---   for i:4. for j:(IdxRange zero i). 1.0
+--   for i:4. for j:zero..<i. 1.0

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -177,12 +177,12 @@ withZeroTangent x = (x, zeroAt (tangentType (getType x)))
 tangentType :: Type -> Type
 tangentType ty = case ty of
   BaseType RealType -> BaseType RealType
-  BaseType   _   -> unitTy
-  IntRange   _ _ -> unitTy
-  IndexRange _ _ -> unitTy
-  TabType n a    -> TabType n (tangentType a)
-  RecType r      -> RecType $ fmap tangentType r
-  Ref a          -> Ref $ tangentType a
+  BaseType   _       -> unitTy
+  IntRange   _ _     -> unitTy
+  IndexRange _ _ _ _ -> unitTy
+  TabType n a        -> TabType n (tangentType a)
+  RecType r          -> RecType $ fmap tangentType r
+  Ref a              -> Ref $ tangentType a
   _ -> error $ "Can't differentiate wrt type " ++ pprint ty
 
 hasDiscreteType :: HasType e => e -> Bool

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -129,7 +129,7 @@ check expr reqEffTy@(allowedEff, reqTy) = case expr of
     e' <- checkPure e et'
     et <- zonk et'
     case et of
-      (IndexRange (Dep low) (Dep _)) -> do
+      (IndexRange (Dep low) _ (Dep _) _) -> do
         low' <- fromAnn TyKind (varAnn low)
         constrainEq reqTy low' (pprint e)
         return $ FPrimExpr $ OpExpr $ Inject e'
@@ -348,9 +348,9 @@ inferKindsM kind ty = case ty of
       b' <- inferKindsM depIntType b
       return $ IntRange a' b'
     where depIntType = DepKind $ BaseType IntType
-  IndexRange a b -> do
+  IndexRange a ai b bi -> do
       -- TODO: Validate the kinds
-      return $ IndexRange a b
+      return $ IndexRange a ai b bi
   Dep v@(name :> _) -> do
     env <- look
     case envLookup env v of

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -75,8 +75,11 @@ instance Pretty Type where
                  _  -> " |" <+> hsep (punctuate "," (map p qs))
     TypeAlias _ _ -> "<type alias>"  -- TODO
     IntRange (DepLit 0) (DepLit n) -> p n
-    IntRange a b -> "(IntRange" <+> p a <+> p b <> ")"
-    IndexRange a b -> "(IndexRange" <+> p a <+> p b <> ")"
+    IntRange a b -> p a <> "...<" <> p b
+    IndexRange a True  b True  -> p a <> "..." <> p b
+    IndexRange a False b True  -> p a <> ">.." <> p b
+    IndexRange a True  b False -> p a <> "..<" <> p b
+    IndexRange a False b False -> p a <> ">.<" <> p b
     DepLit x  -> "(DepLit" <+> p x <+> ")"
     Dep x  -> "(Dep" <+> p x <+> ")"
     NoDep  -> "NoDep"

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -58,7 +58,7 @@ data Type = TypeVar TVar
           | BaseType BaseType
           | ArrowType Mult PiType
           | IntRange Type Type
-          | IndexRange Type Type
+          | IndexRange Type Bool Type Bool -- True if the endpoint is included
           | TabType Type Type
           | ArrayType [Int] BaseType
           | RecType (Record Type)
@@ -745,7 +745,7 @@ traverseType :: Applicative m => (Kind -> Type -> m Type) -> Type -> m Type
 traverseType f ty = case ty of
   BaseType _           -> pure ty
   IntRange a b         -> liftA2 IntRange (f depIntType a) (f depIntType b)
-  IndexRange a b       -> liftA2 IndexRange (f depIntType a) (f depIntType b)
+  IndexRange a ac b bc -> liftA4 IndexRange (f depIntType a) (pure ac) (f depIntType b) (pure bc)
   TabType a b          -> liftA2 TabType (f TyKind a) (f TyKind b)
   ArrayType _ _        -> pure ty
   RecType r            -> liftA RecType $ traverse (f TyKind) r


### PR DESCRIPTION
This is necessary, because unlike Int (at least for practical reasons)
index sets not always have a valid predecessor and successor.

The new (and the old `IntRange`) also got a sleek syntax (inspired by
Haskell and Swift):
- `...` is an `IndexRange` with both bounds included
- `..<` is an `IndexRange` with upper bound excluded
- `>..` is an `IndexRange` with lower bound excluded
- `>.<` is an `IndexRange` that excludes both endpoints
- `...<` is an `IntRange` that excludes its upper bound.
  Note that a literal `4` is equivalent to `0...<4`.