### PR TITLE
Allow index ranges to skip one of their bounds

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -428,6 +428,46 @@ litArr = [10, 5, 3]
     sum for i:0...<n. 1.0
 > 4.0
 
+:p
+  one = asidx @4 1
+  for i:4. sum for j:one...i. 1.0
+> [0.0, 1.0, 2.0, 3.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:one>..i. 1.0
+> [0.0, 0.0, 1.0, 2.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:one..<i. 1.0
+> [0.0, 0.0, 1.0, 2.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:one>.<i. 1.0
+> [0.0, 0.0, 0.0, 1.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:...i. 1.0
+> [1.0, 2.0, 3.0, 4.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:..<i. 1.0
+> [0.0, 1.0, 2.0, 3.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:i.... 1.0
+> [4.0, 3.0, 2.0, 1.0]
+
+:p
+  one = asidx @4 1
+  for i:4. sum for j:i>... 1.0
+> [3.0, 2.0, 1.0, 0.0]
+
 :p idiv 10 3
 > 3
 

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -179,7 +179,7 @@ tangentType ty = case ty of
   BaseType RealType -> BaseType RealType
   BaseType   _       -> unitTy
   IntRange   _ _     -> unitTy
-  IndexRange _ _ _ _ -> unitTy
+  IndexRange _ _     -> unitTy
   TabType n a        -> TabType n (tangentType a)
   RecType r          -> RecType $ fmap tangentType r
   Ref a              -> Ref $ tangentType a

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -76,10 +76,15 @@ instance Pretty Type where
     TypeAlias _ _ -> "<type alias>"  -- TODO
     IntRange (DepLit 0) (DepLit n) -> p n
     IntRange a b -> p a <> "...<" <> p b
-    IndexRange a True  b True  -> p a <> "..." <> p b
-    IndexRange a False b True  -> p a <> ">.." <> p b
-    IndexRange a True  b False -> p a <> "..<" <> p b
-    IndexRange a False b False -> p a <> ">.<" <> p b
+    IndexRange (Just (a, True )) (Just (b, True )) -> p a <> "..." <> p b
+    IndexRange (Just (a, False)) (Just (b, True )) -> p a <> ">.." <> p b
+    IndexRange (Just (a, True )) (Just (b, False)) -> p a <> "..<" <> p b
+    IndexRange (Just (a, False)) (Just (b, False)) -> p a <> ">.<" <> p b
+    IndexRange Nothing (Just (b, True )) -> "..." <> p b
+    IndexRange Nothing (Just (b, False)) -> "..<" <> p b
+    IndexRange (Just (a, True )) Nothing -> p a <> "..."
+    IndexRange (Just (a, False)) Nothing -> p a <> ">.."
+    IndexRange Nothing Nothing -> undefined -- Rejected while parsing
     DepLit x  -> "(DepLit" <+> p x <+> ")"
     Dep x  -> "(Dep" <+> p x <+> ")"
     NoDep  -> "NoDep"


### PR DESCRIPTION
One thing we might want to reconsider is the syntax for skipped bounds, because right now this code is valid:
```
for i:4. for j:i.... 1.0
```
and it says that the inner loop goes from `i` to the upper bound. The first three dots after `i` are the index range operator, while the fourth one terminates the `for`. An alternative would be to e.g. say that bounds can be replaced with a `*` giving:
```
for i:4. for j:i...*. 1.0
```

Of course it is legal to put a space between `...` and `.`, but it's optional and might make the code a little weird (especially that we use 4-character range operators for `Int` restrictions). On the other hand the current syntax is quite nice, as it will allow us to write the type of lower-triangular arrays as `(i:n)=>(...i)=>Real` in the future.