### PR TITLE
Remove duplicate map entries from builtinNames

### DIFF
--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -914,7 +914,6 @@ builtinNames = M.fromList
   , ("fadd", binOp FAdd), ("fsub", binOp FSub)
   , ("fmul", binOp FMul), ("idiv", binOp IDiv)
   , ("pow" , binOp Pow ), ("rem" , binOp Rem )
-  , ("pow" , binOp Pow ), ("rem" , binOp Rem )
   , ("ieq" , binOp (ICmp Equal  )), ("feq", binOp (FCmp Equal  ))
   , ("igt" , binOp (ICmp Greater)), ("fgt", binOp (FCmp Greater))
   , ("and" , binOp And ), ("or"  , binOp Or  ), ("not" , unOp  Not )


### PR DESCRIPTION
I think this line was accidentally duplicated in 53faba5de065fdd1e260b7a6b696d0973ade40c4.