### PR TITLE
Fix build badge branch name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Dex [![Test status](https://travis-ci.org/google-research/dex-lang.svg?branch=master)](https://travis-ci.org/google-research/dex-lang)
+# Dex [![Test status](https://travis-ci.org/google-research/dex-lang.svg?branch=main)](https://travis-ci.org/google-research/dex-lang)
 Dex (named for "index") is a research language for array processing in the
 Haskell/ML family. The goal of the project is to explore:
 


### PR DESCRIPTION
- The build badge was pointing to a `master` branch instead of the `main` GitHub branch.