### PR TITLE
Fix ixsub, which was previously doing addition

### DIFF
--- a/prelude.dx
+++ b/prelude.dx
@@ -202,7 +202,7 @@ def fromOrdinal (n:Type) (i:Int) : n = %asidx n i
 def asidx (n:Type) ?-> (i:Int) : n = fromOrdinal n i
 def (@) (i:Int) (n:Type) : n = fromOrdinal n i
 def ixadd (n:Type) ?-> (i:n) (x:Int) : n = fromOrdinal n $ ordinal i + x
-def ixsub (n:Type) ?-> (i:n) (x:Int) : n = fromOrdinal n $ ordinal i + x
+def ixsub (n:Type) ?-> (i:n) (x:Int) : n = fromOrdinal n $ ordinal i - x
 def iota (n:Type) : n=>Int = for i. ordinal i
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`


### PR DESCRIPTION
`ixsub` was previously adding indices.

I'm not 100% sure how to test this though. Some examples would be really useful.

Initially, I tried this as a test:
```
def identityIx (x:n=>Real) : n=>Real = for i. x.(ixadd (ixsub i 1) 1)

identityIx [0.,1.,2.,3.]
> [0.,1.,2.,3.]  -- what I'd hoped for, not what I got
```
However, because the index value is checked when it is created (ie. when `ixsub` is evaluated), this happens:
```
Index out of bounds. -1 not in [0, 4)
```

Then I thought I had to avoid creating an invalid index (even if it would later become valid before being used), and `select` seemed a likely choice:
```
def shiftRZeroFill (x:n=>Real) : n=>Real = for i. select (ordinal i == 0) 0.0 (x.(ixsub i 1))

:p shiftRZeroFill [5.,6.,7.,8.]
> [0.,5.,6.,7.]  -- what I'd hoped for, not what I got
```
But again:
```
Index out of bounds. -1 not in [0, 4)
```
I guess `select` is evaluating both branches?

I'm a bit stuck thinking about how `ixadd` or `ixsub` could be evaluated at this point, but I'm probably missing something obvious.