### PR TITLE
Remove the builtin Int and Float types

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -35,7 +35,7 @@ library
   c-sources:           src/lib/dexrt.c
   cc-options:          -std=c11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
-                       TupleSections, ScopedTypeVariables, LambdaCase
+                       TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
   if flag(cuda)
     include-dirs:      /usr/local/cuda/include
     extra-libraries:   cuda

--- a/examples/adt-tests.dx
+++ b/examples/adt-tests.dx
@@ -16,7 +16,7 @@ z = MkMyPair 1 2.3
 > MkMyPair 1 2.3
 
 :t z
-> (MyPair Int Float)
+> (MyPair Int64 Float64)
 
 :p
   case z of

--- a/examples/parser-tests.dx
+++ b/examples/parser-tests.dx
@@ -30,8 +30,8 @@ f = \x. x + 10.
 
 :p f -1.0   -- parses as (-) f (-1.0)
 > Type error:
-> Expected: (Float -> Float)
->   Actual: Float
+> Expected: (Float64 -> Float64)
+>   Actual: Float64
 >
 > :p f -1.0   -- parses as (-) f (-1.0)
 >       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -8,13 +8,13 @@ Syntax for records, variants, and their types.
 > { &}
 
 :p {a:Int & b:Float}
-> {a: Int & b: Float}
+> {a: Int64 & b: Float64}
 
 :p {a:Int & b:Float &}
-> {a: Int & b: Float}
+> {a: Int64 & b: Float64}
 
 :p {a:Int & a:Float}
-> {a: Int & a: Float}
+> {a: Int64 & a: Float64}
 
 
 'Records
@@ -32,17 +32,17 @@ Syntax for records, variants, and their types.
 :p {a=3, b=4}
 > {a = 3, b = 4}
 :t {a=3, b=4}
-> {a: Int & b: Int}
+> {a: Int64 & b: Int64}
 
 :p {a=3, b=4,}
 > {a = 3, b = 4}
 :t {a=3, b=4,}
-> {a: Int & b: Int}
+> {a: Int64 & b: Int64}
 
 :p {a=3, a=4}
 > {a = 3, a = 4}
 :t {a=3, a=4}
-> {a: Int & a: Int}
+> {a: Int64 & a: Int64}
 
 
 'Variant (enum) types
@@ -51,13 +51,13 @@ Syntax for records, variants, and their types.
 > { |}
 
 :p {a:Int | b:Float}
-> {a: Int | b: Float}
+> {a: Int64 | b: Float64}
 
 :p {a:Int | b:Float |}
-> {a: Int | b: Float}
+> {a: Int64 | b: Float64}
 
 :p {a:Int | a:Float}
-> {a: Int | a: Float}
+> {a: Int64 | a: Float64}
 
 
 'Variants (enums)
@@ -76,7 +76,7 @@ Syntax for records, variants, and their types.
 :t
   x : {a:Int | a:Float | a:Int} = {| a#1 = 3.0 |}
   x
-> {a: Int | a: Float | a: Int}
+> {a: Int64 | a: Float64 | a: Int64}
 
 
 'Parse errors
@@ -140,7 +140,7 @@ Syntax for records, variants, and their types.
 :p
   ({b=b, a=a1, a=a2}) = {a=1, b=2}
   (a1, a2, b)
-> Type error:Labels in record pattern do not match record type. Expected structure {a: Int & b: Int}
+> Type error:Labels in record pattern do not match record type. Expected structure {a: Int64 & b: Int64}
 >
 >   ({b=b, a=a1, a=a2}) = {a=1, b=2}
 >    ^^^^^^^^^^^^^^^^^

--- a/examples/serialize-tests.dx
+++ b/examples/serialize-tests.dx
@@ -22,7 +22,7 @@
 'Values without a pretty-printer (currently shows warning message):
 
 :p Int
-> Int
+> Int64
 
 :p Fin 10
 > Fin 10

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -53,18 +53,18 @@ help make the errors more local.
 :t
    myid : a:Type ?-> a -> a = \x. x
    myid (myid) (myid 1)
-> Int
+> Int64
 
 :t
    x = iota (Fin 10)
    sum x
-> Int
+> Int64
 
 :t
    x = iota (Fin 10)
    y = iota (Fin 3)
    IToF (sum for i. x.i) + IToF (sum for j. y.j)
-> Float
+> Float64
 
 :t
    x = iota (Fin 10)
@@ -84,19 +84,19 @@ arr  = iota Narr
 xr = map IToF arr
 
 :t arr
-> ((Fin 10) => Int)
+> ((Fin 10) => Int64)
 
 :t (\(x, y). x + y) (1.0, 2.0)
-> Float
+> Float64
 
 :t
    f = \(x, y). x + 2.0 * y
    z = for i. (xr.i, xr.i * xr.i)
    sum (for i. f z.i)
-> Float
+> Float64
 
 :t [1, 2, 3]
-> ((Fin 3) => Int)
+> ((Fin 3) => Int64)
 
 :t []
 > Type error:Empty table constructor must have type annotation
@@ -106,19 +106,19 @@ xr = map IToF arr
 
 :t [1, [2]]
 > Type error:
-> Expected: Int
->   Actual: ((Fin 1) => Int)
+> Expected: Int64
+>   Actual: ((Fin 1) => Int64)
 >
 > :t [1, [2]]
 >        ^^^
 
 :t [[1, 2], [3, 4]]
-> ((Fin 2) => (Fin 2) => Int)
+> ((Fin 2) => (Fin 2) => Int64)
 
 :t [[1, 2], [3]]
 > Type error:
-> Expected: ((Fin 2) => Int)
->   Actual: ((Fin 1) => Int)
+> Expected: ((Fin 2) => Int64)
+>   Actual: ((Fin 1) => Int64)
 >
 > :t [[1, 2], [3]]
 >             ^^^
@@ -128,8 +128,8 @@ f : Int -> Float =
    z = x + 1.0
    x
 > Type error:
-> Expected: Int
->   Actual: Float
+> Expected: Int64
+>   Actual: Float64
 >
 >    z = x + 1.0
 >            ^^^
@@ -217,14 +217,14 @@ g : a -> a = \x. x
 :t
   f = \x:Int. x
   f 1
-> Int
+> Int64
 
 :t
    f = \x:Float. x
    f 1
 > Type error:
-> Expected: Float
->   Actual: Int
+> Expected: Float64
+>   Actual: Int64
 >
 >    f 1
 >      ^
@@ -232,11 +232,11 @@ g : a -> a = \x. x
 g1 : (a -> Int) -> (a -> Int) = \x. x
 
 :t g1
-> ((a:Type) ?-> (a -> Int) -> a -> Int)
+> ((a:Type) ?-> (a -> Int64) -> a -> Int64)
 
 g2 : a -> a = \x. idiv x x
 > Type error:
-> Expected: Int
+> Expected: Int64
 >   Actual: a
 >
 > g2 : a -> a = \x. idiv x x
@@ -249,7 +249,7 @@ h : (a -> b) -> (a -> b) = \x. x
 
 fun : a -> a = \x. sin x
 > Type error:
-> Expected: Float
+> Expected: Float64
 >   Actual: a
 >
 > fun : a -> a = \x. sin x
@@ -264,7 +264,7 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 :p fst newPair
 > Type error:
 > Expected: (a & b)
->   Actual: (NewPair Int Float)
+>   Actual: (NewPair Int64 Float64)
 > (Solving for: [a:Type, b:Type])
 >
 > :p fst newPair
@@ -298,7 +298,7 @@ good_range : Type = (1@Fin 3)..(2@_)
 
 bad_range : Int = (1@Fin 3)..(2@_)
 > Type error:
-> Expected: Int
+> Expected: Int64
 >   Actual: Type
 >
 > bad_range : Int = (1@Fin 3)..(2@_)
@@ -329,7 +329,7 @@ bad_range : Int = (1@Fin 3)..(2@_)
 > ()
 
 :p (\x:Int. x) == (\x:Int. x)
-> Type error:Couldn't synthesize a class dictionary for: (Eq (Int -> Int))
+> Type error:Couldn't synthesize a class dictionary for: (Eq (Int64 -> Int64))
 >
 > :p (\x:Int. x) == (\x:Int. x)
 >                ^^^

--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -43,24 +43,24 @@ idImplicit2 : (a:Type ?-> a -> a) = \x. x
 
 :p 1.0 + 1
 > Type error:
-> Expected: Float
->   Actual: Int
+> Expected: Float64
+>   Actual: Int64
 >
 > :p 1.0 + 1
 >          ^
 
 :p 1 + (1.0 + 2.0)
 > Type error:
-> Expected: Int
->   Actual: Float
+> Expected: Int64
+>   Actual: Float64
 >
 > :p 1 + (1.0 + 2.0)
 >         ^^^^^^^^^
 
 :p 1.0 + (2 + 3)
 > Type error:
-> Expected: Float
->   Actual: Int
+> Expected: Float64
+>   Actual: Int64
 >
 > :p 1.0 + (2 + 3)
 >           ^^^^^
@@ -141,7 +141,7 @@ myPair = (1, 2.3)
   ((x,y),z)
 > Type error:
 > Expected: (a & b)
->   Actual: Int
+>   Actual: Int64
 > (Solving for: [a:Type, b:Type])
 >
 >   ((x,y),z) = (1,2,3)
@@ -157,7 +157,7 @@ myPair = (1, 2.3)
   (x,y)
 > Type error:
 > Expected: (a & b)
->   Actual: Int
+>   Actual: Int64
 > (Solving for: [a:Type, b:Type])
 >
 >   (x,y) = 1

--- a/prelude.dx
+++ b/prelude.dx
@@ -5,8 +5,6 @@
 
 'Wrappers around primitives
 
-Int  = %Int
-Float = %Float
 Unit = %UnitType
 Type = %TyKind
 Effects = %EffKind
@@ -16,6 +14,9 @@ Int32 = %Int32
 Int8  = %Int8
 Float64 = %Float64
 Float32 = %Float32
+
+Int = Int64
+Float = Float64
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
 def (,) (x:a) (y:b) : (a & b) = %pair x y
@@ -48,10 +49,8 @@ def (+)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd add _   _    -> add
 def (-)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd _   sub _    -> sub
 def zero (d:Add a) ?=> : a           = case d of MkAdd _   _   zero -> zero
 
-@instance floatAdd   : Add Float   = MkAdd (\x:Float   y:Float.   %fadd x y) (\x y. %fsub x y) 0.0
 @instance float64Add : Add Float64 = MkAdd (\x:Float64 y:Float64. %fadd x y) (\x y. %fsub x y) (FToF64 0.0)
 @instance float32Add : Add Float32 = MkAdd (\x:Float32 y:Float32. %fadd x y) (\x y. %fsub x y) (FToF32 0.0)
-@instance intAdd     : Add Int     = MkAdd (\x:Int     y:Int.     %iadd x y) (\x y. %isub x y) 0
 @instance int64Add   : Add Int64   = MkAdd (\x:Int64   y:Int64.   %iadd x y) (\x y. %isub x y) (IToI64 0)
 @instance int32Add   : Add Int32   = MkAdd (\x:Int32   y:Int32.   %iadd x y) (\x y. %isub x y) (IToI32 0)
 @instance int8Add    : Add Int8    = MkAdd (\x:Int8    y:Int8.    %iadd x y) (\x y. %isub x y) (IToI8  0)
@@ -68,8 +67,8 @@ def (*) (d:Mul a) ?=> : a -> a -> a = case d of MkMul mul _   -> mul
 def one (d:Mul a) ?=> : a           = case d of MkMul _   one -> one
 
 @instance floatMul : Mul Float = MkMul (\x:Float y:Float. %fmul x y) 1.0
-@instance intMul  : Mul Int  = MkMul (\x:Int y:Int.   %imul x y) 1
-@instance unitMul : Mul Unit = MkMul (\x y. ()) ()
+@instance intMul   : Mul Int   = MkMul (\x:Int   y:Int.   %imul x y) 1
+@instance unitMul  : Mul Unit  = MkMul (\x y. ()) ()
 
 data VSpace a:Type = MkVSpace (Add a) (Float -> a -> a)
 
@@ -85,7 +84,7 @@ def (.*)  (d:VSpace a) ?=> : Float -> a -> a = case d of MkVSpace _ scale -> sca
 def (/) (_:VSpace a) ?=> (v:a) (s:Float) : a = (fdiv 1.0 s) .* v
 def neg (_:VSpace a) ?=> (v:a) : a = (-1.0) .* v
 
-@instance floatVS : VSpace Float = MkVSpace floatAdd (*)
+@instance floatVS : VSpace Float = MkVSpace float64Add (*)
 @instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i
 @instance unitVS : VSpace Unit = MkVSpace unitAdd \s u. ()
 

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -180,7 +180,6 @@ linearizedDiv x y tx ty = do
 linearizePrimCon :: Con -> LinA Atom
 linearizePrimCon con = case con of
   Lit _      -> LinA $ return $ withZeroTangent $ Con con
-  FloatCon _  -> LinA $ return $ withZeroTangent $ Con con
   PairCon x y -> liftA2 PairVal (linearizeAtom x) (linearizeAtom y)
   _ -> error $ "not implemented: " ++ pprint con
 
@@ -210,12 +209,10 @@ withZeroTangent x = (x, return $ zeroAt (tangentType (getType x)))
 tangentType :: Type -> Type
 tangentType (TabTy n a) = TabTy n (tangentType a)
 tangentType (TC con) = case con of
-  FloatType                      -> TC con
   BaseType (Scalar Float64Type) -> TC con
   BaseType (Scalar Float32Type) -> TC con
   BaseType (Vector Float64Type) -> TC con
   BaseType (Vector Float32Type) -> TC con
-  IntType                       -> UnitTy
   BaseType   _                  -> UnitTy
   IntRange   _ _                -> UnitTy
   IndexRange _ _ _              -> UnitTy

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -211,10 +211,10 @@ checkOrInferRho (WithSrc pos expr) reqTy =
   UVariantTy (LabeledItems items) -> do
     items' <- mapM (mapM checkUType) items
     matchRequirement $ VariantTy $ LabeledItems items'
-  UIntLit  x -> matchRequirement $ IntLit  $ Int64Lit $ fromIntegral x
+  UIntLit  x  -> matchRequirement $ Con $ Lit  $ Int64Lit $ fromIntegral x
+  UFloatLit x -> matchRequirement $ Con $ Lit  $ Float64Lit x
   -- TODO: Make sure that this conversion is not lossy!
-  UCharLit x -> matchRequirement $ CharLit $ Int8Lit  $ fromIntegral $ fromEnum x
-  UFloatLit x -> matchRequirement $ FloatLit $ Float64Lit x
+  UCharLit x  -> matchRequirement $ CharLit $ fromIntegral $ fromEnum x
   where
     matchRequirement :: Atom -> UInferM Atom
     matchRequirement x = return x <*
@@ -496,7 +496,7 @@ inferTabTy xs ann = case ann of
    [] -> throw TypeErr $ "Empty table constructor must have type annotation"
    (x:_) -> do
     ty <- getType <$> inferRho x
-    return (FixedIntRange (Int64Lit 0) (Int64Lit $ fromIntegral $ length xs), ty)
+    return (FixedIntRange 0 (fromIntegral $ length xs), ty)
 
 -- Bool flag is just to tweak the reported error message
 fromPiType :: Bool -> UArrow -> Type -> UInferM PiType

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -174,9 +174,7 @@ instance PrettyPrec e => Pretty (PrimTC e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimTC e) where
   prettyPrec con = case con of
     BaseType b     -> prettyPrec b
-    IntType        -> atPrec ArgPrec "Int"
     CharType       -> atPrec ArgPrec "Char"
-    FloatType       -> atPrec ArgPrec "Float"
     ArrayType ty   -> atPrec ArgPrec $ "Arr[" <> pLowest ty <> "]"
     PairType a b   -> atPrec ArgPrec $ parens $ pApp a <+> "&" <+> pApp b
     UnitType       -> atPrec ArgPrec "Unit"
@@ -204,17 +202,13 @@ instance PrettyPrec e => PrettyPrec (PrimCon e) where
 
 instance {-# OVERLAPPING #-} PrettyPrec (PrimCon Atom) where
   prettyPrec con = case (Con con) of
-    IntLit   l | i <- getIntLit  l -> atPrec ArgPrec $ p i
-    FloatLit l | r <- getFloatLit l -> atPrec ArgPrec $ printDouble r
-    CharLit  l | c <- getIntLit  l -> atPrec ArgPrec $ p $ show $ toEnum @Char c
-    _                             -> prettyPrecPrimCon con
+    CharLit c -> atPrec ArgPrec $ p $ show $ toEnum @Char $ fromIntegral c
+    _         -> prettyPrecPrimCon con
 
 prettyPrecPrimCon :: PrettyPrec e => PrimCon e -> DocPrec ann
 prettyPrecPrimCon con = case con of
   Lit l       -> prettyPrec l
   CharCon e   -> atPrec LowestPrec $ "Char" <+> pApp e
-  IntCon  e   -> atPrec LowestPrec $ "Int"  <+> pApp e
-  FloatCon e   -> atPrec LowestPrec $ "Float" <+> pApp e
   ArrayLit _ array -> atPrec ArgPrec $ p array
   PairCon x y -> atPrec ArgPrec $ parens $ pApp x <> "," <+> pApp y
   UnitCon     -> atPrec ArgPrec "()"


### PR DESCRIPTION
After some discussion it became clear that this doesn't seem to be a
good approach and only adds unnecessary complexity. We keep the
distinguished preferred bit-width in the prelude for now, because our
implementation is not generic enough to be able to seamlessly work with
both types, but we should progressively be fixing this.

Now, the compiler has to pick some representation for two things that the
user code doesn't express: the type that backs index sets and the type that
is used to represent sum type tags. Previously both were just set to match
whatever the `Int` type was, but now they are decoupled and for now hardcoded
as `IdxRepTy` and `TagRepTy` in `Syntax.hs`. One nice outcome of this patch is that
`TagRepTy` is just `Int8` which decreases the storage requirements for the `Bool` type
defined in prelude form 8 bytes to 1 byte!. In the future we might want to make
the selection of their bit-widths user controlled.