### PR TITLE
Revert "Link the Dex runtime statically to all LLVM programs we compile"

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,3 @@ scratch/
 test-scratch/
 dist-newstyle/
 *.cache
-*.bc

--- a/dex.cabal
+++ b/dex.cabal
@@ -28,10 +28,11 @@ library
                        blaze-html, cmark, diagrams-lib, ansi-terminal,
                        diagrams-rasterific, JuicyPixels, transformers,
                        base64-bytestring, vector, directory, mmap, unix,
-                       process, primitive, store, file-embed
+                       process, primitive, store
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
+  ld-options:          -rdynamic
   c-sources:           src/lib/dexrt.c
   cc-options:          -std=c11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,

--- a/makefile
+++ b/makefile
@@ -27,26 +27,20 @@ endif
 
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
 STACK_FLAGS = --flag dex:cuda
-CFLAGS = -std=c11 -I/usr/local/cuda/include -DDEX_CUDA -O3
 endif
 
 .PHONY: all
 all: build
 
 # type-check only
-tc: dexrt-llvm
+tc:
 	$(STACK) build $(STACK_FLAGS) --ghc-options -fno-code
 
-build: dexrt-llvm
+build:
 	$(STACK) build $(STACK_FLAGS)
 
-build-prof: dexrt-llvm
+build-prof:
 	$(STACK) build $(PROF)
-
-dexrt-llvm: src/lib/dexrt.bc
-
-%.bc: %.c
-	clang $(CFLAGS) -c -emit-llvm $^ -o $@
 
 # --- running tets ---
 

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -5,13 +5,12 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# LANGUAGE OverloadedStrings #-}
-{-# LANGUAGE TemplateHaskell #-}
 {-# LANGUAGE DuplicateRecordFields #-}
 {-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module LLVMExec (LLVMFunction (..), LLVMKernel (..),
-                 callLLVM, compilePTX) where
+                 callLLVM, compilePTX, linking_hack) where
 
 import qualified LLVM.Analysis as L
 import qualified LLVM.AST as L
@@ -41,13 +40,15 @@ import Control.Monad
 import Control.Exception hiding (throw)
 import Data.ByteString.Char8 (unpack)
 import Data.IORef
-import Data.FileEmbed
 import qualified Data.ByteString as BS
 import qualified Data.Map as M
 
 import Logging
 import Syntax
 import JIT (LLVMFunction (..), LLVMKernel (..), ptxTargetTriple, ptxDataLayout)
+
+-- This forces the linker to link libdex.so. TODO: something better
+foreign import ccall "threefry2x32"  linking_hack :: Int -> Int -> Int
 
 type ExitCode = Int
 
@@ -60,10 +61,8 @@ compilePTX logger (LLVMKernel ast) = do
   withContext $ \ctx ->
     Mod.withModuleFromAST ctx ast $ \m -> do
       withGPUTargetMachine "sm_60" $ \tm -> do
-        linkLibdevice ctx        m
-        linkDexrt     ctx        m
-        internalize   ["kernel"] m
-        compileModule logger tm  m
+        linkLibdevice ctx m
+        compileModule logger tm m
         PTXKernel . unpack <$> Mod.moduleTargetAssembly tm m
 
 callLLVM :: Logger [Output] -> LLVMFunction -> [Ptr ()] -> IO [Ptr ()]
@@ -97,9 +96,7 @@ evalLLVM logger ast argPtr = do
       -- TODO: Consider changing the linking layer, as suggested in:
       --       http://llvm.1065342.n5.nabble.com/llvm-dev-ORC-JIT-Weekly-5-td135203.html
       T.withHostTargetMachine R.PIC CM.Large CGO.Aggressive $ \tm -> do
-        linkDexrt     c            m
-        internalize   ["entryFun"] m
-        compileModule logger tm    m
+        compileModule logger tm m
         JIT.withExecutionSession $ \exe ->
           JIT.withObjectLinkingLayer exe (\k -> (M.! k) <$> readIORef resolvers) $ \linkLayer ->
             JIT.withIRCompileLayer linkLayer tm $ \compileLayer -> do
@@ -157,8 +154,7 @@ runDefaultPasses t m = do
   P.withPassManager defaultPasses $ \pm -> void $ P.runPassManager pm m
   where
     defaultPasses = P.defaultCuratedPassSetSpec {P.optLevel = Just 3}
-    extraPasses = [ P.SuperwordLevelParallelismVectorize
-                  , P.FunctionInlining 0 ]
+    extraPasses = [ P.SuperwordLevelParallelismVectorize ]
 
 
 runPasses :: [P.Pass] -> Maybe T.TargetMachine -> Mod.Module -> IO ()
@@ -174,9 +170,6 @@ showAsm t m = do
   -- Uncomment this to dump assembly to a file that can be linked to a C benchmark suite:
   -- Mod.writeObjectToFile t (Mod.File "asm.o") m
   liftM unpack $ Mod.moduleTargetAssembly t m
-
-internalize :: [String] -> Mod.Module -> IO ()
-internalize names m = runPasses [P.InternalizeFunctions names, P.GlobalDeadCodeElimination] Nothing m
 
 instance Show LLVMKernel where
   show (LLVMKernel ast) = unsafePerformIO $ withContext $ \c -> Mod.withModuleFromAST c ast showModule
@@ -195,17 +188,6 @@ withGPUTargetMachine computeCapability next = do
       CM.Default
       CGO.Aggressive
       next
-
--- === dex runtime ===
-
-dexrtBC :: BS.ByteString
-dexrtBC = $(embedFile "src/lib/dexrt.bc")
-
-linkDexrt :: Context -> Mod.Module -> IO ()
-linkDexrt ctx m = do
-  Mod.withModuleFromBitcode ctx (("dexrt.c" :: String), dexrtBC) $ \dexrtm -> do
-    Mod.linkModules m dexrtm
-    runPasses [P.AlwaysInline True] Nothing m
 
 -- === libdevice support ===
 
@@ -228,7 +210,8 @@ linkLibdevice ctx m =
     Mod.withModuleFromAST ctx libdevice $ \ldm -> do
       Mod.linkModules m ldm
       Mod.linkModules m reflectm
-      runPasses [P.AlwaysInline True] Nothing m
+      -- Inline libdevice functions and internalize the module to only export our kernel
+      runPasses [P.AlwaysInline True, P.InternalizeFunctions ["kernel"]] Nothing m
 
 -- llvm-hs does not expose the NVVM reflect pass, so we have to eliminate all calls to
 -- __nvvm_reflect by ourselves. Since we aren't really interested in setting any reflection


### PR DESCRIPTION
For some reason, LLVM fails to emit proper PIC code for the DexRT code,
because it loads the offset of a statically allocated constant from the
GOT, but then forgets to offset it by the base offset for the whole
binary (which it does for all other such fields). At this point I've
lost faith and I'm willing to call it an LLVM bug, pending some further
investigation, preferrably with someone who knows LLVM better.

Since this is causing segfaults on some systems, I'm reverting the patch.