### PR TITLE
Minor cleanup and reorg of Type.hs

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -9,8 +9,8 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module PPrint (pprint, pprintList,
-               assertEq, ignoreExcept, printLitBlock, asStr) where
+module PPrint (pprint, pprintList, printLitBlock, asStr,
+               assertEq, assertNoShadow, ignoreExcept) where
 
 import Control.Monad.Except hiding (Except)
 import GHC.Float
@@ -357,6 +357,12 @@ assertEq :: (MonadError Err m, Pretty a, Eq a) => a -> a -> String -> m ()
 assertEq x y s = if x == y then return ()
                            else throw CompilerErr msg
   where msg = s ++ ": " ++ pprint x ++ " != " ++ pprint y ++ "\n"
+
+assertNoShadow :: (MonadError Err m, Pretty b) => Env a -> VarP b -> m ()
+assertNoShadow env v = do
+  if v `isin` env
+    then throw CompilerErr $ pprint v ++ " shadowed"
+    else return ()
 
 ignoreExcept :: HasCallStack => Except a -> a
 ignoreExcept (Left e) = error $ pprint e

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -117,7 +117,7 @@ evalSourceBlock env@(TopEnv (typeEnv, _) _ _) block = case sbContents block of
     -- TODO: handle patterns and type annotations in binder
     let (RecLeaf b) = p
     let outEnv = b @> L val
-    return $ TopEnv (substEnvType outEnv, mempty) outEnv mempty
+    return $ TopEnv (fmap getTyOrKind outEnv, mempty) outEnv mempty
   RuleDef ann@(LinearizationDef v) ~(Forall [] [] ty) ~(FTLam [] [] expr) -> do
     let v' = fromString (pprint v ++ "!lin") :> ty  -- TODO: name it properly
     let imports = map (uncurry (:>)) $ envPairs $ freeVars ann <> freeVars ty <> freeVars expr

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -154,7 +154,7 @@ checkKind ty = case ty of
   TC con -> do
     let (conKind, resultKind) = tyConKind con
     void $ traverseTyCon conKind (\(t,k) -> checkKindIs k t)
-                                 (\(e,t) -> checkType e >>= checkConstraint t)
+                                 (\(e,t) -> checkType e >>= checkTypeEq t)
     return resultKind
 
 checkKindIs :: Kind -> Type -> TypeM ()
@@ -442,16 +442,16 @@ getConType :: PrimConType -> Type
 getConType e = ignoreExcept $ traverseConType e ignoreArgs ignoreArgs ignoreArgs
 
 checkOpType :: PrimOpType -> TypeM EffectiveType
-checkOpType e = traverseOpType e checkConstraint checkKindIs checkClassConstraint
+checkOpType e = traverseOpType e checkTypeEq checkKindIs checkClassConstraint
 
 checkConType :: PrimConType -> TypeM Type
-checkConType e = traverseConType e checkConstraint checkKindIs checkClassConstraint
+checkConType e = traverseConType e checkTypeEq checkKindIs checkClassConstraint
 
 ignoreArgs :: Monad m => a -> b -> m ()
 ignoreArgs _ _ = return ()
 
-checkConstraint :: Type -> Type -> TypeM ()
-checkConstraint ty1 ty2 | ty1 == ty2 = return ()
+checkTypeEq :: Type -> Type -> TypeM ()
+checkTypeEq ty1 ty2 | ty1 == ty2 = return ()
                         | otherwise  = throw TypeErr $
                                          pprint ty1 ++ " != " ++ pprint ty2
 


### PR DESCRIPTION
As I was reading the file to better understand the type checking
machinery, I thought it might be a nice occasion to do a small cleanup
too. Most of it is just shuffling existing code around, to better group
it with relevant functions. I also got rid of all the `check*` functions
that were not part of `HasType` typeclass, because I thought it's a bit
weird that they follow the same naming, while each has its own slightly
different meaning.