### PR TITLE
Implement a better lowering for sum types

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -545,11 +545,11 @@ litArr = [10, 5, 3]
 eitherFloor : Either Int Real -> Int
 eitherFloor x = case x
     Left i  -> i
-    Right f -> %%floorDex(f)
+    Right f -> floor f
 
 :p
-  eitherFloor (%right(1.2))
+  eitherFloor (Right 1.2)
 > 1
 
-:p ((%right(1.2)) : (Either Int Real))
-> (False, 1, 1.2)
+:p ((Right 1.2) : (Either Int Real))
+> Right 1.2

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -40,7 +40,7 @@ module Syntax (
     pattern TabTy, pattern NonLin, pattern Lin, pattern FixedIntRange,
     pattern RefTy, pattern BoolTy, pattern IntTy, pattern RealTy,
     pattern RecTy, pattern SumTy, pattern ArrayTy, pattern BaseTy, pattern UnitVal,
-    pattern PairVal, pattern TupVal, pattern RecVal, pattern RealVal)
+    pattern PairVal, pattern TupVal, pattern RecVal, pattern SumVal, pattern RealVal)
   where
 
 import qualified Data.Map.Strict as M
@@ -192,10 +192,11 @@ data PrimExpr ty e lam = OpExpr  (PrimOp ty e lam)
 data PrimCon ty e lam =
         Lit LitVal
       | ArrayLit Array
-      | Lam ty ty lam  -- First type for linearity, second for effects
-      | SumCon ty e (Either () ()) -- Either constructor indicates which constructor to use
+      | Lam ty ty lam      -- First type for linearity, second for effects
+      | AnyValue ty        -- Produces an arbitrary value of a given type
+      | SumCon e e e       -- (bool constructor tag (True is Left), left value, right value)
       | RecCon (Record e)
-      | AsIdx ty e  -- Construct an index from its ordinal index (zero-based int)
+      | AsIdx ty e         -- Construct an index from its ordinal index (zero-based int)
       | AFor ty e
       | AGet e
       | Todo ty
@@ -208,6 +209,8 @@ data PrimOp ty e lam =
       | TabGet e e
       | SumCase e lam lam
       | RecGet e RecField
+      | SumGet e Bool
+      | SumTag e
       | ArrayGep e e
       | LoadScalar e
       | TabCon ty ty [e]
@@ -271,8 +274,6 @@ builtinNames = M.fromList
   , ("indexWriter"     , OpExpr $ IndexEff Writer () () ())
   , ("indexState"      , OpExpr $ IndexEff State  () () ())
   , ("todo"       , ConExpr $ Todo ())
-  , ("left"       , ConExpr $ SumCon () () (Left ()))
-  , ("right"      , ConExpr $ SumCon () () (Right ()))
   , ("ask"        , OpExpr $ PrimEffect () $ MAsk)
   , ("tell"       , OpExpr $ PrimEffect () $ MTell ())
   , ("get"        , OpExpr $ PrimEffect () $ MGet)
@@ -680,6 +681,8 @@ instance TraversableExpr PrimOp where
     TabGet e i           -> liftA2 TabGet (fE e) (fE i)
     SumCase e l r        -> liftA3 SumCase (fE e) (fL l) (fL r)
     RecGet e i           -> liftA2 RecGet (fE e) (pure i)
+    SumGet e s           -> liftA2 SumGet (fE e) (pure s)
+    SumTag e             -> liftA  SumTag (fE e)
     ArrayGep e i         -> liftA2 ArrayGep (fE e) (fE i)
     LoadScalar e         -> liftA  LoadScalar (fE e)
     ScalarBinOp op e1 e2 -> liftA2 (ScalarBinOp op) (fE e1) (fE e2)
@@ -711,12 +714,13 @@ instance TraversableExpr PrimCon where
     Lit l        -> pure $ Lit l
     ArrayLit arr -> pure $ ArrayLit arr
     Lam lin eff lam -> liftA3 Lam (fT lin) (fT eff) (fL lam)
-    AFor n e    -> liftA2 AFor (fT n) (fE e)
-    AGet e      -> liftA  AGet (fE e)
-    AsIdx n e   -> liftA2 AsIdx (fT n) (fE e)
-    SumCon t e c -> liftA3 SumCon (fT t) (fE e) (pure c)
-    RecCon r    -> liftA  RecCon (traverse fE r)
-    Todo ty             -> liftA  Todo (fT ty)
+    AFor n e     -> liftA2 AFor (fT n) (fE e)
+    AGet e       -> liftA  AGet (fE e)
+    AsIdx n e    -> liftA2 AsIdx (fT n) (fE e)
+    AnyValue t   -> AnyValue <$> fT t
+    SumCon c l r -> SumCon <$> fE c <*> fE l <*> fE r
+    RecCon r     -> liftA  RecCon (traverse fE r)
+    Todo ty      -> liftA  Todo (fT ty)
 
 instance (TraversableExpr expr, HasVars ty, HasVars e, HasVars lam)
          => HasVars (expr ty e lam) where
@@ -791,6 +795,9 @@ pattern RealVal x = Con (Lit (RealLit x))
 
 pattern RecVal :: Record Atom -> Atom
 pattern RecVal r = Con (RecCon r)
+
+pattern SumVal :: Atom -> Atom -> Atom -> Atom
+pattern SumVal t l r = Con (SumCon t l r)
 
 pattern TupVal :: [Atom] -> Atom
 pattern TupVal xs = RecVal (Tup xs)

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -559,7 +559,9 @@ traverseOpType op eq kindIs inClass = case fmapExpr op id snd id of
     eq reff noEffect
     eq lb rb
     return $ pureType $ lb
-  RecGet (RecTy r) i    -> return $ pureTy $ recGet r i
+  RecGet (RecTy r) i -> return $ pureTy $ recGet r i
+  SumGet (SumTy l r) isLeft -> return $ pureTy $ if isLeft then l else r
+  SumTag (SumTy _ _) -> return $ pureTy $ TC $ BaseType BoolType
   ArrayGep (ArrayTy (_:shape) b) i -> do
     eq IntTy i
     return $ pureTy $ ArrayTy shape b
@@ -615,9 +617,8 @@ traverseConType con eq kindIs _ = case con of
   Lam l eff (Pi a (eff', b)) -> do
     checkExtends eff eff'
     return $ ArrowType l (Pi a (eff, b))
-  SumCon t' t s -> case s of
-    Left _  -> return $ TC $ SumType (t, t')
-    Right _ -> return $ TC $ SumType (t', t)
+  AnyValue t   -> return $ t
+  SumCon _ l r -> return $ SumTy l r
   RecCon r -> return $ RecTy r
   AFor n a -> return $ TabTy n a
   AGet (ArrayTy _ b) -> return $ BaseTy b  -- TODO: check shape matches AFor scope


### PR DESCRIPTION
Instead of normalizing them out while translating to the core IR,
they're kept there until the Imp backend, which allows us to e.g. shrink
the index sets they represent (by excluding the inhabitants of
`(Bool, l, r)` which are inaccessible). In the end any values are still
lowered to products though, with case statements desugared into masked
function application in the simplification pass.

Also, add a proper parser for Left/Right so that we can avoid the
awkward builtin syntax.