### PR TITLE
Allow floating-point math contractions in LLVM

### DIFF
--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -306,7 +306,7 @@ compilePrimOp (ScalarBinOp op x y) = compileBinOp op x y
 compilePrimOp (VectorBinOp op x y) = compileBinOp op x y
 compilePrimOp (ScalarUnOp op x) = case op of
   -- LLVM has "fneg" but it doesn't seem to be exposed by llvm-hs-pure
-  FNeg      -> emitInstr realTy $ L.FSub L.noFastMathFlags (litReal 0.0) x []
+  FNeg      -> emitInstr realTy $ L.FSub mathFlags (litReal 0.0) x []
   Not       -> emitInstr boolTy $ L.Xor x (litInt 1) []
   BoolToInt -> return x -- bools stored as ints
   UnsafeIntToBool -> return x -- bools stored as ints
@@ -332,15 +332,19 @@ compileBinOp op x y = case op of
   IMul   -> emitInstr longTy $ L.Mul False False x y []
   IDiv   -> emitInstr longTy $ L.SDiv False x y []
   Rem    -> emitInstr longTy $ L.SRem x y []
-  FAdd   -> emitInstr realTy $ L.FAdd L.noFastMathFlags x y []
-  FSub   -> emitInstr realTy $ L.FSub L.noFastMathFlags x y []
-  FMul   -> emitInstr realTy $ L.FMul L.noFastMathFlags x y []
-  FDiv   -> emitInstr realTy $ L.FDiv L.noFastMathFlags x y []
+  FAdd   -> emitInstr realTy $ L.FAdd mathFlags x y []
+  FSub   -> emitInstr realTy $ L.FSub mathFlags x y []
+  FMul   -> emitInstr realTy $ L.FMul mathFlags x y []
+  FDiv   -> emitInstr realTy $ L.FDiv mathFlags x y []
   And    -> emitInstr boolTy $ L.And x y []
   Or     -> emitInstr boolTy $ L.Or  x y []
   ICmp c -> emitInstr boolTy (L.ICmp (intCmpOp   c) x y []) >>= extendOneBit
   FCmp c -> emitInstr boolTy (L.FCmp (floatCmpOp c) x y []) >>= extendOneBit
   _ -> error "Not implemented"
+
+-- FP contractions should only lead to fewer rounding points, so we allow those
+mathFlags :: L.FastMathFlags
+mathFlags = L.noFastMathFlags { L.allowContract = True }
 
 floatCmpOp :: CmpOp -> L.FloatingPointPredicate
 floatCmpOp op = case op of


### PR DESCRIPTION
This allows LLVM to use fused multiply-add instructions, which can help
us speed up e.g. matrix multiples that we emit. If I understand
correctly, contractions will reduce the number of places where rounding
has to occur, so we should only be able to accidentally produce more
accurate code?