### PR TITLE
Non-extensible records and variants

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -516,7 +516,7 @@ litArr = [10, 5, 3]
       c
 > ([3.0, 2.0, 1.0, 0.0], 4.0)
 
-def eitherFloor (x:Int|Real) : Int = oldcase x
+def eitherFloor (x:(Int|Real)) : Int = oldcase x
   Left i  -> i
   Right f -> floor f
 
@@ -524,7 +524,7 @@ def eitherFloor (x:Int|Real) : Int = oldcase x
 > 1
 
 :p
-  x : Int|Real = Right 1.2
+  x : (Int|Real) = Right 1.2
   x
 > (Right 1.2)
 

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -55,7 +55,7 @@ def leapfrogIntegrate
       (_:VSpace a) ?=>
       ((nsteps, dt): HMCParams)
       (logProb: a -> LogProb)
-      ((x, p): a & a)
+      ((x, p): (a & a))
       : (a & a) =
   x = x + (0.5 * dt) .* p
   (x, p) = applyN nsteps (x, p) \(xOld, pOld).

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -196,10 +196,6 @@ myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
  
 :p for i:(Fin 2).
     case myVariantTable.i of
-      {| a=a |} ->
-        res : {a:Real | b:Int} = {| b=a |}
-        res
-      {| b=b |} ->
-        res : {a:Real | b:Int} = {| a=b |}
-        res
+      {| a=a |} -> {| b=a |}:{a:Real | b:Int}
+      {| b=b |} -> {| a=b |}:{a:Real | b:Int}
 > [{| b = 1 |}, {| a = 2.0 |}]

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -176,3 +176,30 @@ x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
     {| a#1 = x |} -> x
     {| b = x |} -> i2r x
 > 3.0
+
+'Table values and imp lowering
+
+myRecordTable : (Fin 2)=>{a:Int & b:Real} =
+  [{a=1, b=2.0}, {a=3, b=4.0}]
+
+:p myRecordTable
+> [{a = 1, b = 2.0}, {a = 3, b = 4.0}]
+
+:p for i:(Fin 2).
+    ({a=a, b=b}) = myRecordTable.i
+    {a=b, b=a}
+> [{a = 2.0, b = 1}, {a = 4.0, b = 3}]
+
+myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
+:p myVariantTable
+> [{| a = 1 |}, {| b = 2.0 |}]
+ 
+:p for i:(Fin 2).
+    case myVariantTable.i of
+      {| a=a |} ->
+        res : {a:Real | b:Int} = {| b=a |}
+        res
+      {| b=b |} ->
+        res : {a:Real | b:Int} = {| a=b |}
+        res
+> [{| b = 1 |}, {| a = 2.0 |}]

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -61,7 +61,7 @@ Syntax for records, variants, and their types.
 
 
 'Variants (enums)
-:p {| a=3 |}
+
 
 :p
   x : {a:Int | b:Real} = {| a=3 |}
@@ -199,3 +199,31 @@ myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
       {| a=a |} -> {| b=a |}:{a:Real | b:Int}
       {| b=b |} -> {| a=b |}:{a:Real | b:Int}
 > [{| b = 1 |}, {| a = 2.0 |}]
+
+'As index sets
+
+:p size {a:Fin 10 & b:Fin 3}
+> 30
+:p ordinal {a=(7@Fin 10), b=(2@Fin 3)}
+> 27
+:p fromOrdinal (Fin 10 & Fin 3) 14
+> (4@(Fin 10), 2@(Fin 3))
+:p fromOrdinal {a:Fin 10 & b:Fin 3} 14
+> {a = 4@Fin 10, b = 1@Fin 3}
+
+recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
+
+-- TODO: error when printing a table indexed by records
+
+:p size {a:Fin 10 | b:Fin 3}
+> 13
+:p ordinal {| b=(2@_) |}:{a:Fin 10 | b:Fin 3}
+> 12
+:p fromOrdinal {a:Fin 10 | b:Fin 3} 4
+> {| a = 4@Fin 10 |}
+:p fromOrdinal {a:Fin 10 | b:Fin 3} 11
+> {| b = 1@Fin 3 |}
+
+variantsAsIndices : {a:Fin 10 | b:Fin 3}=>{a:Fin 10 | b:Fin 3} = for i. i
+
+-- TODO: error when printing a table indexed by variants

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -1,0 +1,126 @@
+
+'Record types
+
+:p {&}
+> { &}
+
+:p {a:Int & b:Real}
+> {a: Int & b: Real}
+
+:p {a:Int & b:Real &}
+> {a: Int & b: Real}
+
+:p {a:Int & a:Real}
+> {a: Int & a: Real}
+
+
+'Records
+
+:p {}
+> {,}
+:t {}
+> { &}
+
+:p {,}
+> {,}
+:t {,}
+> { &}
+
+:p {a=3, b=4}
+> {a = 3, b = 4}
+:t {a=3, b=4}
+> {a: Int & b: Int}
+
+:p {a=3, b=4,}
+> {a = 3, b = 4}
+:t {a=3, b=4,}
+> {a: Int & b: Int}
+
+:p {a=3, a=4}
+> {a = 3, a = 4}
+:t {a=3, a=4}
+> {a: Int & a: Int}
+
+
+'Variant (enum) types
+
+:p {|}
+> { |}
+
+:p {a:Int | b:Real}
+> {a: Int | b: Real}
+
+:p {a:Int | b:Real |}
+> {a: Int | b: Real}
+
+:p {a:Int | a:Real}
+> {a: Int | a: Real}
+
+
+'Variants (enums)
+:p {| a=3 |}
+
+:p
+  x : {a:Int | b:Real} = {| a=3 |}
+  x
+> {| a = 3 |}
+
+:p
+  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+  x
+> {| a#1 = 3.0 |}
+
+:t
+  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+  x
+> {a: Int | a: Real | a: Int}
+
+
+'Parse errors
+
+:p {a:Int & b:Real | c:Int }
+
+> Parse error:81:20:
+>    |
+> 81 | :p {a:Int & b:Real | c:Int }
+>    |                    ^
+> unexpected '|'
+> expecting "..", "..<", "<..", "<..<", "=>", '$', '&', '.', '}', arrow, backquoted name, expression, or infix operator
+:p {a:Int & b:Real & ...c}
+
+> Parse error:89:26:
+>    |
+> 89 | :p {a:Int & b:Real & ...c}
+>    |                          ^
+> Extensible records and variants not implemented
+:p {&...c}
+
+> Parse error:96:10:
+>    |
+> 96 | :p {&...c}
+>    |          ^
+> Extensible records and variants not implemented
+:p {a=3, b=4, ...c}
+
+> Parse error:103:19:
+>     |
+> 103 | :p {a=3, b=4, ...c}
+>     |                   ^
+> Extensible records and variants not implemented
+:p {a:Int | b:Real | ...c}
+
+> Parse error:110:26:
+>     |
+> 110 | :p {a:Int | b:Real | ...c}
+>     |                          ^
+> Extensible records and variants not implemented
+:p {|...c}> Parse error:70:10:
+>    |
+> 70 | :p {|...c}
+>    |          ^
+> Extensible records and variants not implemented
+> Parse error:117:10:
+>     |
+> 117 | :p {|...c}> Parse error:70:10:
+>     |          ^
+> Extensible records and variants not implemented

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -1,4 +1,7 @@
 
+'Basics:
+Syntax for records, variants, and their types.
+
 'Record types
 
 :p {&}
@@ -80,47 +83,77 @@
 
 :p {a:Int & b:Real | c:Int }
 
-> Parse error:81:20:
+> Parse error:84:20:
 >    |
-> 81 | :p {a:Int & b:Real | c:Int }
+> 84 | :p {a:Int & b:Real | c:Int }
 >    |                    ^
 > unexpected '|'
-> expecting "..", "..<", "<..", "<..<", "=>", '$', '&', '.', '}', arrow, backquoted name, expression, or infix operator
+> expecting "..", "..<", expression, or negation
 :p {a:Int & b:Real & ...c}
 
-> Parse error:89:26:
+> Parse error:92:26:
 >    |
-> 89 | :p {a:Int & b:Real & ...c}
+> 92 | :p {a:Int & b:Real & ...c}
 >    |                          ^
 > Extensible records and variants not implemented
 :p {&...c}
 
-> Parse error:96:10:
+> Parse error:99:10:
 >    |
-> 96 | :p {&...c}
+> 99 | :p {&...c}
 >    |          ^
 > Extensible records and variants not implemented
 :p {a=3, b=4, ...c}
 
-> Parse error:103:19:
+> Parse error:106:19:
 >     |
-> 103 | :p {a=3, b=4, ...c}
+> 106 | :p {a=3, b=4, ...c}
 >     |                   ^
 > Extensible records and variants not implemented
 :p {a:Int | b:Real | ...c}
 
-> Parse error:110:26:
+> Parse error:113:26:
 >     |
-> 110 | :p {a:Int | b:Real | ...c}
+> 113 | :p {a:Int | b:Real | ...c}
 >     |                          ^
 > Extensible records and variants not implemented
-:p {|...c}> Parse error:70:10:
->    |
-> 70 | :p {|...c}
->    |          ^
-> Extensible records and variants not implemented
-> Parse error:117:10:
+:p {|...c}
+
+> Parse error:120:10:
 >     |
-> 117 | :p {|...c}> Parse error:70:10:
+> 120 | :p {|...c}
 >     |          ^
 > Extensible records and variants not implemented
+
+'Unpacking
+
+
+:p
+  ({b=b, a=a1, a=a2}) = {a=1, b=2, a=3}
+  (a1, a2, b)
+> (1, (3, 2))
+
+({b=b, a=a1, a=a2}) = {a=1, b=2, a=3}
+:p (a1, a2, b)
+> (1, (3, 2))
+
+:p
+  ({b=b, a=a1, a=a2}) = {a=1, b=2}
+  (a1, a2, b)
+> Type error:Labels in record pattern do not match record type. Expected structure {a: Int & b: Int}
+>
+>   ({b=b, a=a1, a=a2}) = {a=1, b=2}
+>    ^^^^^^^^^^^^^^^^^
+
+:p
+  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+  ({| a#1 = a |}) = x
+  x
+> Type error:Variant not allowed in can't-fail pattern
+>
+>   ({| a#1 = a |}) = x
+>    ^^^^^^^^^^^^^
+
+x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+({| a#1 = a |}) = x
+> Type error:Variant not allowed in can't-fail pattern

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -157,3 +157,22 @@ Syntax for records, variants, and their types.
 x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
 ({| a#1 = a |}) = x
 > Type error:Variant not allowed in can't-fail pattern
+
+
+'Pattern matching
+
+-- Not allowed: use a let binding instead
+:p case {a=1, b=2, a=3} of
+  {b=b, a=a1, a=a2} -> (a1, a2, b)
+> Type error:Case patterns must start with a data constructor or variant pattern
+>
+>   {b=b, a=a1, a=a2} -> (a1, a2, b)
+>   ^^^^^^^^^^^^^^^^^^
+
+:p
+  x : {a:Int | a:Real | b:Int} = {| a#1 = 3.0 |}
+  case x of
+    {| a#0 = x |} -> i2r x
+    {| a#1 = x |} -> x
+    {| b = x |} -> i2r x
+> 3.0

--- a/examples/serialize-tests.dx
+++ b/examples/serialize-tests.dx
@@ -27,5 +27,5 @@
 :p Fin 10
 > Fin 10
 
-:p Fin 10 & Fin 20
-> Fin 10 & Fin 20
+:p (Fin 10 & Fin 20)
+> (Fin 10 & Fin 20)

--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -195,13 +195,13 @@ def passthrough (eff:Effects) ?-> (f:(a -> {|eff} b)) (x:a) : {|eff} b = f x
 >   f : a:Type -> a -> a = \a. \x. myId x
 >                           ^^^^^^^^^^^^^
 
-def myFst (p:a&b) : a =
+def myFst (p:(a&b)) : a =
   (x, _) = p
   x
 :p myFst (1,2)
 > 1
 
-def myOtherFst ((x, _):a&b) : a = x
+def myOtherFst ((x, _):(a&b)) : a = x
 :p myOtherFst (1,2)
 > 1
 

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 ad-tests mandelbrot pi sierpinsky \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator parser-tests serialize-tests tiled-matmul \
-                mcmc
+                mcmc record-variant-tests
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -12,9 +12,9 @@ Type = %TyKind
 Effects = %EffKind
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
-def (,) (x:a) (y:b) : a & b = %pair x y
-def fst (p: a & b) : a = %fst p
-def snd (p: a & b) : b = %snd p
+def (,) (x:a) (y:b) : (a & b) = %pair x y
+def fst (p: (a & b)) : a = %fst p
+def snd (p: (a & b)) : b = %snd p
 
 def idiv (x:Int) (y:Int) : Int = %idiv x y
 def rem  (x:Int) (y:Int) : Int = %irem x y
@@ -99,7 +99,7 @@ def sumCon (isLeft:Bool) (l:a) (r:b) : (a|b) =
 
 def Left  (x:a) : (a|b) = sumCon True  x      anyVal
 def Right (x:b) : (a|b) = sumCon False anyVal x
-def caseAnalysis (x:a|b) (l:a->c) (r:b->c) : c = %caseAnalysis x l r
+def caseAnalysis (x:(a|b)) (l:a->c) (r:b->c) : c = %caseAnalysis x l r
 
 def select (p:Bool) (x:a) (y:a) : a = case p of
   True  -> x
@@ -248,7 +248,7 @@ pi : Real = 3.141592653589793
 def id (x:a) : a = x
 def dup (x:a) : (a & a) = (x, x)
 -- TODO: unpack pair in args once we fix the bug
-def swap (p:a&b) : (b&a) = (snd p, fst p)
+def swap (p:(a&b)) : (b&a) = (snd p, fst p)
 def map (f:a->{|eff} b) (xs: n=>a) : {|eff} (n=>b) = for i. f xs.i
 def zip (xs:n=>a) (ys:n=>b) : (n=>(a&b)) = for i. (xs.i, ys.i)
 def unzip (xys:n=>(a&b)) : (n=>a & n=>b) = (map fst xys, map snd xys)

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -11,8 +11,9 @@ module Algebra (Constant, Monomial, Polynomial,
 
 import Prelude hiding (lookup, sum, pi)
 import Control.Monad
+import qualified Data.Foldable as F
 import Data.Ratio
-import Data.Map.Strict hiding (foldl)
+import Data.Map.Strict hiding (foldl, map)
 import Data.Text.Prettyprint.Doc
 import Data.List (intersperse)
 import Data.Tuple (swap)
@@ -88,6 +89,14 @@ indexSetSize (TC con) = case con of
   PairType l r -> mulC (indexSetSize l) (indexSetSize r)
   SumType l r  -> add  (indexSetSize l) (indexSetSize r)
   _ -> error $ "Not implemented " ++ pprint con
+indexSetSize (RecordTy types) = let
+  sizes = map indexSetSize (F.toList types)
+  one = liftC $ toPolynomial $ IntVal 1
+  in foldl mulC one sizes
+indexSetSize (VariantTy types) = let
+  sizes = map indexSetSize (F.toList types)
+  zero = liftC $ toPolynomial $ IntVal 0
+  in foldl add zero sizes
 indexSetSize ty = error $ "Not implemented " ++ pprint ty
 
 toPolynomial :: Atom -> Polynomial

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -581,6 +581,11 @@ traverseAtom def@(_, fAtom) atom = case atom of
   DataCon dataDef params con args -> DataCon dataDef <$>
     traverse fAtom params <*> pure con <*> traverse fAtom args
   TypeCon dataDef params -> TypeCon dataDef <$> traverse fAtom params
+  Record items -> Record <$> traverse fAtom items
+  RecordTy items -> RecordTy <$> traverse fAtom items
+  Variant types label i value -> Variant <$>
+    traverse fAtom types <*> pure label <*> pure i <*> fAtom value
+  VariantTy items -> VariantTy <$> traverse fAtom items
 
 -- === DCE ===
 

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -114,6 +114,11 @@ toImpExpr env (maybeDest, expr) = case expr of
       DataCon _ _ con args -> do
         let Abs bs body = alts !! con
         toImpBlock (env <> newEnv bs args) (maybeDest, body)
+      Variant types label i x -> do
+        let LabeledItems ixtypes = enumerate types
+        let index = fst $ ixtypes M.! label !! i
+        let Abs bs body = alts !! index
+        toImpBlock (env <> newEnv bs [x]) (maybeDest, body)
       Con (SumAsProd _ tag xss) -> do
         let tag' = fromScalarAtom tag
         dest <- allocDest maybeDest $ getType expr

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -437,7 +437,9 @@ instance PrettyPrec UExpr' where
       nest 2 (hardline <> prettyLines alts)
     URecord items -> prettyLabeledItems items (line' <> ",") " ="
     URecordTy items -> prettyLabeledItems items (line <> "&") ":"
-    UVariant label i value -> prettyVariant label i value
+    UVariant Nothing label i value -> prettyVariant label i value
+    UVariant (Just ann) label i value -> atPrec ArgPrec $
+      prettyVariant label i value AppPrec <> prettyAnn (pApp ann)
     UVariantTy items -> prettyLabeledItems items (line <> "|") ":"
 
 instance Pretty UAlt where

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -489,7 +489,10 @@ baseType =   (symbol "Int"  $> Scalar IntType)
          <|> (symbol "Bool" $> Scalar BoolType)
 
 uVariantExpr :: Parser UExpr
-uVariantExpr = withSrc $ parseVariant expr UVariant
+uVariantExpr = withSrc $ do
+  (thelabel, i, value) <- parseVariant expr (,,)
+  ty <- optional (annot uType)
+  return $ UVariant ty thelabel i value
 
 parseVariant :: Parser a -> (Label -> Int -> a -> b) -> Parser b
 parseVariant subparser f = bracketed (symbol "{|") (symbol "|}") $ do

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -492,10 +492,10 @@ uVariantExpr :: Parser UExpr
 uVariantExpr = withSrc $ parseVariant expr UVariant
 
 parseVariant :: Parser a -> (Label -> Int -> a -> b) -> Parser b
-parseVariant subparser f = bracketed (sym "{|") (sym "|}") $ do
+parseVariant subparser f = bracketed (symbol "{|") (symbol "|}") $ do
   itemLabel <- lexeme $ some rowLabelChar
-  i <- (sym "#" >> uint) <|> return 0
-  sym "="
+  i <- (symbol "#" >> uint) <|> return 0
+  symbol "="
   itemVal <- subparser
   return $ f itemLabel i itemVal
 
@@ -870,5 +870,5 @@ failIf :: Bool -> String -> Parser ()
 failIf True s = fail s
 failIf False _ = return ()
 
-debug :: Show a => String -> Parser a -> Parser a
-debug s m = mapReaderT (Text.Megaparsec.Debug.dbg s) m
+_debug :: Show a => String -> Parser a -> Parser a
+_debug s m = mapReaderT (Text.Megaparsec.Debug.dbg s) m

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -209,14 +209,12 @@ prettyVal val = case val of
       where
         DataConDef conName _ = dataCons !! i
         args = payload !! i
-    SumAsProd (VariantTy ltys@(LabeledItems types)) (IntVal i) payload ->
+    SumAsProd (VariantTy types) (IntVal i) payload ->
       pretty variant
       where
         [value] = payload !! i
-        reflect = LabeledItems $ flip M.mapWithKey types $ \k -> \xs ->
-          map (k,) [0..length xs - 1]
-        (theLabel, repeatNum) = toList reflect !! i
-        variant = Variant ltys theLabel repeatNum value 
+        (theLabel, repeatNum) = toList (reflectLabels types) !! i
+        variant = Variant types theLabel repeatNum value
     _           -> pretty con
   atom -> prettyPrec atom LowestPrec
 

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -24,9 +24,11 @@ import System.IO.MMap
 import System.Posix hiding (ReadOnly, version)
 import Text.Megaparsec hiding (State)
 import Text.Megaparsec.Char
+import Data.Foldable (toList)
 import Data.Store hiding (size)
 import Data.Text.Prettyprint.Doc  hiding (brackets)
 import Data.List (transpose)
+import qualified Data.Map.Strict as M
 
 import Array
 import Interpreter
@@ -207,6 +209,14 @@ prettyVal val = case val of
       where
         DataConDef conName _ = dataCons !! i
         args = payload !! i
+    SumAsProd (VariantTy ltys@(LabeledItems types)) (IntVal i) payload ->
+      pretty variant
+      where
+        [value] = payload !! i
+        reflect = LabeledItems $ flip M.mapWithKey types $ \k -> \xs ->
+          map (k,) [0..length xs - 1]
+        (theLabel, repeatNum) = toList reflect !! i
+        variant = Variant ltys theLabel repeatNum value 
     _           -> pretty con
   atom -> prettyPrec atom LowestPrec
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -97,6 +97,11 @@ simplifyAtom atom = case atom of
   TypeCon def params          -> TypeCon def <$> substEmbedR params
   DataCon def params con args -> DataCon def <$> substEmbedR params
                                              <*> pure con <*> mapM simplifyAtom args
+  Record items -> Record <$> mapM simplifyAtom items
+  RecordTy items -> RecordTy <$> substEmbedR items
+  Variant types label i value -> Variant <$>
+    substEmbedR types <*> pure label <*> pure i <*> simplifyAtom value
+  VariantTy items -> VariantTy <$> substEmbedR items
   where mkAny t = Con . AnyValue <$> substEmbedR t >>= simplifyAtom
 
 -- `Nothing` is equivalent to `Just return` but we can pattern-match on it

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -64,6 +64,7 @@ simplifyDecl (Unpack bs expr) = do
   x <- simplifyExpr expr
   xs <- case x of
     DataCon _ _ _ xs -> return xs
+    Record items -> return $ toList items
     _ -> emitUnpack $ Atom x
   return $ newEnv bs xs
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -205,6 +205,8 @@ data UPat' = UPatBinder UBinder
            | UPatLit LitVal
            | UPatPair UPat UPat
            | UPatUnit
+           | UPatRecord (LabeledItems UPat)
+           | UPatVariant Label Int UPat
              deriving (Show)
 
 data WithSrc a = WithSrc SrcPos a
@@ -630,6 +632,8 @@ instance HasUVars UPat' where
     UPatLit _      -> mempty
     UPatPair p1 p2 -> freeUVars p1 <> freeUVars p2
     UPatUnit       -> mempty
+    UPatRecord items -> freeUVars items
+    UPatVariant _ _ p -> freeUVars p
 
 instance BindsUVars UPat' where
   boundUVars pat = case pat of
@@ -638,6 +642,8 @@ instance BindsUVars UPat' where
     UPatLit _      -> mempty
     UPatPair p1 p2 -> boundUVars p1 <> boundUVars p2
     UPatUnit       -> mempty
+    UPatRecord items -> boundUVars items
+    UPatVariant _ _ p -> boundUVars p
 
 instance HasUVars UDecl where
   freeUVars (ULet _ p expr) = freeUVars p <> freeUVars expr
@@ -700,6 +706,9 @@ instance BindsUVars UConDef where
 
 instance BindsUVars a => BindsUVars (WithSrc a) where
   boundUVars (WithSrc _ x) = boundUVars x
+
+instance BindsUVars a => BindsUVars (LabeledItems a) where
+  boundUVars items = foldMap boundUVars items
 
 nameAsEnv :: Name -> UVars
 nameAsEnv v = v@>()

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -20,7 +20,7 @@ module Syntax (
     ImpProg (..), ImpStatement, ImpInstr (..), IExpr (..), IVal, IPrimOp,
     IVar, IBinder, IType (..), ArrayType, SetVal (..), MonMap (..), LitProg,
     UAlt (..), Alt, binderBinding, Label, LabeledItems (..), labeledSingleton,
-    noLabeledItems,
+    noLabeledItems, reflectLabels,
     MDImpFunction (..), MDImpProg (..), MDImpInstr (..), MDImpStatement,
     ImpKernel (..), PTXKernel (..), HasIVars (..), IScope,
     ScalarTableType, ScalarTableBinder, BinderInfo (..),Bindings,
@@ -156,6 +156,10 @@ labeledSingleton label value = LabeledItems $ M.singleton label [value]
 
 noLabeledItems :: LabeledItems a
 noLabeledItems = LabeledItems M.empty
+
+reflectLabels :: LabeledItems a -> LabeledItems (Label, Int)
+reflectLabels (LabeledItems items) = LabeledItems $
+  flip M.mapWithKey items $ \k xs -> map (k,) [0..length xs - 1]
 
 instance Semigroup (LabeledItems a) where
   LabeledItems items <> LabeledItems items' =
@@ -1155,8 +1159,10 @@ pattern BoolTy :: Type
 pattern BoolTy = TC (BaseType (Scalar BoolType))
 
 pattern PreludeBoolTy :: Type
-pattern PreludeBoolTy <-
-  TypeCon (DataDef _ Empty [DataConDef _ Empty, DataConDef _ Empty]) []
+pattern PreludeBoolTy =
+  TypeCon (DataDef (GlobalName "Bool") Empty
+    [ DataConDef (GlobalName "False") Empty
+    , DataConDef (GlobalName "True") Empty]) []
 
 pattern RealTy :: Type
 pattern RealTy = TC (BaseType (Scalar RealType))

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -176,7 +176,7 @@ data UExpr' = UVar UVar
             | UIndexRange (Limit UExpr) (Limit UExpr)
             | UPrimExpr (PrimExpr Name)
             | URecord (LabeledItems UExpr)
-            | UVariant Label Int UExpr
+            | UVariant (Maybe UExpr) Label Int UExpr
             | URecordTy (LabeledItems UExpr)
             | UVariantTy (LabeledItems UExpr)
               deriving (Show, Generic)
@@ -615,7 +615,7 @@ instance HasUVars UExpr' where
     UPrimExpr _ -> mempty
     UCase e alts -> freeUVars e <> foldMap freeUVars alts
     URecord ulr -> freeUVars ulr
-    UVariant _ _ val -> freeUVars val
+    UVariant types _ _ val -> freeUVars types <> freeUVars val
     URecordTy ulr -> freeUVars ulr
     UVariantTy ulr -> freeUVars ulr
 

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -229,8 +229,12 @@ checkDecl env decl = withTypeEnv env $ addContext ctxStr $ case decl of
     return $ binderBinding b
   Unpack bs rhs -> do
     void $ checkNestedBinders bs
-    TypeCon def params <- typeCheck rhs
-    [DataConDef _ bs'] <- return $ applyDataDefParams def params
+    ty <- typeCheck rhs
+    bs' <- case ty of
+      TypeCon def params -> do
+        [DataConDef _ bs'] <- return $ applyDataDefParams def params
+        return bs'
+      RecordTy types -> return $ toNest $ map Ignore $ toList types
     checkEq bs bs'
     return $ foldMap binderBinding bs
   where ctxStr = "checking decl:\n" ++ pprint decl


### PR DESCRIPTION
This PR adds support for non-extensible records and variants, with optionally repeated labels.

Syntax-wise, records look like
```
x : {a: Int & b: Real} = {a = 3, b = 4.0}
```
and variants look like
```
x : {a: Int | b: Real} = {| a = 3 |}
```

I used `&` and `|` for parity with tuples and Either. Empty records are denoted as `x : {&} = {}`. Technically there's an empty variant type `{|}` but it is uninhabited.

One interesting property of the implementation is that you are allowed to repeat labels. This was originally designed to support easy extensible records (see Daan Leijen's "Extensible records with scoped labels") but I don't think it causes any harm to include them in the non-extensible case. Perhaps this will make it easier to add extensibility in the future.

Records can be unpacked using pattern-matching let bindings, and variants can be unpacked using a case statement. For now, variants need to be explicitly annotated with their type unless it is sufficiently obvious (to the typechecker) from the preceding code what the type is. You can freely put either records or variants into tables, and hopefully can combine them in arbitrary ways.

I've implemented some preliminary logic for treating records and variants as index sets, since records have a nice interpretation as named axes, and variants as named slices/concatenations. However, so far I haven't figured out how to plumb everything through the low level internals. I got far enough that you can create tables indexed by variants, but once you have one of those tables, you can't print it or get anything out of it without getting a bunch of errors. Hopefully this is easy to fix for someone with a better mental model of how Imp and Interpreter work.

Some things I wasn't sure about:

- At some points I needed a binder, but I didn't have one, so I used `Ignore ty` even though I wasn't necessarily going to ignore it. There's probably a better way of doing that, though.
- I sort of hacked together the `Imp` translation rules, so it's very possible that I missed something.
- There were some shenanigans I had to do to get the index set logic working, in particular generating case statements and casting things to `PreludeBoolTy` to enable pattern matching on them. I feel like there's probably something simpler than that? Although I suppose it's not too terrible.

Eventually, we may want to make the records and variants extensible, so that you could write something like `{a=x, b=y, ...c}` to add fields `a` and `b` to a record `c`. This could enable some cool polymorphic helper functions or other interesting use cases, and would also make it so variants don't have to be annotated with a type (since we could infer some extensible type and then let unification figure out what the real type was).