### PR TITLE
Replace AFors with table lambdas

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -543,10 +543,10 @@ def cmpEither (x:Int|Int) (y:Int|Int) : Bool = x == y
 -- TODO: within-module version of this (currently fails in Imp checking)
 upperBound = isum $ for i:(Fin 4). 1
 for j:(Fin upperBound). 1.0
-> [1.0, 1.0, 1.0, 1.0]@(Fin aget Int[1])
+> [1.0, 1.0, 1.0, 1.0]
 
 (for i:(Fin upperBound). 1, for j:(Fin 2). 2)
-> ([1, 1, 1, 1]@(Fin aget Int[1]), [2, 2])
+> ([1, 1, 1, 1], [2, 2])
 
 for i:(Fin 4).
   x = iadd 1 1

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -153,7 +153,7 @@ linearizedDiv x y tx ty = do
 linearizePrimCon :: Con -> LinA Atom
 linearizePrimCon con = case con of
   Lit _    -> LinA $ return (withZeroTangent x)  where x = Con con
-  AFor _ _ -> LinA $ return (withZeroTangent x)  where x = Con con
+  --AFor _ _ -> LinA $ return (withZeroTangent x)  where x = Con con
   PairCon x y -> liftA2 PairVal (linearizeAtom x) (linearizeAtom y)
   _ -> error $ "not implemented: " ++ pprint con
 

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -15,12 +15,14 @@ module Embed (emit, emitOp, buildDepEffLam, buildLamAux, buildAbs,
               getAllowedEffects, withEffects, modifyAllowedEffects,
               buildLam, EmbedT, Embed, MonadEmbed, buildScoped, wrapDecls, runEmbedT,
               runEmbed, zeroAt, addAt, sumAt, getScope, reduceBlock, withBinder,
-              app, add, mul, sub, neg, div', andE, reduceScoped, declAsScope,
+              app, add, iadd, mul, imul, sub, isub, neg, div', andE, reduceScoped, declAsScope,
               select, selectAt, substEmbed, fromPair, getFst, getSnd,
               emitBlock, unzipTab, buildFor, isSingletonType, emitDecl, withNameHint,
               singletonTypeVal, mapScalars, scopedDecls, embedScoped, extendScope,
               embedExtend, boolToInt, intToReal, boolToReal, reduceAtom,
-              unpackConsList, emitRunWriter, tabGet) where
+              unpackConsList, emitRunWriter, tabGet, arrOffset, arrLoad,
+              sumTag, getLeft, getRight, fromSum, unwrapIndex,
+              indexSetSizeE, indexToIntE, intToIndexE) where
 
 import Control.Monad
 import Control.Monad.Fail
@@ -36,6 +38,7 @@ import Syntax
 import Cat
 import Type
 import PPrint
+import Util (bindM2)
 
 newtype EmbedT m a = EmbedT (ReaderT EmbedEnvR (CatT EmbedEnvC m) a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadFail)
@@ -158,11 +161,28 @@ add :: MonadEmbed m => Atom -> Atom -> m Atom
 add (RealVal 0) y = return y
 add x y           = emitOp $ ScalarBinOp FAdd x y
 
+iadd :: MonadEmbed m => Atom -> Atom -> m Atom
+iadd (IntVal 0) y          = return y
+iadd x          (IntVal 0) = return x
+iadd (IntVal x) (IntVal y) = return $ IntVal $ x + y
+iadd x y          = emitOp $ ScalarBinOp IAdd x y
+
 mul :: MonadEmbed m => Atom -> Atom -> m Atom
 mul x y = emitOp $ ScalarBinOp FMul x y
 
+imul :: MonadEmbed m => Atom -> Atom -> m Atom
+imul (IntVal 1) y          = return y
+imul x          (IntVal 1) = return x
+imul (IntVal x) (IntVal y) = return $ IntVal $ x * y
+imul x y = emitOp $ ScalarBinOp IMul x y
+
 sub :: MonadEmbed m => Atom -> Atom -> m Atom
 sub x y = emitOp $ ScalarBinOp FSub x y
+
+isub :: MonadEmbed m => Atom -> Atom -> m Atom
+isub x          (IntVal 0) = return x
+isub (IntVal x) (IntVal y) = return $ IntVal $ x - y
+isub x y = emitOp $ ScalarBinOp ISub x y
 
 andE :: MonadEmbed m => Atom -> Atom -> m Atom
 andE (BoolVal True) y = return y
@@ -173,6 +193,17 @@ select p x y = emitOp $ Select p x y
 
 div' :: MonadEmbed m => Atom -> Atom -> m Atom
 div' x y = emitOp $ ScalarBinOp FDiv x y
+
+idiv :: MonadEmbed m => Atom -> Atom -> m Atom
+idiv x          (IntVal 1) = return x
+idiv (IntVal x) (IntVal y) = return $ IntVal $ x `div` y
+idiv x y = emitOp $ ScalarBinOp IDiv x y
+
+irem :: MonadEmbed m => Atom -> Atom -> m Atom
+irem x y = emitOp $ ScalarBinOp Rem x y
+
+ilt :: MonadEmbed m => Atom -> Atom -> m Atom
+ilt x y = emitOp $ ScalarBinOp (ICmp Less) x y
 
 getFst :: MonadEmbed m => Atom -> m Atom
 getFst (PairVal x _) = return x
@@ -185,12 +216,35 @@ getSnd p = emitOp $ Snd p
 app :: MonadEmbed m => Atom -> Atom -> m Atom
 app x i = emit $ App x i
 
+arrOffset :: MonadEmbed m => Atom -> Atom -> m Atom
+arrOffset x i = emitOp $ ArrayOffset x i
+
+arrLoad :: MonadEmbed m => Atom -> m Atom
+arrLoad x = emitOp $ ArrayLoad x
+
 fromPair :: MonadEmbed m => Atom -> m (Atom, Atom)
-fromPair (PairVal x y) = return (x, y)
 fromPair pair = (,) <$> getFst pair <*> getSnd pair
 
 unpackConsList :: MonadEmbed m => Atom -> m [Atom]
 unpackConsList = undefined
+
+sumTag :: MonadEmbed m => Atom -> m Atom
+sumTag (SumVal t _ _) = return t
+sumTag s = emitOp $ SumTag s
+
+getLeft :: MonadEmbed m => Atom -> m Atom
+getLeft (SumVal _ l _) = return l
+getLeft s = emitOp $ SumGet s True
+
+getRight :: MonadEmbed m => Atom -> m Atom
+getRight (SumVal _ _ r) = return r
+getRight s = emitOp $ SumGet s False
+
+fromSum :: MonadEmbed m => Atom -> m (Atom, Atom, Atom)
+fromSum s = (,,) <$> sumTag s <*> getLeft s <*> getRight s
+
+unwrapIndex :: MonadEmbed m => Atom -> m Atom
+unwrapIndex idx = emitOp $ UnwrapIndex idx
 
 emitRunWriter :: MonadEmbed m => Name -> Type -> (Atom -> m Atom) -> m Atom
 emitRunWriter v ty body = do
@@ -212,17 +266,17 @@ tabGet x i = emit $ App x i
 
 unzipTab :: MonadEmbed m => Atom -> m (Atom, Atom)
 unzipTab tab = do
-  fsts <- buildFor Fwd ("i":>n) $ \i ->
+  fsts <- buildFor Fwd ("i":>varType v) $ \i ->
             liftM fst $ app tab i >>= fromPair
-  snds <- buildFor Fwd ("i":>n) $ \i ->
+  snds <- buildFor Fwd ("i":>varType v) $ \i ->
             liftM snd $ app tab i >>= fromPair
   return (fsts, snds)
-  where TabTy n _ = getType tab
+  where TabTy v _ = getType tab
 
 mapScalars :: MonadEmbed m => (Type -> [Atom] -> m Atom) -> Type -> [Atom] -> m Atom
 mapScalars f ty xs = case ty of
-  TabTy n a -> do
-    buildFor Fwd ("i":>n) $ \i -> do
+  TabTy v a -> do
+    buildFor Fwd ("i":>varType v) $ \i -> do
       xs' <- mapM (flip app i) xs
       mapScalars f a xs'
   BaseTy _           -> f ty xs
@@ -250,10 +304,8 @@ isSingletonType ty = case singletonTypeVal ty of
   Just _  -> True
 
 singletonTypeVal :: Type -> Maybe Atom
-singletonTypeVal (TabTy n a) = liftM (Con . AFor n) $ singletonTypeVal a
+singletonTypeVal (TabTy v a) = TabValA v <$> singletonTypeVal a
 singletonTypeVal (TC con) = case con of
-  -- XXX: This returns Nothing if it's a record that is not an empty tuple (or contains
-  --      anything else than only empty tuples inside)!
   PairType a b -> liftM2 PairVal (singletonTypeVal a) (singletonTypeVal b)
   UnitType     -> return UnitVal
   _            -> Nothing
@@ -267,6 +319,9 @@ intToReal i = emitOp $ ScalarUnOp IntToReal i
 
 boolToReal :: MonadEmbed m => Atom -> m Atom
 boolToReal = boolToInt >=> intToReal
+
+unsafeIntToBool :: MonadEmbed m => Atom -> m Atom
+unsafeIntToBool b = emitOp $ ScalarUnOp UnsafeIntToBool b
 
 instance MonadTrans EmbedT where
   lift m = EmbedT $ lift $ lift m
@@ -401,3 +456,61 @@ reduceExpr scope expr = case expr of
     Lam (Abs b (PureArrow, block)) <- return f'
     reduceBlock scope $ subst (b@>x', scope) block
   _ -> Nothing
+
+indexSetSizeE :: MonadEmbed m => Type -> m Atom
+indexSetSizeE (TC con) = case con of
+  BaseType BoolType -> return $ IntVal 2
+  IntRange low high -> high `isub` low
+  IndexRange n low high -> do
+    low' <- case low of
+      InclusiveLim x -> indexToIntE n x
+      ExclusiveLim x -> indexToIntE n x >>= iadd (IntVal 1)
+      Unlimited      -> return $ IntVal 0
+    high' <- case high of
+      InclusiveLim x -> indexToIntE n x >>= iadd (IntVal 1)
+      ExclusiveLim x -> indexToIntE n x
+      Unlimited      -> indexSetSizeE n
+    high' `isub` low'
+  PairType a b -> bindM2 imul (indexSetSizeE a) (indexSetSizeE b)
+  SumType l r -> bindM2 iadd (indexSetSizeE l) (indexSetSizeE r)
+  _ -> error $ "Not implemented " ++ pprint con
+indexSetSizeE ty = error $ "Not implemented " ++ pprint ty
+
+indexToIntE :: MonadEmbed m => Type -> Atom -> m Atom
+indexToIntE ty idx = case ty of
+  BoolTy  -> boolToInt idx
+  SumTy lType rType -> do
+    (tag, lVal, rVal) <- fromSum idx
+    lTypeSize <- indexSetSizeE lType
+    lInt      <- indexToIntE lType lVal
+    rInt      <- iadd lTypeSize =<< indexToIntE rType rVal
+    select tag lInt rInt
+  PairTy lType rType -> do
+    (lVal, rVal) <- fromPair idx
+    lIdx  <- indexToIntE lType lVal
+    rIdx  <- indexToIntE rType rVal
+    rSize <- indexSetSizeE rType
+    imul rSize lIdx >>= iadd rIdx
+  TC (IntRange _ _)     -> unwrapIndex idx
+  TC (IndexRange n _ _) -> indexToIntE n idx
+  _ -> error $ "Unexpected type " ++ pprint ty
+
+intToIndexE :: MonadEmbed m => Type -> Atom -> m Atom
+intToIndexE ty@(TC con) i = case con of
+  IntRange _ _      -> iAsIdx
+  IndexRange _ _ _  -> iAsIdx
+  BaseType BoolType -> unsafeIntToBool i
+  PairType a b -> do
+    bSize <- indexSetSizeE b
+    iA <- intToIndexE a =<< idiv i bSize
+    iB <- intToIndexE b =<< irem i bSize
+    return $ PairVal iA iB
+  SumType l r -> do
+    lSize <- indexSetSizeE l
+    isLeft <- i `ilt` lSize
+    li <- intToIndexE l i
+    ri <- intToIndexE r =<< i `isub` lSize
+    return $ Con $ SumCon isLeft li ri
+  _ -> error $ "Unexpected type " ++ pprint con
+  where iAsIdx = return $ Con $ AsIdx ty i
+intToIndexE ty _ = error $ "Unexpected type " ++ pprint ty

--- a/src/lib/Flops.hs
+++ b/src/lib/Flops.hs
@@ -40,9 +40,6 @@ statementFlops (_, instr) = case instr of
     tell $ Profile $ M.singleton (showPrimName $ OpExpr op) [n]
   Load _      -> return ()
   Store _ _   -> return ()
-  Copy  _ _ _ -> do
-    n <- ask
-    tell $ Profile $ M.singleton "copy" [n]
   Alloc _ _   -> return ()
   Free _      -> return ()
   IOffset _ _ -> return ()

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -8,17 +8,21 @@
 {-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE TupleSections #-}
 {-# LANGUAGE PatternSynonyms #-}
+{-# LANGUAGE TypeSynonymInstances #-}
+{-# LANGUAGE FlexibleInstances #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Imp (toImpFunction, impExprType) where
 
-import Prelude hiding (pi)
+import Prelude hiding (pi, abs)
 import Control.Monad.Reader
 import Control.Monad.Except hiding (Except)
 import Control.Monad.State
 import Control.Monad.Writer
 import Data.Text.Prettyprint.Doc
+import Data.Foldable
 
+import Embed
 import Array
 import Syntax
 import Env
@@ -27,19 +31,36 @@ import PPrint
 import Cat
 import Util (bindM2)
 
-type EmbedEnv = ([IVar], (Scope, ImpProg))
+
+-- Note [Valid Imp atoms]
+--
+-- The Imp translation functions as an interpreter for the core IR, which has a side effect
+-- of emitting a low-level Imp program that would do the actual math. As an interpreter, each
+-- expression has to produce a valid result Atom, that can be used as an input to all later
+-- equations. However, because the Imp IR only supports a very limited selection of types
+-- (really only base types and pointers to scalar tables), it is safe to assume that only
+-- a subset of atoms can be returned by the impSubst. In particular, the atoms might contain
+-- only:
+--   * Variables of base type or array type
+--   * Table lambdas
+--   * Constructors for: pairs, sum types, AnyValue, Unit and AsIdx
+--
+-- TODO: Use an ImpAtom type alias to better document the code
+
+type EmbedEnv = ((Env Dest, [IVar]), (Scope, ImpProg))
 type ImpM = Cat EmbedEnv
 
-toImpFunction :: ([ScalarTableVar], Block) -> ImpFunction
+toImpFunction :: ([ScalarTableVar], Block) -> (ImpFunction, Atom)
 toImpFunction (vsIn, block) = runImpM vsIn $ do
-  (vsOut, prog) <- scopedBlock $ materializeResult
-  let vsOut' = flip fmap vsOut (\(v :> IRefType t) -> v :> t)
-  return $ ImpFunction vsOut' vsIn prog
+  ((vsOut, atomOut), prog) <- scopedBlock $ materializeResult
+  return $ (ImpFunction (fmap toVar vsOut) vsIn prog, atomOut)
   where
+    toVar = (\(Var x) -> x) . toArrayAtom . IVar
     materializeResult = do
-      (outDest, vsOut) <- allocVars Unmanaged $ getType block
+      outDest <- allocKind Unmanaged $ getType block
       void $ toImpBlock mempty (Just outDest, block)
-      return vsOut
+      atomOut <- destToAtomScalarAction (return . toArrayAtom . IVar) outDest
+      return (toList outDest, atomOut)
 
 runImpM :: [ScalarTableVar] -> ImpM a -> a
 runImpM inVars m = fst $ runCat m (mempty, (inVarScope, mempty))
@@ -62,11 +83,14 @@ toImpDecl env (maybeDest, (Let b bound)) = do
 
 toImpExpr :: SubstEnv -> WithDest Expr -> ImpM Atom
 toImpExpr env (maybeDest, expr) = case expr of
-  App x i -> case getType x of
+  App x' idx' -> case getType x' of
     TabTy _ _ -> do
-      x' <- impSubst env x
-      i' <- impSubst env i
-      copyDest maybeDest =<< impTabGet x' i'
+      x <- impSubst env x'
+      idx <- impSubst env idx'
+      case x of
+        Lam a@(Abs _ (TabArrow, _)) ->
+          toImpBlock mempty (maybeDest, snd $ applyAbs a idx)
+        _ -> error $ "Invalid Imp atom: " ++ pprint x
     _ -> error $ "shouldn't have non-table app left"
   Atom x   -> copyDest maybeDest =<< impSubst env x
   Op   op  -> toImpOp . (maybeDest,) =<< traverse (impSubst env) op
@@ -74,35 +98,35 @@ toImpExpr env (maybeDest, expr) = case expr of
 
 impSubst :: HasVars a => SubstEnv -> a -> ImpM a
 impSubst env x = do
-  -- We already assume that the expression is de-shadowed, so there's no need
-  -- to pass in the scope. We don't even maintain one for the Expr we're traversing.
-  -- The one in ImpM only keeps the scope for the Imp program!
-  return $ subst (env, mempty) x
+  scope <- looks $ fst . snd
+  return $ subst (env, scope) x
 
 toImpOp :: WithDest (PrimOp Atom) -> ImpM Atom
 toImpOp (maybeDest, op) = case op of
-  TabCon (TabTy n _) rows -> do
+  TabCon (TabTy _ _) rows -> do
     dest <- allocDest maybeDest resultTy
     forM_ (zip [0..] rows) $ \(i, row) -> do
-      i' <- intToIndex n $ IIntVal i
-      ithDest <- impTabGet dest i'
+      ithDest <- destGet dest $ IIntVal i
       copyAtom ithDest row
-    return dest
-  SumGet ~(SumVal  _ l r) getLeft -> returnVal $ if getLeft then l else r
-  SumTag ~(SumVal  t _ _)         -> returnVal t
-  Fst    ~(PairVal x _)           -> returnVal x
-  Snd    ~(PairVal _ y)           -> returnVal y
-  PrimEffect ~(Con (RefCon _ ref)) m -> do
+    destToAtom dest
+  SumGet ~(SumVal  _ l r) left -> returnVal $ if left then l else r
+  SumTag ~(SumVal  t _ _)      -> returnVal t
+  Fst    ~(PairVal x _)        -> returnVal x
+  Snd    ~(PairVal _ y)        -> returnVal y
+  PrimEffect ~(Var refVar) m -> do
+    refDest <- looks $ (! refVar) . fst . fst
     case m of
-      MAsk    -> returnVal ref
-      MTell x -> addToAtom ref x >> returnVal UnitVal
-      MPut x  -> copyAtom  ref x >> returnVal UnitVal
+      MAsk    -> returnVal =<< destToAtom refDest
+      MTell x -> addToAtom  refDest x >> returnVal UnitVal
+      MPut x  -> copyAtom   refDest x >> returnVal UnitVal
       MGet -> do
         dest <- allocDest maybeDest resultTy
-        copyAtom dest ref
-        return dest
+        -- It might be more efficient to implement a specialized copy for dests
+        -- than to go through a general purpose atom.
+        copyAtom dest =<< destToAtom refDest
+        destToAtom dest
   IntAsIndex n i -> do
-    i' <- fromScalarAtom i
+    let i' = fromScalarAtom i
     n' <- indexSetSize n
     ans <- emitInstr $ IPrimOp $
              FFICall "int_to_index_set" IntType [i', n']
@@ -118,12 +142,22 @@ toImpOp (maybeDest, op) = case op of
     restrictIdx <- indexToInt rt e
     idx <- impAdd restrictIdx offset
     returnVal =<< intToIndex t idx
-  IndexRef ~(Con (RefCon h ref)) i ->
-    returnVal . (Con . RefCon h) =<< impTabGet ref i
+  IndexRef ~(Var refVar@(_:>(RefTy h (Pi a)))) i -> do
+    refDest    <- looks $ (! refVar) . fst . fst
+    subrefDest <- destGet refDest =<< indexToInt (getType i) i
+    subrefVar  <- freshVar (varName refVar :> RefTy h (snd $ applyAbs a i))
+    extend ((subrefVar @> subrefDest, mempty), mempty)
+    returnVal $ Var subrefVar
+  ArrayOffset arr off -> returnVal . toArrayAtom =<< impOffset (fromArrayAtom arr) (fromScalarAtom off)
+  ArrayLoad arr       -> returnVal . toScalarAtom resultTy =<< load (fromArrayAtom arr)
+  UnwrapIndex idx -> case idx of
+    (Con (AsIdx _ e))  -> returnVal e
+    -- TODO: Handle the AnyValue instance for index sets in simplification instead of here.
+    (Con (AnyValue t)) -> returnVal $ toScalarAtom resultTy (anyValue t)
+    _                  -> error $ "Unsupported UnwrapIndex argument: " ++ pprint idx
   Cmp _ _ _ -> error $ "All instances of Cmp should get resolved in simplification"
   _ -> do
-    op' <- traverse fromScalarAtom op
-    returnVal . toScalarAtom resultTy =<< emitInstr (IPrimOp op')
+    returnVal . toScalarAtom resultTy =<< emitInstr (IPrimOp $ fmap fromScalarAtom op)
   where
     resultTy :: Type
     resultTy = getType $ Op op
@@ -143,73 +177,161 @@ toImpHof env (maybeDest, hof) = do
       dest <- allocDest maybeDest resultTy
       emitLoop d n' $ \i -> do
         i' <- intToIndex idxTy i
-        ithDest <- impTabGet dest i'
+        ithDest <- destGet dest i
         void $ toImpBlock (env <> b @> i') (Just ithDest, body)
-      return dest
-    RunReader r (BinaryFunVal region ref _ body) -> do
-      r' <- impSubst env r
-      toImpBlock (env <> ref @> refVal region r') (maybeDest, body)
-    RunWriter (BinaryFunVal region ref _ body) -> do
-      ~(PairVal aDest wDest) <- allocDest maybeDest resultTy
-      initializeAtomZero wDest
-      void $ toImpBlock (env <> ref @> refVal region wDest) (Just aDest, body)
-      return $ PairVal aDest wDest
-    RunState s (BinaryFunVal region ref _ body) -> do
-      ~(PairVal aDest sDest) <- allocDest maybeDest resultTy
-      s' <- impSubst env s
-      copyAtom sDest s'
-      void $ toImpBlock (env <> ref @> refVal region sDest) (Just aDest, body)
-      return $ PairVal aDest sDest
+      destToAtom dest
+    RunReader r (BinaryFunVal _ ref _ body) -> do
+      rDest <- alloc $ getType r
+      rVar  <- freshVar ref
+      copyAtom rDest =<< impSubst env r
+      withRefScope rVar rDest $
+        toImpBlock (env <> ref @> Var rVar) (maybeDest, body)
+    RunWriter (BinaryFunVal _ ref _ body) -> do
+      ~(DPair aDest wDest) <- allocDest maybeDest resultTy
+      zeroDest wDest
+      wVar <- freshVar ref
+      void $ withRefScope wVar wDest $
+        toImpBlock (env <> ref @> Var wVar) (Just aDest, body)
+      PairVal <$> destToAtom aDest <*> destToAtom wDest
+    RunState s (BinaryFunVal _ ref _ body) -> do
+      ~(DPair aDest sDest) <- allocDest maybeDest resultTy
+      copyAtom sDest =<< impSubst env s
+      sVar <- freshVar ref
+      void $ withRefScope sVar sDest $
+        toImpBlock (env <> ref @> Var sVar) (Just aDest, body)
+      PairVal <$> destToAtom aDest <*> destToAtom sDest
     _ -> error $ "Invalid higher order function primitive: " ++ pprint hof
   where
-    refVal :: Var -> Atom -> Atom
-    refVal region ref = Con (RefCon (Var region) ref)
+    withRefScope :: Var -> Dest -> ImpM a -> ImpM a
+    withRefScope refVar refDest m = do
+      (a, ((_, x), (y, z))) <- scoped $ extend (asFst $ asFst $ refVar @> refDest) >> m
+      extend ((mempty, x), (y, z))
+      return a
 
-type Dest = Atom
+-- === Destination type ===
+--
+-- Desinations are an analog to regular Atoms, except they guarantee that the "leaf"
+-- elements are scalar tables with non-aliasing memory. The Dest data structure is a
+-- view that reverses the structure-of-arrays transformation we apply. When we go to
+-- the atom world, we use table lambdas for the same purpose, but destinations are
+-- a little easier to work with, since they can't contain arbitrary code.
+
+-- This takes a type parameter only so that we can derive Traversalbe. Use Dest instead.
+data DestP ref = DFor   (Abs (DestP ref))
+               | DPair  (DestP ref) (DestP ref)
+               | DUnit
+               | DRef   ref
+               | DAsIdx Type (DestP ref)
+                 deriving (Show, Functor, Foldable, Traversable)
+type Dest = DestP IVar
 type WithDest a = (Maybe Dest, a)
+
+instance HasVars Dest where
+  freeVars dest = case dest of
+    DFor abs               -> freeVars abs
+    DPair l r              -> freeVars l <> freeVars r
+    DUnit                  -> mempty
+    DRef (_ :> IValType _) -> mempty
+    DRef (_ :> IRefType t) -> freeVars t
+    DAsIdx t d             -> freeVars t <> freeVars d
+
+  subst env dest = case dest of
+    DFor abs               -> DFor (subst env abs)
+    DPair l r              -> DPair (subst env l) (subst env r)
+    DUnit                  -> dest
+    DRef (_ :> IValType _) -> dest
+    DRef (v :> IRefType t) -> DRef (v :> IRefType (subst env t))
+    DAsIdx t d             -> DAsIdx (subst env t) (subst env d)
+
+destGet :: Dest -> IExpr -> ImpM Dest
+destGet dest i = case dest of
+  DFor a@(Abs v _) -> do
+    idx <- intToIndex (varType v) i
+    traverse (\ref -> toIVar <$> (IVar ref) `impGet` i) $ applyAbs a idx
+  _ -> error $ "Indexing into a non-array dest"
+  where toIVar ~(IVar v) = v
+
+-- XXX: This should only be called when it is known that the dest will _never_
+--      be modified again, because it doesn't copy the state!
+destToAtom :: Dest -> ImpM Atom
+destToAtom dest = destToAtomScalarAction loadScalarRef dest
+  where
+    loadScalarRef ref = toScalarAtom (BaseTy b) <$> (load $ IVar ref)
+      where ~(_ :> IRefType (BaseTy b)) = ref
+
+destToAtomScalarAction :: (IVar -> ImpM Atom) -> Dest -> ImpM Atom
+destToAtomScalarAction fScalar dest = do
+  scope <- looks $ fst . snd
+  -- FIXME: This does not propagate the scope back!
+  (atom, decls) <- runEmbedT (destToAtom' fScalar [] dest) scope
+  case decls of
+    [] -> return $ atom
+    _  -> error "Unexpected decls"
+
+destToAtom' :: (IVar -> ImpM Atom) -> [Var] -> Dest -> EmbedT ImpM Atom
+destToAtom' fScalar forVars dest = case dest of
+  DFor (Abs v d) -> do
+    scope <- looks $ fst . snd
+    v' <- lift $ case v of
+      (NoName :> t) -> freshVar ("idx" :> t)
+      _             -> freshVar v
+    -- FIXME: This does not propagate the scope back!
+    (res, decls) <- lift $ runEmbedT (destToAtom' fScalar (v' : forVars) d) scope
+    return $ Lam $ makeAbs v' (TabArrow, Block decls (Atom res))
+  DRef ref       -> case forVars of
+    [] -> lift $ fScalar ref
+    _  -> do
+      scalarArray <- foldM arrIndex (toArrayAtom $ IVar ref) $ fmap Var (reverse forVars)
+      arrLoad scalarArray
+      where
+        arrIndex :: Atom -> Atom -> EmbedT ImpM Atom
+        arrIndex arr idx = do
+          ordinal <- indexToIntE (getType idx) idx
+          let (ArrayTy tabTy) = getType arr
+          offset <- tabTy `offsetToE` ordinal
+          arrOffset arr offset
+  DPair dl dr    -> PairVal <$> rec dl <*> rec dr
+  DUnit          -> return $ UnitVal
+  DAsIdx t d     -> Con . AsIdx t <$> rec d
+  where rec = destToAtom' fScalar forVars
 
 splitDest :: WithDest Block -> ImpM ([WithDest Decl], WithDest Expr, [(Dest, Atom)])
 splitDest (maybeDest, (Block decls ans)) = do
   case (maybeDest, ans) of
     (Just dest, Atom atom) -> do
-      (repeatCopies, varDests) <- runStateT (execWriterT $ gatherVarDests [] dest atom) mempty
+      let (gatherCopies, varDests) = runState (execWriterT $ gatherVarDests dest atom) mempty
       -- If any variable appearing in the ans atom is not defined in the
       -- current block (e.g. it comes from the surrounding block), then we need
       -- to do the copy explicitly, as there is no let binding that will use it
       -- as the destination.
       let blockVars = foldMap (\(Let v _) -> v @> ()) decls
-      let closureCopies = fmap (\(n, d) -> (d, Var $ n :> getType d))
+      let closureCopies = fmap (\(n, (d, t)) -> (d, Var $ n :> t))
                                (envPairs $ varDests `envDiff` blockVars)
-      return $ ( fmap (\d@(Let v _) -> (varDests `envLookup` v, d)) decls
+      return $ ( fmap (\d@(Let v _) -> (fst <$> varDests `envLookup` v, d)) decls
                , (Nothing, ans)
-               , repeatCopies ++ closureCopies)
+               , gatherCopies ++ closureCopies)
     _ -> return $ (fmap (Nothing,) decls, (maybeDest, ans), [])
   where
     -- Maps all variables used in the result atom to their respective destinations.
-    gatherVarDests :: [Type] -> Dest -> Atom -> WriterT [(Dest, Atom)] (StateT (Env Dest) ImpM) ()
-    gatherVarDests afors dest result = case (dest, result) of
-      -- The `null afors` check is there just because a variable that is
-      -- embedded in an AFor, but does not use an AGet (we don't handle
-      -- those in the Con case!) would have to be broadcast to match the output
-      -- shape, so so it would require some special handling. However, those don't
-      -- seem to be emitted anywhere right now, so we leave the implementation as is.
-      (_, Var v) | null afors -> do
+    gatherVarDests :: Dest -> Atom -> WriterT [(Dest, Atom)] (State (Env (Dest, Type))) ()
+    gatherVarDests dest result = case (dest, result) of
+      (_, Var v) -> do
         dests <- get
         case dests `envLookup` v of
-          Nothing -> put $ dests <> (v @> dest)
+          Nothing -> modify $ (<> (v @> (dest, varType v)))
           Just _  -> tell [(dest, result)]
-      (Con dCon, Con rCon) -> case (dCon, rCon) of
-        (_, Lit _) -> lift $ lift $ copyAtom (prependAFors dest) (prependAFors result)
-        (PairCon ld rd, PairCon lr rr) -> gatherVarDests afors ld lr >> gatherVarDests afors rd rr
-        (UnitCon      , UnitCon      ) -> return ()
-        (AFor n db    , AFor _ rb    ) -> gatherVarDests (n : afors) db rb
-        (AsIdx _ db   , AsIdx _ rb   ) -> gatherVarDests afors       db rb
-        (SumCon _ _ _, _) -> error "Propagation of destinations through sum constructors is not implemented"
+      -- If the result is a table lambda then there is nothing we can do, except for a copy.
+      (DFor _, TabVal _ _) -> tell [(dest, result)]
+      (_, Con rCon) -> case (dest, rCon) of
+        (DRef _     , Lit _         ) -> tell [(dest, result)]
+        (DPair ld rd, PairCon lr rr ) -> gatherVarDests ld lr >> gatherVarDests rd rr
+        (DUnit      , UnitCon       ) -> return ()
+        (DAsIdx _ db, AsIdx _ rb    ) -> gatherVarDests db rb
+        (_          , SumCon _ _ _  ) -> error "Not implemented"
         _ -> unreachable
       _ -> unreachable
       where
-        unreachable = error $ "Invalid result-atom pair:\n" ++ show result ++ "\n  and:\n" ++ show dest
-        prependAFors a = foldl (\b t -> Con $ AFor t b) a (reverse afors)
+        unreachable = error $ "Invalid dest-result pair:\n" ++ show dest ++ "\n  and:\n" ++ show result
 
 copyDest :: Maybe Dest -> Atom -> ImpM Atom
 copyDest maybeDest atom = case maybeDest of
@@ -221,31 +343,37 @@ allocDest maybeDest t = case maybeDest of
   Nothing   -> alloc t
   Just dest -> return dest
 
-anyValue :: Type -> IExpr
-anyValue (TC (BaseType RealType))   = ILit $ RealLit 1.0
-anyValue (TC (BaseType IntType))    = ILit $ IntLit 1
-anyValue (TC (BaseType BoolType))   = ILit $ BoolLit False
-anyValue (TC (BaseType StrType))    = ILit $ StrLit ""
--- XXX: This is not strictly correct, because those types might not have any
---      inhabitants. We might want to consider emitting some run-time code that
---      aborts the program if this really ends up being the case.
-anyValue (TC (IntRange _ _))        = ILit $ IntLit 0
-anyValue (TC (IndexRange _ _ _))    = ILit $ IntLit 0
-anyValue t = error $ "Expected a scalar type in anyValue, got: " ++ pprint t
+-- Create a destination for a given type. Note that this doesn't actually allocate anything,
+-- so make sure to call alloc for any variables in the dest.
+makeDest :: Name -> Type -> ImpM Dest
+makeDest nameHint destType = go id destType
+  where
+    go :: (ScalarTableType -> ScalarTableType) -> Type -> ImpM Dest
+    go mkTy ty = case ty of
+        -- TODO: Is it ok to reuse the variables here?
+        --       Once might be ok, but the type will have aliasing binders!
+        TabTy v b -> DFor . Abs v <$> go (\t -> mkTy $ TabTy v t) b
+        TC con    -> case con of
+          BaseType b       -> DRef <$> freshVar (nameHint :> (IRefType $ mkTy $ BaseTy b))
+          PairType a b     -> DPair <$> go mkTy a <*> go mkTy b
+          UnitType         -> return DUnit
+          IntRange   _ _   -> scalarIndexSet ty
+          IndexRange _ _ _ -> scalarIndexSet ty
+          _ -> unreachable
+        _ -> unreachable
+      where
+        scalarIndexSet t = DAsIdx t <$> go mkTy IntTy
+        unreachable = error $ "Can't lower type to imp: " ++ pprint ty
 
-fromScalarAtom :: Atom -> ImpM IExpr
+-- === Atom <-> IExpr conversions ===
+
+fromScalarAtom :: Atom -> IExpr
 fromScalarAtom atom = case atom of
-  Var (v:>BaseTy b) -> return $ IVar (v :> IValType b)
-  Con (Lit x)       -> return $ ILit x
-  Con (AGet x)      -> load =<< fromArrayAtom x
+  Var (v:>BaseTy b) -> IVar (v :> IValType b)
+  Con (Lit x)       -> ILit x
   Con (AsIdx _ x)   -> fromScalarAtom x
-  Con (AnyValue ty) -> return $ anyValue ty
+  Con (AnyValue ty) -> anyValue ty
   _ -> error $ "Expected scalar, got: " ++ pprint atom
-
-fromArrayAtom :: Atom -> ImpM IExpr
-fromArrayAtom atom = case atom of
-  Var (n:>t) -> return $ IVar (n :> IRefType t)
-  _ -> error $ "Expected array, got: " ++ pprint atom
 
 toScalarAtom :: Type -> IExpr -> Atom
 toScalarAtom ty ie = case ie of
@@ -259,179 +387,126 @@ toScalarAtom ty ie = case ie of
   where
     unreachable = error $ "Cannot convert " ++ show ie ++ " to " ++ show ty
 
+fromArrayAtom :: Atom -> IExpr
+fromArrayAtom atom = case atom of
+  Var (n :> ArrayTy t) -> IVar (n :> IRefType t)
+  _ -> error $ "Expected array, got: " ++ pprint atom
+
 toArrayAtom :: IExpr -> Atom
 toArrayAtom ie = case ie of
-  IVar (v :> IRefType t) -> Var $ v :> t
+  IVar (v :> IRefType t) -> Var $ v :> ArrayTy t
   _                      -> error $ "Not an array atom: " ++ show ie
 
-data AllocType = Managed | Unmanaged
+-- === Type classes ===
 
-alloc :: Type -> ImpM Atom
-alloc ty = fst <$> allocVars Managed ty
-
-allocVars :: AllocType -> Type -> ImpM (Atom, [IVar])
-allocVars allocTy ty = do
-  (dest, vs) <- makeDest "v" ty
-  flip mapM_ vs $ \v@(_:>IRefType refTy) -> do
-    numel <- elemCount refTy
-    emitStatement (Just v, Alloc refTy numel)
-  case allocTy of
-    Managed   -> extend $ asFst vs
-    Unmanaged -> return ()
-  return (dest, vs)
-
-makeDest :: Name -> Type -> ImpM (Atom, [IVar])
-makeDest name ty = runWriterT $ makeDest' name id ty
-
-makeDest' :: Name -> (ScalarTableType -> ScalarTableType) -> Type -> WriterT [IVar] ImpM Atom
-makeDest' name mkTy (TabTy n b) = do
-  Con . AFor n <$> makeDest' name (\t -> mkTy $ TabTy n t) b
-makeDest' name mkTy ty@(TC con) = case con of
-  BaseType b  -> do
-    v <- lift $ freshVar (name :> (IRefType $ mkTy $ BaseTy b))
-    tell [v] -- TODO: Revise!
-    return $ Con $ AGet $ toArrayAtom (IVar v)
-  PairType a b -> PairVal <$> makeDest' name mkTy a <*> makeDest' name mkTy b
-  UnitType -> return UnitVal
-  IntRange   _ _   -> scalarIndexSet ty
-  IndexRange _ _ _ -> scalarIndexSet ty
-  _ -> error $ "Can't lower type to imp: " ++ pprint con
-  where
-    scalarIndexSet t = Con . AsIdx t <$> makeDest' name mkTy IntTy
-makeDest' _ _ ty = error $ "Can't lower type to imp: " ++ pprint ty
-
-impTabGet :: Atom -> Atom -> ImpM Atom
-impTabGet (Con (AFor it b)) i = do
-  i' <- indexToInt it i
-  flip traverseLeaves b $ \(~(Con (AGet arr))) -> do
-    arr' <- fromArrayAtom arr >>= (`impGet` i')
-    return $ Con $ AGet $ toArrayAtom arr'
-impTabGet _ _ = error "Expected an array atom in impTabGet"
+anyValue :: Type -> IExpr
+anyValue (TC (BaseType RealType))   = ILit $ RealLit 1.0
+anyValue (TC (BaseType IntType))    = ILit $ IntLit 1
+anyValue (TC (BaseType BoolType))   = ILit $ BoolLit False
+anyValue (TC (BaseType StrType))    = ILit $ StrLit ""
+-- XXX: This is not strictly correct, because those types might not have any
+--      inhabitants. We might want to consider emitting some run-time code that
+--      aborts the program if this really ends up being the case.
+anyValue (TC (IntRange _ _))        = ILit $ IntLit 0
+anyValue (TC (IndexRange _ _ _))    = ILit $ IntLit 0
+anyValue t = error $ "Expected a scalar type in anyValue, got: " ++ pprint t
 
 intToIndex :: Type -> IExpr -> ImpM Atom
-intToIndex ty@(TC con) i = case con of
-  IntRange _ _      -> iAsIdx
-  IndexRange _ _ _  -> iAsIdx
-  BaseType BoolType -> toScalarAtom BoolTy <$> emitUnOp UnsafeIntToBool i
-  PairType a b -> do
-    bSize <- indexSetSize b
-    iA <- intToIndex a =<< impDiv i bSize
-    iB <- intToIndex b =<< impRem i bSize
-    return $ PairVal iA iB
-  SumType l r -> do
-    ls <- indexSetSize l
-    isLeft <- impCmp Less i ls
-    li <- intToIndex l i
-    ri <- intToIndex r =<< impSub i ls
-    return $ Con $ SumCon (toScalarAtom BoolTy isLeft) li ri
-  _ -> error $ "Unexpected type " ++ pprint con
-  where
-    iAsIdx = return $ Con $ AsIdx ty $ toScalarAtom IntTy i
-intToIndex ty _ = error $ "Unexpected type " ++ pprint ty
+intToIndex ty i = do
+  scope <- looks $ fst . snd
+  let (atom, decls) = runEmbed (intToIndexE ty (toScalarAtom IntTy i)) scope
+  toImpBlock mempty (Nothing, Block decls (Atom atom))
 
 indexToInt :: Type -> Atom -> ImpM IExpr
-indexToInt ty idx = case ty of
-  BoolTy  -> emitUnOp BoolToInt =<< fromScalarAtom idx
-  SumTy lType rType -> case idx of
-    SumVal con lVal rVal -> do
-      lTypeSize <- indexSetSize lType
-      lInt <- indexToInt lType lVal
-      rInt <- impAdd lTypeSize =<< indexToInt rType rVal
-      conExpr <- fromScalarAtom con
-      impSelect conExpr lInt rInt
-    _ -> error $ "Expected a sum constructor, got: " ++ pprint idx
-  PairTy a b -> case idx of
-    PairVal aIdx bIdx -> do
-      aIdx' <- indexToInt a aIdx
-      bIdx' <- indexToInt b bIdx
-      bSize <- indexSetSize b
-      impMul bSize aIdx' >>= impAdd bIdx'
-    _ -> error $ "Expected a pair constructor, got: " ++ pprint idx
-  TC (IntRange _ _)     -> fromScalarAtom idx
-  TC (IndexRange _ _ _) -> fromScalarAtom idx
-  _ -> error $ "Unexpected type " ++ pprint ty
+indexToInt ty idx = do
+  scope <- looks $ fst . snd
+  let (atom, decls) = runEmbed (indexToIntE ty idx) scope
+  fromScalarAtom <$> toImpBlock mempty (Nothing, Block decls (Atom atom))
 
 indexSetSize :: Type -> ImpM IExpr
-indexSetSize (TC con) = case con of
-  IntRange low high -> do
-    low'  <- fromScalarAtom low
-    high' <- fromScalarAtom high
-    impSub high' low'
-  IndexRange n low high -> do
-    low' <- case low of
-      InclusiveLim x -> indexToInt n x
-      ExclusiveLim x -> indexToInt n x >>= impAdd IOne
-      Unlimited      -> return IZero
-    high' <- case high of
-      InclusiveLim x -> indexToInt n x >>= impAdd IOne
-      ExclusiveLim x -> indexToInt n x
-      Unlimited      -> indexSetSize n
-    impSub high' low'
-  PairType a b -> bindM2 impMul (indexSetSize a) (indexSetSize b)
-  BaseType BoolType -> return $ IIntVal 2
-  SumType l r -> bindM2 impAdd (indexSetSize l) (indexSetSize r)
-  _ -> error $ "Not implemented " ++ pprint con
-indexSetSize ty = error $ "Not implemented " ++ pprint ty
+indexSetSize ty = do
+  scope <- looks $ fst . snd
+  let (atom, decls) = runEmbed (indexSetSizeE ty) scope
+  fromScalarAtom <$> toImpBlock mempty (Nothing, Block decls (Atom atom))
 
 elemCount :: ScalarTableType -> ImpM IExpr
-elemCount t = case t of
-  TabTy n b -> bindM2 impMul (indexSetSize n) (elemCount b)
-  Pi (Abs _ (TabArrow, _)) ->
-    error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint t
-  BaseTy _  -> return IOne
-  _ -> error $ "Not a scalar table type: " ++ pprint t
+elemCount ty = do
+  scope <- looks $ fst . snd
+  let (atom, decls) = runEmbed (elemCountE ty) scope
+  fromScalarAtom <$> toImpBlock mempty (Nothing, Block decls (Atom atom))
 
 offsetTo :: ScalarTableType -> IExpr -> ImpM IExpr
-offsetTo t i = case t of
-  TabTy _ b -> impMul i =<< elemCount b
-  Pi (Abs _ (TabArrow, _)) ->
-    error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint t
+offsetTo ty i = do
+  scope <- looks $ fst . snd
+  let (atom, decls) = runEmbed (offsetToE ty (toScalarAtom IntTy i)) scope
+  fromScalarAtom <$> toImpBlock mempty (Nothing, Block decls (Atom atom))
+
+elemCountE :: MonadEmbed m => ScalarTableType -> m Atom
+elemCountE ty = case ty of
+  BaseTy _  -> return $ IntVal 1
+  TabTy (NoName:>idxTy) b -> bindM2 imul (indexSetSizeE idxTy) (elemCountE b)
+  TabTy _ _ ->
+    error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint ty
+  _ -> error $ "Not a scalar table type: " ++ pprint ty
+
+-- TODO: Accept an index instead of an ordinal?
+offsetToE :: MonadEmbed m => ScalarTableType -> Atom -> m Atom
+offsetToE ty i = case ty of
+  TabTy (NoName:>_) b -> imul i =<< elemCountE b
+  TabTy _ _ ->
+    error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint ty
   BaseTy _  -> error "Indexing into a scalar!"
-  _ -> error $ "Not a scalar table type: " ++ pprint t
+  _ -> error $ "Not a scalar table type: " ++ pprint ty
 
-traverseLeaves :: Applicative m => (Atom -> m Atom) -> Atom -> m Atom
-traverseLeaves f atom = case atom of
-  Var _        -> f atom
-  Con (Lit  _) -> f atom
-  Con (AGet _) -> f atom
-  Con destCon -> Con <$> case destCon of
-    AFor n body -> AFor n  <$> recur body
-    AsIdx n idx -> AsIdx n <$> recur idx
-    PairCon x y -> PairCon <$> recur x <*> recur y
-    UnitCon     -> pure UnitCon
-    _ -> error $ "Not a valid Imp atom: " ++ pprint atom
-  _ ->   error $ "Not a valid Imp atom: " ++ pprint atom
-  where recur = traverseLeaves f
+zipWithDest :: Dest -> Atom -> (IExpr -> IExpr -> ImpM ()) -> ImpM ()
+zipWithDest dest atom f = case (dest, atom) of
+  (DFor (Abs v _), Lam (Abs _ (TabArrow, _))) -> do
+    let idxTy = varType v
+    n <- indexSetSize idxTy
+    emitLoop Fwd n $ \i -> do
+      idx <- intToIndex idxTy i
+      ai  <- toImpExpr mempty (Nothing, App atom idx)
+      di  <- destGet dest i
+      rec di ai
+  (DRef r, Var v) -> case varType v of
+    BaseTy _  -> f (IVar r) (fromScalarAtom atom)
+    _         -> error $ "Type error"
+  (_, Con con) -> case (dest, con) of
+    (DRef r     , Lit _        ) -> f (IVar r) (fromScalarAtom atom)
+    (DPair ld rd, PairCon la ra) -> rec ld la >> rec rd ra
+    (DUnit      , UnitCon      ) -> return () -- We could call f in here as well I guess...
+    (DAsIdx _ d , AsIdx _ a    ) -> rec d a
+    (_          , SumCon _ _ _ ) -> error "Not implemented"
+    _                            -> unreachable
+  _ -> unreachable
+  where
+    rec x y = zipWithDest x y f
+    unreachable = error $ "Not an imp atom, or mismatched dest: " ++ show dest ++ ", and " ++ show atom
 
-leavesList :: Atom -> [Atom]
-leavesList atom = execWriter $ flip traverseLeaves atom $ \l -> tell [l] >> return l
+copyAtom :: Dest -> Atom -> ImpM ()
+copyAtom dest src = zipWithDest dest src store
 
-copyAtom :: Atom -> Atom -> ImpM ()
-copyAtom dest src = zipWithM_ copyLeaf (leavesList dest) (leavesList src)
+zeroDest :: Dest -> ImpM ()
+zeroDest dest = traverse_ (initializeZero . IVar) dest
+  where
+    initializeZero :: IExpr -> ImpM ()
+    initializeZero ref = case impExprType ref of
+      IRefType RealTy      -> store ref (ILit $ RealLit 0.0)
+      IRefType (TabTy v _) -> do
+        n <- indexSetSize $ varType v
+        emitLoop Fwd n $ \i -> impGet ref i >>= initializeZero
+      ty -> error $ "Zeros not implemented for type: " ++ pprint ty
 
-copyLeaf :: Atom -> Atom -> ImpM ()
-copyLeaf ~(Con (AGet dest)) src = case src of
-  Con (AGet src') -> bindM2 copy  dest' (fromArrayAtom src' )
-  _               -> bindM2 store dest' (fromScalarAtom src)
-  where dest' = fromArrayAtom dest
-
-initializeAtomZero :: Atom -> ImpM ()
-initializeAtomZero x = void $ flip traverseLeaves x $ \(~leaf@((Con (AGet dest)))) ->
-  fromArrayAtom dest >>= initializeZero >> return leaf
-
-addToAtom :: Atom -> Atom -> ImpM ()
-addToAtom dest src = zipWithM_ addToAtomLeaf (leavesList dest) (leavesList src)
-
-addToAtomLeaf :: Atom -> Atom -> ImpM ()
-addToAtomLeaf ~(Con (AGet dest)) src = case src of
-  Con (AGet src') -> bindM2 addToDestFromRef dest' (fromArrayAtom src')
-  _               -> bindM2 addToDestScalar  dest' (fromScalarAtom src)
-  where dest' = fromArrayAtom dest
+addToAtom :: Dest -> Atom -> ImpM ()
+addToAtom topDest topSrc = zipWithDest topDest topSrc addToDestScalar
+  where
+    addToDestScalar :: IExpr -> IExpr -> ImpM ()
+    addToDestScalar dest src = do
+      cur     <- load dest
+      updated <- emitInstr $ IPrimOp $ ScalarBinOp FAdd cur src
+      store dest updated
 
 -- === Imp embedding ===
-
-emitUnOp :: ScalarUnOp -> IExpr -> ImpM IExpr
-emitUnOp op x = emitInstr $ IPrimOp $ ScalarUnOp op x
 
 emitBinOp :: ScalarBinOp -> IExpr -> IExpr -> ImpM IExpr
 emitBinOp op x y = emitInstr $ IPrimOp $ ScalarBinOp op x y
@@ -442,44 +517,15 @@ impAdd x IZero = return x
 impAdd (IIntVal x) (IIntVal y) = return $ IIntVal $ x + y
 impAdd x y = emitBinOp IAdd x y
 
-impMul :: IExpr -> IExpr -> ImpM IExpr
-impMul IOne y = return y
-impMul x IOne = return x
-impMul (IIntVal x) (IIntVal y) = return $ IIntVal $ x * y
-impMul x y = emitBinOp IMul x y
-
-impDiv :: IExpr -> IExpr -> ImpM IExpr
-impDiv x IOne = return x
-impDiv x y = emitBinOp IDiv x y
-
-impRem :: IExpr -> IExpr -> ImpM IExpr
-impRem _ IOne = return IZero
-impRem x y = emitBinOp Rem x y
-
-impSub :: IExpr -> IExpr -> ImpM IExpr
-impSub (IIntVal a) (IIntVal b)  = return $ IIntVal $ a - b
-impSub a IZero = return a
-impSub x y = emitBinOp ISub x y
-
-impCmp :: CmpOp -> IExpr -> IExpr -> ImpM IExpr
-impCmp GreaterEqual (IIntVal a) (IIntVal b) = return $ ILit $ BoolLit $ a >= b
-impCmp op x y = emitBinOp (ICmp op) x y
-
--- Precondition: x and y don't have array types
-impSelect :: IExpr -> IExpr -> IExpr -> ImpM IExpr
-impSelect p x y = emitInstr $ IPrimOp $ Select p x y
-
 impGet :: IExpr -> IExpr -> ImpM IExpr
 impGet ref i = case ref of
   (IVar (_ :> IRefType t)) -> emitInstr . IOffset ref =<< (t `offsetTo` i)
   _ -> error $ "impGet called with non-ref: " ++ show ref
 
-copy :: IExpr -> IExpr -> ImpM ()
-copy dest src = case dest of
-  (IVar (_ :> IRefType t)) -> do
-    numElements <- elemCount t
-    emitStatement (Nothing, Copy dest src numElements)
-  _ -> error $ "copy called with non-ref destination: " ++ show dest
+impOffset :: IExpr -> IExpr -> ImpM IExpr
+impOffset ref off = case ref of
+  (IVar (_ :> IRefType _)) -> emitInstr $ IOffset ref off
+  _ -> error $ "impOffset called with non-ref: " ++ show ref
 
 load :: IExpr -> ImpM IExpr
 load x = emitInstr $ Load x
@@ -487,7 +533,24 @@ load x = emitInstr $ Load x
 store :: IExpr -> IExpr -> ImpM ()
 store dest src = emitStatement (Nothing, Store dest src)
 
-freshVar :: IVar -> ImpM IVar
+data AllocType = Managed | Unmanaged
+
+alloc :: Type -> ImpM Dest
+alloc ty = allocKind Managed ty
+
+allocKind :: AllocType -> Type -> ImpM Dest
+allocKind allocTy ty = do
+  dest <- makeDest "v" ty
+  let vs = toList dest
+  flip mapM_ vs $ \v@(_:>IRefType refTy) -> do
+    numel <- elemCount refTy
+    emitStatement (Just v, Alloc refTy numel)
+  case allocTy of
+    Managed   -> extend $ asFst $ asSnd vs
+    Unmanaged -> return ()
+  return dest
+
+freshVar :: VarP a -> ImpM (VarP a)
 freshVar v = do
   scope <- looks (fst . snd)
   let v' = rename v scope
@@ -504,7 +567,7 @@ emitLoop d n body = do
 
 scopedBlock :: ImpM a -> ImpM (a, ImpProg)
 scopedBlock body = do
-  (ans, (allocs, (scope', prog))) <- scoped body
+  (ans, ((_, allocs), (scope', prog))) <- scoped body
   extend (mempty, (scope', mempty))  -- Keep the scope extension to avoid reusing variable names
   let frees = ImpProg [(Nothing, Free v) | v <- allocs]
   return (ans, prog <> frees)
@@ -521,32 +584,6 @@ emitInstr instr = do
       return $ IVar v
     Nothing -> error "Expected non-void result"
 
-addToDestFromRef :: IExpr -> IExpr -> ImpM ()
-addToDestFromRef dest src = case impExprType dest of
-  IRefType RealTy -> do
-    cur  <- load dest
-    src' <- load src
-    updated <- emitInstr $ IPrimOp $ ScalarBinOp FAdd cur src'
-    store dest updated
-  IRefType (TabTy n _) -> do
-    n' <- indexSetSize n
-    emitLoop Fwd n' $ \i -> bindM2 addToDestFromRef (impGet dest i) (impGet src i)
-  ty -> error $ "Addition not implemented for type: " ++ pprint ty
-
-addToDestScalar :: IExpr -> IExpr -> ImpM ()
-addToDestScalar dest src = do
-  cur  <- load dest
-  updated <- emitInstr $ IPrimOp $ ScalarBinOp FAdd cur src
-  store dest updated
-
-initializeZero :: IExpr -> ImpM ()
-initializeZero ref = case impExprType ref of
-  IRefType RealTy      -> store ref (ILit (RealLit 0.0))
-  IRefType (TabTy n _) -> do
-    n' <- indexSetSize n
-    emitLoop Fwd n' $ \i -> impGet ref i >>= initializeZero
-  ty -> error $ "Zeros not implemented for type: " ++ pprint ty
-
 -- === type checking imp programs ===
 
 -- State keeps track of _all_ names used in the program, Reader keeps the type env.
@@ -555,8 +592,9 @@ type ImpCheckM a = StateT (Env ()) (ReaderT (Env IType) (Either Err)) a
 instance Checkable ImpFunction where
   checkValid (ImpFunction _ vsIn (ImpProg prog)) = do
     let scope = foldMap (varAsEnv . fmap (const ())) vsIn
-    let env   = foldMap (varAsEnv . fmap IRefType) vsIn
+    let env   = foldMap (varAsEnv . fmap (IRefType . dropArray)) vsIn
     void $ runReaderT (runStateT (checkProg prog) scope) env
+    where dropArray ~(ArrayTy t) = t
 
 checkProg :: [ImpStatement] -> ImpCheckM ()
 checkProg [] = return ()
@@ -582,11 +620,6 @@ instrTypeChecked instr = case instr of
     b <- (checkIExpr >=> fromScalarRefType) dest
     valTy <- checkIExpr val
     assertEq (IValType b) valTy "Type mismatch in store"
-    return Nothing
-  Copy dest source _ -> do
-    destTy   <- (checkIExpr >=> fromRefType) dest
-    sourceTy <- (checkIExpr >=> fromRefType) source
-    assertEq sourceTy destTy "Type mismatch in copy"
     return Nothing
   Alloc ty _ -> return $ Just $ IRefType ty
   Free _   -> return Nothing  -- TODO: check matched alloc/free
@@ -643,10 +676,6 @@ checkImpOp op = do
     checkEq :: (Pretty a, Show a, Eq a) => a -> a -> ImpCheckM ()
     checkEq t t' = assertEq t t' (pprint op)
 
-fromRefType :: MonadError Err m => IType -> m ScalarTableType
-fromRefType (IRefType ty) = return ty
-fromRefType ty = throw CompilerErr $ "Not a reference type: " ++ pprint ty
-
 fromScalarRefType :: MonadError Err m => IType -> m BaseType
 fromScalarRefType (IRefType (BaseTy b)) = return b
 fromScalarRefType ty = throw CompilerErr $ "Not a scalar reference type: " ++ pprint ty
@@ -659,9 +688,8 @@ impExprType expr = case expr of
 instrType :: MonadError Err m => ImpInstr -> m (Maybe IType)
 instrType instr = case instr of
   IPrimOp op      -> return $ Just $ impOpType op
-  Load ref        -> liftM (Just . IValType) $ fromScalarRefType (impExprType ref)
+  Load ref        -> Just . IValType <$> fromScalarRefType (impExprType ref)
   Store _ _       -> return Nothing
-  Copy  _ _ _     -> return Nothing
   Alloc ty _      -> return $ Just $ IRefType ty
   Free _          -> return Nothing
   Loop _ _ _ _    -> return Nothing
@@ -673,7 +701,7 @@ impOpType :: IPrimOp -> IType
 impOpType (ScalarBinOp op _ _) = IValType ty  where (_, _, ty) = binOpType op
 impOpType (ScalarUnOp  op _  ) = IValType ty  where (_,    ty) = unOpType  op
 impOpType (Select _ x _    )   = impExprType x
-impOpType (FFICall _ ty _ ) = IValType ty
+impOpType (FFICall _ ty _ )    = IValType ty
 impOpType op = error $ "Not allowed in Imp IR: " ++ pprint op
 
 pattern IIntTy :: IType

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -279,10 +279,10 @@ inferTabTy xs ann = case ann of
   Just ty -> do
     ty' <- checkUType ty
     case ty' of
-      TabTy n a -> do
-        unless (indexSetConcreteSize n == Just (length xs)) $
+      TabTy v a -> do
+        unless (indexSetConcreteSize (varType v) == Just (length xs)) $
            throw TypeErr $ "Table size doesn't match annotation"
-        return (n, a)
+        return (varType v, a)
       _ -> throw TypeErr $ "Table constructor annotation must be a table type"
   Nothing -> case xs of
    [] -> throw TypeErr $ "Empty table constructor must have type annotation"

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -4,12 +4,14 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Interpreter (evalBlock) where
+module Interpreter (evalBlock, indices, indexSetSize) where
 
+import Array
 import Cat
 import Syntax
 import Env
 import PPrint
+import Embed
 
 -- TODO: can we make this as dynamic as the compiled version?
 foreign import ccall "sqrt" c_sqrt :: Double -> Double
@@ -25,16 +27,20 @@ foreign import ccall "threefry2x32"  c_threefry :: Int -> Int -> Int
 evalBlock :: SubstEnv -> Block -> Atom
 evalBlock env (Block decls result) = do
   let env' = catFold evalDecl env decls
-  evalExpr $ subst (env <> env', mempty) result
+  evalExpr env $ subst (env <> env', mempty) result
 
 evalDecl :: SubstEnv -> Decl -> SubstEnv
-evalDecl env (Let v rhs) = v @> evalExpr rhs'
+evalDecl env (Let v rhs) = v @> evalExpr env rhs'
   where rhs' = subst (env, mempty) rhs
 
-evalExpr :: Expr -> Atom
-evalExpr expr = case expr of
-  Op op -> evalOp op
-  _     -> undefined
+evalExpr :: SubstEnv -> Expr -> Atom
+evalExpr env expr = case expr of
+  App f x   -> case f of
+    Lam a -> evalBlock env $ snd $ applyAbs a x
+    _     -> error $ "Expected a fully evaluated function value: " ++ pprint f
+  Atom atom -> atom
+  Op op     -> evalOp op
+  Hof _     -> error $ "Not implemented: " ++ pprint expr
 
 evalOp :: Op -> Atom
 evalOp expr = case expr of
@@ -62,4 +68,26 @@ evalOp expr = case expr of
     "randunif" -> RealVal $ c_unif x  where [IntVal x] = args
     "threefry2x32" -> IntVal $ c_threefry x y  where [IntVal x, IntVal y] = args
     _ -> error $ "FFI function not recognized: " ++ name
+  ArrayOffset arrArg offArg -> Con $ ArrayLit (ArrayTy b) (arrayOffset arr off)
+    where (ArrayVal (ArrayTy (TabTy _ b)) arr, IntVal off) = (arrArg, offArg)
+  ArrayLoad arrArg -> Con $ Lit $ arrayHead arr where (ArrayVal (ArrayTy (BaseTy _)) arr) = arrArg
+  UnwrapIndex idxArg -> e                       where (Con (AsIdx _ e)) = idxArg
   _ -> error $ "Not implemented: " ++ pprint expr
+
+indices :: Type -> [Atom]
+indices ty = case ty of
+  TC (BaseType BoolType) -> [BoolVal False, BoolVal True]
+  TC (IntRange _ _)      -> fmap (Con . AsIdx ty . IntVal) [0..n - 1]
+  TC (IndexRange _ _ _)  -> fmap (Con . AsIdx ty . IntVal) [0..n - 1]
+  TC (PairType lt rt)    -> [PairVal l r | l <- indices lt, r <- indices rt]
+  TC (UnitType)          -> [UnitVal]
+  TC (SumType lt rt)     -> fmap (\l -> SumVal (BoolVal True)  l (Con (AnyValue rt))) (indices lt) ++
+                            fmap (\r -> SumVal (BoolVal False) (Con (AnyValue lt)) r) (indices rt)
+  _ -> error $ "Not implemented: " ++ pprint ty
+  where n = indexSetSize ty
+
+indexSetSize :: Type -> Int
+indexSetSize ty = i
+  where
+    (atom, decls) = runEmbed (indexSetSizeE ty) mempty
+    (IntVal i) = evalBlock mempty $ Block decls (Atom atom)

--- a/src/lib/JAX.hs
+++ b/src/lib/JAX.hs
@@ -181,17 +181,17 @@ iotaVarAsIdx = undefined
 fromScalarAtom :: HasCallStack => TmpAtom -> IdxAtom
 fromScalarAtom atom = case atom of
   TmpCon (AsIdx _ x) -> fromScalarAtom x
-  TmpCon (AGet (TmpLeaf x)) -> x
+  --TmpCon (AGet (TmpLeaf x)) -> x
   _ -> error $ "Not a scalar atom: " ++ show atom
 
 toScalarAtom :: IdxAtom -> TmpAtom
-toScalarAtom x = TmpCon $ AGet $ TmpLeaf x
+toScalarAtom x = undefined --TmpCon $ AGet $ TmpLeaf x
 
 traverseArrayLeaves :: HasCallStack => Monad m => TmpAtom -> (IdxAtom -> m IdxAtom) -> m TmpAtom
 traverseArrayLeaves atom f = case atom of
   TmpCon con         -> liftM TmpCon $ case con of
-    AFor n body      -> liftM (AFor n) $ traverseArrayLeaves body f
-    AGet (TmpLeaf x) -> liftM (AGet . TmpLeaf) $ f x
+    --AFor n body      -> liftM (AFor n) $ traverseArrayLeaves body f
+    --AGet (TmpLeaf x) -> liftM (AGet . TmpLeaf) $ f x
     _ -> error $ "Not implemented: " ++ show atom
   TmpLeaf x -> liftM TmpLeaf $ f x
   TmpRefName _ -> error "Unexpected reference name"

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -35,7 +35,6 @@ import Syntax
 import Env
 import PPrint
 import Cat
-import Imp
 
 type CompileEnv = Env Operand
 -- TODO: consider using LLVM.IRBuilder.Monad instead of rolling our own here
@@ -65,8 +64,8 @@ runCompileM env m = evalState (runReaderT m env) initState
 compileTopProg :: ImpFunction -> CompileM LLVMFunction
 compileTopProg (ImpFunction outVars inVars (ImpProg prog)) = do
   -- Set up the argument list. Note that all outputs are pointers to pointers.
-  let inVarTypes  = map (        L.ptr . scalarTy . scalarTableBaseType . varAnn) inVars
-  let outVarTypes = map (L.ptr . L.ptr . scalarTy . scalarTableBaseType . varAnn) outVars
+  let inVarTypes  = map (        L.ptr . scalarTy . arrayBaseType . varAnn) inVars
+  let outVarTypes = map (L.ptr . L.ptr . scalarTy . arrayBaseType . varAnn) outVars
   (inParams, inOperands)   <- unzip <$> mapM freshParamOpPair inVarTypes
   (outParams, outOperands) <- unzip <$> mapM freshParamOpPair outVarTypes
 
@@ -82,6 +81,7 @@ compileTopProg (ImpFunction outVars inVars (ImpProg prog)) = do
   blocks <- gets (reverse . curBlocks)
   return $ LLVMFunction numOutputs $ makeModule (outParams ++ inParams) decls blocks specs
   where
+    arrayBaseType = scalarTableBaseType . (\(ArrayTy t) -> t)
     numOutputs = length outVars
 
 freshParamOpPair :: L.Type -> CompileM (Parameter, Operand)
@@ -122,18 +122,6 @@ compileInstr allowAlloca instr = case instr of
     dest' <- compileExpr dest
     val'  <- compileExpr val
     store dest' val'
-    return Nothing
-  Copy dest source numel -> do
-    let (IRefType t) = impExprType source
-    dest'   <- compileExpr dest
-    source' <- compileExpr source
-    case t of
-      (BaseTy _) -> do
-        x <- load source'
-        store dest' x
-      _  -> do
-        numBytes <- mul (litInt 8) =<< compileExpr numel
-        copy numBytes dest' source'
     return Nothing
   Alloc t numel -> Just <$> case t of
     BaseTy b | allowAlloca -> alloca b
@@ -200,12 +188,6 @@ freshName v = do
   let v'@(name:>_) = rename (v:>()) used
   modify $ \s -> s { usedNames = used <> v'@>() }
   return $ nameToLName name
-
-copy :: Operand -> Operand -> Operand -> CompileM ()
-copy numBytes dest src = do
-  src'  <- castLPtr charTy src
-  dest' <- castLPtr charTy dest
-  addInstr $ L.Do (externCall memcpyFun [dest', src', numBytes])
 
 litVal :: LitVal -> Operand
 litVal lit = case lit of
@@ -337,11 +319,8 @@ mallocFun  = ExternFunSpec "malloc_dex"    charPtrTy [longTy]
 freeFun :: ExternFunSpec
 freeFun = ExternFunSpec "free_dex"      charPtrTy [charPtrTy]
 
-memcpyFun :: ExternFunSpec
-memcpyFun  = ExternFunSpec "memcpy_dex" L.VoidType [charPtrTy, charPtrTy, longTy]
-
 builtinFFISpecs :: [ExternFunSpec]
-builtinFFISpecs = [mallocFun, freeFun, memcpyFun]
+builtinFFISpecs = [mallocFun, freeFun]
 
 charPtrTy :: L.Type
 charPtrTy = L.ptr charTy

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -103,6 +103,7 @@ instance Pretty e => Pretty (PrimExpr e) where
 instance Pretty e => Pretty (PrimTC e) where
   pretty con = case con of
     BaseType b     -> p b
+    ArrayType ty   -> "Arr[" <> p ty <> "]"
     PairType a b   -> parens $ p a <+> "&" <+> p b
     UnitType       -> "Unit"
     IntRange a b -> if s1 == "0...<" then parens ("Fin" <+> p s2) else ans
@@ -127,8 +128,6 @@ instance Pretty e => Pretty (PrimCon e) where
     PairCon x y -> parens $ p x <+> "," <+> p y
     UnitCon     -> "()"
     RefCon _ _  -> "RefCon"
-    AFor n body -> parens $ "afor *:" <> p n <+> "." <+> p body
-    AGet e      -> "aget" <+> p e
     AsIdx n i   -> p i <> "@" <> parens (p n)
     AnyValue t  -> parens $ "AnyValue @" <> p t
     SumCon c l r -> parens $ case pprint c of
@@ -143,6 +142,9 @@ instance Pretty e => Pretty (PrimOp e) where
     SumTag e        -> parens $ "projTag" <+> p e
     PrimEffect ref (MPut val ) ->  p ref <+> ":=" <+> p val
     PrimEffect ref (MTell val) ->  p ref <+> "+=" <+> p val
+    ArrayOffset arr off -> p arr <+> "+>" <+> p off
+    ArrayLoad arr       -> "load" <+> p arr
+    UnwrapIndex idx     -> "unwrap_index" <+> p idx
     _ -> prettyExprDefault $ OpExpr op
 
 instance Pretty e => Pretty (PrimHof e) where
@@ -174,6 +176,7 @@ instance Pretty Decl where
 instance Pretty Atom where
   pretty atom = case atom of
     Var (x:>_)  -> p x
+    Lam (Abs b (TabArrow, body))   -> "for " <> p b <> "." <> p body
     Lam (Abs b (_, body)) -> "\\" <> p b <> "." <> p body
     Pi  (Abs (NoName:>a) (arr, b)) -> parens $ p a <> p arr <> p b
     Pi  (Abs a           (arr, b)) -> parens $ p a <> p arr <> p b
@@ -188,11 +191,6 @@ instance Pretty IExpr where
 instance Pretty IType where
   pretty (IRefType t) = "Ref" <+> (parens $ p t)
   pretty (IValType b) = p b
-
-instance Pretty IDimType where
-  pretty (IUniform (ILit (IntLit sz))) = p sz
-  pretty (IUniform _)     = "<uniform, dependent>"
-  pretty (IPrecomputed _) = "<precomptued>"
 
 instance Pretty ImpProg where
   pretty (ImpProg block) = vcat (map prettyStatement block)
@@ -211,7 +209,6 @@ instance Pretty ImpInstr where
   pretty (IPrimOp op)         = p op
   pretty (Load ref)           = "load"  <+> p ref
   pretty (Store dest val)     = "store" <+> p dest <+> p val
-  pretty (Copy dest source s) = "copy"  <+> p dest <+> p source <+> parens (p s <+> "elems")
   pretty (Alloc t s)          = "alloc" <+> p (scalarTableBaseType t) <> "[" <> p s <> "]" <+> "@" <> p t
   pretty (IOffset expr idx)   = p expr <+> "+>" <+> p idx
   pretty (Free (v:>_))        = "free"  <+> p v

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -144,7 +144,6 @@ instance Pretty e => Pretty (PrimOp e) where
     PrimEffect ref (MTell val) ->  p ref <+> "+=" <+> p val
     ArrayOffset arr off -> p arr <+> "+>" <+> p off
     ArrayLoad arr       -> "load" <+> p arr
-    UnwrapIndex idx     -> "unwrap_index" <+> p idx
     _ -> prettyExprDefault $ OpExpr op
 
 instance Pretty e => Pretty (PrimHof e) where

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -216,7 +216,6 @@ data PrimOp e =
       | Inject e
       | ArrayOffset e e
       | ArrayLoad e
-      | UnwrapIndex e                -- drops AsIdx from the atom
       -- Typeclass operations
       -- Eq and Ord (should get eliminated during simplification)
       | Cmp CmpOp e e

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -25,7 +25,7 @@ module Syntax (
     Val, TopEnv (..), Op, Con, Hof, TC, Module (..), ImpFunction (..),
     ImpProg (..), ImpStatement, ImpInstr (..), IExpr (..), IVal, IPrimOp,
     IVar, IType (..), ArrayType, SetVal (..), MonMap (..), LitProg,
-    IDimType (..), ScalarTableType, ScalarTableVar,
+    ScalarTableType, ScalarTableVar,
     SrcCtx, Result (..), Output (..), OutFormat (..), DataFormat (..),
     Err (..), ErrType (..), Except, throw, throwIf, modifyErr, addContext,
     addSrcContext, catchIOExcept, liftEitherIO, (-->), (--@), (==>),
@@ -36,14 +36,15 @@ module Syntax (
     UPat, UPat', PatP, PatP' (..), UModule (..), UDecl (..), UArrow, arrowEff,
     subst, deShadow, scopelessSubst, absArgType, applyAbs, makeAbs, freshSkolemVar,
     mkConsList, mkConsListTy, fromConsList, fromConsListTy, extendEffRow,
-    scalarTableBaseType, varType,
+    scalarTableBaseType, varType, isTabTy,
     pattern IntVal, pattern UnitTy, pattern PairTy,
     pattern FixedIntRange, pattern RefTy, pattern BoolTy, pattern IntTy,
     pattern RealTy, pattern SumTy, pattern BaseTy, pattern UnitVal,
-    pattern PairVal, pattern SumVal, pattern PureArrow,
-    pattern RealVal, pattern BoolVal, pattern TyKind, pattern TabTy, isTabTy,
+    pattern PairVal, pattern SumVal, pattern PureArrow, pattern ArrayVal,
+    pattern RealVal, pattern BoolVal, pattern TyKind,
+    pattern TabTy, pattern TabVal, pattern TabValA,
     pattern Pure, pattern BinaryFunTy, pattern BinaryFunVal,
-    pattern EffKind, pattern JArrayTy)
+    pattern EffKind, pattern JArrayTy, pattern ArrayTy)
   where
 
 import qualified Data.Map.Strict as M
@@ -84,7 +85,7 @@ data Block = Block [Decl] Expr  deriving (Show, Eq, Generic)
 type Var    = VarP Type
 type Binder = VarP Type
 
-data Abs a = Abs Binder a  deriving (Show, Generic)
+data Abs a = Abs Binder a  deriving (Show, Generic, Functor, Foldable, Traversable)
 type LamExpr = Abs (Arrow, Block)
 type PiType  = Abs (Arrow, Type)
 
@@ -171,7 +172,8 @@ data PrimExpr e =
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimTC e =
-        BaseType BaseType
+        BaseType  BaseType
+      | ArrayType e         -- A pointer to memory storing a ScalarTableType value
       | IntRange e e
       | IndexRange e (Limit e) (Limit e)
       | PairType e e
@@ -189,15 +191,13 @@ data PrimTC e =
 
 data PrimCon e =
         Lit LitVal
-      | ArrayLit e Array -- Used to store results of module evaluation
+      | ArrayLit e Array  -- Used to store results of module evaluation
       | AnyValue e        -- Produces an arbitrary value of a given type
       | SumCon e e e      -- (bool constructor tag (True is Left), left value, right value)
       | PairCon e e
       | UnitCon
       | RefCon e e
       | AsIdx e e         -- Construct an index from its ordinal index (zero-based int)
-      | AFor e e
-      | AGet e
       | Todo e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
@@ -214,6 +214,9 @@ data PrimOp e =
       | IndexRef e e
       | FFICall String BaseType [e]
       | Inject e
+      | ArrayOffset e e
+      | ArrayLoad e
+      | UnwrapIndex e                -- drops AsIdx from the atom
       -- Typeclass operations
       -- Eq and Ord (should get eliminated during simplification)
       | Cmp CmpOp e e
@@ -320,8 +323,7 @@ newtype ImpProg = ImpProg [ImpStatement]
 type ImpStatement = (Maybe IVar, ImpInstr)
 
 data ImpInstr = Load  IExpr
-              | Store IExpr IExpr       -- destination first
-              | Copy  IExpr IExpr Size  -- destination first
+              | Store IExpr IExpr           -- Destination first
               | Alloc ScalarTableType Size  -- Second argument is the size of the table
               | Free IVar
               | IOffset IExpr Index
@@ -337,12 +339,8 @@ type IPrimOp = PrimOp IExpr
 type IVal = IExpr  -- only ILit and IRef constructors
 type IVar = VarP IType
 data IType = IValType BaseType
-           | IRefType ScalarTableType
+           | IRefType ScalarTableType -- This represents ArrayType (ScalarTableType)
              deriving (Show, Eq)
-
-data IDimType = IUniform IExpr
-              | IPrecomputed IVar -- IVar with type IRefType ([IUniform n], IntType)
-                deriving (Show, Eq)
 
 type Size  = IExpr
 type Index = IExpr
@@ -752,6 +750,9 @@ pattern RealVal x = Con (Lit (RealLit x))
 pattern BoolVal :: Bool -> Atom
 pattern BoolVal x = Con (Lit (BoolLit x))
 
+pattern ArrayVal :: Type -> Array -> Atom
+pattern ArrayVal t arr = Con (ArrayLit t arr)
+
 pattern SumVal :: Atom -> Atom -> Atom -> Atom
 pattern SumVal t l r = Con (SumCon t l r)
 
@@ -800,8 +801,17 @@ pattern FixedIntRange low high = TC (IntRange (IntVal low) (IntVal high))
 pattern PureArrow :: Arrow
 pattern PureArrow = PlainArrow Pure
 
-pattern TabTy :: Type -> Type -> Type
-pattern TabTy xs i = Pi (Abs (NoName:>xs) (TabArrow, i))
+pattern ArrayTy :: Type -> Type
+pattern ArrayTy t = TC (ArrayType t)
+
+pattern TabTy :: Var -> Type -> Type
+pattern TabTy v i = Pi (Abs v (TabArrow, i))
+
+pattern TabVal :: Var -> Block -> Atom
+pattern TabVal v b = Lam (Abs v (TabArrow, b))
+
+pattern TabValA :: Var -> Atom -> Atom
+pattern TabValA v a = Lam (Abs v (TabArrow, (Block [] (Atom a))))
 
 isTabTy :: Type -> Bool
 isTabTy (TabTy _ _) = True

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -293,13 +293,6 @@ typeCheckOp op = case op of
   ArrayLoad arr -> do
     ArrayTy (BaseTy b)  <- typeCheck arr
     return $ BaseTy b
-  UnwrapIndex idx -> do
-    ty <- typeCheck idx
-    case ty of
-      TC (IntRange _ _)     -> return IntTy
-      TC (IndexRange _ _ _) -> return IntTy
-      _                     -> throw TypeErr $ "UnwrapIndex on non-index type: " ++ pprint ty
-
 
 typeCheckHof :: Hof -> TypeM Type
 typeCheckHof hof = case hof of

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -206,6 +206,7 @@ withAllowedEff eff m = updateAllowedEff (const eff) m
 typeCheckTyCon :: TC -> TypeM ()
 typeCheckTyCon tc = case tc of
   BaseType _       -> return ()
+  ArrayType t      -> t|:TyKind
   IntRange a b     -> a|:IntTy >> b|:IntTy
   IndexRange t a b -> t|:TyKind >> mapM_ (|:t) a >> mapM_ (|:t) b
   SumType  l r     -> l|:TyKind >> r|:TyKind
@@ -219,14 +220,12 @@ typeCheckTyCon tc = case tc of
 typeCheckCon :: Con -> TypeM Type
 typeCheckCon con = case con of
   Lit l -> return $ BaseTy $ litType l
-  ArrayLit ty _ -> return $ ty
+  ArrayLit ty _ -> return $ ArrayTy ty
   AnyValue t -> t|:TyKind $> t
   SumCon _ l r -> SumTy <$> typeCheck l <*> typeCheck r
   PairCon x y -> PairTy <$> typeCheck x <*> typeCheck y
   UnitCon -> return UnitTy
   RefCon r x -> r|:TyKind >> RefTy r <$> typeCheck x
-  AFor n a -> n|:TyKind >> TabTy n <$> typeCheck a
-  AGet st -> (BaseTy . scalarTableBaseType) <$> typeCheck st
   AsIdx n e -> n|:TyKind >> e|:IntTy $> n
   Todo ty -> ty|:TyKind $> ty
 
@@ -234,10 +233,11 @@ typeCheckOp :: Op -> TypeM Type
 typeCheckOp op = case op of
   TabCon ty xs -> do
     ty |: TyKind
-    TabTy n a <- return ty
+    TabTy v a <- return ty
+    -- TODO: Propagate the binder to support dependently typed dimensions?
     mapM_ (|:a) xs
-    Just n' <- return $ indexSetConcreteSize n
-    assertEq n' (length xs) "Index set size mismatch"
+    Just n <- return $ indexSetConcreteSize $ varType v
+    assertEq n (length xs) "Index set size mismatch"
     return ty
   Fst p -> do { PairTy x _ <- typeCheck p; return x}
   Snd p -> do { PairTy _ y <- typeCheck p; return y}
@@ -282,9 +282,24 @@ typeCheckOp op = case op of
       MAsk    ->         declareEff (Reader, h) $> s
       MTell x -> x|:s >> declareEff (Writer, h) $> UnitTy
   IndexRef ref i -> do
-    RefTy h (TabTy n a) <- typeCheck ref
-    i|:n
+    RefTy h (TabTy v a) <- typeCheck ref
+    i |: (varType v)
     return $ RefTy h a
+  ArrayOffset arr off -> do
+    -- TODO: b should be applied!!
+    ArrayTy (TabTy _ b) <- typeCheck arr
+    off |: IntTy
+    return $ ArrayTy b
+  ArrayLoad arr -> do
+    ArrayTy (BaseTy b)  <- typeCheck arr
+    return $ BaseTy b
+  UnwrapIndex idx -> do
+    ty <- typeCheck idx
+    case ty of
+      TC (IntRange _ _)     -> return IntTy
+      TC (IndexRange _ _ _) -> return IntTy
+      _                     -> throw TypeErr $ "UnwrapIndex on non-index type: " ++ pprint ty
+
 
 typeCheckHof :: Hof -> TypeM Type
 typeCheckHof hof = case hof of

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -11,7 +11,7 @@ module Util (group, ungroup, pad, padLeft, delIdx, replaceIdx,
              composeN, mapMaybe, lookup, uncons, repeated,
              showErr, listDiff, splitMap, enumerate, restructure,
              onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3,
-             bindM2) where
+             bindM2, foldMapM) where
 
 import Data.List (sort)
 import Prelude hiding (lookup)
@@ -196,3 +196,6 @@ bindM2 f ma mb = do
   a <- ma
   b <- mb
   f a b
+
+foldMapM :: (Monad m, Monoid w, Foldable t) => (a -> m w) -> t a -> m w
+foldMapM f xs = foldM (\acc x -> (acc<>) <$> f x ) mempty xs


### PR DESCRIPTION
The recent major refactor has removed DeBruijn variables, meaning that
`AFor`s were no longer considered binders. However, if we want to support
arrays with dimensions that can depend on each other, there needs to be
a way to refer to a variable bound by a previous views.

This could be fixed by making AFor carry around a binder (i.e. wrap an
`Abs Atom`), but at this point it seemed like there was really no excuse
not to try out representing the array-of-structures view as a table
lambda. Once I did that, it turned out that there was a bunch of other
changes that paired with it nicely, which unfortunately made for a
relatively large change in the end. Here's a summary of the main updates:
* The structure-of-arrays conversion is not done using table lambdas,
  instead of the dedicated `AFor` and `AGet` constructors.
* The lack of `AGet` atom also means that we no longer can have scalar
  array references embedded in the types, which is actually nice.
* `AFor`s were used to represent destinations (i.e. writeable atoms) in
  the Imp translation, but they did not enforce the guarantee that their
  terms terminate with variables to references. The new `Dest` structure
  guarantees that and makes the code quite a bit clearer.
* I've added back an `ArrayType`, which is meant to be embedded in table
  lambdas. The only two operations that can be applied to values of this
  type are `ArrayOffset` and `ArrayLoad`. Note that `ArrayOffset`
  requires a linear offset, so all the details of linear index
  calculation have to be embedded in the lambda by each respective
  backend. This has the upside of allowing backends to use different
  representations for their arrays by e.g. padding any raggedness.

This work should allow me to rebase my previous attempts of adding
support for ragged arrays (see #100).

Unfortunately, all this does not come with any downsides. The biggest
problem right now is that the use of table lambdas allows enough
flexibility that the only reliable way to take the data out of the
system (e.g. for plotting) requires a reevaluation of the lambda over
the whole index set which usually boils down to making a copy of the
array in a very inefficient manner. We'll have to think more about this
problem in the future, but for now the plotting performance is not a
big concern.