### PR TITLE
Expand raytracer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ or these example programs:
 
   * [Dex prelude](https://google-research.github.io/dex-lang/prelude.html)
   * [Mandelbrot set](https://google-research.github.io/dex-lang/mandelbrot.html)
+  * [Ray tracer](https://google-research.github.io/dex-lang/raytrace.html)
   * [Estimating pi](https://google-research.github.io/dex-lang/pi.html)
   * [Hamiltonian Monte Carlo](https://google-research.github.io/dex-lang/mcmc.html)
   * [ODE integrator](https://google-research.github.io/dex-lang/ode-integrator.html)

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -10,19 +10,26 @@ Specifically, it's based on his unrolled ```lax.scan``` version.
 ' ### Generic Helper Functions
 Some of these should probably go in prelude.
 
+def Vec (n:Int) : Type = Fin n => Real
+def Mat (n:Int) (m:Int) : Type = Fin n => Fin m => Real
+
 def relu (x:Real) : Real = max x 0.0
 def negvec (v:d=>Real) : d=>Real = for i. -v.i
-def (./) (x: d=>Real) (y: Real) : d=>Real = for i. x.i / y
-def (.-) (x: d=>Real) (y: d=>Real) : d=>Real = for i. x.i - y.i
 def length    (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
-def normalize (x: d=>Real) : d=>Real = x ./ (length x)
+-- TODO: make a newtype for normal vectors
+def normalize (x: d=>Real) : d=>Real = x / (length x)
+def directionAndLength (x: d=>Real) : (d=>Real & Real) =
+  l = length x
+  (x / (length x), l)
+
 def dot (_:VSpace v) ?=> (s:d=>Real) (vs:d=>v) : v = sum for j. s.j .* vs.j
-def randuniform (k:Key) (lower:Real) (upper:Real) : Real =
+def randuniform (lower:Real) (upper:Real) (k:Key) : Real =
   lower + (rand k) * (upper - lower)
 
+-- TODO: put `n` and `a` in scope in body
 def reverse (n:Type) ?-> (a:Type) ?-> (x:n=>a) : n=>a =
   s = size n
-  for i. x.((s - 1 - (ordinal i))@_)
+  for i. x.((s - 1 - ordinal i)@_)
 
 def fliplr (n:Type) ?-> (a:Type) ?-> (x: n=>m=>a) : n=>m=>a =
   for i. reverse for j. x.i.j
@@ -30,144 +37,84 @@ def fliplr (n:Type) ?-> (a:Type) ?-> (x: n=>m=>a) : n=>m=>a =
 def flipud (n:Type) ?-> (a:Type) ?-> (x: n=>m=>a) : n=>m=>a =
   reverse for i. x.i
 
+def sampleAveraged (_:VSpace a) ?=> (sample:Key -> a) (n:Int) (k:Key) : a =
+  snd $ withState zero \total.
+    for i:(Fin n).
+      total := get total + sample (ixkey k i) / i2r n
+
+def positiveProjection (x:n=>Real) (y:n=>Real) : Bool = dot x y > 0.0
+
+def addAt (_:Eq n) ?=> (_:VSpace a) ?=> (xs:n=>a) (i:n) (x:a) : n=>a =
+  for j. case i == j of
+           True  -> xs.j + x
+           False -> xs.j
+
+def gradNumerical (n:Int) ?-> (f:Vec n -> Real) (xs:Vec n) : Vec n =
+  eps = 0.0001
+  for i. (f (addAt xs i eps) - f (addAt xs i (neg eps))) / (2.0 * eps)
+
+data IterResult a:Type b:Type =
+  Continue a
+  Done b
+
+-- A little iteration combinator
+-- TODO: allow effects (currently there's some type inference bug preventing it)
+def iter (init:a) (body: Int -> a -> IterResult a b) : b  =
+  result = snd $ withState Nothing \resultRef.
+    withState init \carryRef.
+      withState 0 \i.
+        while (\(). isNothing (get resultRef)) \().
+          case body (get i) (get carryRef) of
+            Continue carry ->
+              i := get i + 1
+              carryRef := carry
+            Done result ->
+              resultRef := Just result
+  case result of
+    Just ans -> ans
+    Nothing -> todo  -- should be unreachable
 
 ' ### 3D Helper Functions
 
-def cross (a:(Fin 3)=>Real) (b:(Fin 3)=>Real) : (Fin 3)=>Real =
-  (a1, a2, a3) = (a.(0@_), a.(1@_), a.(2@_))
-  (b1, b2, b3) = (b.(0@_), b.(1@_), b.(2@_))
-  [a2 * b3 - a3 * b2, a3 * b1 - a1 * b3, a1 * b2 - a2 * b1]
-
-Vec3 = (Fin 3)=>Real
-
-def unpackvec3 (p:Vec3) : (Real & Real & Real) =
+-- TODO: implement table unpacking
+def unpackvec3 (p:Vec 3) : (Real & Real & Real) =
   (p.(0@(Fin 3)), p.(1@(Fin 3)), p.(2@(Fin 3)))
 
-def rotateX (p:Vec3) (angle:Real) : Vec3 =
+def cross (a:Vec 3) (b:Vec 3) : Vec 3 =
+  (a1, a2, a3) = unpackvec3 a
+  (b1, b2, b3) = unpackvec3 b
+  [a2 * b3 - a3 * b2, a3 * b1 - a1 * b3, a1 * b2 - a2 * b1]
+
+-- TODO: Use `data Color = Red | Green | Blue` and ADTs for index sets
+Color = (Fin 3)=>Real
+def ColorImage     (height:Int) (width:Int) : Type = Fin height => Fin width => Color
+def GrayScaleImage (height:Int) (width:Int) : Type = Fin height => Fin width => Real
+
+xHat : Vec 3 = [1., 0., 0.]
+yHat : Vec 3 = [0., 1., 0.]
+zHat : Vec 3 = [0., 0., 1.]
+
+Angle = Real  -- angle in radians
+
+def rotateX (p:Vec 3) (angle:Angle) : Vec 3 =
   c = cos angle
   s = sin angle
   (px, py, pz) = unpackvec3(p)
   [px, c*py - s*pz, s*py + c*pz]
 
-def rotateY (p:Vec3) (angle:Real) : Vec3 =
+def rotateY (p:Vec 3) (angle:Angle) : Vec 3 =
   c = cos angle
   s = sin angle
   (px, py, pz) = unpackvec3(p)
   [c*px + s*pz, py, - s*px+ c*pz]
 
-def rotateZ (p:Vec3) (angle:Real) : Vec3 =
+def rotateZ (p:Vec 3) (angle:Angle) : Vec 3 =
   c = cos angle
   s = sin angle
   (px, py, pz) = unpackvec3(p)
   [c*px - s*py, s*px+c*py, pz]
 
-
-' ### Raytracer-specific data strutures
-This demo could make much better use of ADTs than it does.
-
-Color = (Fin 3)=>Real
-Distance = Real
-
-data Object =
-  Obj_None
-  Obj_Floor
-  Obj_Ceil
-  Obj_Wall_RD
-  Obj_Wall_WH
-  Obj_Wall_GR
-  Obj_Short_Block
-  Obj_Tall_Block
-  Obj_Light
-
--- Todo: Find a better way to check which kind of thing an object is.
-def isnone (obj:Object) : Bool =
-  case obj of
-    Obj_None -> True
-    Obj_Floor -> False
-    Obj_Ceil -> False
-    Obj_Wall_RD -> False
-    Obj_Wall_WH -> False
-    Obj_Wall_GR -> False
-    Obj_Short_Block -> False
-    Obj_Tall_Block -> False
-    Obj_Light -> False
-
-def islight (obj:Object) : Bool =
-  case obj of
-    Obj_None -> False
-    Obj_Floor -> False
-    Obj_Ceil -> False
-    Obj_Wall_RD -> False
-    Obj_Wall_WH -> False
-    Obj_Wall_GR -> False
-    Obj_Short_Block -> False
-    Obj_Tall_Block -> False
-    Obj_Light -> True
-
-
-' ### Define the scene
-
-nor_light = [0.0, -1., 0.0]  -- Light points straight down.
-LIGHT_AREA = 1.0 * 1.0
-emissive_const = [25.0, 25.0, 25.0] -- Watts
-emittedRadiance = emissive_const ./ (pi * LIGHT_AREA)
-lightDiffuseColor = [0.2, 0.2, 0.2]
-leftWallColor = 1.5 .* [0.611, 0.0555, 0.062]
-rightWallColor = 1.5 .* [0.117, 0.4125, 0.115]
-whiteWallColor = [255.0, 239.0, 196.0] ./ 255.0
-
-
-def brdf_map (obj:Object) : Color =
-  case obj of
-    Obj_None -> zero
-    Obj_Ceil -> whiteWallColor
-    Obj_Floor -> whiteWallColor
-    Obj_Light -> lightDiffuseColor
-    Obj_Short_Block -> whiteWallColor
-    Obj_Tall_Block -> whiteWallColor
-    Obj_Wall_GR -> rightWallColor
-    Obj_Wall_RD -> leftWallColor
-    Obj_Wall_WH -> whiteWallColor
-
-
-def udBox (p: d=>Real) (halfwidths: d=>Real) : Distance =
-  -- distance function for an axis-aligned box.
-  length $ for i. max ((abs p.i) - halfwidths.i) 0.0
-
-def sdScene (p:Vec3) : (Object & Distance) =
-  -- Distance function for the whole scene.
-  -- Todo: define the scene outside this function and pass it in.
-  (px, py, pz) = unpackvec3(p)
-
-  obj_floor = (Obj_Floor, py)
-  obj_ceil  = (Obj_Ceil, 4.0 - py)
-  obj_bwall = (Obj_Wall_WH, 4.0 - pz)
-  obj_lwall = (Obj_Wall_RD, px + 2.0)
-  obj_rwall = (Obj_Wall_GR, 2.0 - px)
-  obj_light = (Obj_Light, udBox (p .- [0.0, 3.9, 2.0]) [0.5, 0.01, 0.5])
-  
-  -- tall block
-  block_height = 1.3
-  p2 = rotateY (p - [(-0.64), block_height, 2.6]) (0.15 * pi)
-  d = udBox p2 [0.6, block_height, 0.6]
-  obj_tall_block = (Obj_Tall_Block, d)
-  
-  -- short block
-  bw = 0.6
-  p2 = rotateY (p - [0.65, bw, 1.7]) ((-0.1) * pi)
-  d = udBox p2 [bw, bw, bw]
-  obj_short_block = (Obj_Short_Block, d)
-  
-  objs = [obj_floor, obj_ceil, obj_bwall, obj_lwall, obj_rwall,
-          obj_light, obj_tall_block, obj_short_block]
-
-  -- find closest object.
-  minimumBy snd objs
-
-
-' Rendering helper functions
-
-def sampleCosineWeightedHemisphere (k:Key) (normal: Vec3) : Vec3 =
+def sampleCosineWeightedHemisphere (normal: Vec 3) (k:Key) : Vec 3 =
   (k1, k2) = splitKey k
   u1 = rand k1
   u2 = rand k2
@@ -180,143 +127,231 @@ def sampleCosineWeightedHemisphere (k:Key) (normal: Vec3) : Vec3 =
   rr = (rx .* uu) + (ry .* vv) + (rz .* normal)
   normalize rr
 
+' ### Raytracer
 
--- Misc. rendering params.
-MAX_ITERS = 50
-HORIZON = 20.0
-MAX_DEPTH = 3
+Distance = Real
+def Image (n:Int) :Type = Fin n => Fin n => Color -- TODO: hide the size
 
-def raymarch (ro:Vec3) (rd: Vec3) : (Object & Distance) =
-  -- Move along ray until we hit an obect.
-  def step (i:(Fin MAX_ITERS)) (pair:(Object & Distance)) : (Object & Distance) =
-    (_, t) = pair
-    (obj, distance) = sdScene (ro + (t .* rd))
-    (obj, t + distance)
+Position  = Vec 3
+Direction = Vec 3  -- Should be normalized. TODO: use a newtype wrapper
 
-  (obj_id, t) = fold (Obj_None, 0.0) step
-  obj_id = select (t > HORIZON) Obj_None obj_id 
-  (obj_id, t)
+BlockHalfWidths = Vec 3
+Radius = Real
+Radiance = Color
 
+data ObjectGeom =
+  Wall Direction Distance
+  Block Position BlockHalfWidths Angle
+  Sphere Position Radius
 
-def calcNormal (p:Vec3) : Vec3 =
-  dist = \p. snd $ sdScene p
-  -- normalize(grad(dist)(p))
+data Surface =
+  Matte Color
+  Mirror
 
-  -- derivative approximation via midpoint rule.
-  -- Todo: Switch to autodiff when it works.
-  eps = 0.001
-  dx = [eps, 0.0, 0.0]
-  dy = [0.0, eps, 0.0]
-  dz = [0.0, 0.0, eps]
-  -- extract just the distance component
-  nor = [(dist(p+dx)) - (dist(p-dx)),
-         (dist(p+dy)) - (dist(p-dy)),
-         (dist(p+dz)) - (dist(p-dz))]
-  normalize nor
+OrientedSurface = (Direction & Surface)
 
+data Object =
+  PassiveObject ObjectGeom Surface
+  -- position, half-width, intensity (assumed to point down)
+  Light Position Real Radiance
 
-def sample_light_point (key:Key) : Vec3 =
-  -- Samples a point uniformly from the surface of the light.
-  -- Todo: remove hardcoded values
-  -- Todo: Allow multiple lights
-  (key1, key2) = splitKey key
-  p_light_x = randuniform key1 (-0.25) (0.25)
-  p_light_z = randuniform key2 (2.0 - 0.25) (2.0 + 0.25)
-  [p_light_x, 3.9, p_light_z]
+Ray = (Position & Direction)
+Filter   = Color
 
+-- TODO: use a record
+-- num samples, num bounces
+Params = (Int & Int)
 
-def direct_light (key:Key) (p:Vec3) (nor:Vec3) (brdf:Color) : Vec3 =
+-- TODO: use a list instead, once they work
+data Scene n:Type = MkScene (n=>Object)
 
-  -- Check for line-of-sight to a random point on the light.
-  p_light = sample_light_point key
-  wi_light = normalize (p_light - p)
-  (obj2, t2) = raymarch (p + 0.001 .* nor) wi_light
+def sampleReflection ((nor, surf):OrientedSurface) ((pos, dir):Ray) (k:Key) : Ray =
+  newDir = case surf of
+    Matte _ -> sampleCosineWeightedHemisphere nor k
+    -- TODO: surely there's some change-of-solid-angle correction we need to
+    -- consider when reflecting off a curved surface.
+    Mirror  -> dir - (2.0 * dot dir nor) .* nor
+  (pos, newDir)
 
-  -- Compute radiance of light from this direction.
-  vis = islight obj2
-  cos1 = relu (vdot nor wi_light)
-  cos2 = relu (vdot nor_light (negvec wi_light))
-  pdf_A = 1.0 / LIGHT_AREA
-  square_distance = sum $ for i. sq (p_light.i - p.i)
-  scale = (cos1 * cos2) / (pdf_A * square_distance)
-  li = for i. scale * emittedRadiance.i * brdf.i
+def probReflection ((nor, surf):OrientedSurface) (_:Ray) ((_, outRayDir):Ray) : Real =
+  case surf of
+    Matte _ -> relu $ dot nor outRayDir
+    Mirror  -> 0.0  -- TODO: this should be a delta function of some sort
 
-  case vis of
-    False -> zero
-    True -> li
+def applyFilter (filter:Filter) (radiance:Radiance) : Radiance =
+  for i. filter.i * radiance.i
 
+def surfaceFilter (filter:Filter) (surf:Surface) : Filter =
+  case surf of
+    Matte color -> for i. filter.i * color.i
+    Mirror      -> filter
 
-def scatter_eye_rays
-    (depth:(Fin MAX_DEPTH)) (carry:(Key & Vec3 & Vec3)) :
-    ((Key & Vec3 & Vec3) & (Bool & Vec3 & Color)) =
-  (rng, ro, rd) = carry
-  (obj, t) = raymarch ro rd
-  brdf = brdf_map obj
-  
-  is_light = islight obj
-  did_intersect = not $ isnone obj
+def sdObject (pos:Position) (obj:Object) : Distance =
+  case obj of
+    PassiveObject geom _ -> case geom of
+      Wall nor d -> d + dot nor pos
+      Block blockPos halfWidths angle ->
+        pos' = rotateY (pos - blockPos) angle
+        length $ for i. max ((abs pos'.i) - halfWidths.i) 0.0
+      Sphere spherePos r ->
+        pos' = pos - spherePos
+        max (length pos' - r) 0.0
+    Light squarePos hw _ ->
+      pos' = pos - squarePos
+      halfWidths = [hw, 0.01, hw]
+      length $ for i. max ((abs pos'.i) - halfWidths.i) 0.0
 
-  li_e = (relu ( vdot (negvec rd) nor_light)) .* emittedRadiance
-  radiance = select is_light li_e zero
-  
-  p = ro + t .* rd
-  nor = calcNormal p
-  
-  -- Contribution directly from light.
-  (rng, subkey) = splitKey rng  
-  li_direct = direct_light subkey p nor brdf
-  radiance = radiance + select did_intersect li_direct zero
+def sdScene (scene:Scene n) (pos:Position) : (Object & Distance) =
+  (MkScene objs) = scene
+  minimumBy snd for i.
+    obj = objs.i
+    (obj, sdObject pos obj)
 
-  -- Sample bounced ray for future indirect contributions.
-  (rng, subkey) = splitKey rng
-  rd2 = sampleCosineWeightedHemisphere subkey nor
+-- TODO: use AD!
+def calcNormal (scene:Scene n) (pos:Position) : Direction =
+  dist = \p. snd $ sdScene scene p
+  normalize (gradNumerical dist pos)
 
-  carry = (rng, ro, rd)
-  outputs = (did_intersect, radiance, brdf)
-  (carry, outputs)
+data RayMarchResult =
+  -- incident ray, surface normal, surface properties
+  HitObj Ray OrientedSurface
+  HitLight Radiance
+  -- Could refine with failure reason (beyond horizon, failed to converge etc)
+  HitNothing
 
+def raymarch (scene:Scene n) (ray:Ray) : RayMarchResult =
+  max_iters = 100
+  tol = 0.01
+  startLength = 10.0 * tol  -- trying to escape the current surface
+  (rayOrigin, rayDir) = ray
+  iter (10.0 * tol) \i rayLength.
+    case i >= max_iters of
+      True -> Done HitNothing
+      False ->
+        rayPos = rayOrigin + rayLength .* rayDir
+        (obj, d) = sdScene scene $ rayPos
+        -- 0.9 ensures we come close to the surface but don't touch it
+        dNew = rayLength + 0.9 * d
+        case d < tol of
+          False -> Continue $ dNew
+          True ->
+            surfNorm = calcNormal scene rayPos
+            case positiveProjection rayDir surfNorm of
+              True ->
+                -- Oops, we didn't escape the surface we're leaving..
+                -- (Is there a more standard way to do this?)
+                Continue dNew
+              False ->
+                -- We made it!
+                Done $ case obj of
+                  PassiveObject _ surf -> HitObj (rayPos, rayDir) (surfNorm, surf)
+                  Light _ _ radiance   -> HitLight radiance
 
--- Add light from each step if there was an intersection.
-def accumulate_outgoing (li_indirect:Vec3) (x:(Bool & Vec3 & Color)) : Vec3 =
-  (did_intersect, radiance, brdf) = x
-  radiance + select did_intersect (for d. brdf.d * li_indirect.d) zero 
+def rayDirectRadiance (scene:Scene n) (ray:Ray) : Radiance =
+  case raymarch scene ray of
+    HitLight intensity -> intensity
+    HitNothing -> zero
+    HitObj _ _ -> zero
 
--- Main loop.
-def trace (rng:Key) (ro:Vec3) (rd:Vec3) (depth:(Fin MAX_DEPTH)) : Vec3 =
-  init = (rng, ro, rd)
-  (carry, outputs) = scan init scatter_eye_rays              -- Forward pass.
-  fold zero \i c. accumulate_outgoing c (reverse outputs).i  -- Backward pass.
+def sampleSquare (hw:Real) (k:Key) : Position =
+ (kx, kz) = splitKey k
+ x = randuniform (- hw) hw kx
+ z = randuniform (- hw) hw kz
+ [x, 0.0, z]
 
+def sampleLightRadiance
+      (scene:Scene n) (osurf:OrientedSurface) (inRay:Ray) (k:Key) : Radiance =
+  (surfNor, surf) = osurf
+  (rayPos, _) = inRay
+  (MkScene objs) = scene
+  snd $ withAccum \radiance.
+    for i. case objs.i of
+      PassiveObject _ _ -> ()
+      Light lightPos hw _ ->
+        (dirToLight, distToLight) = directionAndLength $
+                                      lightPos + sampleSquare hw k - rayPos
+        case positiveProjection dirToLight surfNor of
+          False -> () -- light on the far side of current surface
+          True ->
+            fracSolidAngle = (relu $ dot dirToLight yHat) * sq hw / (pi * sq distToLight)
+            outRay = (rayPos, dirToLight)
+            coeff = fracSolidAngle * probReflection osurf inRay outRay
+            radiance += coeff .* rayDirectRadiance scene outRay
 
-' Setup and draw image
+def trace (params:Params) (scene:Scene n) (init_ray:Ray) (k:Key) : Color =
+  (_, max_bounces) = params
+  -- TODO: we ought to be able to use an accumulator here, but there's a bug
+  noFilter = [1.0, 1.0, 1.0]
+  iter (noFilter, zero, init_ray) $
+    \i (filter, radiance, ray).
+      case i >= max_bounces of
+        True -> Done radiance
+        False -> case raymarch scene ray of
+          HitNothing -> Done radiance
+          HitLight intensity -> case i == 0 of
+            True  -> Done intensity  -- TODO: scale etc
+            False -> Done radiance
+          HitObj incidentRay osurf ->
+            (k1, k2) = splitKey $ hash k i
+            lightRadiance    = sampleLightRadiance scene osurf incidentRay k1
+            outRayHemisphere = sampleReflection          osurf incidentRay k2
+            newFilter = surfaceFilter filter (snd osurf)
+            newRadiance = radiance + applyFilter newFilter lightRadiance
+            Continue (newFilter, newRadiance, outRayHemisphere)
 
-num_samples = 3
-N = 500  -- pixel width and height of image.
+def avgRayColor (params:Params) (scene:Scene m) (ray:Ray) (k:Key) : Color =
+  (num_samples, _) = params
+  sampleAveraged (trace params scene ray) num_samples k
 
-xs = linspace (Fin N) 1.0 0.0  -- Reverse order because of pinhole camera
-rng = newKey 0
+-- TODO: add number of pixels once we can hide sizes
+-- sensor half-width, pinhole-sensor distance, pinhole position
+-- (Assumes we're looking towards -z.)
+Camera = (Position & Real & Real)
+
+def cameraRays (n:Int) (camera:Camera) : Fin n => Fin n => Ray =
+  -- images indexed from top-left
+  (pos, halfWidth, sensorDist) = camera
+  ys = reverse $ linspace (Fin n) (neg halfWidth) halfWidth
+  xs =           linspace (Fin n) (neg halfWidth) halfWidth
+  for i j. (pos, normalize [xs.j, ys.i, neg sensorDist])
+
+def takePicture
+       (params:Params) (scene:Scene m) (n:Int) (camera:Camera)
+      : ColorImage n n =
+  rays = cameraRays n camera
+  rootKey = newKey 0
+  for i j.
+    k = ixkey (ixkey rootKey i) j
+    avgRayColor params scene rays.i.j k
+
+' ### Define the scene and render it
+
+lightColor = [0.2, 0.2, 0.2]
+leftWallColor  = 1.5 .* [0.611, 0.0555, 0.062]
+rightWallColor = 1.5 .* [0.117, 0.4125, 0.115]
+whiteWallColor = [255.0, 239.0, 196.0] / 255.0
+blockColor     = [200.0, 200.0, 255.0] / 255.0
+
+theScene = MkScene $
+    [ Light (1.9 .* yHat) 0.5 lightColor
+    , PassiveObject (Wall      xHat  2.0) (Matte leftWallColor)
+    , PassiveObject (Wall (neg xHat) 2.0) (Matte rightWallColor)
+    , PassiveObject (Wall      yHat  2.0) (Matte whiteWallColor)
+    , PassiveObject (Wall (neg yHat) 2.0) (Matte whiteWallColor)
+    , PassiveObject (Wall      zHat  2.0) (Matte whiteWallColor)
+    , PassiveObject (Block  [ 1.0, -1.6,  1.2] [0.6, 0.8, 0.6] 0.5) (Matte blockColor)
+    , PassiveObject (Sphere [-1.0, -1.2,  0.2] 0.8) (Matte (0.7.* whiteWallColor))
+    , PassiveObject (Sphere [ 2.0,  2.0, -2.0] 1.5) (Mirror)
+    ]
+
+num_pix = 100
+camera = (10.0 .* zHat, 0.3, 1.0)
+
+num_samples = 5
+num_bounces = 5
+params = (num_samples, num_bounces)
 
 %time
-rd = for i. for j. for k:(Fin num_samples).
-  px = -1.0 + 2.0 * xs.j
-  py = -1.0 + 2.0 * xs.i
+image = takePicture params theScene num_pix camera
 
-  -- Render a pinhole camera.
-  eye  = [0.0, 2.0, -3.5]
-  look = [0.0, 2.0, 0.0] -- straight ahead
-  w = normalize (look .- eye)
-  up = [0.0, 1.0, 0.0]
-  u = normalize $ cross w up
-  v = normalize $ cross u w
-  focal_distance = 2.2
-  rd = normalize $ (px .* u) + (py .* v) + (focal_distance .* w)
-  
-  trace (ixkey rng k) eye rd (0@_)
-
-avg_image = for i. for j. for c. mean (for k. rd.i.j.k.c)
-
-def to_black_and_white (im:n=>m=>Color) : (n=>m=>Real) =
-  -- need to do clipping here because of bright spots on edges.
-  for i. for j. 1.5 - (min 1.5 (mean for c. im.i.j.c))
-
-:plotmat to_black_and_white avg_image
+:plotmatcolor 1.0 .* (image / mean (for (i,j,k). image.i.j.k))

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -14,7 +14,6 @@ def Vec (n:Int) : Type = Fin n => Real
 def Mat (n:Int) (m:Int) : Type = Fin n => Fin m => Real
 
 def relu (x:Real) : Real = max x 0.0
-def negvec (v:d=>Real) : d=>Real = for i. -v.i
 def length    (x: d=>Real) : Real = sqrt $ sum for i. sq x.i
 -- TODO: make a newtype for normal vectors
 def normalize (x: d=>Real) : d=>Real = x / (length x)
@@ -30,12 +29,6 @@ def randuniform (lower:Real) (upper:Real) (k:Key) : Real =
 def reverse (n:Type) ?-> (a:Type) ?-> (x:n=>a) : n=>a =
   s = size n
   for i. x.((s - 1 - ordinal i)@_)
-
-def fliplr (n:Type) ?-> (a:Type) ?-> (x: n=>m=>a) : n=>m=>a =
-  for i. reverse for j. x.i.j
-
-def flipud (n:Type) ?-> (a:Type) ?-> (x: n=>m=>a) : n=>m=>a =
-  reverse for i. x.i
 
 def sampleAveraged (_:VSpace a) ?=> (sample:Key -> a) (n:Int) (k:Key) : a =
   snd $ withState zero \total.
@@ -159,8 +152,8 @@ Ray = (Position & Direction)
 Filter   = Color
 
 -- TODO: use a record
--- num samples, num bounces
-Params = (Int & Int)
+-- num samples, num bounces, share seed?
+Params = (Int & Int & Bool)
 
 -- TODO: use a list instead, once they work
 data Scene n:Type = MkScene (n=>Object)
@@ -279,7 +272,7 @@ def sampleLightRadiance
             radiance += coeff .* rayDirectRadiance scene outRay
 
 def trace (params:Params) (scene:Scene n) (init_ray:Ray) (k:Key) : Color =
-  (_, max_bounces) = params
+  (_, max_bounces, _) = params
   -- TODO: we ought to be able to use an accumulator here, but there's a bug
   noFilter = [1.0, 1.0, 1.0]
   iter (noFilter, zero, init_ray) $
@@ -299,30 +292,38 @@ def trace (params:Params) (scene:Scene n) (init_ray:Ray) (k:Key) : Color =
             newRadiance = radiance + applyFilter newFilter lightRadiance
             Continue (newFilter, newRadiance, outRayHemisphere)
 
-def avgRayColor (params:Params) (scene:Scene m) (ray:Ray) (k:Key) : Color =
-  (num_samples, _) = params
-  sampleAveraged (trace params scene ray) num_samples k
-
 -- TODO: add number of pixels once we can hide sizes
 -- sensor half-width, pinhole-sensor distance, pinhole position
 -- (Assumes we're looking towards -z.)
 Camera = (Position & Real & Real)
 
-def cameraRays (n:Int) (camera:Camera) : Fin n => Fin n => Ray =
+def cameraRays (n:Int) (camera:Camera) : Fin n => Fin n => (Key -> Ray) =
   -- images indexed from top-left
   (pos, halfWidth, sensorDist) = camera
+  pixHalfWidth = halfWidth / i2r n
   ys = reverse $ linspace (Fin n) (neg halfWidth) halfWidth
   xs =           linspace (Fin n) (neg halfWidth) halfWidth
-  for i j. (pos, normalize [xs.j, ys.i, neg sensorDist])
+  for i j. \key.
+    (kx, ky) = splitKey key
+    x = xs.j + randuniform (-pixHalfWidth) pixHalfWidth kx
+    y = ys.i + randuniform (-pixHalfWidth) pixHalfWidth ky
+    (pos, normalize [x, y, neg sensorDist])
 
 def takePicture
        (params:Params) (scene:Scene m) (n:Int) (camera:Camera)
       : ColorImage n n =
+  (numSamples, _, shareSeed) = params
   rays = cameraRays n camera
   rootKey = newKey 0
-  for i j.
-    k = ixkey (ixkey rootKey i) j
-    avgRayColor params scene rays.i.j k
+  image = for i j.
+    pixKey = case shareSeed of
+      True  -> rootKey
+      False -> ixkey (ixkey rootKey i) j
+    sampleRayColor : Key -> Color =  \k.
+      (k1, k2) = splitKey k
+      trace params scene (rays.i.j k1) k2
+    sampleAveraged sampleRayColor numSamples pixKey
+  image / mean (for (i,j,k). image.i.j.k)
 
 ' ### Define the scene and render it
 
@@ -344,14 +345,23 @@ theScene = MkScene $
     , PassiveObject (Sphere [ 2.0,  2.0, -2.0] 1.5) (Mirror)
     ]
 
-num_pix = 100
 camera = (10.0 .* zHat, 0.3, 1.0)
 
-num_samples = 5
-num_bounces = 5
-params = (num_samples, num_bounces)
+-- num_pix = 250
+num_pix = 10
+num_samples = 50
+num_bounces = 10
+share_prng = True
+params = (num_samples, num_bounces, share_prng)
 
-%time
+
+-- %time
 image = takePicture params theScene num_pix camera
 
-:plotmatcolor 1.0 .* (image / mean (for (i,j,k). image.i.j.k))
+:plotmatcolor image
+> <graphical output>
+
+'Just for fun, here's what we get with a single sample (sharing the PRNG
+key among pixels)
+
+-- :plotmatcolor takePicture (1, num_bounces, share_prng) theScene num_pix camera

--- a/makefile
+++ b/makefile
@@ -61,7 +61,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 ad-tests mandelbrot pi sierpinsky \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator parser-tests serialize-tests tiled-matmul \
-                mcmc record-variant-tests simple-include-test ctc
+                mcmc record-variant-tests simple-include-test ctc raytrace
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -20,7 +20,6 @@ def idiv (x:Int) (y:Int) : Int = %idiv x y
 def rem  (x:Int) (y:Int) : Int = %irem x y
 def ipow (x:Int) (y:Int) : Int = %ipow x y
 
-def neg  (x:Real)          : Real = %fneg x
 def fdiv (x:Real) (y:Real) : Real = %fdiv x y
 
 data Add a:Type =
@@ -60,6 +59,7 @@ const : a -> b -> a = \x _. x
 def (.*)  (d:VSpace a) ?=> : Real -> a -> a = case d of MkVSpace _ scale -> scale
 (*.)  : VSpace a ?=> a -> Real -> a = flip (.*)
 def (/) (_:VSpace a) ?=> (v:a) (s:Real) : a = (fdiv 1.0 s) .* v
+def neg (_:VSpace a) ?=> (v:a) : a = (-1.0) .* v
 
 @instance realVS : VSpace Real = MkVSpace realAdd (*)
 @instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -346,7 +346,7 @@ instance Pretty a => Pretty (SetVal a) where
 
 instance Pretty Output where
   pretty (TextOut s) = pretty s
-  pretty (HeatmapOut _ _ _) = "<graphical output>"
+  pretty (HeatmapOut _ _ _ _) = "<graphical output>"
   pretty (ScatterOut _ _  ) = "<graphical output>"
   pretty (PassInfo name s) = "===" <+> p name <+> "===" <> hardline <> p s
   pretty (EvalTime t) = "=== Eval time: " <+> p t <> "s ==="

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -154,7 +154,8 @@ explicitCommand = do
     "p"       -> return $ EvalExpr Printed
     "t"       -> return $ GetType
     "plot"    -> return $ EvalExpr Scatter
-    "plotmat" -> return $ EvalExpr Heatmap
+    "plotmat"      -> return $ EvalExpr (Heatmap False)
+    "plotmatcolor" -> return $ EvalExpr (Heatmap True)
     _ -> fail $ "unrecognized command: " ++ show cmdName
   e <- blockOrExpr <* eolf
   return $ case (e, cmd) of

--- a/src/lib/Plot.hs
+++ b/src/lib/Plot.hs
@@ -4,12 +4,11 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE NoMonomorphismRestriction #-}
 {-# LANGUAGE FlexibleContexts          #-}
 {-# LANGUAGE TypeFamilies              #-}
 
-module Plot (scatterHtml, heatmapHtml) where
+module Plot (scatterHtml, heatmapHtml, colorHeatmapHtml) where
 
 import Prelude as P
 import Diagrams.Prelude
@@ -33,6 +32,15 @@ scatterHtml xs ys = diagramToHtml $
     spot = circle 0.005 # fc blue # lw 0
     xsc = LinearScale (minimum xs) (maximum xs)
     ysc = LinearScale (minimum ys) (maximum ys)
+
+colorHeatmapHtml :: Int -> Int -> (V.Vector Double) -> H.Html
+colorHeatmapHtml h w zs = pngToHtml $ generateImage getPix w h
+  where
+    getPix i j = PixelRGB8 r g b
+      where
+        r = fromIntegral $ doubleTo8Bit $ zs  V.! ((j * w + i) * 3 + 0)
+        g = fromIntegral $ doubleTo8Bit $ zs  V.! ((j * w + i) * 3 + 1)
+        b = fromIntegral $ doubleTo8Bit $ zs  V.! ((j * w + i) * 3 + 2)
 
 heatmapHtml :: Int -> Int -> (V.Vector Double) -> H.Html
 heatmapHtml h w zs = pngToHtml $ generateImage getPix w h

--- a/src/lib/RenderHtml.hs
+++ b/src/lib/RenderHtml.hs
@@ -49,7 +49,8 @@ instance ToMarkup Result where
 
 instance ToMarkup Output where
   toMarkup out = case out of
-    HeatmapOut h w zs -> heatmapHtml h w zs
+    HeatmapOut False h w zs -> heatmapHtml h w zs
+    HeatmapOut True h w zs  -> colorHeatmapHtml h w zs
     ScatterOut xs ys  -> scatterHtml (V.toList xs) (V.toList ys)
     _ -> cdiv "result-block" $ toHtml $ pprint out
 

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -4,7 +4,6 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-{-# LANGUAGE OverloadedStrings #-}
 {-# LANGUAGE CPP #-}
 
 module Serialize (DBOHeader (..), dumpDataFile, loadDataFile, pprintVal,
@@ -180,11 +179,16 @@ valToScatter val = case getType val of
   _ -> error $ "Scatter expects a 1D array of tuples, but got: " ++ pprint (getType val)
   where [Array _ (RealVec xs), Array _ (RealVec ys)] = materializeScalarTables val
 
-valToHeatmap :: Val -> Output
-valToHeatmap val = case getType val of
-  TabTy hv (TabTy wv RealTy) ->
-    HeatmapOut (indexSetSize $ binderType hv) (indexSetSize $ binderType wv) xs
-  _ -> error $ "Heatmap expects a 2D array of reals, but got: " ++ pprint (getType val)
+valToHeatmap :: Bool -> Val -> Output
+valToHeatmap color val = case color of
+  False -> case getType val of
+    TabTy hv (TabTy wv RealTy) ->
+       HeatmapOut color (indexSetSize $ binderType hv) (indexSetSize $ binderType wv) xs
+    _ -> error $ "Heatmap expects a 2D array of reals, but got: " ++ pprint (getType val)
+  True -> case getType val of
+    TabTy hv (TabTy wv (TabTy _ RealTy)) ->
+       HeatmapOut color (indexSetSize $ binderType hv) (indexSetSize $ binderType wv) xs
+    _ -> error $ "Color Heatmap expects a 3D array of reals, but got: " ++ pprint (getType val)
   where [(Array _ (RealVec xs))] = materializeScalarTables val
 
 pprintVal :: Val -> String

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -504,14 +504,15 @@ type SrcCtx = Maybe SrcPos
 data Result = Result [Output] (Except ())  deriving (Show, Eq)
 
 data Output = TextOut String
-            | HeatmapOut Int Int (V.Vector Double)
+            | HeatmapOut Bool Int Int (V.Vector Double)  -- Bool indicates if color
             | ScatterOut (V.Vector Double) (V.Vector Double)
             | PassInfo PassName String
             | EvalTime Double
             | MiscLog String
               deriving (Show, Eq, Generic)
 
-data OutFormat = Printed | Heatmap | Scatter   deriving (Show, Eq, Generic)
+data OutFormat = Printed | Heatmap Bool | ColorHeatmap | Scatter
+                 deriving (Show, Eq, Generic)
 data DataFormat = DexObject | DexBinaryObject  deriving (Show, Eq, Generic)
 
 data Err = Err ErrType SrcCtx String  deriving (Show, Eq)

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -83,7 +83,7 @@ evalSourceBlockM env block = case sbContents block of
       case fmt of
         Printed -> do
           logTop $ TextOut $ pprintVal val
-        Heatmap -> logTop $ valToHeatmap val
+        Heatmap color -> logTop $ valToHeatmap color val
         Scatter -> logTop $ valToScatter val
     GetType -> do  -- TODO: don't actually evaluate it
       val <- evalUModuleVal env v m


### PR DESCRIPTION
This expands on @duvenaud's ray tracer (#178). We factor out the description of the scene from the actual ray tracing and allow each object to have a choice of geometry (plane, block, sphere) and surface properties (specular reflection, Lambertian reflection).

The raymarching itself now uses a while loop to converge to a specified tolerance rather than marching for a fixed number of steps. This required some tricks to make sure the ray actually escapes the surface we're leaving (looking at surface normals etc).

Here's a sample with 250x250 pixels, 10 reflections and 50 samples. This took 10 minutes on my laptop! But I think there's a lot of room to improve performance with the general compiler optimizations we're planing: hoisting things out of loops, multicore parallelism for the outer loop, and simd instructions for the inner loops. It should make a nice non-micro benchmark for those optimizations.

![rendering](https://user-images.githubusercontent.com/8833761/89332261-145c8180-d661-11ea-85c9-d2a47382c064.png)

I put a mirror in the top-right corner to see the back of the objects. I'm pretty sure the mirror brightness is off, because there's no correction for solid angles changing on reflection from a curved surface.

Some notes on implementing it:
  * Being able to access record fields, like `params.num_counts` would make things much more readable. (@hexahedria )
  * I made an `iter` combinator on top of the raw while loop, which turned out to be surprisingly nice to work with. It's just `iter : a -> (Int -> a -> IterResult a b) -> b` with `data IterResult a b = Continue a | Done b`. When the body evaluates to `Continue carry` we continue with carry `carry`, and when it evaluates to `Done result` the loops exits, yielding `result`. We should be able to allow effects in the body, but there seems to be a bug in type inference.
  * We pass around a lot of directions as normalized unit vectors, and it's very important that the normalization property is maintained. It's a good use-case for a newtype wrapper, but I ran into compiler bugs when trying it.
  * We should add printf/trace-style debugging.
  * Compilation time is becoming a problem. It can be as long as five seconds! I had to roll up the numerical AD approximation to make it manageable. There are two fixes that would go a long way
      1. Reduce code blowup by allowing non-inlined first-order functions, perhaps with a `@noinline` decorator.
      2. Improve caching, so that just changing numerical values doesn't trigger recompilation. Debugging is often about tweaking parameters rather than changing code.
  * Using `todo` often results in `anyVal` errors rather than the expected runtime error. Also, `todo : a` is cute, but it's harder to search for than `undefined` because of the many `-- TODO: ...` false positives.
  * Should do inference for non-type variables in type annotations, like `n:Int` in `Fin n => Real`.
  * Unused variable warnings would be really useful (this would have caught a bug in the previous version where `rd2` was unused).

