### PR TITLE
add nix

### DIFF
--- a/.nix/compiler.nix
+++ b/.nix/compiler.nix
@@ -1,0 +1,7 @@
+rec {
+  ghc865 = "ghc865";
+  ghc883 = "ghc883";
+  ghc8101 = "ghc8101";
+
+  default = ghc865;
+}

--- a/.nix/nixpkgs.nix
+++ b/.nix/nixpkgs.nix
@@ -1,0 +1,23 @@
+{ compiler ? (import ./compiler.nix).default
+}:
+
+let
+  llvmOverlay = self: super: {
+    haskell = super.haskell // {
+      packages = super.haskell.packages // {
+        "${compiler}" = super.haskell.packages."${compiler}".override {
+          overrides = hself: hsuper: with super.haskell.lib; {
+            llvm-hs = unmarkBroken (hsuper.llvm-hs_9_0_1.override {
+              llvm-config = self.llvm_9;
+            });
+
+            llvm-hs-pure = hsuper.llvm-hs-pure_9_0_0;
+          };
+        };
+      };
+    };
+  };
+in import ./pinned-nixpkgs.nix {
+  config = {};
+  overlays = [ llvmOverlay ];
+}

--- a/.nix/pinned-nixpkgs.nix
+++ b/.nix/pinned-nixpkgs.nix
@@ -1,0 +1,15 @@
+{ config ? {}
+, overlays ? []
+}:
+
+with {
+  owner = "NixOS";
+  repo = "nixpkgs-channels";
+  rev = "41aa2272feb21b1300b9f99de3f8371a6ddd8986";
+  sha256 = "0qj3x0jcsz3lbia93a06dzvp2psayxxqxly62kjmsywvsm0picby";
+};
+
+import (builtins.fetchTarball {
+  url = "https://github.com/${owner}/${repo}/archive/${rev}.tar.gz";
+  inherit sha256;
+}) { inherit config overlays; }

--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -148,6 +148,6 @@ int testit() {
   return 0;
 }
 
-int main(int argc, const char* argv[]) {
-  testit();
-}
+//int main(int argc, const char* argv[]) {
+//  testit();
+//}

--- a/default.nix
+++ b/default.nix
@@ -1,0 +1,15 @@
+{ compiler ? (import ./.nix/compiler.nix).default
+, pkgs ? import ./.nix/nixpkgs.nix { inherit compiler; }
+}:
+
+rec {
+  inherit pkgs compiler;
+  hsPkgs = pkgs.haskell.packages.${compiler};
+
+  dex = pkgs.haskell.lib.overrideCabal (hsPkgs.callCabal2nix "dex" ./. {
+  }) (old: {
+
+    doCheck = false;
+    doHaddock = false;
+  });
+}

--- a/dex.cabal
+++ b/dex.cabal
@@ -31,9 +31,10 @@ library
                        process, primitive, store
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
-  ghc-options:         cbits/libdex.so
-                       -Wall
+  ghc-options:         -Wall
                        -O0
+  c-sources:           cbits/libdex.c
+
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase
 
@@ -45,8 +46,7 @@ executable dex
   default-language:    Haskell2010
   hs-source-dirs:      src
   -- this is clearly a hack. Can't figure out where else to put it
-  ghc-options:         cbits/libdex.so
-                       -threaded
+  ghc-options:         -threaded
                        -Wall
   default-extensions:  CPP
 
@@ -58,8 +58,7 @@ Test-Suite test-dex
   other-modules:       GenExpr, TestPass
   default-language:    Haskell2010
   hs-source-dirs:      tests
-  ghc-options:         cbits/libdex.so
-                       -Wall
+  ghc-options:         -Wall
 
 -- executable dex2jax.so
 --   main-is:             Dex2Jax.hs

--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,19 @@
+with (import ./default.nix {});
+
+hsPkgs.shellFor {
+  packages = _: [
+    dex
+  ];
+
+  withHoogle = true;
+
+  buildInputs = with pkgs; [
+    cabal-install
+    cabal2nix
+    ghcid
+
+    llvm_9
+    gdb
+    lldb
+  ];
+}


### PR DESCRIPTION
Adds nix, so you can just enter a nix-shell to build with cabal, and also nix-build to build.

Additionally resolves #123 since that made things less annoying and I figured I might as well