### PR TITLE
Hardcode support for triangular matrices

### DIFF
--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -15,7 +15,7 @@ module Embed (emit, emitOp, buildDepEffLam, buildLamAux, buildAbs,
               getAllowedEffects, withEffects, modifyAllowedEffects,
               buildLam, EmbedT, Embed, MonadEmbed, buildScoped, wrapDecls, runEmbedT,
               runEmbed, zeroAt, addAt, sumAt, getScope, reduceBlock, withBinder,
-              app, add, iadd, mul, imul, sub, isub, neg, div', andE, reduceScoped, declAsScope,
+              app, add, iadd, mul, imul, sub, isub, neg, div', idiv, andE, reduceScoped, declAsScope,
               select, selectAt, substEmbed, fromPair, getFst, getSnd,
               emitBlock, unzipTab, buildFor, isSingletonType, emitDecl, withNameHint,
               singletonTypeVal, mapScalars, scopedDecls, embedScoped, extendScope,
@@ -216,8 +216,8 @@ getSnd p = emitOp $ Snd p
 app :: MonadEmbed m => Atom -> Atom -> m Atom
 app x i = emit $ App x i
 
-arrOffset :: MonadEmbed m => Atom -> Atom -> m Atom
-arrOffset x i = emitOp $ ArrayOffset x i
+arrOffset :: MonadEmbed m => Atom -> Atom -> Atom -> m Atom
+arrOffset x idx off = emitOp $ ArrayOffset x idx off
 
 arrLoad :: MonadEmbed m => Atom -> m Atom
 arrLoad x = emitOp $ ArrayLoad x

--- a/src/lib/Flops.hs
+++ b/src/lib/Flops.hs
@@ -38,11 +38,11 @@ statementFlops (_, instr) = case instr of
   IPrimOp op -> do
     n <- ask
     tell $ Profile $ M.singleton (showPrimName $ OpExpr op) [n]
-  Load _      -> return ()
-  Store _ _   -> return ()
-  Alloc _ _   -> return ()
-  Free _      -> return ()
-  IOffset _ _ -> return ()
+  Load _        -> return ()
+  Store _ _     -> return ()
+  Alloc _ _     -> return ()
+  Free _        -> return ()
+  IOffset _ _ _ -> return ()
   Loop _ _ size block -> do
     let n = evalSizeExpr size
     local (mulTerm n) $ flops block

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -151,8 +151,10 @@ toImpOp (maybeDest, op) = case op of
     subrefVar  <- freshVar (varName refVar :> RefTy h (snd $ applyAbs a i))
     extend ((subrefVar @> subrefDest, mempty), mempty)
     returnVal $ Var subrefVar
-  ArrayOffset arr off -> returnVal . toArrayAtom =<< impOffset (fromArrayAtom arr) (fromScalarAtom off)
-  ArrayLoad arr       -> returnVal . toScalarAtom resultTy =<< load (fromArrayAtom arr)
+  ArrayOffset arr idx off -> do
+    arrSlice <- impOffset (fromArrayAtom arr) (fromScalarAtom idx) (fromScalarAtom off)
+    returnVal $ toArrayAtom arrSlice
+  ArrayLoad arr -> returnVal . toScalarAtom resultTy =<< load (fromArrayAtom arr)
   Cmp _ _ _ -> error $ "All instances of Cmp should get resolved in simplification"
   _ -> do
     returnVal . toScalarAtom resultTy =<< emitInstr (IPrimOp $ fmap fromScalarAtom op)
@@ -267,11 +269,11 @@ destToAtomScalarAction fScalar dest = do
 
 destToAtom' :: (IVar -> ImpM Atom) -> [Var] -> Dest -> EmbedT ImpM Atom
 destToAtom' fScalar forVars dest = case dest of
-  DFor (Abs v d) -> do
+  DFor a@(Abs v _) -> do
     v' <- lift $ case v of
       (NoName :> t) -> freshVar ("idx" :> t)
       _             -> freshVar v
-    block <- buildScoped $ destToAtom' fScalar (v' : forVars) d
+    block <- buildScoped $ destToAtom' fScalar (v' : forVars) (applyAbs a (Var v'))
     return $ Lam $ makeAbs v' (TabArrow, block)
   DRef ref       -> case forVars of
     [] -> lift $ fScalar ref
@@ -284,7 +286,7 @@ destToAtom' fScalar forVars dest = case dest of
           ordinal <- indexToIntE (getType idx) idx
           let (ArrayTy tabTy) = getType arr
           offset <- tabTy `offsetToE` ordinal
-          arrOffset arr offset
+          arrOffset arr idx offset
   DPair dl dr    -> PairVal <$> rec dl <*> rec dr
   DUnit          -> return $ UnitVal
   DAsIdx t d     -> Con . AsIdx t <$> rec d
@@ -418,6 +420,8 @@ elemCountE :: MonadEmbed m => ScalarTableType -> m Atom
 elemCountE ty = case ty of
   BaseTy _  -> return $ IntVal 1
   TabTy (NoName:>idxTy) b -> bindM2 imul (indexSetSizeE idxTy) (elemCountE b)
+  TabTy v (TabTy (NoName :> TC (IndexRange _ Unlimited (InclusiveLim (Var v')))) (BaseTy _)) | v == v' ->
+    triangularSum =<< indexSetSizeE (varType v)
   TabTy _ _ ->
     error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint ty
   _ -> error $ "Not a scalar table type: " ++ pprint ty
@@ -426,10 +430,18 @@ elemCountE ty = case ty of
 offsetToE :: MonadEmbed m => ScalarTableType -> Atom -> m Atom
 offsetToE ty i = case ty of
   TabTy (NoName:>_) b -> imul i =<< elemCountE b
+  TabTy v (TabTy (NoName :> TC (IndexRange _ Unlimited (InclusiveLim (Var v')))) (BaseTy _)) | v == v' ->
+    triangularSum i
   TabTy _ _ ->
     error $ "Tables with sizes of dimensions dependent on previous dimensions are not supported: " ++ pprint ty
   BaseTy _  -> error "Indexing into a scalar!"
   _ -> error $ "Not a scalar table type: " ++ pprint ty
+
+triangularSum :: MonadEmbed m => Atom -> m Atom
+triangularSum n = do
+  n1 <- iadd n (IntVal 1)
+  num <- imul n n1
+  num `idiv` (IntVal 2)
 
 zipWithDest :: Dest -> Atom -> (IExpr -> IExpr -> ImpM ()) -> ImpM ()
 zipWithDest dest atom f = case (dest, atom) of
@@ -492,12 +504,12 @@ impAdd x y = emitBinOp IAdd x y
 
 impGet :: IExpr -> IExpr -> ImpM IExpr
 impGet ref i = case ref of
-  (IVar (_ :> IRefType t)) -> emitInstr . IOffset ref =<< (t `offsetTo` i)
+  (IVar (_ :> IRefType t)) -> emitInstr . IOffset ref i =<< (t `offsetTo` i)
   _ -> error $ "impGet called with non-ref: " ++ show ref
 
-impOffset :: IExpr -> IExpr -> ImpM IExpr
-impOffset ref off = case ref of
-  (IVar (_ :> IRefType _)) -> emitInstr $ IOffset ref off
+impOffset :: IExpr -> IExpr -> IExpr -> ImpM IExpr
+impOffset ref idx off = case ref of
+  (IVar (_ :> IRefType _)) -> emitInstr $ IOffset ref idx off
   _ -> error $ "impOffset called with non-ref: " ++ show ref
 
 load :: IExpr -> ImpM IExpr
@@ -601,10 +613,10 @@ instrTypeChecked instr = case instr of
     checkBinder i
     extendR (i @> IIntTy) $ checkProg block
     return Nothing
-  IOffset e i -> do
-    ~(IRefType (TabTy _ b)) <- checkIExpr e
+  IOffset e i _ -> do
+    IRefType (TabTyAbs a) <- checkIExpr e
     checkInt i
-    return $ Just $ IRefType b
+    return $ Just $ IRefType $ snd $ applyAbs a (toScalarAtom (absArgType a) i)
 
 checkBinder :: IVar -> ImpCheckM ()
 checkBinder v = do
@@ -666,8 +678,8 @@ instrType instr = case instr of
   Alloc ty _      -> return $ Just $ IRefType ty
   Free _          -> return Nothing
   Loop _ _ _ _    -> return Nothing
-  IOffset e _     -> case impExprType e of
-    IRefType (TabTy _ b) -> return $ Just $ IRefType b
+  IOffset e i _   -> case impExprType e of
+    IRefType (TabTyAbs a) -> return $ Just $ IRefType $ snd $ applyAbs a (toScalarAtom (absArgType a) i)
     ty -> error $ "Can't index into: " ++ pprint ty
 
 impOpType :: IPrimOp -> IType

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -152,7 +152,8 @@ toImpOp (maybeDest, op) = case op of
     extend ((subrefVar @> subrefDest, mempty), mempty)
     returnVal $ Var subrefVar
   ArrayOffset arr idx off -> do
-    arrSlice <- impOffset (fromArrayAtom arr) (fromScalarAtom idx) (fromScalarAtom off)
+    i <- indexToInt (getType idx) idx
+    arrSlice <- impOffset (fromArrayAtom arr) i (fromScalarAtom off)
     returnVal $ toArrayAtom arrSlice
   ArrayLoad arr -> returnVal . toScalarAtom resultTy =<< load (fromArrayAtom arr)
   Cmp _ _ _ -> error $ "All instances of Cmp should get resolved in simplification"

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -268,18 +268,18 @@ destToAtomScalarAction fScalar dest = do
     [] -> return $ atom
     _  -> error "Unexpected decls"
 
-destToAtom' :: (IVar -> ImpM Atom) -> [Var] -> Dest -> EmbedT ImpM Atom
+destToAtom' :: (IVar -> ImpM Atom) -> [Atom] -> Dest -> EmbedT ImpM Atom
 destToAtom' fScalar forVars dest = case dest of
   DFor a@(Abs v _) -> do
-    v' <- lift $ case v of
-      (NoName :> t) -> freshVar ("idx" :> t)
-      _             -> freshVar v
-    block <- buildScoped $ destToAtom' fScalar (v' : forVars) (applyAbs a (Var v'))
-    return $ Lam $ makeAbs v' (TabArrow, block)
+    -- FIXME: buildLam does not maintain the NoName convention, so we have to
+    --        fix it up locally
+    ~(Lam (Abs v'' b)) <- buildLam ("idx" :> varType v) TabArrow $ \v' ->
+      destToAtom' fScalar (v' : forVars) (applyAbs a v')
+    return $ Lam $ makeAbs v'' b
   DRef ref       -> case forVars of
     [] -> lift $ fScalar ref
     _  -> do
-      scalarArray <- foldM arrIndex (toArrayAtom $ IVar ref) $ fmap Var (reverse forVars)
+      scalarArray <- foldM arrIndex (toArrayAtom $ IVar ref) $ reverse forVars
       arrLoad scalarArray
       where
         arrIndex :: Atom -> Atom -> EmbedT ImpM Atom
@@ -352,7 +352,7 @@ makeDest nameHint destType = go id destType
         --       Once might be ok, but the type will have aliasing binders!
         TabTy v b -> DFor . Abs v <$> go (\t -> mkTy $ TabTy v t) b
         TC con    -> case con of
-          BaseType b       -> DRef <$> freshVar (nameHint :> (IRefType $ mkTy $ BaseTy b))
+          BaseType b       -> DRef  <$> freshVar (nameHint :> (IRefType $ mkTy $ BaseTy b))
           PairType a b     -> DPair <$> go mkTy a <*> go mkTy b
           UnitType         -> return DUnit
           IntRange   _ _   -> scalarIndexSet ty

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -49,6 +49,7 @@ evalOp expr = case expr of
     IAdd -> IntVal $ x' + y'      where (IntVal x') = x; (IntVal y') = y
     ISub -> IntVal $ x' - y'      where (IntVal x') = x; (IntVal y') = y
     IMul -> IntVal $ x' * y'      where (IntVal x') = x; (IntVal y') = y
+    IDiv -> IntVal $ x' `div` y'  where (IntVal x') = x; (IntVal y') = y
     Rem  -> IntVal $ x' `rem` y'  where (IntVal x') = x; (IntVal y') = y
     FAdd -> RealVal $ x' + y'  where (RealVal x') = x; (RealVal y') = y
     FSub -> RealVal $ x' - y'  where (RealVal x') = x; (RealVal y') = y
@@ -69,7 +70,7 @@ evalOp expr = case expr of
     "randunif" -> RealVal $ c_unif x  where [IntVal x] = args
     "threefry2x32" -> IntVal $ c_threefry x y  where [IntVal x, IntVal y] = args
     _ -> error $ "FFI function not recognized: " ++ name
-  ArrayOffset arrArg offArg -> Con $ ArrayLit (ArrayTy b) (arrayOffset arr off)
+  ArrayOffset arrArg _ offArg -> Con $ ArrayLit (ArrayTy b) (arrayOffset arr off)
     where (ArrayVal (ArrayTy (TabTy _ b)) arr, IntVal off) = (arrArg, offArg)
   ArrayLoad arrArg -> Con $ Lit $ arrayHead arr where (ArrayVal (ArrayTy (BaseTy _)) arr) = arrArg
   IndexAsInt idxArg -> case idxArg of

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -134,7 +134,7 @@ compileInstr allowAlloca instr = case instr of
     ptr' <- castLPtr charTy v'
     addInstr $ L.Do (externCall freeFun [ptr'])
     return Nothing
-  IOffset x off -> do
+  IOffset x _ off -> do
     x' <- compileExpr x
     off' <- compileExpr off
     Just <$> gep x' off'

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -142,7 +142,7 @@ instance Pretty e => Pretty (PrimOp e) where
     SumTag e        -> parens $ "projTag" <+> p e
     PrimEffect ref (MPut val ) ->  p ref <+> ":=" <+> p val
     PrimEffect ref (MTell val) ->  p ref <+> "+=" <+> p val
-    ArrayOffset arr off -> p arr <+> "+>" <+> p off
+    ArrayOffset arr idx off -> p arr <+> "+>" <+> p off <+> (parens $ "index:" <+> p idx)
     ArrayLoad arr       -> "load" <+> p arr
     _ -> prettyExprDefault $ OpExpr op
 
@@ -205,14 +205,14 @@ prettyStatement (Nothing, instr) = p instr
 prettyStatement (Just b , instr) = p b <+> "=" <+> p instr
 
 instance Pretty ImpInstr where
-  pretty (IPrimOp op)         = p op
-  pretty (Load ref)           = "load"  <+> p ref
-  pretty (Store dest val)     = "store" <+> p dest <+> p val
-  pretty (Alloc t s)          = "alloc" <+> p (scalarTableBaseType t) <> "[" <> p s <> "]" <+> "@" <> p t
-  pretty (IOffset expr idx)   = p expr <+> "+>" <+> p idx
-  pretty (Free (v:>_))        = "free"  <+> p v
-  pretty (Loop d i n block)   = dirStr d <+> p i <+> "<" <+> p n <>
-                                nest 4 (hardline <> p block)
+  pretty (IPrimOp op)            = p op
+  pretty (Load ref)              = "load"  <+> p ref
+  pretty (Store dest val)        = "store" <+> p dest <+> p val
+  pretty (Alloc t s)             = "alloc" <+> p (scalarTableBaseType t) <> "[" <> p s <> "]" <+> "@" <> p t
+  pretty (IOffset expr idx lidx) = p expr <+> "+>" <+> p lidx <+> (parens $ "index:" <+> p idx)
+  pretty (Free (v:>_))           = "free"  <+> p v
+  pretty (Loop d i n block)      = dirStr d <+> p i <+> "<" <+> p n <>
+                                   nest 4 (hardline <> p block)
 
 dirStr :: Direction -> Doc ann
 dirStr Fwd = "for"

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -214,6 +214,9 @@ typeToArrayType :: ScalarTableType -> ArrayType
 typeToArrayType t = case t of
   TabTy (NoName:>n) body -> (indexSetSize n * s, b)
     where (s, b) = typeToArrayType body
+  TabTy v (TabTy (NoName :> TC (IndexRange _ Unlimited (InclusiveLim (Var v')))) (BaseTy b)) | v == v' ->
+    ((n * (n + 1)) `div` 2, b)
+    where n = indexSetSize $ varType v
   TabTy _ _ -> error "Dependent tables not supported yet"
   BaseTy b -> (1, b)
   _ -> error $ "Not a scalar table type: " ++ pprint t

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -285,11 +285,12 @@ typeCheckOp op = case op of
     RefTy h (TabTy v a) <- typeCheck ref
     i |: (varType v)
     return $ RefTy h a
-  ArrayOffset arr off -> do
+  ArrayOffset arr idx off -> do
     -- TODO: b should be applied!!
-    ArrayTy (TabTy _ b) <- typeCheck arr
+    ArrayTy (TabTyAbs a) <- typeCheck arr
     off |: IntTy
-    return $ ArrayTy b
+    idx |: absArgType a
+    return $ ArrayTy $ snd $ applyAbs a idx
   ArrayLoad arr -> do
     ArrayTy (BaseTy b)  <- typeCheck arr
     return $ BaseTy b


### PR DESCRIPTION
Based on the generalization of AFors, we're finally able to support
(structured) ragged arrays, and this is an initial exploration that
hardcodes formulas necessary to handle triangular matrices. An
interesting side effect of having us keep the scalar table type as part
of the array type is that we are now forced to supply to arguments to
both `IOffset` and `ArrayOffset`: one indicating the index value, that
is used to determine the type of the output, while the other one
supplying the linear offset, to be used for evaluation and code
generation.

I think there is an easy option to get rid of the double index in the case of
`ArrayOffset`, although we would have to give up some safety in that the
arrays we would be retrieving from the backends would have no known
length. If we want to keep their length around, we would have to start
returning some extra information e.g. from the LLVM programs, which is
possible as well.