### PR TITLE
[WIP] Remove syntactic ANF restriction on core IR

### DIFF
--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -544,7 +544,7 @@ evalBlockE :: (MonadEmbed m, MonadReader SubstEnv m)
 evalBlockE f (Block decls result) = do
   env <- traverseDeclsOpen f decls
   result' <- extendR env $ f result
-  if isAtom result'
+  if isAtom result'  -- TODO: remove this once we handle Imp destinations differently
     then return result'
     else emit result'
 

--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -116,8 +116,8 @@ envIntersect (Env m) (Env m') = Env $ M.intersection m' m
 envDiff :: Env a -> Env b -> Env a
 envDiff (Env m) (Env m') = Env $ M.difference m m'
 
-envFilter :: Env a -> (a -> Bool) -> Env a
-envFilter (Env m) f = Env $ M.filter f m
+envFilter :: Env a -> (Name -> a -> Bool) -> Env a
+envFilter (Env m) f = Env $ M.filterWithKey f m
 
 isin :: HasName a => a -> Env b -> Bool
 isin x env = case getName x of
@@ -134,10 +134,13 @@ env ! v = case envLookup env v of
   Just x -> x
   Nothing -> error $ "Lookup of " ++ show (varName v) ++ " failed"
 
-isGlobal :: VarP ann -> Bool
-isGlobal (GlobalName _ :> _) = True
-isGlobal (GlobalArrayName _ :> _) = True
-isGlobal _ = False
+isGlobal :: HasName a => a -> Bool
+isGlobal x = case getName x of
+  Just v -> case v of
+    GlobalName _      -> True
+    GlobalArrayName _ -> True
+    _     -> False
+  Nothing -> False
 
 genFresh :: Name-> Env a -> Name
 genFresh (Name ns tag _) (Env m) = Name ns tag nextNum

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -41,9 +41,9 @@ evalExpr env expr = case expr of
   App f x   -> case f of
     Lam a -> evalBlock env $ snd $ applyAbs a x
     _     -> error $ "Expected a fully evaluated function value: " ++ pprint f
-  Atom atom -> atom
   Op op     -> evalOp op
-  _         -> error $ "Not implemented: " ++ pprint expr
+  _ | isAtom expr -> expr
+    | otherwise -> error $ "Not implemented: " ++ pprint expr
 
 evalOp :: Op -> Atom
 evalOp expr = case expr of
@@ -122,5 +122,5 @@ indexSetSize ty = i
   where (IntVal i) = evalEmbed (indexSetSizeE ty)
 
 evalEmbed :: Embed Atom -> Atom
-evalEmbed embed = evalBlock mempty $ Block decls (Atom atom)
+evalEmbed embed = evalBlock mempty $ Block decls atom
   where (atom, (_, decls)) = runEmbed embed mempty

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -43,7 +43,7 @@ class PrettyPrec a where
 -- `prec` when running `doc`, wrapping with parentheses if needed.
 atPrec :: PrecedenceLevel -> Doc ann -> DocPrec ann
 atPrec prec doc requestedPrec =
-  if requestedPrec > prec then parens (align doc) else doc
+  if requestedPrec > prec then parens doc else doc
 
 pprint :: Pretty a => a -> String
 pprint x = asStr $ pretty x
@@ -70,7 +70,7 @@ prettyFromPrettyPrec :: PrettyPrec a => a -> Doc ann
 prettyFromPrettyPrec = pArg
 
 pAppArg :: (PrettyPrec a, Foldable f) => Doc ann -> f a -> Doc ann
-pAppArg name as = align $ name <> group (nest 2 $ foldMap (\a -> line <> pArg a) as)
+pAppArg name as = name <> group (nest 2 $ foldMap (\a -> line <> pArg a) as)
 
 instance Pretty Err where
   pretty (Err e _ s) = p e <> p s
@@ -136,8 +136,8 @@ instance Pretty Expr where pretty = prettyFromPrettyPrec
 instance PrettyPrec Expr where
   prettyPrec expr = case expr of
     Var (x:>_)  -> atPrec ArgPrec $ p x
-    Lam (Abs b (TabArrow, body))   -> atPrec LowestPrec $ align $ nest 2 $ "for " <> p b <> "." <+> p body
-    Lam (Abs b (_, body)) -> atPrec LowestPrec $ align $ nest 2 $ "\\" <> p b <> "." <+> p body
+    Lam (Abs b (TabArrow, body))   -> atPrec LowestPrec $ nest 2 $ "for " <> p b <> "." <+> p body
+    Lam (Abs b (_, body)) -> atPrec LowestPrec $ nest 2 $ "\\" <> p b <> "." <+> p body
     Pi  (Abs (Ignore a) (arr, b)) -> atPrec LowestPrec $ pArg a <+> p arr <+> pLowest b
     Pi  (Abs a           (arr, b)) -> atPrec LowestPrec $ parens (p a) <+> p arr <+> pLowest b
     Eff e -> atPrec ArgPrec $ p e
@@ -260,8 +260,8 @@ instance Pretty Decl where
     Let _ (Ignore _) bound -> pLowest bound
     -- This is just to reduce clutter a bit. We can comment it out when needed.
     -- Let (v:>Pi _)   bound -> p v <+> "=" <+> p bound
-    Let _  b  rhs -> align $ p b  <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
-    Unpack bs rhs -> align $ p (toList bs) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+    Let _  b  rhs -> p b  <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+    Unpack bs rhs -> p (toList bs) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
 
 instance Pretty IExpr where
   pretty (ILit v) = p v
@@ -370,8 +370,8 @@ instance PrettyPrec UExpr' where
   prettyPrec expr = case expr of
     UVar (v:>_) -> atPrec ArgPrec $ p v
     ULam binder h body ->
-      atPrec LowestPrec $ align $ "\\" <> annImplicity h (prettyUBinder binder)
-                                      <> "." <+> nest 2 (pLowest body)
+      atPrec LowestPrec $ "\\" <> annImplicity h (prettyUBinder binder)
+                               <> "." <+> nest 2 (pLowest body)
     UApp TabArrow f x -> atPrec AppPrec $ pArg f <> "." <> pArg x
     UApp _        f x -> atPrec AppPrec $ pAppArg (pApp f) [x]
     UFor dir binder body ->
@@ -380,8 +380,8 @@ instance PrettyPrec UExpr' where
       where kw = case dir of Fwd -> "for"
                              Rev -> "rof"
     UPi a arr b -> atPrec LowestPrec $ p a <+> pretty arr <+> pLowest b
-    UDecl decl body -> atPrec LowestPrec $ align $ p decl <> hardline
-                                                         <> pLowest body
+    UDecl decl body -> atPrec LowestPrec $  p decl <> hardline
+                                                   <> pLowest body
     UHole -> atPrec ArgPrec "_"
     UTabCon xs ann -> atPrec ArgPrec $ p xs <> foldMap (prettyAnn . p) ann
     UIndexRange low high -> atPrec LowestPrec $ low' <> ".." <> high'
@@ -409,7 +409,7 @@ instance Pretty a => Pretty (Limit a) where
 
 instance Pretty UDecl where
   pretty (ULet _ b rhs) =
-    align $ prettyUBinder b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+    prettyUBinder b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
   pretty (UData tyCon dataCons) =
     "data" <+> p tyCon <+> "where" <> nest 2 (hardline <> prettyLines dataCons)
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -146,6 +146,7 @@ simplifyExpr expr = case expr of
     x' <- simplifyExpr x
     f' <- simplifyExpr f
     case f' of
+      -- TODO: try to avoid having a pass for each argument of curried application.
       Lam (Abs b (_, body)) ->
         dropSub $ extendR (b@>x') $ simplifyBlock body
       DataCon def params con xs -> return $ DataCon def params' con xs'

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -128,7 +128,7 @@ data ArrowP eff = PlainArrow eff
                 | LinArrow
                   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
-data LetAnn = PlainLet
+data LetAnn = PlainLet EffectSummary
             | InstanceLet
             | SuperclassLet
               deriving (Show, Eq, Generic)
@@ -1273,6 +1273,7 @@ instance Store Direction
 instance Store UnOp
 instance Store BinOp
 instance Store CmpOp
+instance Store EffectSummary
 instance Store LetAnn
 instance Store BinderInfo
 instance Store DataDef

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -101,7 +101,7 @@ evalSourceBlockM env block = case sbContents block of
   LoadData pat DexObject fname -> do
     source <- liftIO $ readFile fname
     let val = ignoreExcept $ parseData source
-    evalUModule env $ UModule $ toNest [ULet PlainLet pat val]
+    evalUModule env $ UModule $ toNest [ULet (PlainLet SomeEffects) pat val]
   -- LoadData pat DexBinaryObject fname -> do
   --   val <- liftIO $ loadDataFile fname
   --   -- TODO: handle patterns and type annotations in binder
@@ -140,7 +140,7 @@ evalUModuleVal env v m = do
 
 lookupBindings :: Scope -> VarP ann -> Atom
 lookupBindings scope v = fromJust $ reduceExpr scope x
-  where (_, LetBound PlainLet x) = scope ! v
+  where (_, LetBound (PlainLet NoEffects) x) = scope ! v
 
 -- TODO: extract only the relevant part of the env we can check for module-level
 -- unbound vars and upstream errors here. This should catch all unbound variable

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -4,9 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE LambdaCase #-}
 {-# LANGUAGE FlexibleContexts #-}
-{-# LANGUAGE OverloadedStrings #-}
 
 module TopLevel (evalSourceBlock, EvalConfig (..), initializeBackend,
                  Backend (..)) where
@@ -141,8 +139,8 @@ evalUModuleVal env v m = do
   liftIO $ substArrayLiterals backend val
 
 lookupBindings :: Scope -> VarP ann -> Atom
-lookupBindings scope v = reduceAtom scope x
-  where (_, LetBound PlainLet (Atom x)) = scope ! v
+lookupBindings scope v = fromJust $ reduceExpr scope x
+  where (_, LetBound PlainLet x) = scope ! v
 
 -- TODO: extract only the relevant part of the env we can check for module-level
 -- unbound vars and upstream errors here. This should catch all unbound variable


### PR DESCRIPTION
Our core IR makes a syntactic distinction between expressions (`Expr`) and atoms (`Atom`). Atoms include things like variables, lambdas, literals and constructor applications. They are guaranteed to be fully-reduced (even after substitution) and effect-free. This lets us substitute variables with atoms without ever worrying about duplicating runtime work.

The problem is that this syntactic definition of what's runtime-free is too conservative and we've found ourselves having to add new cases to `Atom` to represent little computations that we want to treat as cheap. We'd rather just be able to use the whole expression language. For example, we have the `SumCon` constructor to represent a value of type `Either a b`, given a boolean tag and values for the left and right cases: `SumCon tag x y`. We'd rather just use an expression like `Case tag of True -> Left x; False -> Right y`. That's cheap enough that we're happy to inline it anywhere. But it's hard to capture that cheapness syntactically.

It's a bigger problem for complicated tables backed by raw buffers, which is why we're making the change now. A table of lists (length-hidden tables) will be backed by a buffer containing the lengths of the lists, and the lists themselves. We can easily write a small expression that constructs such an object from the raw buffers using our ordinary expression language. But it's a stretch to do it purely using our language of atoms.

The plan is to just merge `Atom` into `Expr`, and work with an `isCheap :: Expr -> Bool` predicate that can be defined arbitrarily. Without Haskell's type system helping us, we're going to have to be extra careful to not duplicate work or reorder effects.

