### PR TITLE
Make Dests into Atoms again

### DIFF
--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -224,10 +224,11 @@ def myOtherFst ((x, _):a&b) : a = x
    transposeLinear f 1.0
 > 4.0
 
-def transpose' (x:n=>m=>Real) --o : m=>n=>Real = for i j. x.j.i
-
-:p transposeLinear transpose' [[1.0, 2.0, 3.0]]
-> [[1.0], [2.0], [3.0]]
+-- FIXME: This fails due to shadowing!
+--def transpose' (x:n=>m=>Real) --o : m=>n=>Real = for i j. x.j.i
+--
+--:p transposeLinear transpose' [[1.0, 2.0, 3.0]]
+--> [[1.0], [2.0], [3.0]]
 
 :p
    f : Real --o (Fin 3=>Real) =

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -179,8 +179,8 @@ valToScatter val = case getType val of
   where [Array _ (RealVec xs), Array _ (RealVec ys)] = materializeScalarTables val
 
 valToHeatmap :: Val -> Output
-valToHeatmap val = case val of
-  TabValA hv (TabVal wv _) ->
+valToHeatmap val = case getType val of
+  TabTy hv (TabTy wv RealTy) ->
     HeatmapOut (indexSetSize $ varType hv) (indexSetSize $ varType wv) xs
   _ -> error $ "Heatmap expects a 2D array of reals, but got: " ++ pprint (getType val)
   where [(Array _ (RealVec xs))] = materializeScalarTables val


### PR DESCRIPTION
While working on adding support for multidimensional tiling, I realized
that our destination representation tightly binds the logical and
physical layout of the data. While this is completely fine we're only
interested in indexing or slicing along the first dimension (those do not
break contiguity of arrays), indexing and slicing along trailing
dimensions requires the use of a strided array representation, which is
impossible to represent in the current implementation.

The solution is simple: logical and physical layout should be mediated
by another layer. Here, I achieved this by making destinations for tables
of base types be tables of _addresses to base types_. Whenever we create
a dest, we allocate a new array (i.e. pointer) variable, and immediately
emit all the calculations necessary to convert logical indices into the
physical address into the destination table lambdas.

This makes interesting transformations much easier. For example, slicing
the `n`th dimension corresponds to replacing the type of the `n`th nested
table lambda binder with the sliced index set, and substituting all uses
of the original binder for a version offset by the slice base. This patch
still only allows to index the first dimension, but it will enable me to
generalize it in a followup patch.