### PR TITLE
Implement Eq and Ord typeclasses

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -35,7 +35,7 @@ library
                        -Wall
                        -O0
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
-                       TupleSections
+                       TupleSections, ScopedTypeVariables
 
 executable dex
   main-is:             dex.hs

--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -573,7 +573,30 @@ unflatten params =
   ( for i. for j. params.(Left (i,j))
   , for i.        params.(Right i)    )
 
-:p (w, b)
-> ([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], [-1.0, -2.0])
-:p unflatten (flatten (w, b))
-> ([[0.0, 1.0, 2.0], [3.0, 4.0, 5.0]], [-1.0, -2.0])
+:p unflatten (flatten (w, b)) == (w, b)
+> True
+
+:p (1, 2) == (1, 2)
+> True
+
+:p (for i:4. (1.0, asint i)) == (for i:4. (1.0, asint i))
+> True
+
+:p (1, 1) == (1, 2)
+> False
+
+:p (for i:4. 1.0) == (for i:4. 2.0)
+> False
+
+-- Needed to avoid ambiguous type variables if both sides use the same constructor
+cmpEither : Either Int Int -> Either Int Int -> Bool
+cmpEither x y = x == y
+
+:p cmpEither (Left 1) (Left 1)
+> True
+
+:p cmpEither (Left 1) (Left 2)
+> False
+
+:p cmpEither (Left 1) (Right 1)
+> False

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -230,19 +230,19 @@ f2 : Real -> Real
 f2 x = x + x
 
 :t [f1, f2]
-> Type error: Not serializable data: (Real -> Real)
+> Type error:(Real -> Real) is not serializable
 >
 > :t [f1, f2]
 >    ^^^^^^^^
 
 :t select True f1 f2
-> Type error: Not serializable data: (Real -> Real)
+> Type error:(Real -> Real) is not serializable
 >
 > :t select True f1 f2
 >    ^^^^^^^
 
 :t fold f1 \i:3 g. (\x. g (g x))
-> Type error: Not serializable data: (Real -> Real)
+> Type error:(Real -> Real) is not serializable
 >
 > :t fold f1 \i:3 g. (\x. g (g x))
 >    ^^^^^

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -221,6 +221,7 @@ mapScalars f ty xs = case ty of
     liftM RecVal $ sequence $ recZipWith (mapScalars f) r xs'
   BaseTy _           -> f ty xs
   TC con -> case con of
+    -- NOTE: Sum types not implemented, because they don't have a total zipping function!
     IntRange _ _     -> f ty xs
     IndexRange _ _ _ -> f ty xs
     _ -> error $ "Not implemented " ++ pprint ty

--- a/src/lib/JAX.hs
+++ b/src/lib/JAX.hs
@@ -135,7 +135,7 @@ toJaxOp' expr = case expr of
     traverseArrayLeaves tab $ \x -> emitOp $ JGet x $ fromScalarAtom i
   ScalarBinOp op x y -> liftM toScalarAtom $
     emitOp $ JScalarBinOp op (fromScalarAtom x) (fromScalarAtom y)
-  ScalarUnOp IndexAsInt x -> liftM toScalarAtom $
+  IndexAsInt x -> liftM toScalarAtom $
     emitOp $ JId (fromScalarAtom x)
   ScalarUnOp op x -> liftM toScalarAtom $
     emitOp $ JScalarUnOp op (fromScalarAtom x)

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -306,7 +306,6 @@ compilePrimOp (ScalarUnOp op x) = case op of
   BoolToInt -> return x -- bools stored as ints
   UnsafeIntToBool -> return x -- bools stored as ints
   IntToReal -> emitInstr realTy $ L.SIToFP x realTy []
-  _ -> error "Not implemented"
 compilePrimOp (Select ty p x y) = do
   p' <- emitInstr (L.IntegerType 1) $ L.Trunc p (L.IntegerType 1) []
   emitInstr ty $ L.Select p' x y []

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -243,6 +243,8 @@ instance Pretty ClassName where
     Data   -> "Data"
     VSpace -> "VS"
     IdxSet -> "Ix"
+    Eq     -> "Eq"
+    Ord    -> "Ord"
 
 instance Pretty Decl where
   pretty decl = case decl of

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -10,7 +10,7 @@ module Util (group, ungroup, pad, padLeft, delIdx, replaceIdx,
              insertIdx, mvIdx, mapFst, mapSnd, splitOn, traverseFun,
              composeN, mapMaybe, lookup, uncons, repeated,
              showErr, listDiff, splitMap, enumerate, restructure,
-             onSnd, onFst, highlightRegion, findReplace, swapAt) where
+             onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3) where
 
 import Data.List (sort)
 import Prelude hiding (lookup)
@@ -186,3 +186,6 @@ asState f = do
   let (ans, s') = f s
   put s'
   return ans
+
+uncurry3 :: (a -> b -> c -> d) -> (a, b, c) -> d
+uncurry3 f (x, y, z) = f x y z


### PR DESCRIPTION
Previously there was no type checking for equality and comparison
operators, but any attempt to apply them to non-scalar types would cause
a compiler error. This patch implements the type classes for those,
along with some hard-coded instances. The operations of those type
classes (encoded as the `Cmp` prim op) should get desugared into other
primitive operations before the simplification pass is completed.