### PR TITLE
Make Imp translation optionally work in destination-passing style

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -547,3 +547,16 @@ for j:(Fin upperBound). 1.0
 
 (for i:(Fin upperBound). 1, for j:(Fin 2). 2)
 > ([1, 1, 1, 1]@(Fin aget Int[1]), [2, 2])
+
+for i:(Fin 4).
+  x = iadd 1 1
+  (x, x)
+> [(2, 2), (2, 2), (2, 2), (2, 2)]
+
+:p
+  x = 2
+  z = for i:(Fin 4).
+        y = iadd 2 3
+        (x, y)
+  (x, z)
+> (2, [(2, 5), (2, 5), (2, 5), (2, 5)])


### PR DESCRIPTION
Previously, Imp translation was forced to construct the output of each
translated expression, even if its only later use was to be copied into
a destination that was already available at the call site. This
introduced many unnecessary allocations and copies that LLVM had a hard
time optimizing.

After this patch, all translation functions _optionally_ take a
destination parameter with the convention that if it is not `Nothing`,
then they are supposed to be semantically equivalent to the old
implementation + a `copy`/`store` into the destination. However, in many
cases the copy or a store can be readily optimized out at this stage,
allowing us to skip many intermediate allocations.

One interesting bit of the implementation is that when the translated
expression is a sequence of let bindings followed by an atom, then we
propagate the destinations to the respective definition sites. This is
necessary, as all blocks emitted by simplification are of that form.
The current version allows us to elide almost all copies, _except_ for the
results of `RunWriter` and `RunState`. This is because
simplification often emits expressions of the form:
```
a:(200=>(), Real) = %runWriter ...
b:Real = a#1
(b,)
```
and so propagating the destination for `b` would require us to create
a _partial destination_ for `a`, of the form `(Nothing, Just bDest)`.
This is not supported by our current framework, as the `Maybe Atom`
destination parameter would have to contain nested `Maybe`s at each
level of recursion within `Atom`s, making this somewhat difficult to
implement. Fortunately, at least in the scalar case such as in the
example above, when lowering to LLVM we will use an alloca for the
accumulator parameter and LLVM will be able to optimize out the copy.
However, we cannot rely on the same optimization if the writer returns a
non-scalar value.