### PR TITLE
Add support for dependent tables to the parser

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -531,3 +531,8 @@ litArr = [10, 5, 3]
       put ref $ c + 1.0
       c
 > ([3.0, 2.0, 1.0, 0.0], 4.0)
+
+:p
+  x: (i:4=>(...i)=>4) = for i:4. for j:(...i). i
+  1.0
+> Error: variable not in scope: !0

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -16,7 +16,7 @@ module Type (
     isData, Checkable (..), popRow, getTyOrKind, moduleType,
     getKind, checkKindEq, getEffType, getPatName, tyConKind,
     checkRuleDefType, getConType, checkEffType, HasType, indexSetConcreteSize,
-    maybeApplyPi, makePi, applyPi, isDependentType) where
+    maybeApplyPi, makePi, applyPi, isDependentType, PiAbstractable) where
 
 import Control.Monad
 import Control.Monad.Except hiding (Except)


### PR DESCRIPTION
The data model of the syntax has already supported it, but it hasn't
been surfaced to the user-level. At the moment type annotations are
necessary for correct type inference of dependent tables, and (as the
example in eval-tests.dx shows) it is still impossible to actually
compile code that uses them.