### PR TITLE
Preserve source names until LLVM

### DIFF
--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -10,7 +10,7 @@
 module Env (Name (..), Tag, Env (..), NameSpace (..), envLookup, isin, envNames,
             envPairs, envDelete, envSubset, (!), (@>), VarP (..), varAnn, varName,
             envIntersect, varAsEnv, envDiff, envMapMaybe, fmapNames, envAsVars, zipEnv,
-            rawName, nameSpace, rename, renames, nameItems,
+            rawName, nameSpace, nameTag, rename, renames, nameItems,
             renameChoice, tagToStr, isGlobal, asGlobal) where
 
 import Control.Monad
@@ -42,8 +42,8 @@ data NameSpace = GenName | SourceName | JaxIdx | Skolem
 type Tag = T.Text
 data VarP a = (:>) Name a  deriving (Show, Ord, Generic, Functor, Foldable, Traversable)
 
-rawName :: NameSpace -> String -> Name
-rawName s t = Name s (fromString t) 0
+rawName :: NameSpace -> Tag -> Name
+rawName s t = Name s t 0
 
 asGlobal :: Name -> Name
 asGlobal (GlobalName tag) = GlobalName tag
@@ -65,6 +65,12 @@ varName (v:>_) = v
 nameCounter :: Name -> Int
 nameCounter (Name _ _ c) = c
 nameCounter _ = 0
+
+nameTag :: Name -> Tag
+nameTag name = case name of
+  Name _ t _   -> t
+  GlobalName t -> t
+  NoName       -> error "NoName has no tag"
 
 varAsEnv :: VarP a -> Env a
 varAsEnv v = v @> varAnn v

--- a/src/lib/Flops.hs
+++ b/src/lib/Flops.hs
@@ -47,7 +47,6 @@ statementFlops (_, instr) = case instr of
   Loop _ _ size block -> do
     let n = evalSizeExpr size
     local (mulTerm n) $ flops block
-  IWhile _ _    -> return () -- TODO: This is incorrect!
 
 evalSizeExpr :: IExpr -> Term
 evalSizeExpr (ILit (IntLit n)) = litTerm n

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -21,7 +21,6 @@ import Control.Monad.State
 import Control.Monad.Writer
 import Data.Text.Prettyprint.Doc
 import Data.Foldable
-import Data.String
 
 import Embed
 import Array

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -173,7 +173,7 @@ finishBlock term newName = do
 
 compileLoop :: Direction -> IVar -> Operand -> ImpProg -> CompileM ()
 compileLoop d iVar n (ImpProg body) = do
-  let loopName = "loop_" ++ (pprint $ varName iVar)
+  let loopName = "loop_" ++ (showName $ varName iVar)
   loopBlock <- freshName $ fromString $ loopName
   nextBlock <- freshName $ fromString $ "cont_" ++ loopName
   i <- alloca (Scalar IntType)
@@ -445,9 +445,12 @@ externDecl (ExternFunSpec fname retTy retAttrs argTys) =
   }
   where argName i = L.Name $ "arg" <> fromString (show i)
 
+showName :: Name -> String
+showName (Name GenName tag counter) = asStr $ pretty tag <> "." <> pretty counter
+showName _ = error $ "All names in JIT should be from the GenName namespace"
+
 nameToLName :: Name -> L.Name
-nameToLName (Name GenName tag counter) = L.Name (toShort $ pack $ asStr $ pretty tag <> "." <> pretty counter)
-nameToLName _ = error $ "All names in JIT should be from the GenName namespace"
+nameToLName name = L.Name $ toShort $ pack $ showName name
 
 setScalarDecls :: ([NInstr] -> [NInstr]) -> CompileState -> CompileState
 setScalarDecls update s = s { scalarDecls = update (scalarDecls s) }

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -173,8 +173,9 @@ finishBlock term newName = do
 
 compileLoop :: Direction -> IVar -> Operand -> ImpProg -> CompileM ()
 compileLoop d iVar n (ImpProg body) = do
-  loopBlock <- freshName "loop"
-  nextBlock <- freshName "cont"
+  let loopName = "loop_" ++ (pprint $ varName iVar)
+  loopBlock <- freshName $ fromString $ loopName
+  nextBlock <- freshName $ fromString $ "cont_" ++ loopName
   i <- alloca (Scalar IntType)
   i0 <- case d of Fwd -> return $ litInt 0
                   Rev -> n `sub` litInt 1

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -446,7 +446,8 @@ externDecl (ExternFunSpec fname retTy retAttrs argTys) =
   where argName i = L.Name $ "arg" <> fromString (show i)
 
 nameToLName :: Name -> L.Name
-nameToLName v = L.Name (toShort $ pack (pprint v))
+nameToLName (Name GenName tag counter) = L.Name (toShort $ pack $ asStr $ pretty tag <> "." <> pretty counter)
+nameToLName _ = error $ "All names in JIT should be from the GenName namespace"
 
 setScalarDecls :: ([NInstr] -> [NInstr]) -> CompileState -> CompileState
 setScalarDecls update s = s { scalarDecls = update (scalarDecls s) }


### PR DESCRIPTION
This makes it a lot easier to correlate different CFG blocks to loops
appearing in the Imp IR.