### PR TITLE
Make table type a dependent arrow

### DIFF
--- a/makefile
+++ b/makefile
@@ -102,3 +102,6 @@ benchmark:
 	benchmarks/bench 1000
 	$(dex) script benchmarks/time-tests.dx
 	rm benchmarks/bench
+
+clean:
+	$(STACK) clean

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -183,12 +183,12 @@ withZeroTangent :: Atom -> (Atom, EmbedSubM Atom)
 withZeroTangent x = (x, zeroAt (tangentType (getType x)))
 
 tangentType :: Type -> Type
+tangentType (TabTy n a) = TabTy n (tangentType a)
 tangentType (TC con) = case con of
   BaseType RealType  -> TC $ BaseType RealType
   BaseType   _       -> UnitTy
   IntRange   _ _     -> UnitTy
   IndexRange _ _ _   -> UnitTy
-  TabType n a        -> TabTy n (tangentType a)
   RecType r          -> RecTy $ fmap tangentType r
   RefType a          -> RefTy $ tangentType a
   _           -> error $ "Can't differentiate wrt type " ++ pprint con

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -234,9 +234,9 @@ isSingletonType ty = case singletonTypeVal ty of
   Just _  -> True
 
 singletonTypeVal :: Type -> Maybe Atom
+singletonTypeVal (TabTy n a) = liftM (Con . AFor n) $ singletonTypeVal a
 singletonTypeVal (TC con) = case con of
   BaseType  _ -> Nothing
-  TabType n a -> liftM (Con . AFor n) $ singletonTypeVal a
   RecType r   -> liftM RecVal $ traverse singletonTypeVal r
   _           -> Nothing
 singletonTypeVal _ = Nothing

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -61,6 +61,7 @@ instance Pretty Type where
     ArrowType l (Pi a (eff, b))
       | isPure eff -> parens $ p a <+> arrStr l <+>           p b
       | otherwise  -> parens $ p a <+> arrStr l <+> p eff <+> p b
+    TabType (Pi a b)  -> parens $ p a <> "=>" <> p b
     Forall bs qs body -> header <+> p body
       where
         header = "A" <+> hsep (map p bs) <> qual <> "."
@@ -84,7 +85,6 @@ instance Pretty Type where
 instance Pretty ty => Pretty (TyCon ty Atom) where
   pretty con = case con of
     BaseType b  -> p b
-    TabType a b -> parens $ p a <> "=>" <> p b
     RecType r   -> p $ fmap (asStr . p) r
     RefType t   -> "Ref" <+> p t
     TypeApp f xs -> p f <+> hsep (map p xs)
@@ -103,7 +103,7 @@ instance Pretty ty => Pretty (TyCon ty Atom) where
     LinCon    -> "Lin"
     NonLinCon -> "NonLin"
 
-instance Pretty PiType where
+instance Pretty b => Pretty (PiType b) where
   pretty (Pi a b) = "Pi" <+> p a <+> p b
 
 instance Pretty EffectName where
@@ -203,8 +203,11 @@ instance PrettyLam () where
 instance (Pretty a, Pretty b) => PrettyLam (a, b) where
   prettyLam (x, y) = (p x, p y)
 
-instance PrettyLam PiType where
-  prettyLam (Pi a (eff,b)) = (p a, p eff <+> p b)
+instance PrettyLam (PiType EffectiveType) where
+  prettyLam (Pi a (eff, b)) = (p a, p eff <+> p b)
+
+instance PrettyLam (PiType Type) where
+  prettyLam (Pi a b) = (p a, p b)
 
 instance Pretty Kind where
   pretty TyKind      = "Type"

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -602,7 +602,7 @@ arrowType = do
   eff <- effectType <|> return noEffect
   return $ \a b -> ArrowType lin $ Pi a (eff, b)
 
-piType :: Parser PiType
+piType :: Parser (PiType EffectiveType)
 piType = do
   v <- try $ lowerName <* symbol ":"
   a <- tauTypeAtomic

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -139,13 +139,13 @@ reStructureArrays :: Type -> [Val] -> Val
 reStructureArrays ty xs = evalState (reStructureArrays' ty) xs
 
 reStructureArrays' :: Type -> State [Val] Val
+reStructureArrays' (TabTy n a) = liftM (Con . AFor n) $ reStructureArrays' a
 reStructureArrays' ty@(TC con) = case con of
   BaseType _ -> do
     ~(x:xs) <- get
     put xs
     return $ Con $ AGet x
   RecType r -> liftM (Con . RecCon) $ traverse reStructureArrays' r
-  TabType n a -> liftM (Con . AFor n) $ reStructureArrays' a
   IntRange _ _ -> do
     liftM (Con . AsIdx ty) $ reStructureArrays' $ TC $ BaseType IntType
   _ -> error $ "Not implemented: " ++ pprint ty


### PR DESCRIPTION
Even though we support dependent index sets now, all the dependencies
had to be eliminated before the final table has been created. This is
because only function arrow allowed lifting arguments to the type level.
This patch generalizes the existing table type to allow earlier indices
to appear in index spaces of latter dimensions.

Note that there is still no support for this feature in the parser and
in the codegen. Those will be implemented later.