### PR TITLE
Inject implemented, except for a bug in Imp

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -80,10 +80,10 @@ instance Pretty Type where
       where
         low'  = case low  of InclusiveLim x -> p x <> "."
                              ExclusiveLim x -> p x <> "<"
-                             Unlimited      ->       ".."
+                             Unlimited      ->        "."
         high' = case high of InclusiveLim x -> "." <> p x
                              ExclusiveLim x -> "<" <> p x
-                             Unlimited      -> ".."
+                             Unlimited      -> "."
     Lin    -> "Lin"
     NonLin -> "NonLin"
     Effect row t -> "{" <> row' <+> tailVar <> "}"


### PR DESCRIPTION
Inject implementation should be complete now, but it seems like the
substitution of type-level terms in Imp is broken (+ Imp type checker
doesn't manage to catch the error, causing the compiler to crash in
LLVM).