### PR TITLE
Typecheck UIndexRange during type inference

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -293,3 +293,14 @@ newPair2 : NewPairIntReal = mkNewPair (1, 2.0)
 
 :p fst $ fromNewPair newPair
 > 1
+
+
+good_range : Type = (1@Fin 3)..(2@_)
+
+bad_range : Int = (1@Fin 3)..(2@_)
+> Type error:
+> Expected: Int
+>   Actual: Type
+>
+> bad_range : Int = (1@Fin 3)..(2@_)
+>                            ^^

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -131,7 +131,7 @@ checkOrInferRho (WithSrc pos expr) reqTy =
     n <- freshType TyKind
     low'  <- mapM (flip checkRho n) low
     high' <- mapM (flip checkRho n) high
-    return $ TC $ IndexRange n low' high'
+    matchRequirement $ TC $ IndexRange n low' high'
   UHole -> case reqTy of
     Infer -> throw MiscErr "Can't infer type of hole"
     Check ty -> freshType ty


### PR DESCRIPTION
Was reading the type inference logic and noticed that `UIndexRange` is never checked against the annotation:
```
>=> y : Int = (1@Fin 3)..(2@_)

>=> y
1@((Fin 3))...2@((Fin 3))
>=> :t y
Type
```