### PR TITLE
Add benchmarks for pointwise functions

### DIFF
--- a/benchmarks/matmul.py
+++ b/benchmarks/matmul.py
@@ -1,62 +1,17 @@
-# Copyright 2019 Google LLC
+# Copyright 2020 Google LLC
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-import os
-import time
 import sys
-import timeit
-import tempfile
-import subprocess
 
-# Ensure NumPy can only use a single thread for an apples-to-apples comparison
-os.environ["OMP_NUM_THREADS"] = "1"
-os.environ["MKL_NUM_THREADS"] = "1"
-os.environ["OPENBLAS_NUM_THREADS"] = "1"
-
-import numpy as np
+from util import np, bench_python, bench_dex, print_result
 
 n, k, m = map(int, sys.argv[1:])
 x = np.random.randn(n, k).astype(np.float64)
 y = np.random.randn(k, m).astype(np.float64)
 
-x.dot(y) # Warmup
-s = time.perf_counter()
-x.dot(y)
-e = time.perf_counter()
-duration = e - s
-
-loops = max(4, int(2 / duration)) # aim for 2s
-numpy_time = timeit.timeit('x.dot(y)', number=loops, globals=globals()) / loops
-
-def show_time(time_s):
-  if time_s < 1e-1:
-    time_us = time_s * 1e6
-    return "{:.3f}us".format(time_us)
-  else:
-    return "{:.3f}s".format(time_s)
-
-
-with tempfile.NamedTemporaryFile() as f:
-  f.write("""
-n = {}
-k = {}
-m = {}
-loops = {}
-  """.format(n, k, m, loops).encode('ascii'))
-  with open('benchmarks/matmul.dx', 'rb') as src:
-    f.write(src.read())
-  f.flush()
-  dex_result = subprocess.run(['stack', 'exec', 'dex', '--', 'script', '--result-only', f.name],
-                              capture_output=True)
-  dex_output = dex_result.stdout.decode('ascii')
-  try:
-    dex_time = float(dex_output) / loops
-  except:
-    print(dex_output)
-    sys.exit(1)
-
-print('NumPy: {}, Dex: {} (based on {} loops)'.format(
-  show_time(numpy_time), show_time(dex_time), loops))
+numpy_time, loops = bench_python(lambda: x.dot(y))
+dex_time, = bench_dex('matmul.dx', n=n, k=k, m=m, loops=loops)
+print_result('Matrix multiplication', numpy_time, dex_time, loops)

--- a/benchmarks/pointwise.dx
+++ b/benchmarks/pointwise.dx
@@ -1,0 +1,31 @@
+
+-- TODO: Make a generic function for vectorization. Maybe put it in the prelude?
+def add (n : Type) ?-> (a : n=>Real) (b : n=>Real) : n=>Real =
+  (tile (\t:(Tile n (Fin 8 & Fin VectorWidth)).
+          ct = for ti:(Fin 8). loadTile (t ++> ti) a + loadTile (t ++> ti) b
+          for (i,j). indexVector ct.i j)
+        (\i:n. a.i + b.i))
+
+
+def poly (n : Type) ?-> (a : n=>Real) : n=>Real =
+  def p (t : Type) ?-> (_ : VSpace t) ?=> (_ : Mul t) ?=> (x : t) : t =
+    4.0 .* (x * x * x * x) + 3.0 .* (x * x * x) + 2.0 .* (x * x) + x
+  (tile (\t:(Tile n (Fin 8 & Fin VectorWidth)).
+          ct = for ti:(Fin 8). p $ loadTile (t ++> ti) a
+          for (i,j). indexVector ct.i j)
+        (\i:n. p a.i))
+
+--n = 10000
+--loops = 10000
+
+a = for _:(Fin n). 1.0
+b = for _:(Fin n). 1.0
+d = for i:(Fin 1). 0
+
+%time
+e = for _:(Fin loops).
+  (add a b).(UNSAFEFromOrdinal _ d.(UNSAFEFromOrdinal _ 0))
+
+%time
+f = for _:(Fin loops).
+  (poly a).(UNSAFEFromOrdinal _ d.(UNSAFEFromOrdinal _ 0))

--- a/benchmarks/pointwise.py
+++ b/benchmarks/pointwise.py
@@ -1,0 +1,20 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import sys
+
+from util import np, bench_python, bench_dex, print_result
+
+n, = map(int, sys.argv[1:])
+x = np.ones((n,), dtype=np.float64)
+y = np.ones((n,), dtype=np.float64)
+
+np_add_time, add_loops = bench_python(lambda: x + y)
+# Unrolling multiplication with x is a lot faster than using **
+np_poly_time, poly_loops = bench_python(lambda: 4 * x * x * x * x + 3 * x * x * x + 2 * x * x + x)
+dex_add_time, dex_poly_time = bench_dex('pointwise.dx', n=n, loops=add_loops)
+print_result('1D addition', np_add_time, dex_add_time, add_loops)
+print_result('Polynomial evaluation', np_poly_time, dex_poly_time, poly_loops)

--- a/benchmarks/util.py
+++ b/benchmarks/util.py
@@ -1,0 +1,59 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import os
+import time
+import sys
+import timeit
+import tempfile
+import subprocess
+
+# Ensure NumPy can only use a single thread for an apples-to-apples comparison
+os.environ["OMP_NUM_THREADS"] = "1"
+os.environ["MKL_NUM_THREADS"] = "1"
+os.environ["OPENBLAS_NUM_THREADS"] = "1"
+
+import numpy as np
+
+def bench_python(f, loops=None):
+  if loops is None:
+    f()
+    s = time.perf_counter()
+    f()
+    e = time.perf_counter()
+    duration = e - s
+    loops = max(4, int(2 / duration)) # aim for 2s
+  return (timeit.timeit(f, number=loops, globals=globals()) / loops, loops)
+
+
+def bench_dex(file_name, loops, **params):
+  params = dict(params, loops=loops)
+  with tempfile.NamedTemporaryFile() as f:
+    f.write('\n'.join('{} = {}'.format(k, v) for k, v in params.items()).encode('ascii'))
+    with open(os.path.join('benchmarks', file_name), 'rb') as src:
+      f.write(src.read())
+    f.flush()
+    dex_result = subprocess.run(['stack', 'exec', 'dex', '--', 'script', '--result-only', f.name],
+                                capture_output=True)
+    dex_output = dex_result.stdout.decode('ascii')
+    dex_lines = [l for l in dex_output.split('\n') if l]
+    try:
+      return [float(t) / loops for t in dex_lines]
+    except:
+      raise RuntimeError("Unexpected Dex output: " + repr(dex_output))
+
+
+def show_time(time_s):
+  if time_s < 1e-1:
+    time_us = time_s * 1e6
+    return "{:.3f}us".format(time_us)
+  else:
+    return "{:.3f}s".format(time_s)
+
+
+def print_result(bench_name, py_time, dex_time, loops):
+  print('{}:\tNumPy: {}, Dex: {} (based on {} loops)'.format(
+    bench_name, show_time(py_time), show_time(dex_time), loops))

--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -23,10 +23,6 @@ void free_dex(char* ptr) {
   free(ptr);
 }
 
-void memcpy_dex(char* dest, const char* src, long nbytes) {
-  memcpy(dest, src, nbytes);
-}
-
 long int_to_index_set(long i, long n) {
   if (i < 0 || i >= n) {
     printf("Index out of bounds. %ld not in [0, %ld)\n", i, n);

--- a/prelude.dx
+++ b/prelude.dx
@@ -391,11 +391,13 @@ def storeVector (v : VectorReal) : (Fin VectorWidth)=>Real =
 
 def broadcastVector (v : Real) : VectorReal = packVector v v v v
 
-@instance vectorRealAdd : Add (VectorReal) =
+@instance vectorRealAdd : Add VectorReal =
   MkAdd ( \x y. %vfadd x y
         , \x y. %vfsub x y
         , broadcastVector zero )
-@instance vectorRealMul : Mul (VectorReal) = MkMul \x y. %vfmul x y
+@instance vectorRealMul : Mul VectorReal = MkMul \x y. %vfmul x y
+@instance vectorRealVSpace : VSpace VectorReal =
+  MkVSpace vectorRealAdd \x v. broadcastVector x * v
 
 'Tiling
 


### PR DESCRIPTION
Those nicely demonstrates that Dex is also able to get performance
matching the NumPy implementation for simple memory-bandwidth bound
pointwise operations such as vector addition, and greatly exceeds NumPy
performance (~10-20x on my machine) for more complex operations thanks to
loop fusion.