### PR TITLE
Add evalpoly() to prelude and tests for any() and all().

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -718,6 +718,22 @@ arr2d.(1@_)
     r1 := y
 > ((), (2, 1))
 
+
+:p any [True, False]
+> True
+:p any [False, False]
+> False
+:p any []:(Fin 0)=>Bool
+> False
+
+:p all [True, True]
+> True
+:p all [False, True]
+> False
+:p all []:(Fin 0)=>Bool
+> True
+
+
 'Tests for numerical utilies
 
 easy = [(-2.0), 3.0, 3.0, 0.1, 0.0]
@@ -737,3 +753,6 @@ hard = [(-1000.0), 1000.0, 1000.0, 0.1, 0.0]
 
 :p all for i. abs ((softmax hard).i - exp (logsoftmax hard).i) < 0.0000001
 > True
+
+:p evalpoly [2.0, 3.0, 4.0] 10.0
+> 234.0

--- a/prelude.dx
+++ b/prelude.dx
@@ -482,3 +482,7 @@ def softmax (x: n=>Real) : n=>Real =
   e =  for i. exp (x.i - m)
   s = sum e
   for i. e.i / s
+
+def evalpoly (_:VSpace v) ?=> (coefficients:n=>v) (x:Real) : v =
+  -- Evaluate a polynomial at x.  Same as Numpy's polyval.
+  fold zero \i c. coefficients.i + x .* c


### PR DESCRIPTION
It feels a bit silly to add all these one-liners to the prelude, but they exist in Numpy, Jax, and Julia, and are possible to get wrong.  Also, I needed evalpoly() for a Runge-Kutta solver.

The equivalent function and its gradient also was benchmarked for speed in Julia:
https://twitter.com/sethaxen/status/1259973355869925376
they report 17 microseconds for a 10,000 degree polynomial, I got 25 microseconds on my laptop in Dex.

It looks like they took some care to allow evaluation on things like complex numbers and matrices.  My implementation operates on arbitrary vector spaces, so I hope it works on those cases too out of the box but I haven't tests that yet.

Julia also has a custom rule for the gradient:
https://github.com/JuliaDiff/ChainRules.jl/pull/190/files

Jax has fairly short implementation without a custom rule:
https://github.com/google/jax/pull/3076/files
and there's some discussion of tuning the amount of loop unrolling for different architectures:
https://github.com/google/jax/pull/3076

