### PR TITLE
Expand Ord type class to include less-than

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -153,6 +153,17 @@ cumsumplus : n=>Real -> n=>Real =
 :p [ 1 >= 2, 1.0 >= 2.0,  2 >= 2, 2.0 >= 2.0, 2 >= 1, 2.0 >= 1.0]
 > [False, False, True, True, True, True]
 
+infty = 1./0.
+:p infty
+> Infinity
+
+nan = 0./0.
+:p nan
+> NaN
+
+:p [ 0. < infty, 0. < nan, infty < 0., nan < 0., nan < nan, infty < infty ]
+> [True, False, False, False, False, False]
+
 N3 = Fin 3
 N4 = Fin 4
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -125,9 +125,9 @@ def MkEq (f: a -> a -> Bool) : Eq a = unsafeNewtypeCon f
 def fromEq (d:Eq a) : a -> a -> Bool = unsafeFromNewtypeCon d
 
 @newtype
-def Ord (a:Type) : Type = (Eq a & a -> a -> Bool)
-def MkOrd (eq:Eq a) -> (gt: a -> a -> Bool) : Ord a = unsafeNewtypeCon (eq, gt)
-def fromOrd (d:Ord a) : (Eq a & a -> a -> Bool) = unsafeFromNewtypeCon d
+def Ord (a:Type) : Type = (Eq a & a -> a -> Bool & a -> a -> Bool)  -- eq, gt, lt
+def MkOrd (eq:Eq a) -> (gt: a -> a -> Bool) -> (lt: a -> a -> Bool) : Ord a = unsafeNewtypeCon (eq, gt, lt)
+def fromOrd (d:Ord a) : (Eq a & a -> a -> Bool & a -> a-> Bool) = unsafeFromNewtypeCon d
 
 @superclass
 def eqFromOrd (d:Ord a) : Eq a = fst (fromOrd d)
@@ -135,30 +135,32 @@ def eqFromOrd (d:Ord a) : Eq a = fst (fromOrd d)
 def (==) (d:Eq a) ?=> (x:a) (y:a) : Bool = (fromEq d) x y
 def (/=) (d:Eq a) ?=> (x:a) (y:a) : Bool = not $ x == y
 
-def (>)  (d:Ord a) ?=> (x:a) (y:a) : Bool = snd (fromOrd d) x y
-def (<=) (d:Ord a) ?=> (x:a) (y:a) : Bool = not $ x>y
-def (<)  (d:Ord a) ?=> (x:a) (y:a) : Bool = not $ x>y || x==y
+def (>)  (d:Ord a) ?=> (x:a) (y:a) : Bool = fst (snd (fromOrd d)) x y
+def (<)  (d:Ord a) ?=> (x:a) (y:a) : Bool = snd (snd (fromOrd d)) x y
+def (<=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x<y || x==y
 def (>=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x>y || x==y
 
 @instance
 intEq : Eq Int = MkEq \x y. %ieq x y
 
 @instance
-intGt : Ord Int = MkOrd intEq \x y. %igt x y
+intOrd : Ord Int = MkOrd intEq (\x y. %igt x y) (\x y. %ilt x y)
 
 @instance
 realEq : Eq Real = MkEq \x y. %feq x y
 
 @instance
-realGt : Ord Real = MkOrd realEq \x y. %fgt x y
+realOrd : Ord Real = MkOrd realEq (\x y. %fgt x y) (\x y. %flt x y)
 
 @instance
 def pairEq (eqA: Eq a)?=> (eqB: Eq b)?=> : Eq (a & b) = MkEq $
   \(x1,x2) (y1,y2). x1 == y1 && x2 == y2
 
 @instance
-def pairGt (ordA: Ord a)?=> (ordB: Ord b)?=> : Ord (a & b) = MkOrd pairEq $
-  \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
+def pairOrd (ordA: Ord a)?=> (ordB: Ord b)?=> : Ord (a & b) =
+  pairGt = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
+  pairLt = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
+  MkOrd pairEq pairGt pairLt
 
 @instance
 def sumEq (eqA: Eq a)?=> (eqB: Eq b)?=> : Eq (a | b) = MkEq $
@@ -208,7 +210,8 @@ def iota (n:Type) : n=>Int = for i. ordinal i
 def finEq (n:Int) ?-> : Eq (Fin n) = MkEq \x y. ordinal x == ordinal y
 
 @instance
-def finOrd (n:Int) ?-> : Ord (Fin n) = MkOrd finEq \x y. ordinal x > ordinal y
+def finOrd (n:Int) ?-> : Ord (Fin n) =
+  MkOrd finEq (\x y. ordinal x > ordinal y) (\x y. ordinal x < ordinal y)
 
 'Misc
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -917,6 +917,7 @@ builtinNames = M.fromList
   , ("pow" , binOp Pow ), ("rem" , binOp Rem )
   , ("ieq" , binOp (ICmp Equal  )), ("feq", binOp (FCmp Equal  ))
   , ("igt" , binOp (ICmp Greater)), ("fgt", binOp (FCmp Greater))
+  , ("ilt" , binOp (ICmp Less)),    ("flt", binOp (FCmp Less))
   , ("and" , binOp And ), ("or"  , binOp Or  ), ("not" , unOp  Not )
   , ("fneg", unOp  FNeg)
   , ("True" , ConExpr $ Lit $ BoolLit True)


### PR DESCRIPTION
- Fixes #121 (mandelbrot.dx).
- Expands the definition of the `Ord` type class to include a third, less-than function.
- Implement the less-than component in `Ord` instances.
- Add `%ilt` and `%flt` built-ins for integer and floating-point less-than operations.
- Add basic comparison tests for floats; some of which would fail under the previous definition of `Ord`.