### PR TITLE
Replace built-in `Either` with a prelude-defined ADT version.

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -24,14 +24,14 @@ def interleave (blank:v) (labels: m=>v) : (m & (Fin 2))=>v =
   pairs = for i. [labels.i, blank]
   for (i, j). pairs.i.j
 
-def prepend (first: v) (seq: m=>v) : (Unit|m)=>v =
+def prepend (first: v) (seq: m=>v) : ({head:Unit | tail:m }=>v) =
   -- Concatenates a single element to the beginning of a sequence.
-  for idx. case idx
-    Left () -> first
-    Right i -> seq.i
+  for idx. case idx of
+    {| head = () |} -> first
+    {| tail = i  |} -> seq.i
 
-def prepend_and_interleave (blank:v) (seq: m=>v) : 
-  ((Unit | (m & (Fin 2)))=>v) =
+def prepend_and_interleave (blank:v) (seq: m=>v) :
+  ({head:Unit | tail:(m & (Fin 2))}=>v) =
   -- Turns "text" into " t e x t".
   -- The output of this function has a slightly complicated output type, which
   -- has size 1 + 2 * (size m).
@@ -63,7 +63,12 @@ def ctc (time : Type) ?-> (vocab : Type) ?-> (position : Type) ?->
   logprob_start_with_blank = normalized_logits.(0@_).blank
   logprob_of_first_label   = normalized_logits.(0@_).(labels.(0@_))
   log_prob_seq_t0 = for pos.
-    select  (pos == (0@_)) logprob_start_with_blank (select (pos == (1@_)) logprob_of_first_label (log 0.000001))
+    -- TODO: allow pattern-matching on integer literals
+    case ordinal pos == 0 of
+      True -> logprob_start_with_blank
+      False -> case ordinal pos == 1 of
+        True  -> logprob_of_first_label
+        False -> log 0.000001
 
   same_as_last = \ilabels s.
     o = ordinal s
@@ -75,22 +80,22 @@ def ctc (time : Type) ?-> (vocab : Type) ?-> (position : Type) ?->
   -- Todo: As suggested by Adam Paske, we could get rid of these
   -- logaddexp calls with a newtype that overloads + and *
   update = \t prev.
-    select (t == (0@_)) log_prob_seq_t0 for s.
-      cond = ilabels.s == blank || same_as_last ilabels s
-      labar = logaddexp prev.s (safe_idx prev ((ordinal s) - 1))
-      other = logaddexp labar  (safe_idx prev ((ordinal s) - 2))
-      ans = select cond labar other
-      ans + normalized_logits.t.(ilabels.s)
+    case ordinal t == 0 of
+      True -> log_prob_seq_t0
+      False -> for s.
+        cond = ilabels.s == blank || same_as_last ilabels s
+        labar = logaddexp prev.s (safe_idx prev ((ordinal s) - 1))
+        other = logaddexp labar  (safe_idx prev ((ordinal s) - 2))
+        ans = select cond labar other
+        ans + normalized_logits.t.(ilabels.s)
 
   log_prob_seq_final = fold log_prob_seq_t0 update
 
   -- Todo: nicer way to get last two elements of log_prob_seq_final.
-  padded_positions = Unit | (position & (Fin 2))
-  seq_length = size padded_positions
+  seq_length = 1 + size (position & (Fin 2))
   endlabel = log_prob_seq_final.((seq_length - 2)@_)
   endspace = log_prob_seq_final.((seq_length - 1)@_)
   logaddexp endlabel endspace
-
 
 
 '### Demo
@@ -110,9 +115,11 @@ logits = for i:time j:vocab. (randn $ ixkey2 (newKey 0) i j)
 -- Create random labels
 labels = for i:position. randIdxNoZero vocab (newKey (ordinal i))
 :p labels
+> [1@(Fin 6), 5@(Fin 6), 5@(Fin 6)]
 
 -- Evaluate marginal probability of labels given logits
 :p exp $ ctc blank logits labels
+> 1.0398494e-3
 
 
 
@@ -126,9 +133,12 @@ labels = for i:position. randIdxNoZero vocab (newKey (ordinal i))
 
 :p sum for i:vocab.
   exp $ ctc blank logits [i]
+> 0.14146832
 
 :p sum for (i, j):(vocab & vocab).
   exp $ ctc blank logits [i, j]
+> 0.7091231
 
 :p sum for (i, j, k):(vocab & vocab & vocab).
   exp $ ctc blank logits [i, j, k]
+> 0.9251014

--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -516,7 +516,7 @@ litArr = [10, 5, 3]
       c
 > ([3.0, 2.0, 1.0, 0.0], 4.0)
 
-def eitherFloor (x:(Int|Real)) : Int = oldcase x
+def eitherFloor (x:(Int|Real)) : Int = case x of
   Left i  -> i
   Right f -> floor f
 
@@ -526,24 +526,24 @@ def eitherFloor (x:(Int|Real)) : Int = oldcase x
 :p
   x : (Int|Real) = Right 1.2
   x
-> (Right 1.2)
+> Right 1.2
 
 -- Sum types as flattened index sets!
 def Weights (n:Type) (m:Type) : Type = n=>m=>Real
 def Biases  (n:Type)          : Type = n=>Real
-def Params  (n:Type) (m:Type) : Type = ((n&m)|n)=>Real
+def Params  (n:Type) (m:Type) : Type = {weights:(n&m) | biases:n}=>Real
 
 w = for i:(Fin 2). for j:(Fin 3). (i2r (ordinal i)) * 3.0 + (i2r (ordinal j))
 b = for j:(Fin 2). neg (i2r (ordinal j) + 1.0)
 
 def flatten ((w,b):(Weights n m & Biases n)): Params n m =
-  for idx. oldcase idx
-    Left (i,j) -> w.i.j
-    Right i    -> b.i
+  for idx. case idx of
+    {| weights = (i,j) |} -> w.i.j
+    {| biases  = i     |} -> b.i
 
 def unflatten (params:Params n m) : (Weights n m & Biases n) =
-  ( for i. for j. params.(Left (i,j))
-  , for i.        params.(Right i)    )
+  ( for i. for j. params.({| weights = (i,j)|})
+  , for i.        params.({| biases  = i    |}))
 
 :p unflatten (flatten (w, b)) == (w, b)
 > True

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -327,3 +327,9 @@ bad_range : Int = (1@Fin 3)..(2@_)
 
 5.0 .* ()
 > ()
+
+:p (\x:Int. x) == (\x:Int. x)
+> Type error:Couldn't synthesize a class dictionary for: (Eq (Int -> Int))
+>
+> :p (\x:Int. x) == (\x:Int. x)
+>                ^^^

--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -238,7 +238,7 @@ def myOtherFst ((x, _):(a&b)) : a = x
 
 id'' : b -> b = id
 
-def eitherFloor (x:(Int|Real)) : Int = oldcase x
+def eitherFloor (x:(Int|Real)) : Int = case x of
   Left  i -> i
   Right f -> floor f
 

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 ad-tests mandelbrot pi sierpinsky \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator parser-tests serialize-tests tiled-matmul \
-                mcmc record-variant-tests simple-include-test
+                mcmc record-variant-tests simple-include-test ctc
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -99,15 +99,9 @@ def isNothing (x:Maybe a) : Bool = case x of
   Nothing -> True
   Just _ -> False
 
-def (|) (a:Type) (b:Type) : Type = %SumType a b
-def anyVal (a:Type) ?-> : a = %anyVal a
-def sumCon (isLeft:Bool) (l:a) (r:b) : (a|b) =
-  isLeft' = unsafeCoerce InternalBool isLeft
-  %sumCon isLeft' l r
-
-def Left  (x:a) : (a|b) = sumCon True  x      anyVal
-def Right (x:b) : (a|b) = sumCon False anyVal x
-def caseAnalysis (x:(a|b)) (l:a->c) (r:b->c) : c = %caseAnalysis x l r
+data (|) a:Type b:Type =
+  Left  a
+  Right b
 
 def select (p:Bool) (x:a) (y:a) : a = case p of
   True  -> x
@@ -189,16 +183,6 @@ def pairOrd (ordA: Ord a)?=> (ordB: Ord b)?=> : Ord (a & b) =
   pairGt = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
   pairLt = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
   MkOrd pairEq pairGt pairLt
-
-@instance
-def sumEq (eqA: Eq a)?=> (eqB: Eq b)?=> : Eq (a | b) = MkEq $
-  \x y. oldcase x
-    Left  xVal -> oldcase y
-      Left  yVal -> xVal == yVal
-      Right yVal -> False
-    Right xVal -> oldcase y
-      Left  yVal -> False
-      Right yVal -> xVal == yVal
 
 -- TODO: accumulate using the True/&& monoid
 @instance

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -87,7 +87,6 @@ indexSetSize (TC con) = case con of
         ExclusiveLim h -> toPolynomial h
         Unlimited      -> undefined
   PairType l r -> mulC (indexSetSize l) (indexSetSize r)
-  SumType l r  -> add  (indexSetSize l) (indexSetSize r)
   _ -> error $ "Not implemented " ++ pprint con
 indexSetSize (RecordTy types) = let
   sizes = map indexSetSize (F.toList types)

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -141,10 +141,8 @@ toImpOp (maybeDest, op) = case op of
       ithDest <- destGet dest =<< intToIndex (binderType b) (IIntVal i)
       copyAtom ithDest row
     destToAtom dest
-  SumGet ~(SumVal  _ l r) left -> returnVal $ if left then l else r
-  SumTag ~(SumVal  t _ _)      -> returnVal t
-  Fst    ~(PairVal x _)        -> returnVal x
-  Snd    ~(PairVal _ y)        -> returnVal y
+  Fst ~(PairVal x _) -> returnVal x
+  Snd ~(PairVal _ y) -> returnVal y
   PrimEffect ~(Var refVar) m -> do
     refDest <- looks $ (! refVar) . fst . fst
     case m of
@@ -453,7 +451,6 @@ splitDest (maybeDest, (Block decls ans)) = do
                                             gatherVarDests (Dest rd) rr
         (UnitCon       , UnitCon       ) -> return ()
         (Coerce _ db   , Coerce _ rb   ) -> gatherVarDests (Dest db) rb
-        (_             , SumCon _ _ _  ) -> error "Not implemented"
         _ -> unreachable
       _ -> unreachable
       where
@@ -626,7 +623,6 @@ zipWithDest dest@(Dest destAtom) atom f = case (destAtom, atom) of
     (PairCon ld rd, PairCon la ra) -> rec (Dest ld) la >> rec (Dest rd) ra
     (UnitCon      , UnitCon      ) -> return ()
     (Coerce _ d   , Coerce _ a   ) -> rec (Dest d) a
-    (SumCon _ _ _ , SumCon _ _ _ ) -> error "Not implemented"
     (SumAsProd _ tag xs, SumAsProd _ tag' xs') -> do
       recDest tag tag'
       zipWithM_ (zipWithM_ recDest) xs xs'

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -713,12 +713,20 @@ unify t1 t2 = do
        when (void arr /= void arr') $ throw TypeErr ""
        unify resultTy resultTy'
        unifyEff (arrowEff arr) (arrowEff arr')
+    (RecordTy  items, RecordTy  items') -> unifyLabeledItems items items'
+    (VariantTy items, VariantTy items') -> unifyLabeledItems items items'
     (TypeCon f xs, TypeCon f' xs')
       | f == f' && length xs == length xs' -> zipWithM_ unify xs xs'
     (TC con, TC con') | void con == void con' ->
       zipWithM_ unify (toList con) (toList con')
     (Eff eff, Eff eff') -> unifyEff eff eff'
     _ -> throw TypeErr ""
+
+unifyLabeledItems :: (MonadCat SolverEnv m, MonadError Err m)
+                  => LabeledItems Type -> LabeledItems Type -> m ()
+unifyLabeledItems m m' = do
+  when (reflectLabels m /= reflectLabels m') $ throw TypeErr ""
+  zipWithM_ unify (toList m) (toList m')
 
 unifyEff :: (MonadCat SolverEnv m, MonadError Err m)
          => EffectRow -> EffectRow -> m ()

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -102,8 +102,6 @@ evalOpDefined expr = case expr of
     _ -> evalEmbed (indexToIntE (getType idxArg) idxArg)
   Fst p         -> x                     where (PairVal x _) = p
   Snd p         -> y                     where (PairVal _ y) = p
-  SumTag s      -> t                     where (SumVal t _ _) = s
-  SumGet s left -> if left then l else r where (SumVal _ l r) = s
   _ -> error $ "Not implemented: " ++ pprint expr
 
 indices :: Type -> [Atom]
@@ -113,8 +111,6 @@ indices ty = case ty of
   TC (IndexRange _ _ _)  -> fmap (Con . Coerce ty . IntVal) [0..n - 1]
   TC (PairType lt rt)    -> [PairVal l r | l <- indices lt, r <- indices rt]
   TC (UnitType)          -> [UnitVal]
-  TC (SumType lt rt)     -> fmap (\l -> SumVal (BoolVal True)  l (Con (AnyValue rt))) (indices lt) ++
-                            fmap (\r -> SumVal (BoolVal False) (Con (AnyValue lt)) r) (indices rt)
   RecordTy types         -> let
     subindices = map indices (toList types)
     products = foldl (\prevs curs -> [cur:prev | cur <- curs, prev <- prevs]) [[]] subindices

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -204,7 +204,7 @@ instance PrettyPrec e => PrettyPrec (PrimCon e) where
     AnyValue t  -> atPrec AppPrec $ pAppArg "%anyVal" [t]
     SumAsProd ty tag payload -> atPrec LowestPrec $
       "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
-    ClassDictHole _ -> atPrec ArgPrec "_"
+    ClassDictHole _ _ -> atPrec ArgPrec "_"
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -227,7 +227,6 @@ flattenType (TC con) = case con of
   BaseType b       -> [BaseTy b]
   IntRange _ _     -> [IntTy]
   IndexRange _ _ _ -> [IntTy]
-  SumType _ _      -> undefined
   _ -> error $ "Unexpected type: " ++ show con
 flattenType ty = error $ "Unexpected type: " ++ show ty
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -254,7 +254,7 @@ data PrimCon e =
       | UnitCon
       | RefCon e e
       | Coerce e e        -- Type, then value. See Type.hs for valid coercions.
-      | ClassDictHole e   -- Only used during type inference
+      | ClassDictHole SrcCtx e   -- Only used during type inference
       | SumAsProd e e [[e]] -- type, tag, payload (only used during Imp lowering)
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -346,8 +346,8 @@ instance CoreVariant (PrimOp a) where
 
 instance CoreVariant (PrimCon a) where
   checkVariant e = case e of
-    ClassDictHole _ -> goneBy Core
-    RefCon _ _      -> neverAllowed
+    ClassDictHole _ _ -> goneBy Core
+    RefCon _ _ -> neverAllowed
     _ -> alwaysAllowed
 
 instance CoreVariant (PrimHof a) where
@@ -471,7 +471,7 @@ typeCheckCon con = case con of
     checkValidCoercion sourceTy destTy
     return destTy
   SumAsProd ty _ _ -> return ty  -- TODO: check!
-  ClassDictHole ty -> ty |: TyKind >> return ty
+  ClassDictHole _ ty -> ty |: TyKind >> return ty
 
 checkValidCoercion :: Type -> Type -> TypeM ()
 checkValidCoercion sourceTy destTy = case (sourceTy, destTy) of


### PR DESCRIPTION
We still don't have index set instances for ADTs, but we can use variants added
in #180 for sum types as index sets.

Also add unification rules for records and variants.