### PR TITLE
Adaptive-step Runge Kutta Example

### DIFF
--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -1,60 +1,183 @@
-'## Euler Integrator
-Using only generic vector operations.
+'Integrate systems of ordinary differential equations (ODEs) using the Dormand-Prince method for adaptive integration
+stepsize calculation.
 
-Time : Type = Float
 
--- State of Euler solver: (old state, old time, new state, new time)
-def Eulerstate (a:Type) : Type = (a & Time & a & Time)
+Time = Real
 
-def eulerStep
-  (dict: VSpace a) ?=> (zt: Eulerstate a)
-  (dynamics: a -> Time -> a) (dt: Time)
-  : (Eulerstate a) =
-  (z_old, t_old, z, t) = zt
-  (z, t, z + dt .* dynamics z t, t + dt)
+-- Should these go in the prelude?
+def norm (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
+def (./) (x: d=>Real) (y: d=>Real) : d=>Real = for i. x.i / y.i
 
-def singleEuler (dict: VSpace a) ?=> (dynamics: a -> Time -> a)
-(zt:Eulerstate a) (t1: Time) (dt: Time) : (Eulerstate a) =
-  -- Take steps until we pass t1
-  snd $ withState zt \ztref.
-    while ( \().
-      (_, _, _, t) = get ztref
-      (t < t1)) \().  -- stopping condition
-        ztref := eulerStep (get ztref) dynamics dt
+-- Todo: Add this general operation to prelude?  In Jax this is just dot.
+def mydot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v =
+  sum for j. s.j .* vs.j
+ 
+-- TODO: Replace these with 1e-x when Dex can parse it.
+oneem3 = 0.001
+oneem5 = 0.00001
+oneem6 = 0.000001
+oneem15 = 0.000000000000001
 
-def linear_interp
-  (dict: VSpace a) ?=> (z0: a) --o (z1: a) --o (t0: Time) (t1: Time) (t: Time) --o : a =
-  z0 + ((t - t0) / ((t1 - t0) + 0.000000001)) .* (z1 - z0)
+def fit_4th_order_polynomial (_:VSpace v) ?=>
+    (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
+  a = -2.0 * dt .* dz0 + 2.0 * dt .* dz1 -  8.0 .* z0 -  8.0 .* z1 + 16.0 .* z_mid
+  b =  5.0 * dt .* dz0 - 3.0 * dt .* dz1 + 18.0 .* z0 + 14.0 .* z1 - 32.0 .* z_mid
+  c = -4.0 * dt .* dz0 +       dt .* dz1 - 11.0 .* z0 -  5.0 .* z1 + 16.0 .* z_mid
+  d = dt .* dz0
+  e = z0
+  [a, b, c, d, e]
 
-def odeint (dict: VSpace a) ?=> (dynamics: a -> Time -> a)
-  (z0: a) (t0: Time) (times: n=>Time) (dt: Time) : n=>a =
-  -- todo: assert / enforce that times is monotonically increasing
-  -- todo: never go past final time
+dps_c_mid = [6025192743.0 / 30085553152.0 / 2.0, 0.0, 51252292925.0 / 65400821598.0 / 2.0,
+            -2691868925.0 / 45128329728.0 / 2.0, 187940372067.0 / 1594534317056.0 / 2.0,
+            -1776094331.0 / 19743644256.0 / 2.0, 11237099.0 / 235043384.0 / 2.0]
 
-  init = (z0, t0, z0, t0)
-  
-  body = \i state.
-    t = times.i
-    (za, ta, zb, tb) = singleEuler dynamics state t dt
-    zt = linear_interp za zb ta tb t
-    ((za, ta, zb, tb), zt)
-  snd $ scan init body
+def interp_fit_dopri (_:VSpace v) ?=> (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
+  -- Fit a polynomial to the results of a Runge-Kutta step.
+  z_mid = z0 + dt .* (mydot dps_c_mid k)
+  fit_4th_order_polynomial z0 z1 z_mid k.(0@_) k.(1@_) dt
+
+def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
+                      (order:Int) (rtol:Real) (atol:Real) (f0:d=>Real) : Time =
+  -- Algorithm from: E. Hairer, S. P. Norsett G. Wanner,
+  -- Solving Ordinary Differential Equations I: Nonstiff Problems, Sec. II.4.
+  scale = for i. atol + ((abs z0.i) * rtol)
+  d0 = norm (z0 ./ scale)
+  d1 = norm (f0 ./ scale)
+  h0 = select ((d0 < oneem5) || (d1 < oneem5)) oneem6 (0.01 * (d0 / d1))
+  z1 = z0 + h0 .* f0
+  f1 = fun z1 (t0 + h0)
+  d2 = (norm ((f1 - f0) ./ scale)) / h0
+  left = max oneem6 (h0 * oneem3)
+  right = pow (0.01 / (d1 + d2)) (1.0 / ((i2r order) + 1.0))
+  h1 = select ((d1 <= oneem15) && (d2 <= oneem15)) left right
+  min (100.0 * h0) h1
+
+-- Dopri5 Butcher tableaux
+alpha = [1.0 / 5.0, 3.0 / 10.0, 4.0 / 5.0, 8.0 / 9.0, 1., 1.]
+-- Todo: convert beta to triangular array.
+beta = [[1.0 / 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+       [3.0 / 40.0, 9.0 / 40.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+       [44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0, 0.0, 0.0, 0.0, 0.0],
+       [19372.0 / 6561.0, -25360.0 / 2187.0, 64448.0 / 6561.0, -212.0 / 729.0, 0.0, 0.0, 0.0],
+       [9017.0 / 3168.0, -355.0 / 33.0, 46732.0 / 5247.0, 49.0 / 176.0, -5103.0 / 18656.0, 0.0, 0.0],
+       [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0]]
+c_sol = [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0]
+c_error = [35.0 / 384.0 - 1951.0 / 21600.0, 0.0, 500.0 / 1113.0 - 22642.0 / 50085.0,
+                      125.0 / 192.0 - 451.0 / 720.0, -2187.0 / 6784.0 + 12231.0 / 42400.0,
+                      11.0 / 84.0 - 649.0 / 6300.0, -1.0 / 60.0]
+
+def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
+    (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
+
+  runge_kutta_stage = \i k.
+    ti = t0 + dt .* alpha.i
+    zi = z0 + dt .* (mydot beta.i k)
+    func zi ti
+
+  k_init = for i. select (i == (0@_)) f0 zero
+
+  k_filled = snd $ withState k_init \k. for i.
+    ft = runge_kutta_stage i (get k)
+    k!(((ordinal i) + 1)@_) := ft
+
+  z_last =  z0 + dt .* (mydot c_sol   k_filled)
+  z_last_error = dt .* (mydot c_error k_filled)
+  f_last = k_filled.(6@_)
+  (z_last, f_last, z_last_error, k_filled)
+
+def error_ratio (error_estimates:d=>Real) (rtol:Real) (atol:Real)
+                (z0:d=>Real) (z1:d=>Real) : Real =
+  err_tols = for i. atol + rtol * (max (abs z0.i) (abs z1.i))
+  err_ratios = error_estimates ./ err_tols
+  mean for i. sq err_ratios.i
+
+def optimal_step_size (last_step:Time) (mean_error_ratio:Real) : Time =
+  safety = 0.9
+  ifactor = 10.0
+  dfactor = 0.2
+  order = 5.0
+  dfactor = select (mean_error_ratio < 1.0) 1.0 dfactor
+  err_ratio = sqrt mean_error_ratio
+  factor = max (1.0 / ifactor) (min ( (pow err_ratio (1.0 / order)) / safety) (1.0 / dfactor))
+  select (mean_error_ratio == 0.0) (last_step * ifactor) (last_step / factor)
+
+
+-- State of solver: (next state, next f, next time, dt, t, interp coeffs)
+-- def SolverState (v:Type) : Type = (v & v & Time & Time & Time & (Fin 5)=>v)
+-- This ended up being unnecessary to spell anywhere, but was
+-- useful for debugging.
+
+def odeint (func: d=>Real -> Time -> d=>Real)
+           (z0: d=>Real) (t0: Time) (times: n=>Time) : n=>d=>Real =
+  -- Adaptive stepsize (Dormand-Prince) Runge-Kutta odeint implementation.
+  --  Args:
+  --    func: time derivative of the solution z at time t.
+  --    z0: the initial value for the state.
+  --    t: times for evaluation. values must be strictly increasing.
+  --  Returns:
+  --    Values of the solution at each time point in times.
+  rtol = 0.000000014 -- relative local error tolerance for solver.
+  atol = 0.000000014 -- absolute local error tolerance for solver.
+  max_iters = 1000000
+
+  integrate_to_next_time = \iter init_carry.
+    target_t = times.iter
+
+    stopping_condition = \(_, _, t, dt, _, _).
+      (t < target_t) && (dt > 0.0) && (ordinal iter < max_iters)
+
+    possible_step = \(z, f, t, dt, last_t, interp_coeff).
+      (next_z, next_f, next_z_error, k) = runge_kutta_step func z f t dt
+      next_t = t + dt
+      ratio = error_ratio next_z_error rtol atol z next_z
+      new_interp_coeff = interp_fit_dopri z next_z k dt
+      new_dt = optimal_step_size dt ratio
+
+      move_state = (next_z, next_f, next_t, new_dt,      t, new_interp_coeff)
+      stay_state = (     z,      f,      t, new_dt, last_t,     interp_coeff)
+      select (ratio <= 1.0) move_state stay_state
+
+    -- Take steps until we pass target_t
+    new_state = snd $ withState init_carry \state.
+      while (\(). stopping_condition (get state)) \().
+        state := possible_step (get state)
+    (_, _, t, _, last_t, interp_coeff) = new_state
+
+    -- Interpolate to the target time.
+    relative_output_time = (target_t - last_t) / (t - last_t)
+    z_target = evalpoly interp_coeff relative_output_time
+    (new_state, z_target)
+
+  f0 = func z0 t0
+  init_step = initial_step_size func t0 z0 4 rtol atol f0
+  init_interp_coeff = zero  -- dummy vals
+  init_carry = (z0, f0, t0, init_step, t0, init_interp_coeff)
+  snd $ scan init_carry integrate_to_next_time
+
 
 '#### Example: Linear dynamics
 
-def myDyn (dict: VSpace a) ?=> (z : a) -> (t:Time) : a = z
+def myDyn (z : a) -> (t:Time) : a = z
 
 z0 = [1.0]
 t0 = 0.0
 t1 = [1.0]
-dt = 0.001
 
-:p odeint myDyn z0 t0 t1 dt
-> [[2.7169456]]
+approx_e = odeint myDyn z0 t0 t1
+:p approx_e
+
+exact_e = [[exp 1.0]]
+
+:p (approx_e - exact_e)
+
+f0 = myDyn z0 t0
+:p runge_kutta_step myDyn z0 f0 t0 1.0
+
+
+times = linspace (Fin 100) 0.00001 1.0
+ys = odeint myDyn z0 t0 times
 
 :plot
-  xs = linspace (Fin 100) 0.0 1.0
-  ys = odeint myDyn z0 t0 xs dt
   ys' = for i. ys.i.(fromOrdinal _ 0)
-  zip xs ys'
-> <graphical output>
+  zip times ys'
+> <graphical output

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -1,8 +1,8 @@
 'Integrate systems of ordinary differential equations (ODEs) using the Dormand-Prince method for adaptive integration
 stepsize calculation.
 This version is a port of the [Jax implementation](https://github.com/google/jax/blob/4236eb2b5929b9643977553f7f988ca518b7df4e/jax/experimental/ode.py).
-A notable algorithmic difference is that it uses a lower-triangular
-matrix type for the Butcher tableua, and so avoid zero-padding everywhere.
+One difference is that it uses a lower-triangular
+matrix type for the Butcher tableau, and so avoids zero-padding everywhere.
 
 Time = Float
 
@@ -66,17 +66,14 @@ c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
 def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
     (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
 
-  runge_kutta_stage = \i func_evals.
-    ti = t0 + dt .* alpha.i
-    zi = z0 + dt .* dot beta.i func_evals
-    func zi ti
-
-  evals_init = for i. select (i == (0@_)) f0 zero
+  evals_init = snd $ withState zero \r.
+    r!(0@_) := f0
 
   evals_filled = snd $ withState evals_init \func_evals. for i:(Fin 6).
-    cur_evals = for j:(..i). (get func_evals).((ordinal j)@_)
-    ft = runge_kutta_stage i cur_evals
-    func_evals!(((ordinal i) + 1)@_) := ft
+    cur_evals = for j:(..i). get func_evals!((ordinal j)@_)
+    ti = t0 + dt .* alpha.i
+    zi = z0 + dt .* dot beta.i cur_evals
+    func_evals!(((ordinal i) + 1)@_) := func zi ti
 
   z_last =  z0 + dt .* dot c_sol   evals_filled
   z_last_error = dt .* dot c_error evals_filled

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -1,14 +1,14 @@
 'Integrate systems of ordinary differential equations (ODEs) using the Dormand-Prince method for adaptive integration
 stepsize calculation.
 This version is a port of the [Jax implementation](https://github.com/google/jax/blob/4236eb2b5929b9643977553f7f988ca518b7df4e/jax/experimental/ode.py).
-A notable algorithmic difference is that it avoids zero-padding the butcher tableaux when computing the Runge-Kutta stages.
+A notable algorithmic difference is that it uses a lower-triangular
+matrix type for the Butcher tableua, and so avoid zero-padding everywhere.
 
 Time = Float
 
 -- Should these go in the prelude?
 def length (x: d=>Float) : Float = sqrt $ sum for i. sq x.i
 def (./) (x: d=>Float) (y: d=>Float) : d=>Float = for i. x.i / y.i
-
 def dot (_:VSpace v) ?=> (s:d=>Float) (vs:d=>v) : v = sum for j. s.j .* vs.j
 
 def fit_4th_order_polynomial (_:VSpace v) ?=>
@@ -50,15 +50,13 @@ def initial_step_size (fun:d=>Float -> Time -> d=>Float) (t0:Time) (z0:d=>Float)
 -- Dopri5 Butcher tableaux
 alpha = [1. / 5., 3. / 10., 4. / 5., 8. / 9., 1., 1.]
 
--- Todo: Write as triangular array when concrete syntax supports it.
-beta' = [[1. / 5., 0., 0., 0., 0., 0.],
-       [3. / 40., 9. / 40., 0., 0., 0., 0.],
-       [44. / 45., -56. / 15., 32.0 / 9., 0., 0., 0.],
-       [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729., 0., 0.],
-       [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656., 0.],
+beta : (i:(Fin 6)=>(..i)=>Float) =  -- triangular array type.
+       [[1. / 5.],
+       [3. / 40., 9. / 40.],
+       [44. / 45., -56. / 15., 32.0 / 9.],
+       [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729.],
+       [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656.],
        [35. / 384., 0., 500. / 1113., 125./192., -2187./6784., 11./84.]]
--- Convert to triangular array type.
-beta = for i. for j:(..i). beta'.i.((ordinal j)@(Fin 6))
 
 c_sol = [35. /384., 0., 500. /1113., 125. /192., -2187. /6784., 11. / 84., 0.]
 c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
@@ -165,12 +163,12 @@ t1 = [1.0]
 
 approx_e = odeint myDyn z0 t0 t1
 :p approx_e
-> [[2.720203]]
+> [[2.719482]]
 
 exact_e = [[exp 1.0]]
 
 :p (approx_e - exact_e)
-> [[1.9211608e-3]]
+> [[1.2001991e-3]]  -- amount of numerical error
 
 times = linspace (Fin 100) 0.00001 1.0
 ys = odeint myDyn z0 t0 times

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -8,15 +8,7 @@ Time = Real
 def norm (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
 def (./) (x: d=>Real) (y: d=>Real) : d=>Real = for i. x.i / y.i
 
--- Todo: Add this general operation to prelude?  In Jax this is just dot.
-def mydot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v =
-  sum for j. s.j .* vs.j
- 
--- TODO: Replace these with 1e-x when Dex can parse it.
-oneem3 = 0.001
-oneem5 = 0.00001
-oneem6 = 0.000001
-oneem15 = 0.000000000000001
+def dot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v = sum for j. s.j .* vs.j
 
 def fit_4th_order_polynomial (_:VSpace v) ?=>
     (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
@@ -33,7 +25,7 @@ dps_c_mid = [6025192743.0 / 30085553152.0 / 2.0, 0.0, 51252292925.0 / 6540082159
 
 def interp_fit_dopri (_:VSpace v) ?=> (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
   -- Fit a polynomial to the results of a Runge-Kutta step.
-  z_mid = z0 + dt .* (mydot dps_c_mid k)
+  z_mid = z0 + dt .* (dot dps_c_mid k)
   fit_4th_order_polynomial z0 z1 z_mid k.(0@_) k.(1@_) dt
 
 def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
@@ -43,45 +35,55 @@ def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
   scale = for i. atol + ((abs z0.i) * rtol)
   d0 = norm (z0 ./ scale)
   d1 = norm (f0 ./ scale)
-  h0 = select ((d0 < oneem5) || (d1 < oneem5)) oneem6 (0.01 * (d0 / d1))
+  h0 = select ((d0 < 1.0e-5) || (d1 < 1.0e-5)) 1.0e-6 (0.01 * (d0 / d1))
   z1 = z0 + h0 .* f0
   f1 = fun z1 (t0 + h0)
   d2 = (norm ((f1 - f0) ./ scale)) / h0
-  left = max oneem6 (h0 * oneem3)
+  left = max 1.0e-6 (h0 * 1.0e-3)
   right = pow (0.01 / (d1 + d2)) (1.0 / ((i2r order) + 1.0))
-  h1 = select ((d1 <= oneem15) && (d2 <= oneem15)) left right
+  h1 = select ((d1 <= 1.0e-15) && (d2 <= 1.0e-15)) left right
   min (100.0 * h0) h1
 
 -- Dopri5 Butcher tableaux
 alpha = [1.0 / 5.0, 3.0 / 10.0, 4.0 / 5.0, 8.0 / 9.0, 1., 1.]
--- Todo: convert beta to triangular array.
-beta = [[1.0 / 5.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-       [3.0 / 40.0, 9.0 / 40.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-       [44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0, 0.0, 0.0, 0.0, 0.0],
-       [19372.0 / 6561.0, -25360.0 / 2187.0, 64448.0 / 6561.0, -212.0 / 729.0, 0.0, 0.0, 0.0],
-       [9017.0 / 3168.0, -355.0 / 33.0, 46732.0 / 5247.0, 49.0 / 176.0, -5103.0 / 18656.0, 0.0, 0.0],
-       [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0]]
+
+-- Todo: Write as triangular array when concrete syntax supports it.
+beta' = [[1.0 / 5.0, 0.0, 0.0, 0.0, 0.0, 0.0],
+       [3.0 / 40.0, 9.0 / 40.0, 0.0, 0.0, 0.0, 0.0],
+       [44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0, 0.0, 0.0, 0.0],
+       [19372.0 / 6561.0, -25360.0 / 2187.0, 64448.0 / 6561.0, -212.0 / 729.0, 0.0, 0.0],
+       [9017.0 / 3168.0, -355.0 / 33.0, 46732.0 / 5247.0, 49.0 / 176.0, -5103.0 / 18656.0, 0.0],
+       [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0]]
+
+-- Convert beta to a triangular array.
+beta = for i:(Fin 6). for j:(..i). beta'.i.((ordinal j)@(Fin 6))
+:t beta
+
 c_sol = [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0]
 c_error = [35.0 / 384.0 - 1951.0 / 21600.0, 0.0, 500.0 / 1113.0 - 22642.0 / 50085.0,
                       125.0 / 192.0 - 451.0 / 720.0, -2187.0 / 6784.0 + 12231.0 / 42400.0,
                       11.0 / 84.0 - 649.0 / 6300.0, -1.0 / 60.0]
 
-def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
+def runge_kutta_step (v:Type) ?-> (_:VSpace v) ?=> (func:v->Time->v)
     (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
 
+  --def runge_kutta_stage (m:Type) -> (k:m=>v) : v =
   runge_kutta_stage = \i k.
+    --i = (size m)@(Fin 6)
     ti = t0 + dt .* alpha.i
-    zi = z0 + dt .* (mydot beta.i k)
+    cur_b = beta.i -- for j:m. beta.i.j
+    zi = z0 + dt .* (dot cur_b k)
     func zi ti
 
   k_init = for i. select (i == (0@_)) f0 zero
 
-  k_filled = snd $ withState k_init \k. for i.
-    ft = runge_kutta_stage i (get k)
+  k_filled = snd $ withState k_init \k. for i:(Fin 6).
+    cur_k = for j:(..i). (get k).j
+    ft = runge_kutta_stage i cur_k
     k!(((ordinal i) + 1)@_) := ft
 
-  z_last =  z0 + dt .* (mydot c_sol   k_filled)
-  z_last_error = dt .* (mydot c_error k_filled)
+  z_last =  z0 + dt .* (dot c_sol   k_filled)
+  z_last_error = dt .* (dot c_error k_filled)
   f_last = k_filled.(6@_)
   (z_last, f_last, z_last_error, k_filled)
 

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -3,13 +3,13 @@ stepsize calculation.
 This version is a port of the [Jax implementation](https://github.com/google/jax/blob/4236eb2b5929b9643977553f7f988ca518b7df4e/jax/experimental/ode.py).
 A notable algorithmic difference is that it avoids zero-padding the butcher tableaux when computing the Runge-Kutta stages.
 
-Time = Real
+Time = Float
 
 -- Should these go in the prelude?
-def length (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
-def (./) (x: d=>Real) (y: d=>Real) : d=>Real = for i. x.i / y.i
+def length (x: d=>Float) : Float = sqrt $ sum for i. sq x.i
+def (./) (x: d=>Float) (y: d=>Float) : d=>Float = for i. x.i / y.i
 
-def dot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v = sum for j. s.j .* vs.j
+def dot (_:VSpace v) ?=> (s:d=>Float) (vs:d=>v) : v = sum for j. s.j .* vs.j
 
 def fit_4th_order_polynomial (_:VSpace v) ?=>
     (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
@@ -31,8 +31,8 @@ def interp_fit_dopri (_:VSpace v) ?=>
   z_mid = z0 + dt .* (dot dps_c_mid k)
   fit_4th_order_polynomial z0 z1 z_mid k.(0@_) k.(1@_) dt
 
-def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
-                      (order:Int) (rtol:Real) (atol:Real) (f0:d=>Real) : Time =
+def initial_step_size (fun:d=>Float -> Time -> d=>Float) (t0:Time) (z0:d=>Float)
+                      (order:Int) (rtol:Float) (atol:Float) (f0:d=>Float) : Time =
   -- Algorithm from: E. Hairer, S. P. Norsett G. Wanner,
   -- Solving Ordinary Differential Equations I: Nonstiff Problems, Sec. II.4.
   scale = for i. atol + ((abs z0.i) * rtol)
@@ -43,7 +43,7 @@ def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
   f1 = fun z1 (t0 + h0)
   d2 = (length ((f1 - f0) ./ scale)) / h0
   left = max 1.0e-6 (h0 * 1.0e-3)
-  right = pow (0.01 / (d1 + d2)) (1. / ((i2r order) + 1.))
+  right = pow (0.01 / (d1 + d2)) (1. / ((IToF order) + 1.))
   h1 = select ((d1 <= 1.0e-15) && (d2 <= 1.0e-15)) left right
   min (100. * h0) h1
 
@@ -57,7 +57,7 @@ beta' = [[1. / 5., 0., 0., 0., 0., 0.],
        [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729., 0., 0.],
        [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656., 0.],
        [35. / 384., 0., 500. / 1113., 125./192., -2187./6784., 11./84.]]
--- Convert to triangular array.
+-- Convert to triangular array type.
 beta = for i. for j:(..i). beta'.i.((ordinal j)@(Fin 6))
 
 c_sol = [35. /384., 0., 500. /1113., 125. /192., -2187. /6784., 11. / 84., 0.]
@@ -85,13 +85,13 @@ def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
   f_last = evals_filled.(6@_)
   (z_last, f_last, z_last_error, evals_filled)
 
-def error_ratio (error_estimates:d=>Real) (rtol:Real) (atol:Real)
-                (z0:d=>Real) (z1:d=>Real) : Real =
+def error_ratio (error_estimates:d=>Float) (rtol:Float) (atol:Float)
+                (z0:d=>Float) (z1:d=>Float) : Float =
   err_tols = for i. atol + rtol * (max (abs z0.i) (abs z1.i))
   err_ratios = error_estimates ./ err_tols
   mean for i. sq err_ratios.i
 
-def optimal_step_size (last_step:Time) (mean_error_ratio:Real) : Time =
+def optimal_step_size (last_step:Time) (mean_error_ratio:Float) : Time =
   safety = 0.9
   ifactor = 10.
   dfactor = 0.2
@@ -103,8 +103,8 @@ def optimal_step_size (last_step:Time) (mean_error_ratio:Real) : Time =
   select (mean_error_ratio == 0.) (last_step * ifactor) (last_step / factor)
 
 
-def odeint (func: d=>Real -> Time -> d=>Real)
-           (z0: d=>Real) (t0: Time) (times: n=>Time) : n=>d=>Real =
+def odeint (func: d=>Float -> Time -> d=>Float)
+           (z0: d=>Float) (t0: Time) (times: n=>Time) : n=>d=>Float =
   -- Adaptive stepsize (Dormand-Prince) Runge-Kutta odeint implementation.
   --  Args:
   --    func: time derivative of the solution z at time t.

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -163,12 +163,12 @@ t1 = [1.0]
 
 approx_e = odeint myDyn z0 t0 t1
 :p approx_e
-> [[2.719482]]
+> [[2.7201762]]
 
 exact_e = [[exp 1.0]]
 
-:p (approx_e - exact_e)
-> [[1.2001991e-3]]  -- amount of numerical error
+:p (approx_e - exact_e) -- amount of numerical error
+> [[1.894474e-3]]
 
 times = linspace (Fin 100) 0.00001 1.0
 ys = odeint myDyn z0 t0 times

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -1,29 +1,32 @@
 'Integrate systems of ordinary differential equations (ODEs) using the Dormand-Prince method for adaptive integration
 stepsize calculation.
-
+This version is a port of the [Jax implementation](https://github.com/google/jax/blob/4236eb2b5929b9643977553f7f988ca518b7df4e/jax/experimental/ode.py).
+A notable algorithmic difference is that it avoids zero-padding the butcher tableaux when computing the Runge-Kutta stages.
 
 Time = Real
 
 -- Should these go in the prelude?
-def norm (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
+def length (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
 def (./) (x: d=>Real) (y: d=>Real) : d=>Real = for i. x.i / y.i
 
 def dot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v = sum for j. s.j .* vs.j
 
 def fit_4th_order_polynomial (_:VSpace v) ?=>
     (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
-  a = -2.0 * dt .* dz0 + 2.0 * dt .* dz1 -  8.0 .* z0 -  8.0 .* z1 + 16.0 .* z_mid
-  b =  5.0 * dt .* dz0 - 3.0 * dt .* dz1 + 18.0 .* z0 + 14.0 .* z1 - 32.0 .* z_mid
-  c = -4.0 * dt .* dz0 +       dt .* dz1 - 11.0 .* z0 -  5.0 .* z1 + 16.0 .* z_mid
+  -- dz0 and dz1 are gradient evaluations.
+  a = -2. * dt .* dz0 + 2. * dt .* dz1 -  8. .* z0 -  8. .* z1 + 16. .* z_mid
+  b =  5. * dt .* dz0 - 3. * dt .* dz1 + 18. .* z0 + 14. .* z1 - 32. .* z_mid
+  c = -4. * dt .* dz0 +      dt .* dz1 - 11. .* z0 -  5. .* z1 + 16. .* z_mid
   d = dt .* dz0
   e = z0
-  [a, b, c, d, e]
+  [a, b, c, d, e]  -- polynomial coefficients.
 
-dps_c_mid = [6025192743.0 / 30085553152.0 / 2.0, 0.0, 51252292925.0 / 65400821598.0 / 2.0,
-            -2691868925.0 / 45128329728.0 / 2.0, 187940372067.0 / 1594534317056.0 / 2.0,
-            -1776094331.0 / 19743644256.0 / 2.0, 11237099.0 / 235043384.0 / 2.0]
+dps_c_mid = [6025192743. /30085553152. /2., 0., 51252292925. /65400821598. /2.,
+            -2691868925. /45128329728. /2., 187940372067. /1594534317056. /2.,
+            -1776094331. /19743644256. /2., 11237099. /235043384. /2.]
 
-def interp_fit_dopri (_:VSpace v) ?=> (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
+def interp_fit_dopri (_:VSpace v) ?=>
+    (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
   -- Fit a polynomial to the results of a Runge-Kutta step.
   z_mid = z0 + dt .* (dot dps_c_mid k)
   fit_4th_order_polynomial z0 z1 z_mid k.(0@_) k.(1@_) dt
@@ -33,59 +36,54 @@ def initial_step_size (fun:d=>Real -> Time -> d=>Real) (t0:Time) (z0:d=>Real)
   -- Algorithm from: E. Hairer, S. P. Norsett G. Wanner,
   -- Solving Ordinary Differential Equations I: Nonstiff Problems, Sec. II.4.
   scale = for i. atol + ((abs z0.i) * rtol)
-  d0 = norm (z0 ./ scale)
-  d1 = norm (f0 ./ scale)
+  d0 = length (z0 ./ scale)
+  d1 = length (f0 ./ scale)
   h0 = select ((d0 < 1.0e-5) || (d1 < 1.0e-5)) 1.0e-6 (0.01 * (d0 / d1))
   z1 = z0 + h0 .* f0
   f1 = fun z1 (t0 + h0)
-  d2 = (norm ((f1 - f0) ./ scale)) / h0
+  d2 = (length ((f1 - f0) ./ scale)) / h0
   left = max 1.0e-6 (h0 * 1.0e-3)
-  right = pow (0.01 / (d1 + d2)) (1.0 / ((i2r order) + 1.0))
+  right = pow (0.01 / (d1 + d2)) (1. / ((i2r order) + 1.))
   h1 = select ((d1 <= 1.0e-15) && (d2 <= 1.0e-15)) left right
-  min (100.0 * h0) h1
+  min (100. * h0) h1
 
 -- Dopri5 Butcher tableaux
-alpha = [1.0 / 5.0, 3.0 / 10.0, 4.0 / 5.0, 8.0 / 9.0, 1., 1.]
+alpha = [1. / 5., 3. / 10., 4. / 5., 8. / 9., 1., 1.]
 
 -- Todo: Write as triangular array when concrete syntax supports it.
-beta' = [[1.0 / 5.0, 0.0, 0.0, 0.0, 0.0, 0.0],
-       [3.0 / 40.0, 9.0 / 40.0, 0.0, 0.0, 0.0, 0.0],
-       [44.0 / 45.0, -56.0 / 15.0, 32.0 / 9.0, 0.0, 0.0, 0.0],
-       [19372.0 / 6561.0, -25360.0 / 2187.0, 64448.0 / 6561.0, -212.0 / 729.0, 0.0, 0.0],
-       [9017.0 / 3168.0, -355.0 / 33.0, 46732.0 / 5247.0, 49.0 / 176.0, -5103.0 / 18656.0, 0.0],
-       [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0]]
+beta' = [[1. / 5., 0., 0., 0., 0., 0.],
+       [3. / 40., 9. / 40., 0., 0., 0., 0.],
+       [44. / 45., -56. / 15., 32.0 / 9., 0., 0., 0.],
+       [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729., 0., 0.],
+       [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656., 0.],
+       [35. / 384., 0., 500. / 1113., 125./192., -2187./6784., 11./84.]]
+-- Convert to triangular array.
+beta = for i. for j:(..i). beta'.i.((ordinal j)@(Fin 6))
 
--- Convert beta to a triangular array.
-beta = for i:(Fin 6). for j:(..i). beta'.i.((ordinal j)@(Fin 6))
-:t beta
+c_sol = [35. /384., 0., 500. /1113., 125. /192., -2187. /6784., 11. / 84., 0.]
+c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
+           125. / 192. - 451. / 720., -2187. / 6784. + 12231. / 42400.,
+           11. / 84. - 649. / 6300., -1. / 60.]
 
-c_sol = [35.0 / 384.0, 0.0, 500.0 / 1113.0, 125.0 / 192.0, -2187.0 / 6784.0, 11.0 / 84.0, 0.0]
-c_error = [35.0 / 384.0 - 1951.0 / 21600.0, 0.0, 500.0 / 1113.0 - 22642.0 / 50085.0,
-                      125.0 / 192.0 - 451.0 / 720.0, -2187.0 / 6784.0 + 12231.0 / 42400.0,
-                      11.0 / 84.0 - 649.0 / 6300.0, -1.0 / 60.0]
-
-def runge_kutta_step (v:Type) ?-> (_:VSpace v) ?=> (func:v->Time->v)
+def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
     (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
 
-  --def runge_kutta_stage (m:Type) -> (k:m=>v) : v =
-  runge_kutta_stage = \i k.
-    --i = (size m)@(Fin 6)
+  runge_kutta_stage = \i func_evals.
     ti = t0 + dt .* alpha.i
-    cur_b = beta.i -- for j:m. beta.i.j
-    zi = z0 + dt .* (dot cur_b k)
+    zi = z0 + dt .* dot beta.i func_evals
     func zi ti
 
-  k_init = for i. select (i == (0@_)) f0 zero
+  evals_init = for i. select (i == (0@_)) f0 zero
 
-  k_filled = snd $ withState k_init \k. for i:(Fin 6).
-    cur_k = for j:(..i). (get k).j
-    ft = runge_kutta_stage i cur_k
-    k!(((ordinal i) + 1)@_) := ft
+  evals_filled = snd $ withState evals_init \func_evals. for i:(Fin 6).
+    cur_evals = for j:(..i). (get func_evals).((ordinal j)@_)
+    ft = runge_kutta_stage i cur_evals
+    func_evals!(((ordinal i) + 1)@_) := ft
 
-  z_last =  z0 + dt .* (dot c_sol   k_filled)
-  z_last_error = dt .* (dot c_error k_filled)
-  f_last = k_filled.(6@_)
-  (z_last, f_last, z_last_error, k_filled)
+  z_last =  z0 + dt .* dot c_sol   evals_filled
+  z_last_error = dt .* dot c_error evals_filled
+  f_last = evals_filled.(6@_)
+  (z_last, f_last, z_last_error, evals_filled)
 
 def error_ratio (error_estimates:d=>Real) (rtol:Real) (atol:Real)
                 (z0:d=>Real) (z1:d=>Real) : Real =
@@ -95,19 +93,15 @@ def error_ratio (error_estimates:d=>Real) (rtol:Real) (atol:Real)
 
 def optimal_step_size (last_step:Time) (mean_error_ratio:Real) : Time =
   safety = 0.9
-  ifactor = 10.0
+  ifactor = 10.
   dfactor = 0.2
-  order = 5.0
-  dfactor = select (mean_error_ratio < 1.0) 1.0 dfactor
+  order = 5.
+  dfactor = select (mean_error_ratio < 1.) 1. dfactor
   err_ratio = sqrt mean_error_ratio
-  factor = max (1.0 / ifactor) (min ( (pow err_ratio (1.0 / order)) / safety) (1.0 / dfactor))
-  select (mean_error_ratio == 0.0) (last_step * ifactor) (last_step / factor)
+  minfac = min ( (pow err_ratio (1. / order)) / safety) (1. / dfactor)
+  factor = max (1. / ifactor) minfac
+  select (mean_error_ratio == 0.) (last_step * ifactor) (last_step / factor)
 
-
--- State of solver: (next state, next f, next time, dt, t, interp coeffs)
--- def SolverState (v:Type) : Type = (v & v & Time & Time & Time & (Fin 5)=>v)
--- This ended up being unnecessary to spell anywhere, but was
--- useful for debugging.
 
 def odeint (func: d=>Real -> Time -> d=>Real)
            (z0: d=>Real) (t0: Time) (times: n=>Time) : n=>d=>Real =
@@ -118,14 +112,18 @@ def odeint (func: d=>Real -> Time -> d=>Real)
   --    t: times for evaluation. values must be strictly increasing.
   --  Returns:
   --    Values of the solution at each time point in times.
-  rtol = 0.000000014 -- relative local error tolerance for solver.
-  atol = 0.000000014 -- absolute local error tolerance for solver.
-  max_iters = 1000000
+  rtol = 1.4e-8 -- relative local error tolerance for solver.
+  atol = 1.4e-8 -- absolute local error tolerance for solver.
+  max_iters = 10000
 
   integrate_to_next_time = \iter init_carry.
     target_t = times.iter
 
     stopping_condition = \(_, _, t, dt, _, _).
+      -- State of solver: (next state, next f, next time, dt, t, interp coeffs)
+      -- def State (v:Type) : Type = (v & v & Time & Time & Time & (Fin 5)=>v)
+      -- This ended up being unnecessary to spell anywhere, but was
+      -- useful for debugging.
       (t < target_t) && (dt > 0.0) && (ordinal iter < max_iters)
 
     possible_step = \(z, f, t, dt, last_t, interp_coeff).
@@ -167,14 +165,12 @@ t1 = [1.0]
 
 approx_e = odeint myDyn z0 t0 t1
 :p approx_e
+> [[2.720203]]
 
 exact_e = [[exp 1.0]]
 
 :p (approx_e - exact_e)
-
-f0 = myDyn z0 t0
-:p runge_kutta_step myDyn z0 f0 t0 1.0
-
+> [[1.9211608e-3]]
 
 times = linspace (Fin 100) 0.00001 1.0
 ys = odeint myDyn z0 t0 times
@@ -182,4 +178,4 @@ ys = odeint myDyn z0 t0 times
 :plot
   ys' = for i. ys.i.(fromOrdinal _ 0)
   zip times ys'
-> <graphical output
+> <graphical output>


### PR DESCRIPTION
I ported over the [jax implementation of Dopri5](https://github.com/google/jax/blob/master/jax/experimental/ode.py) to Dex.  Its error gets arbitrarily small as you tighten the error tolerances, but for some reason its output doesn't match that of the Jax demo.  More on that below.  Notes on writing this:

1. Having the type system catch lots of errors was nice, because it let me mostly debug one function at a time as I wrote it.  The type system caught two redundant ops that I had mistakenly included when I wrote the original jax version.  They were left over from the hand-vmapped pytorch version by Ricky Chen that I based it on.
2. The type system reduced the need for comments.  About half the comments in jax's ```odeint``` simply list the types of arguments.  However  I wasn't sure how often to annotate inner functions with types.  Whenever I had a top-level type mismatch, I annotated the inner functions' types to narrow down the error.  However, for brevity and flexibility I removed them after and it might have hurt readability.  Notably, I never had to write the type of the complex solver state tuple.
3. The generic ```zero``` function is really nice to avoid writing sizes when initializing.  I would have also liked an analogous ```nans``` function, but I couldn't figure out how to write an equally powerful argumentless ```nans``` function without polluting the typeclasses.
4. Dex's support for triangular arrays means it could skip some redundant ops in the inner loop inherited from the Jax and PyTorch versions where they multiplying with zero-padded arrays.

Unfortunately there is some sort of mismatch with the Jax version, and this version ends up having slightly higher error on my simple test function.  I compared everything line by line twice and can't find any algorithmic difference.  The RK steps in Jax and Dex give slightly different answers in the last printed decimal place.  I think this might just be a float32 v float64 issue but I don't really know how to control float32 v 64 in both Jax and Dex, so that's where I left it for now.

Dex RK step:
```
:p runge_kutta_step myDyn z0 f0 t0 1.0
( [2.7183332]
, ( [2.7183332]
, ( [-3.5e-4]
, [[1.0], [1.2], [1.345], [2.28], [2.5863924], [2.8436363], [2.7183332]] ) ) )
```

Jax RK step:

```
(DeviceArray([2.7183337], dtype=float32), DeviceArray([2.7183337], dtype=float32), DeviceArray([-0.00035], dtype=float32), DeviceArray([[1.       ],
             [1.2      ],
             [1.345    ],
             [2.2800002],
             [2.5863914],
             [2.8436356],
             [2.7183337]], dtype=float32))
```