### PR TITLE
remove return type from dex_free

### DIFF
--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -14,7 +14,7 @@ char* malloc_dex(long nbytes) {
   return malloc(nbytes);
 }
 
-char* free_dex(char* ptr) {
+void free_dex(char* ptr) {
   free(ptr);
 }
 

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -335,7 +335,7 @@ mallocFun :: ExternFunSpec
 mallocFun  = ExternFunSpec "malloc_dex"    charPtrTy [longTy]
 
 freeFun :: ExternFunSpec
-freeFun = ExternFunSpec "free_dex"      charPtrTy [charPtrTy]
+freeFun = ExternFunSpec "free_dex" L.VoidType [charPtrTy]
 
 memcpyFun :: ExternFunSpec
 memcpyFun  = ExternFunSpec "memcpy_dex" L.VoidType [charPtrTy, charPtrTy, longTy]


### PR DESCRIPTION
This fixes the warning during compilation
```
cbits/libdex.c:148:1: warning: control reaches end of non-void function [-Wreturn-type]
```

I am not sure what that `char *` was intended for but it was not being returned I guess it could have been the same as the input, but i fail to see why we would want an extra reference to a pointer freed  memory.