### PR TITLE
Fix warning during compilation from testit

### DIFF
--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -145,6 +145,7 @@ int testit() {
   printf("%" PRIx64 "\n", threefry2x32(-1,-1)); // expected: 0x1cb996fc0xbb002be7
   printf("%" PRIx64 "\n", threefry2x32(
      0x13198a2e03707344,  0x243f6a8885a308d3)); // expected: 0xc4923a9c0x483df7a0
+  return 0;
 }
 
 int main(int argc, const char* argv[]) {


### PR DESCRIPTION
This change fixes:
```
cbits/libdex.c:148:1: warning: control reaches end of non-void function [-Wreturn-type]
```

Arguably one could be using `sprint` and then checking the number of mismatch's and returning that as the error code, but is that useful?