### PR TITLE
Add precedence and smart indentation to pretty printer

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -595,7 +595,7 @@ for i:(Fin 4).
 > (2, [(2, 5), (2, 5), (2, 5), (2, 5)])
 
 for i:(Range 4 1). 1.0
-> []@4...<1
+> []@(%IntRange 4 1)
 
 x = 2 - 4
 for i:(Range 0 x). 1.0
@@ -603,7 +603,7 @@ for i:(Range 0 x). 1.0
 
 -- Make sure that we can construct and print an array using a pair index set
 for i:(Fin 2 & Fin 2). 1.0
-> [1.0, 1.0, 1.0, 1.0]@((Fin 2) & (Fin 2))
+> [1.0, 1.0, 1.0, 1.0]@(Fin 2 & Fin 2)
 
 1@(Fin 2 & Fin 2)
 > (0@(Fin 2), 1@(Fin 2))
@@ -612,11 +612,11 @@ for i:(Fin 5). for j:(..i).
   ir = i2r $ ordinal i
   jr = i2r $ ordinal j
   ir * (ir + 1.0) / 2.0 + jr
-> [ [0.0]@...0@((Fin 5))
-> , [1.0, 2.0]@...1@((Fin 5))
-> , [3.0, 4.0, 5.0]@...2@((Fin 5))
-> , [6.0, 7.0, 8.0, 9.0]@...3@((Fin 5))
-> , [10.0, 11.0, 12.0, 13.0, 14.0]@...4@((Fin 5)) ]
+> [ [0.0]@(..(0@Fin 5))
+> , [1.0, 2.0]@(..(1@Fin 5))
+> , [3.0, 4.0, 5.0]@(..(2@Fin 5))
+> , [6.0, 7.0, 8.0, 9.0]@(..(3@Fin 5))
+> , [10.0, 11.0, 12.0, 13.0, 14.0]@(..(4@Fin 5)) ]
 
 -- TODO: fix!
 -- -- Exercise the use of free variables in the sum solver

--- a/examples/parser-tests.dx
+++ b/examples/parser-tests.dx
@@ -30,7 +30,7 @@ f = \x. x + 10.
 
 :p f -1.0   -- parses as (-) f (-1.0)
 > Type error:
-> Expected: (Real->Real)
+> Expected: (Real -> Real)
 >   Actual: Real
 >
 > :p f -1.0   -- parses as (-) f (-1.0)

--- a/examples/serialize-tests.dx
+++ b/examples/serialize-tests.dx
@@ -25,7 +25,7 @@
 > Int
 
 :p Fin 10
-> (Fin 10)
+> Fin 10
 
 :p Fin 10 & Fin 20
-> ((Fin 10) & (Fin 20))
+> Fin 10 & Fin 20

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -84,7 +84,7 @@ arr  = iota Narr
 xr = map i2r arr
 
 :t arr
-> ((Fin 10)=>Int)
+> ((Fin 10) => Int)
 
 :t (\(x, y). x + y) (1.0, 2.0)
 > Real
@@ -96,7 +96,7 @@ xr = map i2r arr
 > Real
 
 :t [1, 2, 3]
-> ((Fin 3)=>Int)
+> ((Fin 3) => Int)
 
 :t []
 > Type error:Empty table constructor must have type annotation
@@ -107,18 +107,18 @@ xr = map i2r arr
 :t [1, [2]]
 > Type error:
 > Expected: Int
->   Actual: ((Fin 1)=>Int)
+>   Actual: ((Fin 1) => Int)
 >
 > :t [1, [2]]
 >        ^^^
 
 :t [[1, 2], [3, 4]]
-> ((Fin 2)=>((Fin 2)=>Int))
+> ((Fin 2) => (Fin 2) => Int)
 
 :t [[1, 2], [3]]
 > Type error:
-> Expected: ((Fin 2)=>Int)
->   Actual: ((Fin 1)=>Int)
+> Expected: ((Fin 2) => Int)
+>   Actual: ((Fin 1) => Int)
 >
 > :t [[1, 2], [3]]
 >             ^^^
@@ -212,7 +212,7 @@ fEff : Unit -> {| a} a = todo
 g : a -> a = \x. x
 
 :t g
-> (a:Type?->(a->a))
+> ((a:Type) ?-> a -> a)
 
 :t
   f = \x:Int. x
@@ -232,7 +232,7 @@ g : a -> a = \x. x
 g1 : (a -> Int) -> (a -> Int) = \x. x
 
 :t g1
-> (a:Type?->((a->Int)->(a->Int)))
+> ((a:Type) ?-> (a -> Int) -> a -> Int)
 
 g2 : a -> a = \x. idiv x x
 > Type error:
@@ -245,7 +245,7 @@ g2 : a -> a = \x. idiv x x
 h : (a -> b) -> (a -> b) = \x. x
 
 :t h
-> (a:Type?->(a1:Type?->((a->a1)->(a->a1))))
+> ((a:Type) ?-> (a1:Type) ?-> (a -> a1) -> a -> a1)
 
 fun : a -> a = \x. sin x
 > Type error:
@@ -266,7 +266,7 @@ newPair : NewPair Int Real = mkNewPair (1, 2.0)
 :p fst newPair
 > Type error:
 > Expected: (a & b)
->   Actual: NewPair Int Real
+>   Actual: (NewPair Int Real)
 > (Solving for: [a:Type, b:Type])
 >
 > :p fst newPair

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -811,5 +811,8 @@ makeEntryPoint wrapperName argTypes f = runCompile mempty $ do
 instance Pretty L.Operand where
   pretty x = pretty (show x)
 
+instance PrettyPrec L.Operand where
+  prettyPrec = atPrec AppPrec . pretty 
+
 instance Pretty L.Type where
   pretty x = pretty (show x)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -10,7 +10,8 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module PPrint (pprint, pprintList, printLitBlock, asStr,
-               assertEq, ignoreExcept) where
+               assertEq, ignoreExcept, PrecedenceLevel(..), DocPrec,
+               PrettyPrec(..), atPrec) where
 
 import Control.Monad.Except hiding (Except)
 import GHC.Float
@@ -24,6 +25,25 @@ import Env
 import Array
 import Syntax
 
+-- Specifies what kinds of operations are allowed to be printed at this point.
+-- Printing at AppPrec level means that applications can be printed
+-- with no parentheses, but binops must be parenthesized. 
+data PrecedenceLevel  = BinOpPrec
+                      | AppPrec 
+                      | ArgPrec  -- Only single symbols and parens allowed
+                      deriving (Eq, Ord)
+
+type DocPrec ann = PrecedenceLevel -> Doc ann
+
+class PrettyPrec a where
+  prettyPrec :: a -> DocPrec ann
+
+-- `atPrec prec doc` will ensure that the precedence level is at most
+-- `prec` when running `doc`, wrapping with parentheses if needed.
+atPrec :: PrecedenceLevel -> Doc ann -> DocPrec ann
+atPrec prec doc requestedPrec =
+  if requestedPrec > prec then parens (align doc) else doc
+
 pprint :: Pretty a => a -> String
 pprint x = asStr $ pretty x
 
@@ -35,6 +55,19 @@ asStr doc = unpack $ renderStrict $ layoutPretty defaultLayoutOptions $ doc
 
 p :: Pretty a => a -> Doc ann
 p = pretty
+
+pBinOp :: PrettyPrec a => a -> Doc ann
+pBinOp a = prettyPrec a BinOpPrec
+
+pArg :: PrettyPrec a => a -> Doc ann
+pArg a = prettyPrec a ArgPrec
+
+pApp :: PrettyPrec a => a -> Doc ann
+pApp a = prettyPrec a AppPrec
+
+prettyFromPrettyPrec :: PrettyPrec a => a -> Doc ann
+prettyFromPrettyPrec = pArg
+
 
 instance Pretty Err where
   pretty (Err e _ s) = p e <> p s
@@ -61,13 +94,15 @@ instance Pretty ErrType where
 instance Pretty TyQual where
   pretty (TyQual v c) = p c <+> p v
 
-instance Pretty BaseType where
-  pretty b = case b of
-    Scalar sb -> pretty sb
-    Vector sb -> "<" <> p vectorWidth <+> "x" <+> p sb <> ">"
+instance Pretty BaseType where pretty = prettyFromPrettyPrec
+instance PrettyPrec BaseType where
+  prettyPrec b = case b of
+    Scalar sb -> prettyPrec sb
+    Vector sb -> atPrec ArgPrec $ "<" <> p vectorWidth <+> "x" <+> p sb <> ">"
 
-instance Pretty ScalarBaseType where
-  pretty sb = case sb of
+instance Pretty ScalarBaseType where pretty = prettyFromPrettyPrec
+instance PrettyPrec ScalarBaseType where
+  prettyPrec sb = atPrec ArgPrec $ case sb of
     IntType  -> "Int"
     BoolType -> "Bool"
     RealType -> "Real"
@@ -76,96 +111,108 @@ instance Pretty ScalarBaseType where
 printDouble :: Double -> Doc ann
 printDouble x = p (double2Float x)
 
-instance Pretty LitVal where
-  pretty (IntLit  x) = p x
-  pretty (RealLit x) = printDouble x
-  pretty (StrLit  x) = p x
-  pretty (VecLit  l) = encloseSep "<" ">" ", " $ fmap p l
-  pretty (BoolLit b) = if b then "True" else "False"
+instance Pretty LitVal where pretty = prettyFromPrettyPrec
+instance PrettyPrec LitVal where
+  prettyPrec (IntLit  x) = atPrec ArgPrec $ p x
+  prettyPrec (RealLit x) = atPrec ArgPrec $ printDouble x
+  prettyPrec (StrLit  x) = atPrec ArgPrec $ p x
+  prettyPrec (VecLit  l) = atPrec ArgPrec $ encloseSep "<" ">" ", " $ fmap p l
+  prettyPrec (BoolLit b) = atPrec ArgPrec $ if b then "True" else "False"
 
 instance Pretty Block where
-  pretty (Block [] expr) = " " <> p expr
-  pretty (Block decls expr) = nest 2 $ hardline <> prettyLines decls <> p expr
+  pretty (Block [] expr) = pBinOp expr
+  pretty (Block decls expr) = nest 2 $ hardline <> prettyLines decls <> pBinOp expr
 
 prettyLines :: Pretty a => [a] -> Doc ann
 prettyLines xs = foldMap (\d -> p d <> hardline) xs
 
-instance Pretty Expr where
-  pretty (App f x) = parens (p f) <+> parens (p x)
-  pretty (Atom x ) = p x
-  pretty (Op  op ) = p op
-  pretty (Hof hof) = p hof
+instance Pretty Expr where pretty = prettyFromPrettyPrec
+instance PrettyPrec Expr where
+  prettyPrec (App f x) =
+    atPrec AppPrec $ pApp f <+> pArg x
+  prettyPrec (Atom x ) = prettyPrec x
+  prettyPrec (Op  op ) = prettyPrec op
+  prettyPrec (Hof hof) = prettyPrec hof
 
-prettyExprDefault :: Pretty e => PrimExpr e -> Doc ann
+prettyExprDefault :: PrettyPrec e => PrimExpr e -> DocPrec ann
 prettyExprDefault expr =
-  p ("%" ++ showPrimName expr) <> foldMap (\x -> " " <> p x) expr
+  case length expr of
+    0 -> atPrec ArgPrec primName
+    _ -> atPrec AppPrec $ primName <> foldMap (\x -> " " <> pArg x) expr
+  where primName = p $ "%" ++ showPrimName expr
 
-instance Pretty e => Pretty (Abs e) where
-  pretty (Abs binder body) = "\\" <> p binder <> "." <> p body
+instance PrettyPrec e => Pretty (Abs e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (Abs e) where
+  prettyPrec (Abs binder body) = atPrec BinOpPrec $ "\\" <> p binder <> "." <> pBinOp body
 
-instance Pretty e => Pretty (PrimExpr e) where
-  pretty (TCExpr  e) = p e
-  pretty (ConExpr e) = p e
-  pretty (OpExpr  e) = p e
-  pretty (HofExpr e) = p e
+instance PrettyPrec e => Pretty (PrimExpr e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (PrimExpr e) where
+  prettyPrec (TCExpr  e) = prettyPrec e
+  prettyPrec (ConExpr e) = prettyPrec e
+  prettyPrec (OpExpr  e) = prettyPrec e
+  prettyPrec (HofExpr e) = prettyPrec e
 
-instance Pretty e => Pretty (PrimTC e) where
-  pretty con = case con of
-    BaseType b     -> p b
-    ArrayType ty   -> "Arr[" <> p ty <> "]"
-    PairType a b   -> parens $ p a <+> "&" <+> p b
-    SumType  a b   -> parens $ p a <+> "|" <+> p b
-    UnitType       -> "Unit"
-    IntRange a b -> if s1 == "0...<" then parens ("Fin" <+> p s2) else ans
-      where ans = p a <> "...<" <> p b
-            (s1, s2) = splitAt 5 (asStr ans)
-    IndexRange _ low high -> low' <> "." <> high'
+instance PrettyPrec e => Pretty (PrimTC e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (PrimTC e) where
+  prettyPrec con = case con of
+    BaseType b     -> prettyPrec b
+    ArrayType ty   -> atPrec ArgPrec $ "Arr[" <> pBinOp ty <> "]"
+    PairType a b   -> atPrec BinOpPrec $ pApp a <+> "&" <+> pApp b
+    SumType  a b   -> atPrec BinOpPrec $ pApp a <+> "|" <+> pApp b
+    UnitType       -> atPrec ArgPrec "Unit"
+    IntRange a b -> if asStr (pArg a) == "0"
+      then atPrec AppPrec ("Fin" <+> pArg b)
+      else prettyExprDefault $ TCExpr con
+    IndexRange _ low high -> atPrec BinOpPrec $ low' <> ".." <> high'
       where
-        low'  = case low  of InclusiveLim x -> p x <> "."
-                             ExclusiveLim x -> p x <> "<"
-                             Unlimited      ->        "."
-        high' = case high of InclusiveLim x -> "." <> p x
-                             ExclusiveLim x -> "<" <> p x
-                             Unlimited      -> "."
-    RefType h a -> parens $ "Ref" <+> p h <+> p a
-    TypeKind -> "Type"
-    EffectRowKind -> "EffKind"
-    NewtypeApp f xs -> p f <> foldMap (\x -> " " <> p x) xs
+        low'  = case low  of InclusiveLim x -> pApp x
+                             ExclusiveLim x -> pApp x <> "<"
+                             Unlimited      -> ""
+        high' = case high of InclusiveLim x -> pApp x
+                             ExclusiveLim x -> "<" <> pApp x
+                             Unlimited      -> ""
+    RefType h a -> atPrec AppPrec $ "Ref" <+> pArg h <+> pArg a
+    TypeKind -> atPrec ArgPrec "Type"
+    EffectRowKind -> atPrec ArgPrec "EffKind"
+    NewtypeApp f xs -> atPrec AppPrec $ pApp f <> foldMap (\x -> " " <> pArg x) xs
     _ -> prettyExprDefault $ TCExpr con
 
-instance Pretty e => Pretty (PrimCon e) where
-  pretty con = case con of
-    Lit l       -> p l
-    ArrayLit _ array -> p array
-    PairCon x y -> parens $ p x <+> "," <+> p y
-    UnitCon     -> "()"
-    RefCon _ _  -> "RefCon"
-    Coerce t i  -> p i <> "@" <> parens (p t)
-    AnyValue t  -> parens $ "AnyValue @" <> p t
-    SumCon c l r -> parens $ case pprint c of
-      "True"  -> "Left"  <+> p l
-      "False" -> "Right" <+> p r
-      _ -> "SumCon" <+> p c <+> p l <+> p r
-    NewtypeCon f xs -> parens (p f <+> p xs)
-    ClassDictHole _ -> "_"
-    Todo e -> "<undefined " <> p e <> ""
+instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (PrimCon e) where
+  prettyPrec con = case con of
+    Lit l       -> prettyPrec l
+    ArrayLit _ array -> atPrec ArgPrec $ p array
+    PairCon x y -> atPrec ArgPrec $ parens $ pApp x <> "," <+> pApp y
+    UnitCon     -> atPrec ArgPrec "()"
+    RefCon _ _  -> atPrec ArgPrec "RefCon"
+    Coerce t i  -> atPrec BinOpPrec $ pApp i <> "@" <> pApp t
+    AnyValue t  -> atPrec AppPrec $ "%anyVal" <+> pArg t
+    SumCon c l r -> atPrec AppPrec $ case asStr (pArg c) of
+      "True"  ->  "Left"  <+> pArg l
+      "False" -> "Right" <+> pArg r
+      _ -> "SumCon" <+> pArg c <+> pArg l <+> pArg r
+    NewtypeCon f xs -> atPrec AppPrec $ pApp f <> pArg xs
+    ClassDictHole _ -> atPrec ArgPrec "_"
+    Todo e -> atPrec ArgPrec $ "<undefined " <> pArg e <> ">"
 
-instance Pretty e => Pretty (PrimOp e) where
-  pretty op = case op of
-    SumGet e isLeft -> parens $ (if isLeft then "getLeft" else "getRight") <+> p e
-    SumTag e        -> parens $ "getTag" <+> p e
-    PrimEffect ref (MPut val ) ->  p ref <+> ":=" <+> p val
-    PrimEffect ref (MTell val) ->  p ref <+> "+=" <+> p val
-    ArrayOffset arr idx off -> p arr <+> "+>" <+> p off <+> (parens $ "index:" <+> p idx)
-    ArrayLoad arr       -> "load" <+> p arr
+instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (PrimOp e) where
+  prettyPrec op = case op of
+    SumGet e isLeft -> atPrec AppPrec $ (if isLeft then "getLeft" else "getRight") <+> pArg e
+    SumTag e        -> atPrec AppPrec $ "getTag" <+> pArg e
+    PrimEffect ref (MPut val ) -> atPrec BinOpPrec $ pApp ref <+> ":=" <+> pApp val
+    PrimEffect ref (MTell val) -> atPrec BinOpPrec $ pApp ref <+> "+=" <+> pApp val
+    ArrayOffset arr idx off -> atPrec BinOpPrec $ pApp arr <+> "+>" <+> pApp off <+> (parens $ "index:" <+> pBinOp idx)
+    ArrayLoad arr       -> atPrec AppPrec $ "load" <+> pArg arr
     _ -> prettyExprDefault $ OpExpr op
 
-instance Pretty e => Pretty (PrimHof e) where
-  pretty hof = case hof of
-    For dir lam -> dirStr dir <+> p lam
-    SumCase c l r -> "case" <+> parens (p c) <> hardline
-                  <> nest 2 (p l)            <> hardline
-                  <> nest 2 (p r)
+instance PrettyPrec e => Pretty (PrimHof e) where pretty = prettyFromPrettyPrec
+instance PrettyPrec e => PrettyPrec (PrimHof e) where
+  prettyPrec hof = case hof of
+    For dir lam -> atPrec BinOpPrec $ dirStr dir <+> pArg lam
+    SumCase c l r -> atPrec BinOpPrec $ "case" <+> pArg c <> hardline
+                  <> nest 2 (pBinOp l)            <> hardline
+                  <> nest 2 (pBinOp r)
     _ -> prettyExprDefault $ HofExpr hof
 
 instance Pretty a => Pretty (VarP a) where
@@ -181,29 +228,34 @@ instance Pretty ClassName where
 
 instance Pretty Decl where
   pretty decl = case decl of
-    Let _ (NoName:>_) bound -> p bound
+    Let _ (NoName:>_) bound -> pBinOp bound
     -- This is just to reduce clutter a bit. We can comment it out when needed.
     -- Let (v:>Pi _)   bound -> p v <+> "=" <+> p bound
-    Let _ b bound -> p b <+> "=" <+> p bound
+    Let _ b bound -> p b <+> "=" <+> pBinOp bound
 
-instance Pretty Atom where
-  pretty atom = case atom of
-    Var (x:>_)  -> p x
-    Lam (Abs b (TabArrow, body))   -> "for " <> p b <> "." <> p body
-    Lam (Abs b (_, body)) -> "\\" <> p b <> "." <> p body
-    Pi  (Abs (NoName:>a) (arr, b)) -> parens $ p a <> p arr <> p b
-    Pi  (Abs a           (arr, b)) -> parens $ p a <> p arr <> p b
-    TC  e -> p e
-    Con e -> p e
-    Eff e -> p e
+instance Pretty Atom where pretty = prettyFromPrettyPrec
+instance PrettyPrec Atom where
+  prettyPrec atom = case atom of
+    Var (x:>_)  -> atPrec ArgPrec $ p x
+    Lam (Abs b (TabArrow, body))   -> atPrec BinOpPrec $ "for " <> p b <> "." <> p body
+    Lam (Abs b (_, body)) -> atPrec BinOpPrec $ "\\" <> p b <> "." <> p body
+    Pi  (Abs (NoName:>a) (arr, b)) -> atPrec BinOpPrec $ pArg a <+> p arr <+> pBinOp b
+    Pi  (Abs a           (arr, b)) -> atPrec BinOpPrec $ parens (p a) <+> p arr <+> pBinOp b
+    TC  e -> prettyPrec e
+    Con e -> prettyPrec e
+    Eff e -> atPrec ArgPrec $ p e
 
 instance Pretty IExpr where
   pretty (ILit v) = p v
   pretty (IVar (v:>_)) = p v
 
+instance PrettyPrec IExpr where prettyPrec = atPrec ArgPrec . pretty 
+
 instance Pretty IType where
   pretty (IRefType t) = "Ref" <+> (parens $ p t)
   pretty (IValType t) = p t
+
+instance PrettyPrec IType where prettyPrec = atPrec ArgPrec . pretty 
 
 instance Pretty ImpProg where
   pretty (ImpProg block) = vcat (map prettyStatement block)
@@ -219,7 +271,7 @@ prettyStatement (Nothing, instr) = p instr
 prettyStatement (Just b , instr) = p b <+> "=" <+> p instr
 
 instance Pretty ImpInstr where
-  pretty (IPrimOp op)            = p op
+  pretty (IPrimOp op)            = pBinOp op
   pretty (Load ref)              = "load"  <+> p ref
   pretty (Store dest val)        = "store" <+> p dest <+> p val
   pretty (Alloc t s)             = "alloc" <+> p (scalarTableBaseType t) <> "[" <> p s <> "]" <+> "@" <> p t
@@ -284,23 +336,34 @@ instance Pretty UModule where
 instance Pretty a => Pretty (WithSrc a) where
   pretty (WithSrc _ x) = p x
 
-instance Pretty UExpr' where
-  pretty expr = case expr of
-    UVar (v:>_) -> p v
+instance PrettyPrec a => PrettyPrec (WithSrc a) where
+  prettyPrec (WithSrc _ x) = prettyPrec x
+
+instance Pretty UExpr' where pretty = prettyFromPrettyPrec
+instance PrettyPrec UExpr' where
+  prettyPrec expr = case expr of
+    UVar (v:>_) -> atPrec ArgPrec $ p v
     ULam pat h body ->
-      "\\" <> annImplicity h (p pat) <> "." <> nest 2 (hardline <> p body)
-    UApp TabArrow f x -> p f <> "." <> p x
-    UApp _        f x -> p f <+> p x
+      atPrec BinOpPrec $ align $ "\\" <> annImplicity h (p pat) <> "." <+> nest 2 (pBinOp body)
+    UApp TabArrow f x -> atPrec AppPrec $ pArg f <> "." <> pArg x
+    UApp _        f x -> atPrec AppPrec $ pApp f <+> pArg x
     UFor dir pat body ->
-      kw <+> p pat <+> "." <> nest 2 (hardline <> p body)
+      atPrec BinOpPrec $ kw <+> p pat <+> "." <> nest 2 (hardline <> pBinOp body)
       where kw = case dir of Fwd -> "for"
                              Rev -> "rof"
-    UPi a arr b -> parens (p a) <> pretty arr <> p b
-    UDecl decl body -> p decl <> hardline <> p body
-    UHole -> "_"
-    UTabCon xs ann -> p xs <> foldMap (prettyAnn . p) ann
-    UIndexRange low high -> "IndexRange" <+> p low <+> p high
-    UPrimExpr prim -> p prim
+    UPi a arr b -> atPrec BinOpPrec $ parens (p a) <> pretty arr <> pBinOp b
+    UDecl decl body -> atPrec BinOpPrec $ align $ p decl <> hardline <> pBinOp body
+    UHole -> atPrec ArgPrec "_"
+    UTabCon xs ann -> atPrec ArgPrec $ p xs <> foldMap (prettyAnn . p) ann
+    UIndexRange low high -> atPrec BinOpPrec $ low' <> ".." <> high'
+      where
+        low'  = case low of  InclusiveLim x -> pApp x
+                             ExclusiveLim x -> pApp x <> "<"
+                             Unlimited      -> ""
+        high' = case high of InclusiveLim x -> pApp x
+                             ExclusiveLim x -> "<" <> pApp x
+                             Unlimited      -> ""
+    UPrimExpr prim -> prettyPrec prim
 
 prettyAnn :: Doc ann -> Doc ann
 prettyAnn ty = ":" <+> ty
@@ -311,7 +374,7 @@ instance Pretty a => Pretty (Limit a) where
   pretty (InclusiveLim x) = "incLim" <+> p x
 
 instance Pretty UDecl where
-  pretty (ULet _ pat rhs) = p pat <+> "=" <+> p rhs
+  pretty (ULet _ pat rhs) = p pat <+> "=" <+> pBinOp rhs
 
 instance Pretty a => Pretty (PatP' a) where
   pretty pat = case pat of
@@ -353,6 +416,9 @@ instance Pretty Array where
 
 instance Pretty ArrayRef where
   pretty (ArrayRef (size, b) ptr) = p b <> "[" <> p size <> "]@" <> (pretty $ show ptr)
+
+instance PrettyPrec () where prettyPrec = atPrec ArgPrec . pretty
+instance PrettyPrec Name where prettyPrec = atPrec ArgPrec . pretty
 
 printLitBlock :: Bool -> SourceBlock -> Result -> String
 printLitBlock isatty block (Result outs result) =

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -201,7 +201,7 @@ prettyVal val = case val of
     Coerce t i  -> pretty i <> "@" <> pretty t
     Lit x       -> pretty x
     _           -> pretty con
-  atom -> pretty atom
+  atom -> prettyPrec atom LowestPrec
 
 getValArrays :: Val -> [Array]
 getValArrays = undefined

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -55,7 +55,7 @@ class Pretty a => Checkable a where
 
 instance Checkable Module where
   checkValid m@(Module ir decls bindings) =
-    addContext ("Checking module:\n" ++ pprint m) $ asCompilerErr $ do
+    addContext ("Checking module:\n" ++ pprint m ++ "\nModule free vars:\n" ++ pprint (freeVars m)) $ asCompilerErr $ do
       let env = freeVars m
       addContext "Checking IR variant" $ checkModuleVariant m
       addContext "Checking body types" $ do

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -55,7 +55,7 @@ class Pretty a => Checkable a where
 
 instance Checkable Module where
   checkValid m@(Module ir decls bindings) =
-    addContext ("Checking module:\n" ++ pprint m ++ "\nModule free vars:\n" ++ pprint (freeVars m)) $ asCompilerErr $ do
+    addContext ("Checking module:\n" ++ pprint m) $ asCompilerErr $ do
       let env = freeVars m
       addContext "Checking IR variant" $ checkModuleVariant m
       addContext "Checking body types" $ do


### PR DESCRIPTION
There are some cases where the existing pretty printer adds unnecessary parentheses, and others where it doesn't include parentheses that are necessary. Although I don't think I've caught everything, this seems to be an improvement in most cases.

The main changes I've made are:

- Add a precedence argument to the pretty printing logic. Right now there are only three precedence levels, corresponding to places where a binop is ok without parens, places where a function application is ok without parens, and places where the only valid non-parenthesized expressions are single symbols. Note that this isn't as fine grained as the actual precedence levels in the parser, but since we aren't rendering most infix things as infix in the pretty printer I think it's a reasonable compromise; we can add more levels if we need to.
- Add a bunch of `group`, `nest`, and `line` directives to get the pretty printer to make input that felt nice to me. This was a bit of trial and error, and might be able to be improved further.
- Change how patterns are pretty-printed in UExprs so that they match the syntax.

Expand below for an example:
<details>

Extracted a few compiler passes for the mandelbrot example. Note in particular:

- `linspace Fin 300 -2.0 1.0` was ambiguous, now it prints as `linspace (Fin 300) -2.0 1.0`
- `(linspace) ((Fin 300))` was excessive, now is just `linspace (Fin 300)`
- `tmp14` used to go off of the screen in simp, now it wraps nicely


Before this change:
```
> === parse ===
> (_ans_:(), ) = (xs:(), ) = linspace Fin 300 -2.0 1.0
> (ys:(), ) = linspace Fin 200 -1.0 1.0
> for (j:(), ) .
>   for (i:(), ) .
>     escapeTime (,) xs.i ys.j
> === typed ===
> Module (Typed)
>   unevaluated decls:
>   tmp:Type = (Fin) (300)
>   tmp1:(Real->(Real->((Fin 300)=>Real))) = (linspace) ((Fin 300))
>   tmp2:(Real->((Fin 300)=>Real)) = (tmp1) (-2.0)
>   tmp3:((Fin 300)=>Real) = (tmp2) (1.0)
>   xs:((Fin 300)=>Real) = tmp3
>   tmp4:Type = (Fin) (200)
>   tmp5:(Real->(Real->((Fin 200)=>Real))) = (linspace) ((Fin 200))
>   tmp6:(Real->((Fin 200)=>Real)) = (tmp5) (-1.0)
>   tmp7:((Fin 200)=>Real) = (tmp6) (1.0)
>   ys:((Fin 200)=>Real) = tmp7
>   tmp8:((Fin 200)=>((Fin 300)=>Real)) = for \j:(Fin 200). for \i:(Fin 300).
>     tmp9:(a1:Type?->(Real->(a1->(Real & a1)))) = ((,)) (Real)
>     tmp10:(Real->(Real->(Real & Real))) = (tmp9) (Real)
>     tmp11:Real = (xs) (i)
>     tmp12:(Real->(Real & Real)) = (tmp10) (tmp11)
>     tmp13:Real = (ys) (j)
>     tmp14:(Real & Real) = (tmp12) (tmp13)
>     (escapeTime) (tmp14)
>   _ans_:((Fin 200)=>((Fin 300)=>Real)) = tmp8
>
>   evaluated bindings:
>   ()
> === simp ===
> Module (Simp)
>   unevaluated decls:
>   tmp:Real = %fsub 1.0 -2.0
>   tmp1:Int = %idxSetSize (Fin 300)
>   tmp2:Real = %inttoreal tmp1
>   tmp3:Real = %fdiv 1.0 tmp2
>   tmp4:Real = %fmul tmp3 tmp
>   tmp5:((Fin 300)=>Real) = for \i:(Fin 300).
>     tmp5:Int = %asint i
>     tmp6:Real = %inttoreal tmp5
>     tmp7:Real = %fmul tmp6 tmp4
>     %fadd -2.0 tmp7
>   tmp6:Real = %fsub 1.0 -1.0
>   tmp7:Int = %idxSetSize (Fin 200)
>   tmp8:Real = %inttoreal tmp7
>   tmp9:Real = %fdiv 1.0 tmp8
>   tmp10:Real = %fmul tmp9 tmp6
>   tmp11:((Fin 200)=>Real) = for \i:(Fin 200).
>     tmp11:Int = %asint i
>     tmp12:Real = %inttoreal tmp11
>     tmp13:Real = %fmul tmp12 tmp10
>     %fadd -1.0 tmp13
>   tmp12:((Fin 200)=>((Fin 300)=>Real)) = for \j:(Fin 200). for \i:(Fin 300).
>     tmp12:Real = (tmp5) (i)
>     tmp13:Real = (tmp11) (j)
>     tmp14:(((Fin 1000)=>Unit) & (Real & (Real & Real))) = %runState (0.0 , (0.0 , 0.0)) \h':Type. \ref:(Ref h' (Real & (Real & Real))). for \_:(Fin 1000).
>       tmp14:(Real & (Real & Real)) = %get ref
>       tmp15:Real = %fst tmp14
>       tmp16:(Real & Real) = %snd tmp14
>       --- ... omitted ...
>       tmp35:Real = %fadd tmp15 tmp34
>       ref := (tmp35 , (tmp27 , tmp28))
>     tmp16:(Real & (Real & Real)) = %snd tmp14
>     %fst tmp16
>
>   evaluated bindings:
>   (_ans_ @> (((Fin 200)=>((Fin 300)=>Real)), tmp12))
```

And after:
```
> === parse ===
> _ans_ =
>   xs = linspace (Fin 300) -2.0 1.0
>   ys = linspace (Fin 200) -1.0 1.0
>   for j. for i. escapeTime ((,) (xs.i) (ys.j))
> === typed ===
> Module (Typed)
>   unevaluated decls:
>   tmp:Type = Fin 300
>   tmp1:(Real -> Real -> (Fin 300) => Real) = linspace (Fin 300)
>   tmp2:(Real -> (Fin 300) => Real) = tmp1 -2.0
>   tmp3:((Fin 300) => Real) = tmp2 1.0
>   xs:((Fin 300) => Real) = tmp3
>   tmp4:Type = Fin 200
>   tmp5:(Real -> Real -> (Fin 200) => Real) = linspace (Fin 200)
>   tmp6:(Real -> (Fin 200) => Real) = tmp5 -1.0
>   tmp7:((Fin 200) => Real) = tmp6 1.0
>   ys:((Fin 200) => Real) = tmp7
>   tmp8:((Fin 200) => (Fin 300) => Real) =
>     for (\j:(Fin 200).
>            for (\i:(Fin 300).
>                   tmp9:((a1:Type) ?-> Real -> a1 -> Real & a1) = (,) Real
>                   tmp10:(Real -> Real -> Real & Real) = tmp9 Real
>                   tmp11:Real = xs i
>                   tmp12:(Real -> Real & Real) = tmp10 tmp11
>                   tmp13:Real = ys j
>                   tmp14:(Real & Real) = tmp12 tmp13
>                   escapeTime tmp14))
>   _ans_:((Fin 200) => (Fin 300) => Real) = tmp8
>
>   evaluated bindings:
>   ()
> === simp ===
> Module (Simp)
>   unevaluated decls:
>   tmp:Real = %fsub 1.0 -2.0
>   tmp1:Int = %idxSetSize (Fin 300)
>   tmp2:Real = %inttoreal tmp1
>   tmp3:Real = %fdiv 1.0 tmp2
>   tmp4:Real = %fmul tmp3 tmp
>   tmp5:((Fin 300) => Real) =
>     for (\i:(Fin 300).
>            tmp5:Int = %asint i
>            tmp6:Real = %inttoreal tmp5
>            tmp7:Real = %fmul tmp6 tmp4
>            %fadd -2.0 tmp7)
>   tmp6:Real = %fsub 1.0 -1.0
>   tmp7:Int = %idxSetSize (Fin 200)
>   tmp8:Real = %inttoreal tmp7
>   tmp9:Real = %fdiv 1.0 tmp8
>   tmp10:Real = %fmul tmp9 tmp6
>   tmp11:((Fin 200) => Real) =
>     for (\i:(Fin 200).
>            tmp11:Int = %asint i
>            tmp12:Real = %inttoreal tmp11
>            tmp13:Real = %fmul tmp12 tmp10
>            %fadd -1.0 tmp13)
>   tmp12:((Fin 200) => (Fin 300) => Real) =
>     for (\j:(Fin 200).
>            for (\i:(Fin 300).
>                   tmp12:Real = tmp5 i
>                   tmp13:Real = tmp11 j
>                   tmp14:(((Fin 1000) => Unit) & (Real & (Real & Real))) =
>                     %runState
>                       (0.0, (0.0, 0.0))
>                       (\h':Type.
>                          \ref:(Ref h' (Real & (Real & Real))).
>                            for (\_:(Fin 1000).
>                                   tmp14:(Real & (Real & Real)) = %get ref
>                                   tmp15:Real = %fst tmp14
>                                   tmp16:(Real & Real) = %snd tmp14
>                                   --- ... omitted ...
>                                   tmp35:Real = %fadd tmp15 tmp34
>                                   ref := (tmp35, (tmp27, tmp28))))
>                   tmp16:(Real & (Real & Real)) = %snd tmp14
>                   %fst tmp16))
>
>   evaluated bindings:
>   (_ans_ @> (((Fin 200) => (Fin 300) => Real), tmp12))
```
</details>