### PR TITLE
Build and link the Dex runtime using Cabal

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -11,10 +11,6 @@ author:              Dougal Maclaurin
 maintainer:          dougalm@google.com
 build-type:          Simple
 
-flag inotify
-  description:         Uses inotify to watch for source changes
-  default:             False
-
 flag cuda
   description:         Enables building with CUDA support
   default:             False
@@ -35,13 +31,17 @@ library
                        process, primitive, store
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
-  ghc-options:         cbits/libdex.so
-                       -Wall
-                       -O0
+  ghc-options:         -Wall -O0
+  ld-options:          -rdynamic
+  c-sources:           src/lib/dexrt.c
+  cc-options:          -std=c11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase
   if flag(cuda)
-    cpp-options: -DDEX_CUDA
+    include-dirs:      /usr/local/cuda/include
+    extra-libraries:   cuda
+    cc-options:        -DDEX_CUDA
+    cpp-options:       -DDEX_CUDA
 
 executable dex
   main-is:             dex.hs
@@ -50,10 +50,6 @@ executable dex
                        optparse-applicative, unix, store, bytestring
   default-language:    Haskell2010
   hs-source-dirs:      src
-  -- this is clearly a hack. Can't figure out where else to put it
-  ghc-options:         cbits/libdex.so
-                       -threaded
-                       -Wall
   default-extensions:  CPP
 
 Test-Suite test-dex

--- a/makefile
+++ b/makefile
@@ -26,8 +26,7 @@ endif
 # --- building Dex ---
 
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
-STACK_FLAGS  = --flag dex:cuda
-LIBDEX_FLAGS = -I/usr/local/cuda/include -lcuda -DDEX_CUDA
+STACK_FLAGS = --flag dex:cuda
 endif
 
 .PHONY: all
@@ -35,23 +34,13 @@ all: build
 
 # type-check only
 tc:
-	$(STACK) build --ghc-options -fno-code
+	$(STACK) build $(STACK_FLAGS) --ghc-options -fno-code
 
-build: libdex
+build:
 	$(STACK) build $(STACK_FLAGS)
 
-build-prof: libdex
+build-prof:
 	$(STACK) build $(PROF)
-
-all-inotify: build-inotify
-
-build-inotify: libdex
-	$(STACK) build --flag dex:inotify $(PROF)
-
-%.so: %.c
-	gcc -std=c11 -fPIC -shared $^ $(LIBDEX_FLAGS) -o $@
-
-libdex: cbits/libdex.so
 
 # --- running tets ---
 
@@ -115,13 +104,6 @@ doc/%.html: examples/%.dx
 
 doc/%.css: static/%.css
 	cp $^ $@
-
-benchmark:
-	python benchmarks/numpy-bench.py 1000
-	gcc -O3 -ffast-math benchmarks/cbench.c -o benchmarks/bench
-	benchmarks/bench 1000
-	$(dex) script benchmarks/time-tests.dx
-	rm benchmarks/bench
 
 clean:
 	$(STACK) clean

--- a/src/lib/dexrt.c
+++ b/src/lib/dexrt.c
@@ -145,10 +145,6 @@ int testit() {
   return 0;
 }
 
-int main(int argc, const char* argv[]) {
-  testit();
-}
-
 #ifdef DEX_CUDA
 #include <cuda.h>
 


### PR DESCRIPTION
This lets us simplify some logic in the makefile and also should make it
easier to figure out e.g. Nix builds, since Dex can now be built using
Cabal alone, with no preprocessing steps required.