### PR TITLE
Make it possible to represent all values of indexSetSize in Algebra

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -106,13 +106,6 @@ evalSumClampPolynomial :: MonadEmbed m => SumClampPolynomial -> Atom -> m Atom
 evalSumClampPolynomial (SumClampPolynomial cp summedVar) a = evalPolynomialP (evalClampMonomial varVal) cp
   where varVal v = if MVar v == sumVar summedVar then a else Var v
 
-evalPolynomial :: MonadEmbed m => Polynomial -> m Atom
-evalPolynomial p = evalPolynomialP (evalMonomial Var) p
-
-evalSumPolynomial :: MonadEmbed m => SumPolynomial -> Atom -> m Atom
-evalSumPolynomial (SumPolynomial p summedVar) a = evalPolynomialP (evalMonomial varVal) p
-  where varVal v = if MVar v == sumVar summedVar then a else Var v
-
 -- We have to be extra careful here, because we're evaluating a polynomial
 -- that we know is guaranteed to return an integral number, but it has rational
 -- coefficients. This is why we have to find the least common multiples and do the
@@ -149,10 +142,6 @@ ipow x i = foldM imul (IntVal 1) (replicate i x)
 
 -- === Polynomial math ===
 
-mul :: Polynomial -> Polynomial -> Polynomial
-mul x y = poly [(cx * cy, mulMono mx my) | (mx, cx) <- toList x, (my, cy) <- toList y]
-  where mulMono = unionWith (+) -- + because monomials store variable powers
-
 mulC :: ClampPolynomial -> ClampPolynomial -> ClampPolynomial
 mulC x y = cpoly [(cx * cy, mulMono mx my) | (mx, cx) <- toList x, (my, cy) <- toList y]
   where mulMono (ClampMonomial cx mx) (ClampMonomial cy my) = ClampMonomial (cx ++ cy) (unionWith (+) mx my)
@@ -168,12 +157,6 @@ sumPolys = unionsWith (+)
 
 mulConst :: Ord mono => Constant -> PolynomialP mono -> PolynomialP mono
 mulConst c p = (*c) <$> p
-
-sum :: Var -> Polynomial -> SumPolynomial
-sum v p = SumPolynomial sp v
-  where
-    sp = sumPolys $ fmap sumMono' $ toList p
-    sumMono' (m, c) = let (SumPolynomial sm _) = sumMono v m in mulConst c sm
 
 -- (Lazy) infinite list of powers of p
 powersL :: (a -> a -> a) -> a -> a -> [a]

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -24,7 +24,7 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               unpackConsList, emitRunWriter, tabGet, SubstEmbedT, runSubstEmbedT,
               TraversalDef, traverseModule, traverseBlock, traverseExpr,
               traverseAtom, arrOffset, arrLoad,
-              sumTag, getLeft, getRight, fromSum,
+              sumTag, getLeft, getRight, fromSum, clampPositive,
               indexSetSizeE, indexToIntE, intToIndexE, anyValue) where
 
 import Control.Applicative
@@ -558,10 +558,12 @@ indexSetSizeE (TC con) = case con of
   SumType l r -> bindM2 iadd (indexSetSizeE l) (indexSetSizeE r)
   _ -> error $ "Not implemented " ++ pprint con
   where
-    clampPositive x = do
-      isNegative <- x `ilt` (IntVal 0)
-      select isNegative (IntVal 0) x
 indexSetSizeE ty = error $ "Not implemented " ++ pprint ty
+
+clampPositive :: MonadEmbed m => Atom -> m Atom
+clampPositive x = do
+  isNegative <- x `ilt` (IntVal 0)
+  select isNegative (IntVal 0) x
 
 -- XXX: Be careful if you use this function as an interpretation for
 --      IndexAsInt instruction, as for Int and IndexRanges it will

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -425,8 +425,7 @@ elemCountE ty = case ty of
 offsetToE :: MonadEmbed m => ScalarTableType -> Atom -> m Atom
 offsetToE ty i = case ty of
   BaseTy _  -> error "Indexing into a scalar!"
-  TabTy (NoName :> _) b -> imul i =<< elemCountE b
-  TabTy _ _             -> A.evalSumPolynomial (A.offsetTo ty) i
+  TabTy _ _ -> A.evalSumClampPolynomial (A.offsets ty) i
   _ -> error $ "Not a scalar table type: " ++ pprint ty
 
 zipWithDest :: Dest -> Atom -> (IExpr -> IExpr -> ImpM ()) -> ImpM ()

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -215,9 +215,7 @@ flattenType ty = error $ "Unexpected type: " ++ show ty
 
 typeToArrayType :: ScalarTableType -> ArrayType
 typeToArrayType t = case t of
-  TabTy (NoName:>n) body -> (indexSetSize n * s, b)
-    where (s, b) = typeToArrayType body
+  BaseTy b  -> (1, b)
   TabTy _ _ -> (size, scalarTableBaseType t)
-    where (IntVal size) = evalEmbed $ A.evalPolynomial (A.elemCount t)
-  BaseTy b -> (1, b)
+    where (IntVal size) = evalEmbed $ A.evalClampPolynomial (A.elemCount t)
   _ -> error $ "Not a scalar table type: " ++ pprint t


### PR DESCRIPTION
This allows us to stop implementing fallbacks for square matrices, and
makes all element count and offset calculations go through the algebraic
simplification engine.