### PR TITLE
Link the Dex runtime statically to all LLVM programs we compile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ scratch/
 test-scratch/
 dist-newstyle/
 *.cache
+*.bc

--- a/dex.cabal
+++ b/dex.cabal
@@ -28,11 +28,10 @@ library
                        blaze-html, cmark, diagrams-lib, ansi-terminal,
                        diagrams-rasterific, JuicyPixels, transformers,
                        base64-bytestring, vector, directory, mmap, unix,
-                       process, primitive, store
+                       process, primitive, store, file-embed
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
-  ld-options:          -rdynamic
   c-sources:           src/lib/dexrt.c
   cc-options:          -std=c11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,

--- a/makefile
+++ b/makefile
@@ -27,20 +27,26 @@ endif
 
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
 STACK_FLAGS = --flag dex:cuda
+CFLAGS = -std=c11 -I/usr/local/cuda/include -DDEX_CUDA -O3
 endif
 
 .PHONY: all
 all: build
 
 # type-check only
-tc:
+tc: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS) --ghc-options -fno-code
 
-build:
+build: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS)
 
-build-prof:
+build-prof: dexrt-llvm
 	$(STACK) build $(PROF)
+
+dexrt-llvm: src/lib/dexrt.bc
+
+%.bc: %.c
+	clang $(CFLAGS) -c -emit-llvm $^ -o $@
 
 # --- running tets ---
 

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -5,12 +5,13 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# LANGUAGE OverloadedStrings #-}
+{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module LLVMExec (LLVMFunction (..), LLVMKernel (..),
-                 callLLVM, compilePTX, linking_hack) where
+                 callLLVM, compilePTX) where
 
 import qualified LLVM.Analysis as L
 import qualified LLVM.AST as L
@@ -40,15 +41,13 @@ import Control.Monad
 import Control.Exception hiding (throw)
 import Data.ByteString.Char8 (unpack)
 import Data.IORef
+import Data.FileEmbed
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
 
 import Logging
 import Syntax
 import JIT (LLVMFunction (..), LLVMKernel (..), ptxTargetTriple, ptxDataLayout)
-
--- This forces the linker to link libdex.so. TODO: something better
-foreign import ccall "threefry2x32"  linking_hack :: Int -> Int -> Int
 
 type ExitCode = Int
 
@@ -61,8 +60,10 @@ compilePTX logger (LLVMKernel ast) = do
   withContext $ \ctx ->
     Mod.withModuleFromAST ctx ast $ \m -> do
       withGPUTargetMachine "sm_60" $ \tm -> do
-        linkLibdevice ctx m
-        compileModule logger tm m
+        linkLibdevice ctx        m
+        linkDexrt     ctx        m
+        internalize   ["kernel"] m
+        compileModule logger tm  m
         PTXKernel . unpack <$> Mod.moduleTargetAssembly tm m
 
 callLLVM :: Logger [Output] -> LLVMFunction -> [Ptr ()] -> IO [Ptr ()]
@@ -96,7 +97,9 @@ evalLLVM logger ast argPtr = do
       -- TODO: Consider changing the linking layer, as suggested in:
       --       http://llvm.1065342.n5.nabble.com/llvm-dev-ORC-JIT-Weekly-5-td135203.html
       T.withHostTargetMachine R.PIC CM.Large CGO.Aggressive $ \tm -> do
-        compileModule logger tm m
+        linkDexrt     c            m
+        internalize   ["entryFun"] m
+        compileModule logger tm    m
         JIT.withExecutionSession $ \exe ->
           JIT.withObjectLinkingLayer exe (\k -> (M.! k) <$> readIORef resolvers) $ \linkLayer ->
             JIT.withIRCompileLayer linkLayer tm $ \compileLayer -> do
@@ -154,7 +157,8 @@ runDefaultPasses t m = do
   P.withPassManager defaultPasses $ \pm -> void $ P.runPassManager pm m
   where
     defaultPasses = P.defaultCuratedPassSetSpec {P.optLevel = Just 3}
-    extraPasses = [ P.SuperwordLevelParallelismVectorize ]
+    extraPasses = [ P.SuperwordLevelParallelismVectorize
+                  , P.FunctionInlining 0 ]
 
 
 runPasses :: [P.Pass] -> Maybe T.TargetMachine -> Mod.Module -> IO ()
@@ -170,6 +174,9 @@ showAsm t m = do
   -- Uncomment this to dump assembly to a file that can be linked to a C benchmark suite:
   -- Mod.writeObjectToFile t (Mod.File "asm.o") m
   liftM unpack $ Mod.moduleTargetAssembly t m
+
+internalize :: [String] -> Mod.Module -> IO ()
+internalize names m = runPasses [P.InternalizeFunctions names, P.GlobalDeadCodeElimination] Nothing m
 
 instance Show LLVMKernel where
   show (LLVMKernel ast) = unsafePerformIO $ withContext $ \c -> Mod.withModuleFromAST c ast showModule
@@ -188,6 +195,17 @@ withGPUTargetMachine computeCapability next = do
       CM.Default
       CGO.Aggressive
       next
+
+-- === dex runtime ===
+
+dexrtBC :: BS.ByteString
+dexrtBC = $(embedFile "src/lib/dexrt.bc")
+
+linkDexrt :: Context -> Mod.Module -> IO ()
+linkDexrt ctx m = do
+  Mod.withModuleFromBitcode ctx (("dexrt.c" :: String), dexrtBC) $ \dexrtm -> do
+    Mod.linkModules m dexrtm
+    runPasses [P.AlwaysInline True] Nothing m
 
 -- === libdevice support ===
 
@@ -210,8 +228,7 @@ linkLibdevice ctx m =
     Mod.withModuleFromAST ctx libdevice $ \ldm -> do
       Mod.linkModules m ldm
       Mod.linkModules m reflectm
-      -- Inline libdevice functions and internalize the module to only export our kernel
-      runPasses [P.AlwaysInline True, P.InternalizeFunctions ["kernel"]] Nothing m
+      runPasses [P.AlwaysInline True] Nothing m
 
 -- llvm-hs does not expose the NVVM reflect pass, so we have to eliminate all calls to
 -- __nvvm_reflect by ourselves. Since we aren't really interested in setting any reflection


### PR DESCRIPTION
This comes with multiple benefits:
(1) if we were to add an `.o` emitter path for AOT compilation,
    then the object files would be completely self-contained,
(2) we no longer have to depend on some linker tricks to make the
    functions visible in the dynamic linker,
(3) we should be able to use PRNGs on the GPU!
(4) index-casts that can be seen as in-bounds statically (e.g.
    `0@(Fin 5)`) now compile as no-ops, so there is no run-time
    overhead!

There are unfortunately problems too. If I compile `dexrt.c` without
`-O3`, then the programs that use `randunif` segfault, because LLVM
seems to be emitting malformed assembly (the code forgets to add the
GOT base offset)? After spending some time digging around this I
concluded that this really doesn't look as our bug and I'm happy to
blame LLVM for it for now. It wouldn't be too surprising given that
we're on an old version which uses deprecated JIT bindings, but fixing
that would require a lot of work in llvm-hs...