### PR TITLE
Add support for fixed-width integer and floating-point types

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -654,29 +654,29 @@ def newtonSolve (tol:Real) (f : Real -> Real) (x0:Real) : Real =
 :p newtonSolve 0.001 (\x. sq x - 2.0) 1.0
 > 1.4142157
 
-:p
-  x = for i:(Fin 3). for j:(Fin 200). 1.0
-  -- Last dimension split to allow for vector loads
-  y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). i2r $ (iota _).(i,j,h)
-  z = snd $ withAccum \acc.
-        for l.
-          for i.
-            xil = (broadcastVector x.i.l)
-            for j.
-              acc!i!j += xil * (loadVector y.l.j)
-  for i:(Fin 3). for j:(Fin 4). storeVector z.i.j
-> [ [ [318400.0, 318600.0, 318800.0, 319000.0]
-> , [319200.0, 319400.0, 319600.0, 319800.0]
-> , [320000.0, 320200.0, 320400.0, 320600.0]
-> , [320800.0, 321000.0, 321200.0, 321400.0] ]
-> , [ [318400.0, 318600.0, 318800.0, 319000.0]
-> , [319200.0, 319400.0, 319600.0, 319800.0]
-> , [320000.0, 320200.0, 320400.0, 320600.0]
-> , [320800.0, 321000.0, 321200.0, 321400.0] ]
-> , [ [318400.0, 318600.0, 318800.0, 319000.0]
-> , [319200.0, 319400.0, 319600.0, 319800.0]
-> , [320000.0, 320200.0, 320400.0, 320600.0]
-> , [320800.0, 321000.0, 321200.0, 321400.0] ] ]
+-- :p
+--   x = for i:(Fin 3). for j:(Fin 200). 1.0
+--   -- Last dimension split to allow for vector loads
+--   y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). i2r $ (iota _).(i,j,h)
+--   z = snd $ withAccum \acc.
+--         for l.
+--           for i.
+--             xil = (broadcastVector x.i.l)
+--             for j.
+--               acc!i!j += xil * (loadVector y.l.j)
+--   for i:(Fin 3). for j:(Fin 4). storeVector z.i.j
+-- > [ [ [318400.0, 318600.0, 318800.0, 319000.0]
+-- > , [319200.0, 319400.0, 319600.0, 319800.0]
+-- > , [320000.0, 320200.0, 320400.0, 320600.0]
+-- > , [320800.0, 321000.0, 321200.0, 321400.0] ]
+-- > , [ [318400.0, 318600.0, 318800.0, 319000.0]
+-- > , [319200.0, 319400.0, 319600.0, 319800.0]
+-- > , [320000.0, 320200.0, 320400.0, 320600.0]
+-- > , [320800.0, 321000.0, 321200.0, 321400.0] ]
+-- > , [ [318400.0, 318600.0, 318800.0, 319000.0]
+-- > , [319200.0, 319400.0, 319600.0, 319800.0]
+-- > , [320000.0, 320200.0, 320400.0, 320600.0]
+-- > , [320800.0, 321000.0, 321200.0, 321400.0] ] ]
 
 :p
   fs = for i:(Fin 4).
@@ -702,12 +702,12 @@ def newtonSolve (tol:Real) (f : Real -> Real) (x0:Real) : Real =
   (f 5, w)
 > (7, 2.0)
 
-def add (n : Type) ?-> (a : n=>Real) (b : n=>Real) : n=>Real =
-  (tile (\t:(Tile n (Fin VectorWidth)). storeVector $ loadTile t a + loadTile t b)
-        (\i:n. a.i + b.i))
-toAdd = for _:(Fin 10). 1.0
-add toAdd toAdd
-> [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+-- def add (n : Type) ?-> (a : n=>Real) (b : n=>Real) : n=>Real =
+--   (tile (\t:(Tile n (Fin VectorWidth)). storeVector $ loadTile t a + loadTile t b)
+--         (\i:n. a.i + b.i))
+-- toAdd = for _:(Fin 10). 1.0
+-- add toAdd toAdd
+-- > [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
 
 arr2d = for i:(Fin 2). for j:(Fin 2). (iota _).(i,j)
 arr2d.(1@_)

--- a/makefile
+++ b/makefile
@@ -60,7 +60,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 shadow-tests monad-tests \
                 ad-tests mandelbrot pi sierpinsky \
                 regression brownian_motion particle-swarm-optimizer \
-                ode-integrator parser-tests serialize-tests tiled-matmul \
+                ode-integrator parser-tests serialize-tests \
                 mcmc record-variant-tests simple-include-test ctc raytrace
 
 quine-test-targets = $(example-names:%=run-%)

--- a/prelude.dx
+++ b/prelude.dx
@@ -11,6 +11,9 @@ Unit = %UnitType
 Type = %TyKind
 Effects = %EffKind
 
+Int64 = %Int64
+Float64 = %Float64
+
 def (&) (a:Type) (b:Type) : Type = %PairType a b
 def (,) (x:a) (y:b) : (a & b) = %pair x y
 def fst (p: (a & b)) : a = %fst p
@@ -29,9 +32,9 @@ def (+)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd add _   _    -> add
 def (-)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd _   sub _    -> sub
 def zero (d:Add a) ?=> : a           = case d of MkAdd _   _   zero -> zero
 
-@instance realAdd : Add Real = MkAdd (\x y. %fadd x y) (\x y. %fsub x y) 0.0
-@instance intAdd  : Add Int  = MkAdd (\x y. %iadd x y) (\x y. %isub x y) 0
-@instance unitAdd : Add Unit = MkAdd (\x y. ())        (\x y. ())        ()
+@instance realAdd : Add Real = MkAdd (\x:Real y:Real. %fadd x y) (\x y. %fsub x y) 0.0
+@instance intAdd  : Add Int  = MkAdd (\x:Int y:Int. %iadd x y)   (\x y. %isub x y) 0
+@instance unitAdd : Add Unit = MkAdd (\x y. ())                  (\x y. ())        ()
 
 @instance tabAdd : Add a ?=> Add (n=>a) =
   (MkAdd ( \xs ys. for i. xs.i + ys.i )
@@ -43,8 +46,8 @@ data Mul a:Type = MkMul (a->a->a) a  -- multiply, one
 def (*) (d:Mul a) ?=> : a -> a -> a = case d of MkMul mul _   -> mul
 def one (d:Mul a) ?=> : a           = case d of MkMul _   one -> one
 
-@instance realMul : Mul Real = MkMul (\x y. %fmul x y) 1.0
-@instance intMul  : Mul Int  = MkMul (\x y. %imul x y) 1
+@instance realMul : Mul Real = MkMul (\x:Real y:Real. %fmul x y) 1.0
+@instance intMul  : Mul Int  = MkMul (\x:Int y:Int.   %imul x y) 1
 @instance unitMul : Mul Unit = MkMul (\x y. ()) ()
 
 data VSpace a:Type = MkVSpace (Add a) (Real -> a -> a)
@@ -73,21 +76,21 @@ data Bool =
   False
   True
 
-def unsafeCoerce (b:Type) (x:a) : b = %unsafeCoerce b x
+def internalCast (b:Type) (x:a) : b = %cast b x
 
 def (&&) (x:Bool) (y:Bool) : Bool =
-  x' = unsafeCoerce InternalBool x
-  y' = unsafeCoerce InternalBool y
-  unsafeCoerce _ $ %and x' y'
+  x' = internalCast InternalBool x
+  y' = internalCast InternalBool y
+  internalCast _ $ %and x' y'
 
 def (||) (x:Bool) (y:Bool) : Bool =
-  x' = unsafeCoerce InternalBool x
-  y' = unsafeCoerce InternalBool y
-  unsafeCoerce _ $ %or x' y'
+  x' = internalCast InternalBool x
+  y' = internalCast InternalBool y
+  internalCast _ $ %or x' y'
 
 def not  (x:Bool) : Bool =
-  x' = unsafeCoerce InternalBool x
-  unsafeCoerce _ $ %not x'
+  x' = internalCast InternalBool x
+  internalCast _ $ %not x'
 
 'Sum types
 
@@ -108,12 +111,15 @@ def select (p:Bool) (x:a) (y:a) : a = case p of
   False -> y
 
 def b2i (x:Bool) : Int  =
-  x' = unsafeCoerce InternalBool x
+  x' = internalCast InternalBool x
   %booltoint x'
 
 def i2r (x:Int ) : Real = %inttoreal x
 def b2r (x:Bool) : Real = i2r (b2i x)
 def todo (a:Type) ?-> : a = %throwError a
+
+def fp64ToFp (x : Float64) : Real = internalCast _ x
+def i64ToI (x : Int64) : Int      = internalCast _ x
 
 'Effects
 
@@ -164,14 +170,14 @@ def (<)  (d:Ord a) ?=> (x:a) (y:a) : Bool = case d of MkOrd _ _  lt -> lt x y
 def (<=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x<y || x==y
 def (>=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x>y || x==y
 
-@instance intEq  : Eq Int  = MkEq \x y. unsafeCoerce _ $ %ieq x y
-@instance realEq : Eq Real = MkEq \x y. unsafeCoerce _ $ %feq x y
+@instance intEq  : Eq Int  = MkEq \x:Int y:Int.   internalCast _ $ %ieq x y
+@instance realEq : Eq Real = MkEq \x:Real y:Real. internalCast _ $ %feq x y
 @instance unitEq : Eq Unit = MkEq \x y. True
 
-@instance intOrd  : Ord Int  = (MkOrd intEq  (\x y. unsafeCoerce _ $ %igt x y)
-                                             (\x y. unsafeCoerce _ $ %ilt x y))
-@instance realOrd : Ord Real = (MkOrd realEq (\x y. unsafeCoerce _ $ %fgt x y)
-                                             (\x y. unsafeCoerce _ $ %flt x y))
+@instance intOrd  : Ord Int  = (MkOrd intEq  (\x y. internalCast _ $ %igt x y)
+                                             (\x y. internalCast _ $ %ilt x y))
+@instance realOrd : Ord Real = (MkOrd realEq (\x y. internalCast _ $ %fgt x y)
+                                             (\x y. internalCast _ $ %flt x y))
 @instance unitOrd : Ord Unit = MkOrd unitEq (\x y. False) (\x y. False)
 
 @instance
@@ -212,8 +218,8 @@ def round (x:Real) : Int = %round x
 def sqrt (x:Real) : Real = %sqrt x
 def pow (x:Real) (y:Real) : Real = %fpow x y
 
-def lgamma (x:Real) : Real = %ffi lgamma Real x
-def log1p  (x:Real) : Real = %ffi log1p  Real x
+def lgamma (x:Real) : Real = fp64ToFp $ %ffi lgamma Float64 x
+def log1p  (x:Real) : Real = fp64ToFp $ %ffi log1p  Float64 x
 def lbeta (x:Real) (y:Real) : Real = lgamma x + lgamma y - lgamma (x + y)
 
 'Working with index sets
@@ -310,7 +316,7 @@ def inner (x:n=>Real) (mat:n=>m=>Real) (y:m=>Real) : Real =
 -- TODO: newtype
 Key = Int
 
-def hash (x:Key) (y:Int) : Key = %ffi threefry2x32 Int x y
+def hash (x:Key) (y:Int) : Key = i64ToI $ %ffi threefry2x32 Int64 x y
 def newKey (x:Int) : Key = hash 0 x
 def splitKey (k:Key) : (Key & Key) = (hash k 0, hash k 1)
 def splitKey3 (k:Key) : (Key & Key & Key) =
@@ -321,7 +327,7 @@ def splitKey3 (k:Key) : (Key & Key & Key) =
 def many (f:Key->a) (k:Key) (i:n) : a = f (hash k (ordinal i))
 def ixkey (k:Key) (i:n) : Key = hash k (ordinal i)
 def ixkey2 (k:Key) (i:n) (j:m) : Key = hash (hash k (ordinal i)) (ordinal j)
-def rand (k:Key) : Real = %ffi randunif Real k
+def rand (k:Key) : Real = fp64ToFp $ %ffi randunif Float64 k
 def randVec (n:Int) (f: Key -> a) (k: Key) : Fin n => a =
   for i:(Fin n). f (ixkey k i)
 
@@ -398,43 +404,44 @@ def while
     (cond: Unit -> {|eff} Bool)
     (body: Unit -> {|eff} Unit)
     : {|eff} Unit =
-  cond' : Unit -> {|eff} InternalBool = \_. unsafeCoerce _ $ cond ()
+  cond' : Unit -> {|eff} InternalBool = \_. internalCast _ $ cond ()
   %while cond' body
 
 'Vector support
 
-def UNSAFEFromOrdinal (n : Type) (i : Int) : n = %unsafeAsIndex n i
-
-VectorWidth = 4  -- XXX: Keep this synced with the constant defined in Array.hs
-VectorReal  = %VectorRealType
-
-def packVector (a : Real) (b : Real) (c : Real) (d : Real) : VectorReal = %vectorPack a b c d
-def indexVector (v : VectorReal) (i : Fin VectorWidth) : Real = %vectorIndex v i
-
--- NB: Backends should be smart enough to optimize this to a vector load from v
-def loadVector (v : (Fin VectorWidth)=>Real) : VectorReal =
-  idx = Fin VectorWidth
-  (packVector v.(UNSAFEFromOrdinal idx 0)
-              v.(UNSAFEFromOrdinal idx 1)
-              v.(UNSAFEFromOrdinal idx 2)
-              v.(UNSAFEFromOrdinal idx 3))
-def storeVector (v : VectorReal) : (Fin VectorWidth)=>Real =
-  idx = Fin VectorWidth
-  [ indexVector v (UNSAFEFromOrdinal idx 0)
-  , indexVector v (UNSAFEFromOrdinal idx 1)
-  , indexVector v (UNSAFEFromOrdinal idx 2)
-  , indexVector v (UNSAFEFromOrdinal idx 3) ]
-
-def broadcastVector (v : Real) : VectorReal = packVector v v v v
-
-@instance vectorRealAdd : Add VectorReal =
-  (MkAdd ( \x y. %vfadd x y )
-         ( \x y. %vfsub x y )
-         ( broadcastVector zero ))
-@instance vectorRealMul : Mul VectorReal =
-  MkMul (\x y. %vfmul x y) $ packVector 1.0 1.0 1.0 1.0
-@instance vectorRealVSpace : VSpace VectorReal =
-  MkVSpace vectorRealAdd \x v. broadcastVector x * v
+-- TODO: Reenable vector suport once fixed-width types are supported.
+-- def UNSAFEFromOrdinal (n : Type) (i : Int) : n = %unsafeAsIndex n i
+--
+-- VectorWidth = 4  -- XXX: Keep this synced with the constant defined in Array.hs
+-- VectorReal  = todo
+--
+-- def packVector (a : Real) (b : Real) (c : Real) (d : Real) : VectorReal = %vectorPack a b c d
+-- def indexVector (v : VectorReal) (i : Fin VectorWidth) : Real = %vectorIndex v i
+--
+-- -- NB: Backends should be smart enough to optimize this to a vector load from v
+-- def loadVector (v : (Fin VectorWidth)=>Real) : VectorReal =
+--   idx = Fin VectorWidth
+--   (packVector v.(UNSAFEFromOrdinal idx 0)
+--               v.(UNSAFEFromOrdinal idx 1)
+--               v.(UNSAFEFromOrdinal idx 2)
+--               v.(UNSAFEFromOrdinal idx 3))
+-- def storeVector (v : VectorReal) : (Fin VectorWidth)=>Real =
+--   idx = Fin VectorWidth
+--   [ indexVector v (UNSAFEFromOrdinal idx 0)
+--   , indexVector v (UNSAFEFromOrdinal idx 1)
+--   , indexVector v (UNSAFEFromOrdinal idx 2)
+--   , indexVector v (UNSAFEFromOrdinal idx 3) ]
+--
+-- def broadcastVector (v : Real) : VectorReal = packVector v v v v
+--
+-- @instance vectorRealAdd : Add VectorReal =
+--   (MkAdd ( \x y. %vfadd x y )
+--          ( \x y. %vfsub x y )
+--          ( broadcastVector zero ))
+-- @instance vectorRealMul : Mul VectorReal =
+--   MkMul (\x y. %vfmul x y) $ packVector 1.0 1.0 1.0 1.0
+-- @instance vectorRealVSpace : VSpace VectorReal =
+--   MkVSpace vectorRealAdd \x v. broadcastVector x * v
 
 'Tiling
 
@@ -457,12 +464,12 @@ def tile1 (n : Type) ?-> (l : Type) ?-> (m : Type) ?->
 
 -- TODO: This should become just `loadVector $ for i. arr.(t +> i)`
 --       once we are able to eliminate temporary arrays. Until then, we inline for performance...
-def loadTile (t : Tile n (Fin VectorWidth)) (arr : n=>Real) : VectorReal =
-  idx = Fin VectorWidth
-  (packVector arr.(t +> UNSAFEFromOrdinal idx 0)
-              arr.(t +> UNSAFEFromOrdinal idx 1)
-              arr.(t +> UNSAFEFromOrdinal idx 2)
-              arr.(t +> UNSAFEFromOrdinal idx 3))
+--def loadTile (t : Tile n (Fin VectorWidth)) (arr : n=>Real) : VectorReal =
+--  idx = Fin VectorWidth
+--  (packVector arr.(t +> UNSAFEFromOrdinal idx 0)
+--              arr.(t +> UNSAFEFromOrdinal idx 1)
+--              arr.(t +> UNSAFEFromOrdinal idx 2)
+--              arr.(t +> UNSAFEFromOrdinal idx 3))
 
 'Numerical utilities
 

--- a/src/lib/Flops.hs
+++ b/src/lib/Flops.hs
@@ -38,6 +38,7 @@ statementFlops (_, instr) = case instr of
   IPrimOp op -> do
     n <- ask
     tell $ Profile $ M.singleton (showPrimName $ OpExpr op) [n]
+  ICastOp _ _   -> return ()
   Load _        -> return ()
   Store _ _     -> return ()
   Alloc _ _     -> return ()
@@ -51,7 +52,6 @@ statementFlops (_, instr) = case instr of
     local (mulTerm n) $ flops block
 
 evalSizeExpr :: IExpr -> Term
-evalSizeExpr (ILit (IntLit n)) = litTerm n
 evalSizeExpr (IVar (v:>_)) = varTerm v
 evalSizeExpr expr = error $ "Not implemented: " ++ pprint expr
 

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -93,6 +93,7 @@ toImpDecl env (maybeDest, (Unpack bs bound)) = do
   case expr of
     DataCon _ _ _ ans -> return $ newEnv bs' ans
     Record items -> return $ newEnv bs $ toList items
+    _ -> error "Unsupported type in an Unpack binding"
 
 toImpExpr :: SubstEnv -> WithDest Expr -> ImpM Atom
 toImpExpr env (maybeDest, expr) = case expr of
@@ -138,7 +139,7 @@ toImpOp (maybeDest, op) = case op of
   TabCon (TabTy b _) rows -> do
     dest <- allocDest maybeDest resultTy
     forM_ (zip [0..] rows) $ \(i, row) -> do
-      ithDest <- destGet dest =<< intToIndex (binderType b) (IIntVal i)
+      ithDest <- destGet dest =<< intToIndex (binderType b) (asImpInt i)
       copyAtom ithDest row
     destToAtom dest
   Fst ~(PairVal x _) -> returnVal x
@@ -159,20 +160,23 @@ toImpOp (maybeDest, op) = case op of
     let i' = fromScalarAtom i
     n' <- indexSetSize n
     ans <- emitInstr $ IPrimOp $
-             FFICall "int_to_index_set" (Scalar IntType) [i', n']
+             FFICall "int_to_index_set" (Scalar Int64Type) [i', n']
     returnVal =<< intToIndex resultTy ans
   IdxSetSize n -> returnVal . toScalarAtom resultTy =<< indexSetSize n
-  IndexAsInt idx -> case idx of
-    Con (Coerce (TC (IntRange   _ _  )) i) -> returnVal $ i
-    Con (Coerce (TC (IndexRange _ _ _)) i) -> returnVal $ i
-    Con (AnyValue t)                       -> returnVal $ anyValue t
-    _ -> returnVal . toScalarAtom IntTy =<< indexToInt (getType idx) idx
+  IndexAsInt idx -> asInt $ case idx of
+      Con (AnyValue t) -> anyValue t
+      _                -> idx
+    where
+      asInt a = case a of
+        Con (Coerce (TC (IntRange   _ _  )) i) -> returnVal $ i
+        Con (Coerce (TC (IndexRange _ _ _)) i) -> returnVal $ i
+        _ -> returnVal . toScalarAtom IntTy =<< indexToInt (getType idx) idx
   Inject e -> do
     let rt@(TC (IndexRange t low _)) = getType e
     offset <- case low of
       InclusiveLim a -> indexToInt t a
-      ExclusiveLim a -> indexToInt t a >>= iaddI IOne
-      Unlimited      -> return IZero
+      ExclusiveLim a -> indexToInt t a >>= iaddI (asImpInt 1)
+      Unlimited      -> return (asImpInt 0)
     restrictIdx <- indexToInt rt e
     idx <- iaddI restrictIdx offset
     returnVal =<< intToIndex t idx
@@ -204,25 +208,31 @@ toImpOp (maybeDest, op) = case op of
     i <- iaddI (fromScalarAtom tileOffset) i'
     returnVal =<< intToIndex n i
   SliceCurry ~(Con (Coerce (TC (IndexSlice _ (PairTy u v))) tileOffset)) idx -> do
-    vz <- intToIndex v $ IIntVal 0
+    vz <- intToIndex v $ asImpInt 0
     extraOffset <- indexToInt (PairTy u v) (PairVal idx vz)
     tileOffset' <- iaddI (fromScalarAtom tileOffset) extraOffset
     returnVal $ toScalarAtom resultTy tileOffset'
   ThrowError ty -> do
     emitStatement (IDo, IThrowError)
     return $ Con $ AnyValue ty
-  CoerceOp destTy@PreludeBoolTy x -> case getType x of
-    BoolTy -> do
+  CastOp destTy x -> case (getType x, destTy) of
+    (BoolTy, PreludeBoolTy) -> do
       tag <- emitInstr $ IPrimOp $ ScalarUnOp BoolToInt $ fromScalarAtom x
       returnVal $ Con $ SumAsProd destTy (toScalarAtom IntTy tag) [[], []]
-    ty -> error $ "unexpected type: " ++ pprint ty
-  CoerceOp BoolTy x -> case x of
-    DataCon _ [] 0 [] -> returnVal $ Con $ Lit $ BoolLit False
-    DataCon _ [] 1 [] -> returnVal $ Con $ Lit $ BoolLit True
-    Con (SumAsProd _ tag [[],[]]) -> do
-      ans <- emitInstr $ IPrimOp $ ScalarUnOp UnsafeIntToBool $ fromScalarAtom tag
-      returnVal $ toScalarAtom BoolTy ans
-    _ -> error $ "Not a prelude bool: " ++ pprint x
+    (PreludeBoolTy, BoolTy) -> case x of
+      DataCon _ [] 0 [] -> returnVal $ BoolLit $ Int8Lit 0
+      DataCon _ [] 1 [] -> returnVal $ BoolLit $ Int8Lit 1
+      Con (SumAsProd _ tag [[],[]]) -> do
+        ans <- emitInstr $ IPrimOp $ ScalarUnOp UnsafeIntToBool $ fromScalarAtom tag
+        returnVal $ toScalarAtom BoolTy ans
+      _ -> error $ "Not a prelude bool: " ++ pprint x
+    (BaseTy (Scalar Int64Type  ), IntTy ) -> castTo $ Scalar Int64Type
+    (BaseTy (Scalar Float64Type), RealTy) -> castTo $ Scalar Float64Type
+    _ -> error $ "Invalid cast: " ++ pprint (getType x) ++ " -> " ++ pprint destTy
+    where
+      castTo bt = do
+        result <- emitInstr (ICastOp (IValType bt) $ fromScalarAtom x)
+        returnVal $ toScalarAtom destTy result
   _ -> do
     returnVal . toScalarAtom resultTy =<< emitInstr (IPrimOp $ fmap fromScalarAtom op)
   where
@@ -267,7 +277,7 @@ toImpHof env (maybeDest, hof) = do
         void $ toImpBlock (env <> sb @> idx) (Just sDest, sBody)
       destToAtom dest
     While (Lam (Abs _ (_, cond))) (Lam (Abs _ (_, body))) -> do
-      ~condVarDest@(Dest condVar) <- allocDest Nothing BoolTy
+      ~condVarDest@(Dest (Con (Coerce (ArrayTy BoolTy) condVar))) <- allocDest Nothing BoolTy
       void $ toImpBlock env (Just condVarDest, cond)
       (_, body') <- scopedBlock $do
         void $ toImpBlock env (Nothing, body)
@@ -401,9 +411,13 @@ destToAtom' fScalar scalar (Dest destAtom) = case destAtom of
   Record items -> Record <$> mapM rec items
   Variant types label i item -> Variant types label i <$> rec item
   Con destCon -> Con <$> case destCon of
-    PairCon dl dr        -> PairCon <$> rec dl <*> rec dr
-    UnitCon              -> return $ UnitCon
-    Coerce (ArrayTy t) d -> Coerce t <$> rec d
+    PairCon dl dr             -> PairCon <$> rec dl <*> rec dr
+    UnitCon                   -> return $ UnitCon
+    Coerce (ArrayTy IntTy ) d -> IntCon   <$> rec d
+    Coerce (ArrayTy RealTy) d -> RealCon  <$> rec d
+    Coerce (ArrayTy BoolTy) d -> BoolCon  <$> rec d
+    Coerce (ArrayTy CharTy) d -> CharCon  <$> rec d
+    Coerce (ArrayTy t     ) d -> Coerce t <$> rec d
     SumAsProd ty tag xs -> SumAsProd ty <$> rec tag <*> mapM (mapM rec) xs
     _ -> unreachable
   _ -> unreachable
@@ -450,6 +464,18 @@ splitDest (maybeDest, (Block decls ans)) = do
         (PairCon ld rd , PairCon lr rr ) -> gatherVarDests (Dest ld) lr >>
                                             gatherVarDests (Dest rd) rr
         (UnitCon       , UnitCon       ) -> return ()
+        (Coerce (ArrayTy IntTy ) d, IntCon a ) -> case getType a of
+          BaseTy (Scalar Int64Type)   -> gatherVarDests (Dest d) a
+          _                           -> tell [(dest, result)]
+        (Coerce (ArrayTy RealTy) d, RealCon a) -> case getType a of
+          BaseTy (Scalar Float64Type) -> gatherVarDests (Dest d) a
+          _                           -> tell [(dest, result)]
+        (Coerce (ArrayTy BoolTy) d, BoolCon a) -> case getType a of
+          BaseTy (Scalar Int8Type)    -> gatherVarDests (Dest d) a
+          _                           -> tell [(dest, result)]
+        (Coerce (ArrayTy CharTy) d, CharCon a) -> case getType a of
+          BaseTy (Scalar Int8Type)    -> gatherVarDests (Dest d) a
+          _                           -> tell [(dest, result)]
         (Coerce _ db   , Coerce _ rb   ) -> gatherVarDests (Dest db) rb
         _ -> unreachable
       _ -> unreachable
@@ -510,14 +536,19 @@ makeDest nameHint destType = do
                 let (ArrayTy tabTy) = getType arr
                 offset <- tabTy `offsetToE` ordinal
                 arrOffset arr idx offset
+          IntType          -> scalarCoerce Int64Type
+          RealType         -> scalarCoerce Float64Type
+          BoolType         -> scalarCoerce Int8Type
+          CharType         -> scalarCoerce Int8Type
           PairType a b     -> PairVal <$> rec a <*> rec b
           UnitType         -> return UnitVal
-          IntRange   _ _   -> scalarIndexSet ty
-          IndexRange _ _ _ -> scalarIndexSet ty
+          IntRange   _ _   -> recCoerce IntTy
+          IndexRange _ _ _ -> recCoerce IntTy
           _ -> unreachable
         _ -> unreachable
       where
-        scalarIndexSet t = Con . Coerce (ArrayTy t) <$> rec IntTy
+        scalarCoerce rep = recCoerce (BaseTy $ Scalar rep)
+        recCoerce rep = Con . Coerce (ArrayTy ty) <$> rec rep
         rec = go bindings mkTy idxVars
         unreachable = error $ "Can't lower type to imp: " ++ pprint destType
 
@@ -529,17 +560,30 @@ fromScalarAtom atom = case atom of
   Con (Lit x)       -> ILit x
   Con (Coerce _ x)  -> fromScalarAtom x
   Con (AnyValue ty) -> fromScalarAtom $ anyValue ty
+  -- TODO: Handle AnyValue inside the constructors?
+  Con (IntCon  (Con (Lit l)))  -> ILit $ Int64Lit   $ fromIntegral $ getIntLit l
+  Con (RealCon (Con (Lit l)))  -> ILit $ Float64Lit $ getRealLit l
+  Con (CharCon (Con (Lit l)))  -> ILit $ Int8Lit    $ fromIntegral $ getIntLit l
+  Con (BoolCon (Con (Lit l)))  -> ILit $ Int8Lit    $ fromIntegral $ getIntLit l
+  Con (IntCon  (Var (v :> (BaseTy (Scalar Int64Type)))))   -> IVar (v :> IValType (Scalar Int64Type))
+  Con (RealCon (Var (v :> (BaseTy (Scalar Float64Type))))) -> IVar (v :> IValType (Scalar Float64Type))
+  Con (CharCon (Var (v :> (BaseTy (Scalar Int8Type)))))    -> IVar (v :> IValType (Scalar Int8Type))
+  Con (BoolCon (Var (v :> (BaseTy (Scalar Int8Type)))))    -> IVar (v :> IValType (Scalar Int8Type))
   _ -> error $ "Expected scalar, got: " ++ pprint atom
 
 toScalarAtom :: Type -> IExpr -> Atom
-toScalarAtom ty ie = case ie of
-  ILit l -> Con $ Lit l
-  IVar (v :> IValType b) -> case ty of
-    BaseTy b' | b == b'     -> Var (v :> ty)
-    TC (IntRange _ _)       -> Con $ Coerce ty $ toScalarAtom IntTy ie
-    TC (IndexRange ty' _ _) -> Con $ Coerce ty $ toScalarAtom ty' ie
-    TC (IndexSlice _ _)     -> Con $ Coerce ty $ toScalarAtom IntTy ie
+toScalarAtom ty ie = case ty of
+  BaseTy b -> case ie of
+    ILit l                            -> Con $ Lit l
+    IVar (v :> IValType b') | b == b' -> Var (v :> ty)
     _ -> unreachable
+  IntTy  -> Con $ IntCon  $ toScalarAtom (BaseTy $ Scalar Int64Type  ) ie
+  RealTy -> Con $ RealCon $ toScalarAtom (BaseTy $ Scalar Float64Type) ie
+  BoolTy -> Con $ BoolCon $ toScalarAtom (BaseTy $ Scalar Int8Type   ) ie
+  CharTy -> Con $ CharCon $ toScalarAtom (BaseTy $ Scalar Int8Type   ) ie
+  TC (IntRange _ _)     -> Con $ Coerce ty $ toScalarAtom IntTy ie
+  TC (IndexRange _ _ _) -> Con $ Coerce ty $ toScalarAtom IntTy ie
+  TC (IndexSlice _ _)   -> Con $ Coerce ty $ toScalarAtom IntTy ie
   _ -> unreachable
   where
     unreachable = error $ "Cannot convert " ++ show ie ++ " to " ++ show ty
@@ -578,7 +622,7 @@ offsetTo ty i     = fromScalarAtom <$> fromEmbed (offsetToE ty (toScalarAtom Int
 
 elemCountE :: MonadEmbed m => ScalarTableType -> m Atom
 elemCountE ty = case ty of
-  BaseTy _  -> return $ IntVal 1
+  BaseTy _  -> return $ IntLit $ Int64Lit 1
   TabTy b _ -> offsetToE ty =<< indexSetSizeE (binderType b)
   _ -> error $ "Not a scalar table type: " ++ pprint ty
 
@@ -609,19 +653,23 @@ zipWithDest dest@(Dest destAtom) atom f = case (destAtom, atom) of
     | fmap (const ()) items == fmap (const ()) items' -> do
         zipWithM_ rec (map Dest (toList items)) (toList items')
   -- TODO: Check array type?
-  (Var _, Var _)       -> f (fromArrayAtom destAtom) (fromScalarAtom atom)
-  (Var _, Con (Lit _)) -> f (fromArrayAtom destAtom) (fromScalarAtom atom)
+  (Var d, Var a)           | varType d == ArrayTy (varType a)    -> f (fromArrayAtom destAtom) (fromScalarAtom atom)
+  (Var d, Con (Lit _))     | varType d == ArrayTy (getType atom) -> f (fromArrayAtom destAtom) (fromScalarAtom atom)
   (Con (SumAsProd _ tag payload), DataCon _ _ con x) -> do
-    recDest tag (IntVal con)
+    recDest tag (IntLit $ Int64Lit $ fromIntegral con)
     zipWithM_ recDest (payload !! con) x
   (Con (SumAsProd _ tag payload), Variant types label i x) -> do
     let LabeledItems ixtypes = enumerate types
     let index = fst $ (ixtypes M.! label) !! i
-    recDest tag (IntVal index)
+    recDest tag (IntLit $ Int64Lit $ fromIntegral index)
     zipWithM_ recDest (payload !! index) [x]
   (Con dcon, Con acon) -> case (dcon, acon) of
     (PairCon ld rd, PairCon la ra) -> rec (Dest ld) la >> rec (Dest rd) ra
     (UnitCon      , UnitCon      ) -> return ()
+    (Coerce (ArrayTy IntTy ) d, IntCon _ ) -> f (fromArrayAtom d) (fromScalarAtom atom)
+    (Coerce (ArrayTy RealTy) d, RealCon _) -> f (fromArrayAtom d) (fromScalarAtom atom)
+    (Coerce (ArrayTy BoolTy) d, BoolCon _) -> f (fromArrayAtom d) (fromScalarAtom atom)
+    (Coerce (ArrayTy CharTy) d, CharCon _) -> f (fromArrayAtom d) (fromScalarAtom atom)
     (Coerce _ d   , Coerce _ a   ) -> rec (Dest d) a
     (SumAsProd _ tag xs, SumAsProd _ tag' xs') -> do
       recDest tag tag'
@@ -642,8 +690,8 @@ zeroDest dest = mapM_ (initializeZero . IVar) (destArrays dest)
   where
     initializeZero :: IExpr -> ImpM ()
     initializeZero ref = case impExprType ref of
-      IRefType (BaseTy (Scalar RealType)) -> store ref (ILit $ RealLit 0.0)
-      IRefType (BaseTy (Vector RealType)) -> store ref (ILit $ VecLit $ replicate vectorWidth $ RealLit 0.0)
+      IRefType (BaseTy (Scalar Float64Type)) -> store ref (ILit $ Float64Lit 0.0)
+      IRefType (BaseTy (Vector Float64Type)) -> store ref (ILit $ VecLit $ replicate vectorWidth $ Float64Lit 0.0)
       IRefType (TabTy b _) -> do
         n <- indexSetSize $ binderType b
         emitLoop "i" Fwd n $ \i -> impGet ref i >>= initializeZero
@@ -734,7 +782,7 @@ emitSwitch testIdx = rec 0
     rec _ [] = error "Shouldn't have an empty list of alternatives"
     rec _ [body] = body
     rec curIdx (body:rest) = do
-      cond <- emitInstr $ IPrimOp $ ScalarBinOp (ICmp Equal) testIdx (IIntVal curIdx)
+      cond <- emitInstr $ IPrimOp $ ScalarBinOp (ICmp Equal) testIdx (asImpInt curIdx)
       thisCase   <- liftM snd $ scopedBlock $ body
       otherCases <- liftM snd $ scopedBlock $ rec (curIdx + 1) rest
       emitStatement (IDo, If cond thisCase otherCases)
@@ -794,6 +842,15 @@ checkProg ((binder, instr):prog) = do
 instrTypeChecked :: ImpInstr -> ImpCheckM IType
 instrTypeChecked instr = case instr of
   IPrimOp op -> checkImpOp op
+  ICastOp dt x -> do
+    case dt of
+      IValType (Scalar Int64Type  ) -> checkInt x
+      IValType (Scalar Int32Type  ) -> checkInt x
+      IValType (Scalar Int8Type   ) -> checkInt x
+      IValType (Scalar Float64Type) -> checkFloat x
+      IValType (Scalar Float32Type) -> checkFloat x
+      _ -> throw CompilerErr $ "Invalid cast destination type: " ++ pprint dt
+    return dt
   Load ref -> do
     b <- (checkIExpr >=> fromScalarRefType) ref
     return $ IValType b
@@ -807,16 +864,17 @@ instrTypeChecked instr = case instr of
   Loop _ i size (ImpProg block) -> do
     checkInt size
     checkBinder i
+    assertEq (binderAnn i) (impExprType size) $ "Mismatch between the loop iterator and upper bound type"
     extendR (i @> IIntTy) $ checkProg block
     return IVoidType
   IWhile cond (ImpProg body) -> do
     condRefTy <- checkIExpr cond
-    assertEq (IRefType BoolTy) condRefTy $ "Not a bool ref: " ++ pprint cond
+    assertEq (IRefType $ BaseTy $ Scalar Int8Type) condRefTy $ "Not a bool ref: " ++ pprint cond
     checkProg body
     return IVoidType
   If predicate (ImpProg consequent) (ImpProg alternative) -> do
     predTy <- checkIExpr predicate
-    assertEq (IValType $ Scalar BoolType) predTy "Type mismatch in predicate"
+    assertEq IBoolTy predTy "Type mismatch in predicate"
     checkProg consequent
     checkProg alternative
     return IVoidType
@@ -846,19 +904,21 @@ checkIExpr expr = case expr of
 
 checkInt :: IExpr -> ImpCheckM ()
 checkInt expr = do
-  ty <- checkIExpr expr
-  assertEq (IValType $ Scalar IntType) ty $ "Not an int: " ++ pprint expr
+  (IValType bt) <- checkIExpr expr
+  checkIntBaseType False (BaseTy bt)
+
+checkFloat :: IExpr -> ImpCheckM ()
+checkFloat expr = do
+  (IValType bt) <- checkIExpr expr
+  checkFloatBaseType False (BaseTy bt)
 
 checkImpOp :: IPrimOp -> ImpCheckM IType
 checkImpOp op = do
   op' <- traverse checkIExpr op
   case op' of
-    ScalarBinOp binOp x y -> checkBinOp Scalar binOp x y
-    VectorBinOp binOp x y -> checkBinOp Vector binOp x y
-    ScalarUnOp scalarOp x -> do
-      checkEq x (IValType $ Scalar x')
-      return $ IValType $ Scalar ty
-      where (x', ty) = unOpType scalarOp
+    ScalarBinOp bop x y -> checkImpBinOp bop x y
+    VectorBinOp bop x y -> checkImpBinOp bop x y
+    ScalarUnOp  uop x   -> checkImpUnOp  uop x
     Select _ x y -> checkEq x y >> return x
     FFICall _ ty _ -> return $ IValType ty
     VectorPack xs -> do
@@ -867,19 +927,13 @@ checkImpOp op = do
       return $ IValType $ Vector ty
     VectorIndex x i -> do
       IValType (Vector ty) <- return x
-      assertEq (IValType $ Scalar IntType) i $ "Not an int: " ++ pprint i
+      IValType ibt         <- return i
+      checkIntBaseType False $ BaseTy ibt
       return $ IValType $ Scalar ty
     _ -> error $ "Not allowed in Imp IR: " ++ pprint op
   where
     checkEq :: (Pretty a, Show a, Eq a) => a -> a -> ImpCheckM ()
     checkEq t t' = assertEq t t' (pprint op)
-
-    checkBinOp :: (ScalarBaseType -> BaseType) -> BinOp -> IType -> IType -> ImpCheckM IType
-    checkBinOp toBase binOp x y = do
-      checkEq x (IValType $ toBase x')
-      checkEq y (IValType $ toBase y')
-      return $ IValType $ toBase ty
-      where (x', y', ty) = binOpType binOp
 
 fromScalarRefType :: MonadError Err m => IType -> m BaseType
 fromScalarRefType (IRefType (BaseTy b)) = return b
@@ -893,6 +947,7 @@ impExprType expr = case expr of
 instrType :: MonadError Err m => ImpInstr -> m IType
 instrType instr = case instr of
   IPrimOp op      -> return $ impOpType op
+  ICastOp t _     -> return t
   Load ref        -> IValType <$> fromScalarRefType (impExprType ref)
   Store _ _       -> return IVoidType
   Alloc ty _      -> return $ IRefType ty
@@ -903,29 +958,49 @@ instrType instr = case instr of
   If _ _ _        -> return IVoidType
   IThrowError     -> return IVoidType
 
+checkImpBinOp :: MonadError Err m => BinOp -> IType -> IType -> m IType
+checkImpBinOp op (IValType x) (IValType y) = do
+  retTy <- checkBinOp op (BaseTy x) (BaseTy y)
+  case retTy of
+    BoolTy    -> return $ IValType $ Scalar Int8Type
+    BaseTy bt -> return $ IValType bt
+    _         -> throw CompilerErr $ "Unexpected BinOp return type: " ++ pprint retTy
+checkImpBinOp _ _ _ = throw CompilerErr "BinOp with reference arguments"
+
+checkImpUnOp :: MonadError Err m => UnOp -> IType -> m IType
+checkImpUnOp op (IValType x) = do
+  retTy <- checkUnOp op (BaseTy x)
+  case retTy of
+    IntTy     -> return $ IValType $ Scalar Int64Type
+    RealTy    -> return $ IValType $ Scalar Float64Type
+    BoolTy    -> return $ IValType $ Scalar Int8Type
+    CharTy    -> return $ IValType $ Scalar Int8Type
+    BaseTy bt -> return $ IValType bt
+    _         -> throw CompilerErr $ "Unexpected UnOp return type: " ++ pprint retTy
+checkImpUnOp _ _ = throw CompilerErr "UnOp with reference arguments"
+
 impOpType :: IPrimOp -> IType
-impOpType (ScalarBinOp op _ _) = IValType $ Scalar ty  where (_, _, ty) = binOpType op
-impOpType (ScalarUnOp  op _  ) = IValType $ Scalar ty  where (_,    ty) = unOpType  op
-impOpType (VectorBinOp op _ _) = IValType $ Vector ty  where (_, _, ty) = binOpType op
-impOpType (FFICall _ ty _ )    = IValType ty
-impOpType (Select _ x _    )   = impExprType x
-impOpType (VectorPack xs)      = IValType $ Vector ty
-  where (IValType (Scalar ty)) = impExprType $ head xs
-impOpType (VectorIndex x _)    = IValType $ Scalar ty
-  where (IValType (Vector ty)) = impExprType x
-impOpType op = error $ "Not allowed in Imp IR: " ++ pprint op
+impOpType pop = case pop of
+  ScalarBinOp op x y -> ignoreExcept $ checkImpBinOp op (impExprType x) (impExprType y)
+  ScalarUnOp  op x   -> ignoreExcept $ checkImpUnOp  op (impExprType x)
+  VectorBinOp op x y -> ignoreExcept $ checkImpBinOp op (impExprType x) (impExprType y)
+  FFICall _ ty _     -> IValType ty
+  Select  _ x  _     -> impExprType x
+  VectorPack xs      -> IValType $ Vector ty
+    where (IValType (Scalar ty)) = impExprType $ head xs
+  VectorIndex x _    -> IValType $ Scalar ty
+    where (IValType (Vector ty)) = impExprType x
+  _ -> unreachable
+  where unreachable = error $ "Not allowed in Imp IR: " ++ pprint pop
 
 pattern IIntTy :: IType
-pattern IIntTy = IValType (Scalar IntType)
+pattern IIntTy = IValType (Scalar Int64Type)
 
-pattern IIntVal :: Int -> IExpr
-pattern IIntVal x = ILit (IntLit x)
+pattern IBoolTy :: IType
+pattern IBoolTy = IValType (Scalar Int8Type)
 
-pattern IZero :: IExpr
-pattern IZero = IIntVal 0
-
-pattern IOne :: IExpr
-pattern IOne = IIntVal 1
+asImpInt :: Int -> IExpr
+asImpInt x = ILit (Int64Lit (fromIntegral x))
 
 instance Pretty Dest where
   pretty (Dest atom) = "Dest" <+> pretty atom

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -17,13 +17,6 @@ import Data.Foldable
 import Util (restructure)
 
 -- TODO: can we make this as dynamic as the compiled version?
-foreign import ccall "sqrt" c_sqrt :: Double -> Double
-foreign import ccall "sin"  c_sin  :: Double -> Double
-foreign import ccall "cos"  c_cos  :: Double -> Double
-foreign import ccall "tan"  c_tan  :: Double -> Double
-foreign import ccall "exp"  c_exp  :: Double -> Double
-foreign import ccall "log"  c_log  :: Double -> Double
-foreign import ccall "pow"  c_pow  :: Double -> Double -> Double
 foreign import ccall "randunif"      c_unif     :: Int -> Double
 foreign import ccall "threefry2x32"  c_threefry :: Int -> Int -> Int
 
@@ -50,7 +43,7 @@ evalOp :: Op -> Atom
 evalOp expr = case expr of
   -- Any ops that might have a defined result even with AnyValue arguments
   -- should be implemented here.
-  Select (BoolVal b) t f -> if b then t else f
+  Select p t f -> if (getBool p) then t else f
   _ -> if any isUndefined (toList expr)
          then Con $ AnyValue (getType $ Op expr)
          else evalOpDefined expr
@@ -61,39 +54,32 @@ evalOp expr = case expr of
 evalOpDefined :: Op -> Atom
 evalOpDefined expr = case expr of
   ScalarBinOp op x y -> case op of
-    IAdd -> IntVal $ x' + y'      where (IntVal x') = x; (IntVal y') = y
-    ISub -> IntVal $ x' - y'      where (IntVal x') = x; (IntVal y') = y
-    IMul -> IntVal $ x' * y'      where (IntVal x') = x; (IntVal y') = y
-    IDiv -> IntVal $ x' `div` y'  where (IntVal x') = x; (IntVal y') = y
-    IRem -> IntVal $ x' `rem` y'  where (IntVal x') = x; (IntVal y') = y
-    FAdd -> RealVal $ x' + y'  where (RealVal x') = x; (RealVal y') = y
-    FSub -> RealVal $ x' - y'  where (RealVal x') = x; (RealVal y') = y
-    FMul -> RealVal $ x' * y'  where (RealVal x') = x; (RealVal y') = y
-    FDiv -> RealVal $ x' / y'  where (RealVal x') = x; (RealVal y') = y
-    ICmp cmp -> BoolVal $ case cmp of
+    IAdd -> asIntVal  $ x' + y'       where x' = getInt x ; y' = getInt y
+    ISub -> asIntVal  $ x' - y'       where x' = getInt x ; y' = getInt y
+    IMul -> asIntVal  $ x' * y'       where x' = getInt x ; y' = getInt y
+    IDiv -> asIntVal  $ x' `div` y'   where x' = getInt x ; y' = getInt y
+    IRem -> asIntVal  $ x' `rem` y'   where x' = getInt x ; y' = getInt y
+    FAdd -> asRealVal $ x' + y'       where x' = getReal x; y' = getReal y
+    FSub -> asRealVal $ x' - y'       where x' = getReal x; y' = getReal y
+    FMul -> asRealVal $ x' * y'       where x' = getReal x; y' = getReal y
+    FDiv -> asRealVal $ x' / y'       where x' = getReal x; y' = getReal y
+    ICmp cmp -> asBoolVal $ case cmp of
       Less         -> x' <  y'
       Greater      -> x' >  y'
       Equal        -> x' == y'
       LessEqual    -> x' <= y'
       GreaterEqual -> x' >= y'
-      where (IntVal x') = x; (IntVal y') = y
+      where x' = getInt x; y' = getInt y
     _ -> error $ "Not implemented: " ++ pprint expr
   ScalarUnOp op x -> case op of
-    FNeg -> RealVal (-x')  where (RealVal x') = x
+    FNeg -> asRealVal (-x')  where x' = getReal x
     _ -> error $ "Not implemented: " ++ pprint expr
   FFICall name _ args -> case name of
-    "sqrt" -> RealVal $ c_sqrt x   where [RealVal x] = args
-    "sin"  -> RealVal $ c_sin  x   where [RealVal x] = args
-    "cos"  -> RealVal $ c_cos  x   where [RealVal x] = args
-    "tan"  -> RealVal $ c_tan  x   where [RealVal x] = args
-    "exp"  -> RealVal $ c_exp  x   where [RealVal x] = args
-    "log"  -> RealVal $ c_log  x   where [RealVal x] = args
-    "pow"  -> RealVal $ c_pow x y  where [RealVal x, RealVal y] = args
-    "randunif" -> RealVal $ c_unif x  where [IntVal x] = args
-    "threefry2x32" -> IntVal $ c_threefry x y  where [IntVal x, IntVal y] = args
+    "randunif"     -> asRealVal $ c_unif x         where [x]    = getInt <$> args
+    "threefry2x32" -> asIntVal  $ c_threefry x y   where [x, y] = getInt <$> args
     _ -> error $ "FFI function not recognized: " ++ name
   ArrayOffset arrArg _ offArg -> Con $ ArrayLit (ArrayTy b) (arrayOffset arr off)
-    where (ArrayVal (ArrayTy (TabTy _ b)) arr, IntVal off) = (arrArg, offArg)
+    where (ArrayVal (ArrayTy (TabTy _ b)) arr, off) = (arrArg, getInt offArg)
   ArrayLoad arrArg -> Con $ Lit $ arrayHead arr where (ArrayVal (ArrayTy (BaseTy _)) arr) = arrArg
   IndexAsInt idxArg -> case idxArg of
     Con (Coerce (TC (IntRange   _ _  )) i) -> i
@@ -106,9 +92,8 @@ evalOpDefined expr = case expr of
 
 indices :: Type -> [Atom]
 indices ty = case ty of
-  BoolTy                 -> [BoolVal False, BoolVal True]
-  TC (IntRange _ _)      -> fmap (Con . Coerce ty . IntVal) [0..n - 1]
-  TC (IndexRange _ _ _)  -> fmap (Con . Coerce ty . IntVal) [0..n - 1]
+  TC (IntRange _ _)      -> fmap (Con . Coerce ty . asIntVal) [0..n - 1]
+  TC (IndexRange _ _ _)  -> fmap (Con . Coerce ty . asIntVal) [0..n - 1]
   TC (PairType lt rt)    -> [PairVal l r | l <- indices lt, r <- indices rt]
   TC (UnitType)          -> [UnitVal]
   RecordTy types         -> let
@@ -123,9 +108,21 @@ indices ty = case ty of
   _ -> error $ "Not implemented: " ++ pprint ty
   where n = indexSetSize ty
 
+getInt :: Atom -> Int
+getInt (IntLit l) = getIntLit l
+getInt x = error $ "Expected an integer atom, got: " ++ pprint x
+
+getReal :: Atom -> Double
+getReal (RealLit l) = getRealLit l
+getReal x = error $ "Expected a real atom, got: " ++ pprint x
+
+getBool :: Atom -> Bool
+getBool (BoolLit l) = getBoolLit l
+getBool x = error $ "Expected a bool atom, got: " ++ pprint x
+
 indexSetSize :: Type -> Int
-indexSetSize ty = i
-  where (IntVal i) = evalEmbed (indexSetSizeE ty)
+indexSetSize ty = getIntLit l
+  where (IntLit l) = evalEmbed (indexSetSizeE ty)
 
 evalEmbed :: Embed Atom -> Atom
 evalEmbed embed = evalBlock mempty $ Block decls (Atom atom)

--- a/src/lib/MDImp.hs
+++ b/src/lib/MDImp.hs
@@ -43,7 +43,8 @@ stmtToMDInstr (d, instr) = case instr of
   Free v    -> do
     isHost <- isHostPtr v
     if isHost then keep else return $ MDFree v
-  IPrimOp _ -> keep
+  IPrimOp _   -> keep
+  ICastOp _ _ -> keep
   -- XXX: This is super unsafe! We have no guarantee that different iterations won't race!
   --      Now that Imp is not necessarily the last stop before codegen, we should make it
   --      emit some extra loop tags to ensure that transforms like this one are safe!

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -108,23 +108,23 @@ instance PrettyPrec BaseType where
 instance Pretty ScalarBaseType where pretty = prettyFromPrettyPrec
 instance PrettyPrec ScalarBaseType where
   prettyPrec sb = atPrec ArgPrec $ case sb of
-    CharType -> "Char"
-    IntType  -> "Int"
-    BoolType -> "Bool"
-    RealType -> "Real"
-    StrType  -> "Str"
+    Int64Type   -> "Int64"
+    Int32Type   -> "Int32"
+    Int8Type    -> "Int8"
+    Float64Type -> "Float64"
+    Float32Type -> "Float32"
 
 printDouble :: Double -> Doc ann
 printDouble x = p (double2Float x)
 
 instance Pretty LitVal where pretty = prettyFromPrettyPrec
 instance PrettyPrec LitVal where
-  prettyPrec (CharLit x) = atPrec ArgPrec $ p $ show x
-  prettyPrec (IntLit  x) = atPrec ArgPrec $ p x
-  prettyPrec (RealLit x) = atPrec ArgPrec $ printDouble x
-  prettyPrec (StrLit  x) = atPrec ArgPrec $ p x
+  prettyPrec (Int64Lit   x) = atPrec ArgPrec $ p x
+  prettyPrec (Int32Lit   x) = atPrec ArgPrec $ p x
+  prettyPrec (Int8Lit    x) = atPrec ArgPrec $ p x
+  prettyPrec (Float64Lit x) = atPrec ArgPrec $ printDouble x
+  prettyPrec (Float32Lit x) = atPrec ArgPrec $ printDouble $ realToFrac x
   prettyPrec (VecLit  l) = atPrec ArgPrec $ encloseSep "<" ">" ", " $ fmap p l
-  prettyPrec (BoolLit b) = atPrec ArgPrec $ if b then "True" else "False"
 
 instance Pretty Block where
   pretty (Block Empty expr) = group $ line <> pLowest expr
@@ -169,10 +169,15 @@ instance PrettyPrec e => PrettyPrec (PrimExpr e) where
   prettyPrec (OpExpr  e) = prettyPrec e
   prettyPrec (HofExpr e) = prettyPrec e
 
+
 instance PrettyPrec e => Pretty (PrimTC e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimTC e) where
   prettyPrec con = case con of
     BaseType b     -> prettyPrec b
+    IntType        -> atPrec ArgPrec "Int"
+    BoolType       -> atPrec ArgPrec "Bool"
+    CharType       -> atPrec ArgPrec "Char"
+    RealType       -> atPrec ArgPrec "Real"
     ArrayType ty   -> atPrec ArgPrec $ "Arr[" <> pLowest ty <> "]"
     PairType a b   -> atPrec ArgPrec $ parens $ pApp a <+> "&" <+> pApp b
     UnitType       -> atPrec ArgPrec "Unit"
@@ -193,18 +198,34 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
     _ -> prettyExprDefault $ TCExpr con
 
 instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec
+instance {-# OVERLAPPING #-} Pretty (PrimCon Atom) where pretty = prettyFromPrettyPrec
+
 instance PrettyPrec e => PrettyPrec (PrimCon e) where
-  prettyPrec con = case con of
-    Lit l       -> prettyPrec l
-    ArrayLit _ array -> atPrec ArgPrec $ p array
-    PairCon x y -> atPrec ArgPrec $ parens $ pApp x <> "," <+> pApp y
-    UnitCon     -> atPrec ArgPrec "()"
-    RefCon _ _  -> atPrec ArgPrec "RefCon"
-    Coerce t i  -> atPrec LowestPrec $ pApp i <> "@" <> pApp t
-    AnyValue t  -> atPrec AppPrec $ pAppArg "%anyVal" [t]
-    SumAsProd ty tag payload -> atPrec LowestPrec $
-      "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
-    ClassDictHole _ _ -> atPrec ArgPrec "_"
+  prettyPrec = prettyPrecPrimCon
+
+instance {-# OVERLAPPING #-} PrettyPrec (PrimCon Atom) where
+  prettyPrec con = case (Con con) of
+    IntLit  l | i <- getIntLit  l -> atPrec ArgPrec $ p i
+    RealLit l | r <- getRealLit l -> atPrec ArgPrec $ printDouble r
+    BoolLit l | b <- getBoolLit l -> atPrec ArgPrec $ if b then "True" else "False"
+    CharLit l | c <- getIntLit  l -> atPrec ArgPrec $ p $ show $ toEnum @Char c
+    _                             -> prettyPrecPrimCon con
+
+prettyPrecPrimCon :: PrettyPrec e => PrimCon e -> DocPrec ann
+prettyPrecPrimCon con = case con of
+  Lit l       -> prettyPrec l
+  BoolCon e   -> atPrec LowestPrec $ "Bool" <+> pApp e
+  CharCon e   -> atPrec LowestPrec $ "Char" <+> pApp e
+  IntCon  e   -> atPrec LowestPrec $ "Int"  <+> pApp e
+  RealCon e   -> atPrec LowestPrec $ "Real" <+> pApp e
+  ArrayLit _ array -> atPrec ArgPrec $ p array
+  PairCon x y -> atPrec ArgPrec $ parens $ pApp x <> "," <+> pApp y
+  UnitCon     -> atPrec ArgPrec "()"
+  Coerce t i  -> atPrec LowestPrec $ pApp i <> "@" <> pApp t
+  AnyValue t  -> atPrec AppPrec $ pAppArg "%anyVal" [t]
+  SumAsProd ty tag payload -> atPrec LowestPrec $
+    "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
+  ClassDictHole _ _ -> atPrec ArgPrec "_"
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where
@@ -321,6 +342,7 @@ prettyStatement (b       , instr) = p b <+> "=" <+> p instr
 
 instance Pretty ImpInstr where
   pretty (IPrimOp op)            = pLowest op
+  pretty (ICastOp t x)           = "cast"  <+> p x <+> "to" <+> p t
   pretty (Load ref)              = "load"  <+> p ref
   pretty (Store dest val)        = "store" <+> p dest <+> p val
   pretty (Alloc t s)             = "alloc" <+> p (scalarTableBaseType t) <> "[" <> p s <> "]" <+> "@" <> p t
@@ -431,6 +453,9 @@ instance PrettyPrec UExpr' where
     UVariant (Just ann) label i value -> atPrec ArgPrec $
       prettyVariant label i value AppPrec <> prettyAnn (pApp ann)
     UVariantTy items -> prettyLabeledItems items (line <> "|") ":"
+    UIntLit  v -> atPrec ArgPrec $ p v
+    UCharLit v -> atPrec ArgPrec $ p v
+    URealLit v -> atPrec ArgPrec $ p v
 
 instance Pretty UAlt where
   pretty (UAlt pat body) = p pat <+> "->" <+> p body
@@ -459,7 +484,6 @@ instance PrettyPrec UPat' where
     UPatPair x y -> atPrec ArgPrec $ parens $ p x <> ", " <> p y
     UPatUnit -> atPrec ArgPrec $ "()"
     UPatCon con pats -> atPrec AppPrec $ parens $ p con <+> spaced pats
-    UPatLit x -> atPrec ArgPrec $ p x
     UPatRecord pats -> prettyLabeledItems pats (line <> "&") ":"
     UPatVariant label i value -> prettyVariant label i value
 


### PR DESCRIPTION
So far Dex has only supported 64-bit wide types, which are fine to work
with on the CPU, but not very well supported on most accelerator
hardware. Now that we have a GPU backend, if we want it to start
generating decent code, we need to have the ability to emit 32-bit math
or we will never match other systems.

While this initially seemed to be a straightforward task, it has
actually turned out to be a pretty involved rewrite. A lot of pattern
matching had to be generalized to allow multiple options. Also, most
places that handle `BaseType`s (which now only represent fixed-width
types) now has to handle the new generic constructors (e.g. `IntCon`
which takes any fixed-width integer type to the built-in `Int` type).
Finally, initially it was not obvious at which point in our compilation
pipeline should be actually pick the width of those builtin types, but
Imp has worked out to be a very good place for that. Because the generic
constructors are `TC`s, they're disallowed in `IType` and so starting
form the Imp IR all types have a known width, which makes the LLVM
translation quite straightforward.

Note that the Imp translation is still implemented in a way that
hard-codes `Int` and `Real` to 64-bit values, but it should be
straightforward to revise that choice in the future, and possibly expose
it as a command-line flag. My aim for this patch wasn't to add a lot of
new functionality, but only to set the stage for future improvements
which should be much easier to do now. One easy win though is that `Bool`
is finally stored as an 8-bit value.

Finally, there is one regression: we've lost the vector types. In the
future we should add them back, but only once we build out more
infrastructure around casting and math of those fixed-point types.
At that point we will also be in a much better place to allow vectors of
differing widths, which will be useful for targetting architectures
other than just AVX2.