### PR TITLE
Desugar sum types into product types

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -541,3 +541,15 @@ litArr = [10, 5, 3]
 > Lookup of DeBruijn 0 failed
 > CallStack (from HasCallStack):
 >   error, called at src/lib/Env.hs:98:14 in dex-0.1.0.0-HJSwFDIBGLApX0gaH8Fs9:Env
+
+eitherFloor : Either Int Real -> Int
+eitherFloor x = case x
+    Left i  -> i
+    Right f -> %%floorDex(f)
+
+:p
+  eitherFloor (%right(1.2))
+> 1
+
+:p ((%right(1.2)) : (Either Int Real))
+> (1, 1.2, False)

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -368,3 +368,15 @@ differentCaseResultTypes x = case x
 inferEither x = case x
     Left i -> iadd i 1
     Right f -> floor f
+
+caseEffects : wRef:(Ref Real) -> (Either Int Real) -> {Writer wRef} ()
+caseEffects ref x = case x
+    Left  i -> ()
+    Right r -> tell ref r
+> Type error:
+> Expected: { }
+>   Actual: {Writer ref | ?_36:Effect}
+> In: ((tell ref) r)
+>
+> caseEffects ref x = case x
+>                     ^^^^^^^

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -180,6 +180,8 @@ instance (Pretty ty, Pretty e, PrettyLam lam) => Pretty (PrimCon ty e lam) where
   pretty (AFor n body) = parens $ "afor *:" <> p n <+> "." <+> p body
   pretty (AGet e)      = "aget" <+> p e
   pretty (AsIdx n i)   = p i <> "@" <> p n
+  pretty (SumCon t e (Left _))  = parens $ "Left @"  <> p t <+> p e
+  pretty (SumCon t e (Right _)) = parens $ "Right @" <> p t <+> p e
   pretty con = prettyExprDefault (ConExpr con)
 
 prettyExprDefault :: (Pretty e, PrettyLam lam) => PrimExpr ty e lam -> Doc ann

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -551,6 +551,8 @@ traverseOpType op eq kindIs inClass = case fmapExpr op id snd id of
     unless (not $ any isDependentType [lp, lr]) $ throw TypeErr $
         "Return type of cases cannot depend on the matched value"
     eq st (SumTy la ra)
+    inClass Data la
+    inClass Data ra
     eq leff noEffect
     eq reff noEffect
     eq lb rb


### PR DESCRIPTION
`Either a b` becomes `(Bool, a, b)`, where the bool tag stores the
used constructor. The value of type that doesn't correspond to the right
case is left unspecified (arbitrary value will be selected during
compilation). `SumCase` operators are desugared into applications of
both branches and then a `Select` operator.

Note that this approach has the benefit of being very simple, but it has
some pretty significant downsides:

- A type obtained by taking an n-time sum of a type `T` is supposed to
  have `|T|*n` inhabitants, not `|T|^n * 2`.
- We keep doing unnecessary compute on the unspecified value only to
  keep throwing it away.
- Cases might generate hardware traps or aborts, which we would have to
  mask to obtain desired semantics.
- It's impossible to always generate a value of a type that is stored in
  one `Either` constructor, because it might not have any inhabitants.
  `0....0` (i.e. `IntRange 0 0`) is a good and simple example.