### PR TITLE
Make sum types valid index sets

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -552,4 +552,4 @@ eitherFloor x = case x
 > 1
 
 :p ((%right(1.2)) : (Either Int Real))
-> (1, 1.2, False)
+> (False, 1, 1.2)

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -304,6 +304,7 @@ compilePrimOp (ScalarUnOp op x) = case op of
   FNeg      -> emitInstr realTy $ L.FSub L.noFastMathFlags (litReal 0.0) x []
   Not       -> emitInstr boolTy $ L.Xor x (litInt 1) []
   BoolToInt -> return x -- bools stored as ints
+  UnsafeIntToBool -> return x -- bools stored as ints
   IntToReal -> emitInstr realTy $ L.SIToFP x realTy []
   _ -> error "Not implemented"
 compilePrimOp (Select ty p x y) = do

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -234,7 +234,7 @@ data ScalarBinOp = IAdd | ISub | IMul | IDiv | ICmp CmpOp
                  | And | Or | Rem
                    deriving (Show, Eq, Generic)
 
-data ScalarUnOp = Not | FNeg | IntToReal | BoolToInt | IndexAsInt
+data ScalarUnOp = Not | FNeg | IntToReal | BoolToInt | UnsafeIntToBool | IndexAsInt
                   deriving (Show, Eq, Generic)
 
 data CmpOp = Less | Greater | Equal | LessEqual | GreaterEqual


### PR DESCRIPTION
Also, make `Bool` an index set. Now, the following runs correctly:

```haskell
type Weights n m = n=>m=>Real

type Biases n = n=>Real

type Params n m = (Either (n,m) n)=>Real

flatten : (Weights n m, Biases n) -> Params n m
flatten (w, b) = for idx. case idx
                Left (i,j) -> w.i.j
                Right i    -> b.i

w = for i:2. for j:2. (real (asint i)) * 2.0 + (real (asint j))
b = for j:2. neg (real (asint j))

restructure : Params n m -> (Weights n m, Biases n)
restructure params = ( for i. for j. params.(%left((i,j)))
                     , for i.        params.(%right(i))    )

(w, b)
restructure (flatten (w, b))
```

with the last two expressions returning the same values!