### PR TITLE
Add an experimental LLVM-CUDA backend

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -17,7 +17,7 @@ flag inotify
 
 library
   exposed-modules:     Env, Syntax, Type, Inference, JIT, LLVMExec,
-                       Parser, Util, Imp, PPrint, Array, Algebra,
+                       Parser, Util, Imp, MDImp, PPrint, Array, Algebra,
                        Actor, Cat, Flops, Embed, Serialize,
                        RenderHtml, Plot, LiveOutput, Simplify, TopLevel,
                        Autodiff, JAX, Interpreter, Logging, PipeRPC

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -136,8 +136,11 @@ optionList opts = eitherReader $ \s -> case lookup s opts of
 parseEvalOpts :: Parser EvalConfig
 parseEvalOpts = EvalConfig
   <$> (option
-         (optionList [("LLVM", LLVM), ("JAX", JAX), ("interp", Interp)])
-         (long "backend" <> value LLVM <> help "Backend (LLVM|JAX|interp)"))
+         (optionList [ ("LLVM", LLVM)
+                     , ("LLVM-CUDA", LLVMCUDA)
+                     , ("JAX", JAX)
+                     , ("interp", Interp)])
+         (long "backend" <> value LLVM <> help "Backend (LLVM|LLVM-CUDA|JAX|interp)"))
   <*> (strOption $ long "prelude" <> value "prelude.dx" <> metavar "FILE"
                                   <> help "Prelude file" <> showDefault)
   <*> (optional $ strOption $ long "logto"

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -6,8 +6,8 @@
 
 {-# LANGUAGE OverloadedStrings #-}
 
-module LLVMExec (LLVMFunction (..), callLLVM,
-                 linking_hack) where
+module LLVMExec (LLVMFunction (..), LLVMKernel (..),
+                 callLLVM, compilePTX, linking_hack) where
 
 import qualified LLVM.Analysis as L
 import qualified LLVM.AST as L
@@ -23,6 +23,7 @@ import qualified LLVM.OrcJIT as JIT
 import LLVM.Internal.OrcJIT.CompileLayer as JIT
 import LLVM.Context
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
+import System.IO.Unsafe
 
 import Foreign.Marshal.Alloc
 import Foreign.Ptr
@@ -41,8 +42,30 @@ foreign import ccall "threefry2x32"  linking_hack :: Int -> Int -> Int
 foreign import ccall "dynamic"
   callFunPtr :: FunPtr (Ptr () -> IO ()) -> Ptr () -> IO ()
 
--- First element holds the number of outputs
-data LLVMFunction = LLVMFunction Int L.Module
+type NumOutputs   = Int
+data LLVMFunction = LLVMFunction NumOutputs L.Module
+data LLVMKernel   = LLVMKernel L.Module
+
+compilePTX :: Logger [Output] -> LLVMKernel -> IO PTXKernel
+compilePTX logger (LLVMKernel ast) = do
+  T.initializeAllTargets
+  withContext $ \c ->
+    Mod.withModuleFromAST c ast $ \m -> do
+      (tripleTarget, _) <- T.lookupTarget Nothing ptxTargetTriple
+      T.withTargetOptions $ \topt ->
+        T.withTargetMachine
+          tripleTarget
+          ptxTargetTriple
+          "sm_60"
+          (M.singleton (T.CPUFeature "ptx64") True)
+          topt
+          R.Default
+          CM.Default
+          CGO.Aggressive $ \tm -> do
+            compileModule logger tm m
+            PTXKernel . unpack <$> Mod.moduleTargetAssembly tm m
+  where
+    ptxTargetTriple = "nvptx64-nvidia-cuda"
 
 callLLVM :: Logger [Output] -> LLVMFunction -> [Ptr ()] -> IO [Ptr ()]
 callLLVM logger (LLVMFunction numOutputs ast) inArrays = do
@@ -72,11 +95,7 @@ evalLLVM logger ast argPtr = do
       -- TODO: Consider changing the linking layer, as suggested in:
       --       http://llvm.1065342.n5.nabble.com/llvm-dev-ORC-JIT-Weekly-5-td135203.html
       T.withHostTargetMachine R.PIC CM.Large CGO.Aggressive $ \tm -> do
-        showModule    m >>= logPass logger JitPass
-        L.verify      m
-        runPasses  tm m
-        showModule    m >>= logPass logger LLVMOpt
-        showAsm    tm m >>= logPass logger AsmPass
+        compileModule logger tm m
         JIT.withExecutionSession $ \exe ->
           JIT.withObjectLinkingLayer exe (\k -> (M.! k) <$> readIORef resolvers) $ \linkLayer ->
             JIT.withIRCompileLayer linkLayer tm $ \compileLayer -> do
@@ -109,6 +128,14 @@ evalLLVM logger ast argPtr = do
                     , JIT.jitSymbolFlags = JIT.defaultJITSymbolFlags { JIT.jitSymbolExported = True, JIT.jitSymbolAbsolute = True }
                     }
 
+compileModule :: Logger [Output] -> T.TargetMachine -> Mod.Module -> IO ()
+compileModule logger tm m = do
+  showModule    m >>= logPass logger JitPass
+  L.verify      m
+  runPasses  tm m
+  showModule    m >>= logPass logger LLVMOpt
+  showAsm    tm m >>= logPass logger AsmPass
+
 logPass :: Logger [Output] -> PassName -> String -> IO ()
 logPass logger passName s = logThis logger [PassInfo passName s]
 
@@ -136,3 +163,6 @@ showAsm t m = do
 
 passes :: P.PassSetSpec
 passes = P.defaultCuratedPassSetSpec {P.optLevel = Just 3}
+
+instance Show LLVMKernel where
+  show (LLVMKernel ast) = unsafePerformIO $ withContext $ \c -> Mod.withModuleFromAST c ast showModule

--- a/src/lib/MDImp.hs
+++ b/src/lib/MDImp.hs
@@ -1,0 +1,38 @@
+-- Copyright 2020 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+
+module MDImp (impToMDImp) where
+
+import Env
+import Syntax
+import PPrint
+
+impToMDImp :: ImpFunction -> MDImpFunction ImpKernel
+impToMDImp (ImpFunction dests args prog) = MDImpFunction dests args $ progToMD prog
+
+progToMD :: ImpProg -> MDImpProg ImpKernel
+progToMD (ImpProg stmts) = MDImpProg $ fmap (\(b, instr) -> MDImpStatement (b, instrToMD instr)) stmts
+
+-- TODO: Collapse loops, hoist allocations, etc.
+instrToMD :: ImpInstr -> MDImpInstr ImpKernel
+instrToMD instr = case instr of
+  Alloc t s      -> MDAlloc t s
+  Free v         -> MDFree v
+  IPrimOp op     -> MDPrimOp op
+  -- XXX: This is super unsafe! We have no guarantee that different iterations won't race!
+  --      Now that Imp is not necessarily the last stop before codegen, we should make it
+  --      emit some extra loop tags to ensure that transforms like this one are safe!
+  Loop Fwd v s p -> MDLaunch s args $ ImpKernel args v p
+    where args = envAsVars $ (freeIVars p `envDiff` (v @> ()))
+  Load _         -> notAllowed
+  Store _ _      -> notAllowed
+  IOffset _ _ _  -> notAllowed
+  IWhile _ _     -> notAllowed -- TODO: Allow while loops? Those are not paralellizable anyway.
+  Loop _ _ _ _   -> notAllowed
+  where notAllowed = error $ "Not allowed in multi-device program: " ++ pprint instr


### PR DESCRIPTION
This is the first of a series of patches that add a GPU backend for Dex.
For now, we assume that the outer loop in every program is parallel, and
distribute its iterations over GPU threads. Programs with nested loops
might not work too well just yet and might require flattening them into
a single loop over tuple index sets.

The backend itself does not work yet, but it is capable of converting a
sequential Imp program into a multi-device Imp IR where kernel launches
are explicit. It is also able to generate valid LLVM NVPTX IR and
compile it down to PTX assembly.