### PR TITLE
Complete the prototype of the LLVM-CUDA backend

### DIFF
--- a/cbits/libdex.c
+++ b/cbits/libdex.c
@@ -148,3 +148,19 @@ int testit() {
 int main(int argc, const char* argv[]) {
   testit();
 }
+
+#ifdef DEX_CUDA
+#include <cuda.h>
+
+void check_result(const char *msg, int result) {
+  if (result != 0) {
+    printf("CUDA API error at %s: %d\n", msg, result);
+  }
+}
+
+void* load_cuda_array(void* device_ptr, int64_t bytes) {
+  void* host_ptr = malloc_dex(bytes);
+  check_result("cuMemcpyDtoH", cuMemcpyDtoH(host_ptr, (CUdeviceptr)device_ptr, bytes));
+  return host_ptr;
+}
+#endif

--- a/dex.cabal
+++ b/dex.cabal
@@ -15,12 +15,16 @@ flag inotify
   description:         Uses inotify to watch for source changes
   default:             False
 
+flag cuda
+  description:         Enables building with CUDA support
+  default:             False
+
 library
   exposed-modules:     Env, Syntax, Type, Inference, JIT, LLVMExec,
                        Parser, Util, Imp, MDImp, PPrint, Array, Algebra,
                        Actor, Cat, Flops, Embed, Serialize,
                        RenderHtml, Plot, LiveOutput, Simplify, TopLevel,
-                       Autodiff, JAX, Interpreter, Logging, PipeRPC
+                       Autodiff, JAX, Interpreter, Logging, PipeRPC, CUDA
   build-depends:       base, containers, mtl, binary, bytestring,
                        time, tf-random, llvm-hs-pure ==9.*, llvm-hs ==9.*,
                        aeson, megaparsec, warp, wai,
@@ -36,6 +40,8 @@ library
                        -O0
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase
+  if flag(cuda)
+    cpp-options: -DDEX_CUDA
 
 executable dex
   main-is:             dex.hs

--- a/makefile
+++ b/makefile
@@ -31,19 +31,25 @@ all: build
 tc:
 	$(STACK) build --ghc-options -fno-code
 
-build: cbits/libdex.so
+build: libdex
 	$(STACK) build
 
-build-prof: cbits/libdex.so
+build-prof: libdex
 	$(STACK) build $(PROF)
+
+build-cuda: libdex-cuda
+	$(STACK) build --flag dex:cuda
 
 all-inotify: build-inotify
 
-build-inotify: cbits/libdex.so
+build-inotify: libdex
 	$(STACK) build --flag dex:inotify $(PROF)
 
 %.so: %.c
 	gcc -std=c11 -fPIC -shared $^ -o $@
+
+libdex-cuda: cbits/libdex.c
+	gcc -std=c11 -DDEX_CUDA -fPIC -shared cbits/libdex.c -I/usr/local/cuda/include -lcuda -o cbits/libdex.so
 
 libdex: cbits/libdex.so
 

--- a/src/lib/CUDA.hs
+++ b/src/lib/CUDA.hs
@@ -1,0 +1,21 @@
+
+module CUDA (hasCUDA, loadCUDAArray) where
+
+import Data.Int
+import Foreign.Ptr
+
+hasCUDA :: Bool
+
+#ifdef DEX_CUDA
+foreign import ccall "load_cuda_array"  loadCUDAArrayImpl :: Ptr () -> Int64 -> IO (Ptr ())
+
+hasCUDA = True
+#else
+loadCUDAArrayImpl :: Ptr () -> Int64 -> IO (Ptr ())
+loadCUDAArrayImpl _ _ = error "Dex built without CUDA support"
+
+hasCUDA = False
+#endif
+
+loadCUDAArray :: Ptr () -> Int -> IO (Ptr ())
+loadCUDAArray ptr bytes = loadCUDAArrayImpl ptr (fromIntegral bytes)

--- a/src/lib/MDImp.hs
+++ b/src/lib/MDImp.hs
@@ -17,7 +17,7 @@ impToMDImp :: ImpFunction -> MDImpFunction ImpKernel
 impToMDImp (ImpFunction dests args prog) = MDImpFunction dests args $ progToMD prog
 
 progToMD :: ImpProg -> MDImpProg ImpKernel
-progToMD (ImpProg stmts) = MDImpProg $ fmap (\(b, instr) -> MDImpStatement (b, instrToMD instr)) stmts
+progToMD (ImpProg stmts) = MDImpProg $ fmap (\(b, instr) -> (b, instrToMD instr)) stmts
 
 -- TODO: Collapse loops, hoist allocations, etc.
 instrToMD :: ImpInstr -> MDImpInstr ImpKernel

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -24,10 +24,10 @@ module Syntax (
     PrimHof (..), LamExpr, PiType, WithSrc (..), srcPos, LetAnn (..),
     BinOp (..), UnOp (..), CmpOp (..), SourceBlock (..),
     ReachedEOF, SourceBlock' (..), SubstEnv, Scope, CmdName (..),
-    Val, TopEnv, Op, Con, Hof, TC, Module (..), ImpFunction (..),
+    Val, TopEnv, Op, Con, Hof, TC, Module (..), ImpFunction (..), Statement,
     ImpProg (..), ImpStatement, ImpInstr (..), IExpr (..), IVal, IPrimOp,
     IVar, IType (..), ArrayType, SetVal (..), MonMap (..), LitProg,
-    MDImpFunction (..), MDImpProg (..), MDImpStatement (..), MDImpInstr (..),
+    MDImpFunction (..), MDImpProg (..), MDImpInstr (..), MDImpStatement,
     ImpKernel (..), PTXKernel (..), HasIVars (..), IScope,
     ScalarTableType, ScalarTableVar, BinderInfo (..),Bindings,
     SrcCtx, Result (..), Output (..), OutFormat (..), DataFormat (..),
@@ -362,6 +362,7 @@ data ImpFunction = ImpFunction [ScalarTableVar] [ScalarTableVar] ImpProg  -- des
                    deriving (Show, Eq)
 newtype ImpProg = ImpProg [ImpStatement]
                   deriving (Show, Eq, Generic, Semigroup, Monoid)
+type Statement instr = (Maybe IVar, instr)
 type ImpStatement = (Maybe IVar, ImpInstr)
 
 data ImpInstr = Load  IExpr
@@ -396,8 +397,7 @@ data MDImpFunction k = MDImpFunction [ScalarTableVar] [ScalarTableVar] (MDImpPro
                        deriving (Show, Eq, Functor, Foldable, Traversable)
 data MDImpProg k = MDImpProg [MDImpStatement k]
                    deriving (Show, Eq, Functor, Foldable, Traversable)
-newtype MDImpStatement k = MDImpStatement (Maybe IVar, MDImpInstr k)
-                           deriving (Show, Eq, Functor, Foldable, Traversable)
+type MDImpStatement k = Statement (MDImpInstr k)
 
 -- NB: No loads/stores since we're dealing with device pointers.
 --     No loops, because loops are kernels!

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -11,7 +11,7 @@ module Util (group, ungroup, pad, padLeft, delIdx, replaceIdx,
              composeN, mapMaybe, lookup, uncons, repeated,
              showErr, listDiff, splitMap, enumerate, restructure,
              onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3,
-             bindM2, foldMapM) where
+             bindM2, foldMapM, (...)) where
 
 import Data.List (sort)
 import Prelude hiding (lookup)
@@ -196,6 +196,9 @@ bindM2 f ma mb = do
   a <- ma
   b <- mb
   f a b
+
+(...) :: (c -> d) -> (a -> b -> c) -> a -> b -> d
+f ... g = \x y -> f $ g x y
 
 foldMapM :: (Monad m, Monoid w, Foldable t) => (a -> m w) -> t a -> m w
 foldMapM f xs = foldM (\acc x -> (acc<>) <$> f x ) mempty xs


### PR DESCRIPTION
This is the second half of the previous patch, which extends the LLVM
code generator to allow it to generate host code to dispatch CUDA
kernels. So far it's not been tested very thoroughly, so it's likely
that there are many rough edges and problems to be found, but I've
verified that it should be able to execute some simple pointwise maps.