### PR TITLE
Add reduce to prelude and express some parallel ops in terms of it

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -6,12 +6,12 @@
    double 10.0
 > 20.0
 
-:p isum (iota (Fin 10))
+:p sum (iota (Fin 10))
 > 45
 
 :p
    x = iota (Fin 10)
-   isum (for i. x.i)
+   sum (for i. x.i)
 > 45
 
 :p
@@ -40,7 +40,7 @@ arr = iota NArr
 :p for i:NArr. (iota _).i + (iota _).i
 > [0, 2, 4, 6, 8, 10, 12]
 
-:p isum for i:NArr. 1
+:p sum for i:NArr. 1
 > 7
 
 fun = \y. sum (map i2r arr) + y
@@ -187,7 +187,7 @@ N4 = Fin 4
 
 mat = for i:N3 j:N4. (iota _).i + (10 * (iota _).j)
 
--- :p isum for (i,j). mat.i.j
+-- :p sum for (i,j). mat.i.j
 -- > 192
 
 litArr = [10, 5, 3]
@@ -574,7 +574,7 @@ def cmpEither (x:Int|Int) (y:Int|Int) : Bool = x == y
 > False
 
 -- TODO: within-module version of this (currently fails in Imp checking)
-upperBound = isum $ for i:(Fin 4). 1
+upperBound = sum $ for i:(Fin 4). 1
 :p for j:(Fin upperBound). 1.0
 > [1.0, 1.0, 1.0, 1.0]
 

--- a/examples/interp-tests.dx
+++ b/examples/interp-tests.dx
@@ -11,7 +11,7 @@ xs = for i. _, N = unpack range (asint i)
             pack x, N, E n. n=>Int
 
 for i. x, N2 = unpack xs.i  -- TODO: underscore type binder
-       isum x
+       sum x
 > [0, 0, 1, 3]
 
 :p filter (lam x. x > 2.0) [4.0, 0.0, 10.0, 2.0]

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -57,13 +57,13 @@ help make the errors more local.
 
 :t
    x = iota (Fin 10)
-   isum x
+   sum x
 > Int
 
 :t
    x = iota (Fin 10)
    y = iota (Fin 3)
-   i2r (isum for i. x.i) + i2r (isum for j. y.j)
+   i2r (sum for i. x.i) + i2r (sum for j. y.j)
 > Real
 
 :t

--- a/prelude.dx
+++ b/prelude.dx
@@ -260,7 +260,7 @@ def reduce (identity:a) (binop:(a->a->a)) (xs:n=>a) : a =
   -- `binop` should be a commutative and associative, and form a
   -- commutative monoid with `identity`
   -- TODO: implement with a parallelizable monoid-parameterized writer
-  fold identity (\i c. body c xs.i)
+  fold identity (\i c. binop c xs.i)
 
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)

--- a/prelude.dx
+++ b/prelude.dx
@@ -256,16 +256,24 @@ def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
     y
 
 def fold (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
+def reduce (identity:a) (binop:(a->a->a)) (xs:n=>a) : a =
+  -- `binop` should be a commutative and associative, and form a
+  -- commutative monoid with `identity`
+  -- TODO: implement with a parallelizable monoid-parameterized writer
+  fold identity (\i c. body c xs.i)
+
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
 def fsum (xs:n->Real) : Real = snd $ withAccum \ref. for i. ref += xs i
-def sum  (xs:n=>Real) : Real = snd $ withAccum \ref. for i. ref += xs.i
-def isum (xs:n=>Int) : Int = fold 0 \i c. c + xs.i
+def sum  (_: Add v) ?=> (xs:n=>v) : v = reduce zero (+) xs
+-- TODO: Add 'one' to Mul typeclass when adts branch is merged, then add prod
+-- def prod (_: Mul v) ?=> (xs:n=>v) : v = reduce one  (*) xs
 def mean (n:Type) ?-> (xs:n=>Real) : Real = sum xs / i2r (size n)
 def std (xs:n=>Real) : Real = sqrt $ mean (map sq xs) - sq (mean xs)
-def any (xs:n=>Bool) : Bool = fold False \i c. c || xs.i
-def all (xs:n=>Bool) : Bool = fold True  \i c. c && xs.i
+def any (xs:n=>Bool) : Bool = reduce False (||) xs
+def all (xs:n=>Bool) : Bool = reduce True  (&&) xs
+
 
 def applyN (n:Int) (x:a) (f:a -> a) : a =
   snd $ withState x \ref. for _:(Fin n).
@@ -322,23 +330,31 @@ def bern (p:Real) (k:Key) : Bool = rand k < p
 def randnVec (n:Type) ?-> (k:Key) : n=>Real =
   for i. randn (ixkey k i)
 
-'min / max etc  (TODO: implement with a monoid-parameterized writer)
+'min / max etc
 
-def minBy (f:a->Real) (x:a) (y:a) : a = select ((f x) < (f y)) x y
-def maxBy (f:a->Real) : a -> a -> a = minBy (neg `compose` f)
+def minBy (_:Ord o) ?=> (f:a->o) (x:a) (y:a) : a =
+  select ((f x) < (f y)) x y
+def maxBy (_:Ord o) ?=> (f:a->o) (x:a) (y:a) : a =
+  select ((f x) > (f y)) x y
 
-min : Real -> Real -> Real = minBy id
-max : Real -> Real -> Real = maxBy id
+def min (_:Ord o) ?=> (x1: o) -> (x2: o) : o = minBy id x1 x2
+def max (_:Ord o) ?=> (x1: o) -> (x2: o) : o = maxBy id x1 x2
 
-def minimumBy (f:a->Real) (xs:n=>a) : a = fold xs.(fromOrdinal _ 0) (\i. minBy f xs.i)
-def maximumBy (f:a->Real) (xs:n=>a) : a = minimumBy (neg `compose` f) xs
+def minimumBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : a =
+  reduce xs.(0@_) (minBy f) xs
+def maximumBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : a =
+  reduce xs.(0@_) (maxBy f) xs
 
-def minimum (xs:n=>Real) : Real = minimumBy id xs
-def maximum (xs:n=>Real) : Real = maximumBy id xs
+def minimum (_:Ord o) ?=> (xs:n=>o) : o = minimumBy id xs
+def maximum (_:Ord o) ?=> (xs:n=>o) : o = maximumBy id xs
 
-def argmin (xs:n=>Real) : n =
-  fst $ fold (fromOrdinal _ 0, xs.(fromOrdinal _ 0)) \i (bestIx, bestDist).
-    select (xs.i < bestDist) (i, xs.i) (bestIx, bestDist)
+def argmin (_:Ord o) ?=> (xs:n=>o) : n =
+  zeroth = (0@_, xs.(0@_))
+  compare = \(idx1, x1) (idx2, x2).
+    select (x1 < x2) (idx1, x1) (idx2, x2)
+  zipped = for i. (i, xs.i)
+  fst $ reduce zeroth compare zipped
+
 
 'Automatic differentiation
 


### PR DESCRIPTION
Previously, ```min```, ```max```, ```any```, ```all```, and one of the three flavors of ```sum``` were written in terms of ```fold```.   This PR introduces an orderless ```reduce``` function to the prelude, and writes all the above functions in terms of it.  The current implementation of ```reduce``` simply calls ```fold``` internally, but should be replaced down the road by a suitably general parallelizable monoid-parameterized writer.

Note that this ```reduce``` function has a different type than ```fold``:
```
def fold   (init:a)     (body: (n->a->a))           : a = ...
def reduce (identity:a) (binop:(a->a->a)) (xs:n=>a) : a = ...
```
Reduce is meant to only operate on commutative functions, so the order of ```xs``` should never matter.  This definition of ```reduce``` seems like a minor point of departure from Haskell and Python, which seem to only provide order-sensitive variants.  However I think the orderless definition of ```reduce``` more closely matches the academic literature, in particular the MapReduce framework.

This PR also replaces two of the flavors of ```sum``` with a general version that works on any instance of the ```Add``` typeclass.  I left ```fsum``` as is for now because I didn't want to interfere with the parallelization and flop tests, but presumably ```fsum``` can be unified with ```sum``` down the road.  However, this change causes one autodiff test to fail that I don't know how to fix: ```ad-tests.dx``` gives ```src/lib/Autodiff.hs:(137,24)-(152,32): Non-exhaustive patterns in case```.

Finally, this PR generalizes all the ```max``` and ```min``` variants to general ```Ord``` typeclasses.