### PR TITLE
Use OrcJIT instead of MCJIT

### DIFF
--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -10,8 +10,13 @@
 #include "string.h"
 #include "inttypes.h"
 
-char* malloc_dex(long nbytes) {
-  return malloc(nbytes);
+char* malloc_dex(int64_t nbytes) {
+  // XXX: Changes to this value might require additional changes to parameter attributes in LLVM
+  static const int64_t alignment = 64;
+  // Round nbytes up to the nearest multiple of alignment, as required by the C11 standard.
+  nbytes = ((nbytes + alignment - 1) / alignment) * alignment;
+  char* result = aligned_alloc(alignment, nbytes);
+  return result;
 }
 
 void free_dex(char* ptr) {

--- a/makefile
+++ b/makefile
@@ -43,7 +43,7 @@ build-inotify: cbits/libdex.so
 	$(STACK) build --flag dex:inotify $(PROF)
 
 %.so: %.c
-	gcc -fPIC -shared $^ -o $@
+	gcc -std=c11 -fPIC -shared $^ -o $@
 
 libdex: cbits/libdex.so
 

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -90,8 +90,9 @@ compileTopProg (ImpFunction outVars inVars (ImpProg prog)) = do
 freshParamOpPair :: L.Type -> CompileM (Parameter, Operand)
 freshParamOpPair ty = do
   v <- freshName "arg"
-  -- TODO: align? dereferenceable? nofree?
-  return (L.Parameter ty v [L.NoAlias, L.NoCapture, L.NonNull], L.LocalReference ty v)
+  return (L.Parameter ty v attrs, L.LocalReference ty v)
+  -- TODO: Add nofree once we bump the LLVM version
+  where attrs = [L.NoAlias, L.NoCapture, L.NonNull, L.Alignment 64, L.Dereferenceable 64]
 
 compileProg :: [ImpStatement] -> CompileM ()
 compileProg [] = return ()
@@ -363,7 +364,7 @@ intCmpOp op = case op of
   Equal        -> L.EQ
 
 mallocFun :: ExternFunSpec
-mallocFun  = ExternFunSpec "malloc_dex"    charPtrTy [L.NoAlias] [longTy]
+mallocFun  = ExternFunSpec "malloc_dex" charPtrTy [L.NoAlias] [longTy]
 
 freeFun :: ExternFunSpec
 freeFun = ExternFunSpec "free_dex" L.VoidType [] [charPtrTy]


### PR DESCRIPTION
1. Use OrcJIT instead of MCJIT

llvm-hs doesn't specify the target correctly when using MCJIT making it
emit highly suboptimal assembly (e.g. no AVX2). Moving to the OrcJIT API
fixes this and also offers some other improvements, like making the
linking story more explicit.

2. Make malloc_dex allocate aligned memory

We cast pointers returned by malloc_dex to pointers to vector types,
which might be assumed to have certain alignment properties that regular
`malloc` does not guarantee. This wasn't an issue previously, because
the MCJIT has only emitted SSE code at best, but the more aggressive
optimization of OrcJIT started causing some segfaults due to unaligned
addresses being used in aligned load instructions.

