### PR TITLE
Allow implicit, class, and linear lambdas using arrow annotations 

### DIFF
--- a/examples/parser-tests.dx
+++ b/examples/parser-tests.dx
@@ -38,3 +38,41 @@ f = \x. x + 10.
 
 :p f (-1.0)
 > 9.0
+
+'Lambdas can have specific arrow annotations.
+
+lam1 = \n ?-> \x. fromOrdinal n x
+:t lam1
+> ((n:Type) ?-> Int32 -> n)
+
+lam2 = \x --o 2.0 * x
+:t lam2
+> (Float32 --o Float32)
+
+lam3 = \d:(Eq Int) ?=> ()
+:t lam3
+> ((Eq Int32) ?=> Unit)
+
+lam4 = \n m ?-> (0@n, 0@m)
+:t lam4
+> ((n:Type) ?-> (m:Type) ?-> (n & m))
+
+-- Not allowed to write regular lambdas or tables using explicit arrows:
+
+\x -> x + 1.0
+
+> Parse error:62:7:
+>    |
+> 62 | \x -> x + 1.0
+>    |       ^
+> To construct an explicit lambda function, use '.' instead of '->'
+>
+
+\i => i
+
+> Parse error:71:7:
+>    |
+> 71 | \i => i
+>    |       ^
+> To construct a table, use 'for i. body' instead of '\i => body'
+>

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -300,7 +300,11 @@ prettyLamHelper lamExpr lamType = let
         | lamType == PrettyFor dir ->
             let (binders', block) = rec next False
             in (thisOne <> binders', block)
-      _ -> (thisOne <> ".", body')
+      _ -> (thisOne <> punctuation, body')
+        where punctuation = case lamType of
+                PrettyFor _ -> "."
+                PrettyLam PureArrow -> "."
+                PrettyLam arr -> " " <> p arr
   (binders, body) = rec lamExpr True
   in align (group $ nest 4 $ binders) <> (group $ nest 2 $ p body)
 
@@ -513,9 +517,12 @@ instance Pretty UExpr' where pretty = prettyFromPrettyPrec
 instance PrettyPrec UExpr' where
   prettyPrec expr = case expr of
     UVar (v:>_) -> atPrec ArgPrec $ p v
-    ULam binder h body ->
-      atPrec LowestPrec $ align $ "\\" <> annImplicity h (prettyUBinder binder)
-                                      <> "." <+> nest 2 (pLowest body)
+    ULam binder arr body ->
+      atPrec LowestPrec $ align $ "\\" <> prettyUBinder binder
+                                      <> punctuation <+> nest 2 (pLowest body)
+      where punctuation = case arr of
+                            PlainArrow () -> "."
+                            _ -> " " <> p arr
     UApp TabArrow f x -> atPrec AppPrec $ pArg f <> "." <> pArg x
     UApp _        f x -> atPrec AppPrec $ pAppArg (pApp f) [x]
     UFor dir binder body ->
@@ -600,10 +607,6 @@ instance Pretty EffectName where
     Reader -> "Read"
     Writer -> "Accum"
     State  -> "State"
-
-annImplicity :: ArrowP a -> Doc ann -> Doc ann
-annImplicity ImplicitArrow x = braces x
-annImplicity _ x = x
 
 instance Pretty eff => Pretty (ArrowP eff) where
   pretty arr = case arr of


### PR DESCRIPTION
EDIT: Based on discussion below, this PR no longer replaces the `.` for normal explicit lambdas, and does not allow constructing table lambdas; it's still possible to explicitly write `?->`, `?=>`, or `--o`.

---

Lambdas are associated with a particular arrow type, but in the current lexical syntax there is no way to actually write down a lambda with a non-plain arrow (i.e. anything other than `->`). This means that there are things that are definable using `def` that cannot be equivalently defined using a lambda, and in particular binding implicit arrows requires `def`:
```
-- This works:
def asidx (n:Type) ?-> (i:Int) : n = fromOrdinal n i

-- This does not, since `n` can't be bound in a plain-arrow lambda
asidx : (n:Type) ?-> Int -> n = \n i. fromOrdinal n i
```
As discussed with @dougalm (see [this comment](https://github.com/google-research/dex-lang/pull/103#issuecomment-647525748)), it might be useful to add lexical syntax for the other arrow types. One straightforward way to do this is to replace the `.` in normal lambdas with an explicit arrow type, similarly to how lambdas are written in Haskell:
```
asidx : (n:Type) ?-> Int -> n = \n ?-> \i -> fromOrdinal n i
```

All binders within the lambda (i.e. between the `\` and the arrow) share the same arrow type; to change arrow types you need to write the lambda twice.

Most of this PR is just finding and replacing lambdas; it might be useful to look at the individual commits to see the real changes.

Some other notes:

- Arrows in `def` syntax still only apply to the single argument before them, which is different to lambdas. For lambdas, I think it's natural that everything between the `\` and `->` is treated the same way. For `def`s, there isn't a clear beginning or end to the arrows, so I haven't changed anything there. (Perhaps in the future we can modify the `def` syntax to bring it closer to the lambda syntax.)
- `for` syntax still uses a `.`, which might be a bit inconsistent. I suppose this could be changed to a `=>` but `for` blocks are already unambiguous with respect to their arrow type, so it's not really necessary.
- This makes it possible to explicitly write out table lambdas like `\i => ordinal i` in userspace. It's effectively already possible to do this with `def` syntax, though.
- I wonder if it would be possible to infer the arrow type if it wasn't given explicitly? I'm not sure how the type inference logic works, but it seems like there would usually be enough information to infer this at least in some cases. If so, we could allow the `.` suffix instead of requiring users to use an explicit arrow. Or, alternatively, we could make it so that using `.` is simply syntactic sugar for `->` and every other arrow has to be written out. On the other hand, maybe it's better to be explicit and have only one option here?