### PR TITLE
Extensible records and variants

### DIFF
--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -169,12 +169,13 @@ myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
 :p myVariantTable
 > [{| a = 1 |}, {| b = 2.0 |}]
 
--- :p for i:(Fin 2).
---     v : {a:_ | b:_} = case myVariantTable.i of
---       {| a=a |} -> {| b=a |}
---       {| b=b |} -> {| a=b |}
---     v
--- > [{| b = 1 |}, {| a = 2.0 |}]
+%passes
+:p for i:(Fin 2).
+    v : {a:_ | b:_} = case myVariantTable.i of
+      {| a=a |} -> {| b=a |}
+      {| b=b |} -> {| a=b |}
+    v
+> [{| b = 1 |}, {| a = 2.0 |}]
 
 'As index sets
 

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -202,6 +202,81 @@ myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
     v
 > [{| b = 1 |}, {| a = 2.0 |}]
 
+-- Known variant, unused tail pattern
+:p
+  x : {a:Int | a:Real | b:Int | c:Int } = {| a | a = 3.0 |}
+  case x of
+    {| a = x |} -> 1.0
+    {| a | a = x |} -> x
+    {|a|a| ..._ |} -> 5.0
+> 3.0
+
+-- Known variant, missing pattern
+:p
+  x : {a:Int | a:Real | b:Int | c:Int } = {| a | a = 3.0 |}
+  case x of
+    {| a = x |} -> 1.0
+    {| a | a = x |} -> x
+> 3.0
+
+-- Known variant, used tail pattern
+myVal =
+  x : {a:Int | a:Real | b:Int | c:Int } = {| b = 4 |}
+  case x of
+    {| a = x |} -> todo
+    {|a| ...rest |} -> rest
+
+:p myVal
+> {| b = 4 |}
+:t myVal
+> {a: Real | b: Int | c: Int}
+
+-- Badly written tail pattern
+:p
+  x : {a:Int | a:Real | b:Int | c:Int } = {| b = 4 |}
+  case x of
+    {| a = x |} -> 1
+    {| ...rest |} -> 2
+> Type error:Variant explicit alternatives overlap with tail pattern.
+>
+>   case x of
+>   ^^^^^^^^^^
+
+-- Too many tail patterns
+:p
+  x : {a:Int | a:Real | b:Int | c:Int } = {| b = 4 |}
+  case x of
+    {| a = x |} -> 1
+    {|a| ...rest |} -> 2
+    {| ...rest2 |} -> 3
+> Type error:Can't specify more than one variant tail pattern.
+>
+>   case x of
+>   ^^^^^^^^^^
+
+def splitTwoFoosOrABar (rest:Types)?-> 
+                       (x : {foo:a | foo:b | bar:c | ...rest})
+                       : ({x:a | y:b | z:c} | {|...rest}) =
+  case x of
+    {| foo=x |}                 -> Left {| x=x |}
+    {| foo | foo=y |}           -> Left {| y=y |}
+    {| bar=z |}                 -> Left {| z=z |}
+    {|foo|foo|bar| ...other |}  -> Right other
+
+myStuff = [ {| foo=1 |},
+            {| bar=2 |},
+            {| foo | foo=3 |},
+            {| baz=4 |},
+            {| foo | foo | foo=5 |}
+          ]:(Fin 5 => {foo:_ | foo:_ | foo:_ | bar:_ | baz:_})
+
+:p for i. splitTwoFoosOrABar myStuff.i
+> [ (Left {| x = 1 |})
+> , (Left {| z = 2 |})
+> , (Left {| y = 3 |})
+> , (Right {| baz = 4 |})
+> , (Right {| foo = 5 |}) ]
+
 'As index sets
 
 :p size {a:Fin 10 & b:Fin 3}

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -44,10 +44,11 @@ Syntax for records, variants, and their types.
 :t {a=3, a=4}
 > {a: Int & a: Int}
 
--- :p
---   x = {a=5.0, b=2}
---   y : {a:Int & b:Int & ..._} = {a=3, a=4, ...x}
---   y
+:p
+  x = {a=5.0, b=2}
+  y : {a:Int & b:Int & ..._} = {a=3, a=4, ...x}
+  y
+> {a = 3, a = 4, a = 5.0, b = 2}
 
 'Variant (enum) types
 
@@ -82,19 +83,20 @@ Syntax for records, variants, and their types.
   x
 > {a: Int | a: Real | a: Int}
 
--- :p
---   x : {a:Int | b:Real} = {| a=3 |}
---   y : {a:Real | a:Int | ..._} = {| a | ...x |}
---   y
+:p
+  x : {a:Int | b:Real} = {| a=3 |}
+  y : {a:Real | a:Int | ..._} = {| a | ...x |}
+  y
+> {|a| a = 3 |}
 
 
 'Parse errors
 
 :p {a:Int & b:Real | c:Int }
 
-> Parse error:93:20:
+> Parse error:95:20:
 >    |
-> 93 | :p {a:Int & b:Real | c:Int }
+> 95 | :p {a:Int & b:Real | c:Int }
 >    |                    ^
 > unexpected '|'
 > expecting "..", "..<", expression, or negation
@@ -169,7 +171,6 @@ myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
 :p myVariantTable
 > [{| a = 1 |}, {| b = 2.0 |}]
 
-%passes
 :p for i:(Fin 2).
     v : {a:_ | b:_} = case myVariantTable.i of
       {| a=a |} -> {| b=a |}

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -123,14 +123,14 @@ Syntax for records, variants, and their types.
 :p foo
 > 1
 
-def getFoo (rest : Types)?-> (x : {foo:a & ...rest}) : a =
+def getFoo (rest : Fields)?-> (x : {foo:a & ...rest}) : a =
   ({foo=foo, ..._}) = x
   foo
 
 :p getFoo {foo=1, foo=0.0, bar=2, baz=3}
 > 1
 
-def getTwoFoosAndABar (rest : Types)?->
+def getTwoFoosAndABar (rest : Fields)?->
                       (x : {foo:a & foo:b & bar:c & ...rest}) : (a&b&c) =
   ({foo=f1, foo=f2, bar=b, ..._}) = x
   (f1, f2, b)
@@ -270,7 +270,7 @@ myVal =
 >   case x of
 >   ^^^^^^^^^^
 
-def splitTwoFoosOrABar (rest:Types)?-> 
+def splitTwoFoosOrABar (rest:Fields)?->
                        (x : {foo:a | foo:b | bar:c | ...rest})
                        : ({x:a | y:b | z:c} | {|...rest}) =
   case x of

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -44,6 +44,10 @@ Syntax for records, variants, and their types.
 :t {a=3, a=4}
 > {a: Int & a: Int}
 
+-- :p
+--   x = {a=5.0, b=2}
+--   y : {a:Int & b:Int & ..._} = {a=3, a=4, ...x}
+--   y
 
 'Variant (enum) types
 
@@ -69,61 +73,32 @@ Syntax for records, variants, and their types.
 > {| a = 3 |}
 
 :p
-  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+  x : {a:Int | a:Real | a:Int} = {| a | a = 3.0 |}
   x
-> {| a#1 = 3.0 |}
+> {|a| a = 3.0 |}
 
 :t
-  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
+  x : {a:Int | a:Real | a:Int} = {| a | a = 3.0 |}
   x
 > {a: Int | a: Real | a: Int}
+
+-- :p
+--   x : {a:Int | b:Real} = {| a=3 |}
+--   y : {a:Real | a:Int | ..._} = {| a | ...x |}
+--   y
 
 
 'Parse errors
 
 :p {a:Int & b:Real | c:Int }
 
-> Parse error:84:20:
+> Parse error:93:20:
 >    |
-> 84 | :p {a:Int & b:Real | c:Int }
+> 93 | :p {a:Int & b:Real | c:Int }
 >    |                    ^
 > unexpected '|'
 > expecting "..", "..<", expression, or negation
-:p {a:Int & b:Real & ...c}
 
-> Parse error:92:26:
->    |
-> 92 | :p {a:Int & b:Real & ...c}
->    |                          ^
-> Extensible records and variants not implemented
-:p {&...c}
-
-> Parse error:99:10:
->    |
-> 99 | :p {&...c}
->    |          ^
-> Extensible records and variants not implemented
-:p {a=3, b=4, ...c}
-
-> Parse error:106:19:
->     |
-> 106 | :p {a=3, b=4, ...c}
->     |                   ^
-> Extensible records and variants not implemented
-:p {a:Int | b:Real | ...c}
-
-> Parse error:113:26:
->     |
-> 113 | :p {a:Int | b:Real | ...c}
->     |                          ^
-> Extensible records and variants not implemented
-:p {|...c}
-
-> Parse error:120:10:
->     |
-> 120 | :p {|...c}
->     |          ^
-> Extensible records and variants not implemented
 
 'Unpacking
 
@@ -146,16 +121,16 @@ Syntax for records, variants, and their types.
 >    ^^^^^^^^^^^^^^^^^
 
 :p
-  x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
-  ({| a#1 = a |}) = x
+  x : {a:Int | a:Real | a:Int} = {| a | a = 3.0 |}
+  ({| a | a = a |}) = x
   x
 > Type error:Variant not allowed in can't-fail pattern
 >
->   ({| a#1 = a |}) = x
->    ^^^^^^^^^^^^^
+>   ({| a | a = a |}) = x
+>    ^^^^^^^^^^^^^^^
 
-x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
-({| a#1 = a |}) = x
+x : {a:Int | a:Real | a:Int} = {| a | a = 3.0 |}
+({| a | a = a |}) = x
 > Type error:Variant not allowed in can't-fail pattern
 
 
@@ -170,10 +145,10 @@ x : {a:Int | a:Real | a:Int} = {| a#1 = 3.0 |}
 >   ^^^^^^^^^^^^^^^^^^
 
 :p
-  x : {a:Int | a:Real | b:Int} = {| a#1 = 3.0 |}
+  x : {a:Int | a:Real | b:Int} = {| a | a = 3.0 |}
   case x of
-    {| a#0 = x |} -> i2r x
-    {| a#1 = x |} -> x
+    {| a = x |} -> i2r x
+    {| a | a = x |} -> x
     {| b = x |} -> i2r x
 > 3.0
 
@@ -193,12 +168,13 @@ myRecordTable : (Fin 2)=>{a:Int & b:Real} =
 myVariantTable = [{| a=1 |}, {| b=2.0 |}]: (Fin 2)=>{a:Int | b:Real}
 :p myVariantTable
 > [{| a = 1 |}, {| b = 2.0 |}]
- 
-:p for i:(Fin 2).
-    case myVariantTable.i of
-      {| a=a |} -> {| b=a |}:{a:Real | b:Int}
-      {| b=b |} -> {| a=b |}:{a:Real | b:Int}
-> [{| b = 1 |}, {| a = 2.0 |}]
+
+-- :p for i:(Fin 2).
+--     v : {a:_ | b:_} = case myVariantTable.i of
+--       {| a=a |} -> {| b=a |}
+--       {| b=b |} -> {| a=b |}
+--     v
+-- > [{| b = 1 |}, {| a = 2.0 |}]
 
 'As index sets
 
@@ -215,10 +191,15 @@ recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 
 :p size {a:Fin 10 | b:Fin 3}
 > 13
-:p ordinal {| b=(2@_) |}:{a:Fin 10 | b:Fin 3}
+
+:p
+  x : {a:Fin 10 | b:Fin 3} = {| b=(2@_) |}
+  ordinal x
 > 12
+
 :p fromOrdinal {a:Fin 10 | b:Fin 3} 4
 > {| a = 4@Fin 10 |}
+
 :p fromOrdinal {a:Fin 10 | b:Fin 3} 11
 > {| b = 1@Fin 3 |}
 

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -159,6 +159,19 @@ x : {a:Int | a:Real | a:Int} = {| a | a = 3.0 |}
 ({| a | a = a |}) = x
 > Type error:Variant not allowed in can't-fail pattern
 
+'Record puns
+
+:p
+  foo = 1
+  bar = 2.0
+  {foo, bar}
+> {bar = 2.0, foo = 1}
+
+:p
+  ({foo, ...}) = {foo=1, bar=2.0}
+  foo
+> 1
+
 
 'Pattern matching
 

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -94,10 +94,10 @@ Syntax for records, variants, and their types.
 
 :p {a:Int & b:Float | c:Int }
 
-> Parse error:95:20:
+> Parse error:95:21:
 >    |
 > 95 | :p {a:Int & b:Float | c:Int }
->    |                    ^
+>    |                     ^
 > unexpected '|'
 > expecting "..", "..<", expression, or negation
 
@@ -186,9 +186,9 @@ x : {a:Int | a:Float | a:Int} = {| a | a = 3.0 |}
 :p
   x : {a:Int | a:Float | b:Int} = {| a | a = 3.0 |}
   case x of
-    {| a = x |} -> i2r x
+    {| a = x |} -> IToF x
     {| a | a = x |} -> x
-    {| b = x |} -> i2r x
+    {| b = x |} -> IToF x
 > 3.0
 
 'Table values and imp lowering
@@ -242,7 +242,7 @@ myVal =
 :p myVal
 > {| b = 4 |}
 :t myVal
-> {a: Float | b: Int | c: Int}
+> {a: Float64 | b: Int64 | c: Int64}
 
 -- Badly written tail pattern
 :p

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -115,6 +115,30 @@ Syntax for records, variants, and their types.
 > (1, (3, 2))
 
 :p
+  ({foo=foo, ..._}) = {foo=1, bar=2, baz=3}
+  foo
+> 1
+
+({foo=foo, ..._}) = {foo=1, bar=2, baz=3}
+:p foo
+> 1
+
+def getFoo (rest : Types)?-> (x : {foo:a & ...rest}) : a =
+  ({foo=foo, ..._}) = x
+  foo
+
+:p getFoo {foo=1, foo=0.0, bar=2, baz=3}
+> 1
+
+def getTwoFoosAndABar (rest : Types)?->
+                      (x : {foo:a & foo:b & bar:c & ...rest}) : (a&b&c) =
+  ({foo=f1, foo=f2, bar=b, ..._}) = x
+  (f1, f2, b)
+
+:p getTwoFoosAndABar {foo=1, bar=2, foo=0.0, foo=4, baz=3.0, bar=7}
+> (1, (0.0, 2))
+
+:p
   ({b=b, a=a1, a=a2}) = {a=1, b=2}
   (a1, a2, b)
 > Type error:Labels in record pattern do not match record type. Expected structure {a: Int & b: Int}

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -141,7 +141,10 @@ def getTwoFoosAndABar (rest : Types)?->
 :p
   ({b=b, a=a1, a=a2}) = {a=1, b=2}
   (a1, a2, b)
-> Type error:Labels in record pattern do not match record type. Expected structure {a: Int64 & b: Int64}
+> Type error:
+> Expected: {a: a & a: b & b: c}
+>   Actual: {a: Int64 & b: Int64}
+> (Solving for: [a:Type, b:Type, c:Type])
 >
 >   ({b=b, a=a1, a=a2}) = {a=1, b=2}
 >    ^^^^^^^^^^^^^^^^^

--- a/prelude.dx
+++ b/prelude.dx
@@ -8,7 +8,7 @@
 Unit = %UnitType
 Type = %TyKind
 Effects = %EffKind
-Types = %LabeledRowKind
+Fields = %LabeledRowKind
 
 Int64 = %Int64
 Int32 = %Int32

--- a/prelude.dx
+++ b/prelude.dx
@@ -10,6 +10,7 @@ Real = %Real
 Unit = %UnitType
 Type = %TyKind
 Effects = %EffKind
+Types = %LabeledRowKind
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
 def (,) (x:a) (y:b) : (a & b) = %pair x y

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -88,11 +88,11 @@ indexSetSize (TC con) = case con of
         Unlimited      -> undefined
   PairType l r -> mulC (indexSetSize l) (indexSetSize r)
   _ -> error $ "Not implemented " ++ pprint con
-indexSetSize (RecordTy types) = let
+indexSetSize (RecordTy (NoExt types)) = let
   sizes = map indexSetSize (F.toList types)
   one = liftC $ toPolynomial $ IntVal 1
   in foldl mulC one sizes
-indexSetSize (VariantTy types) = let
+indexSetSize (VariantTy (NoExt types)) = let
   sizes = map indexSetSize (F.toList types)
   zero = liftC $ toPolynomial $ IntVal 0
   in foldl add zero sizes

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -103,7 +103,7 @@ emitUnpack expr = do
       return bs
     RecordTy (NoExt types) -> do
       -- TODO: is using Ignore here appropriate? We don't have any existing
-      -- binders to bind, but we still plan to use the resulgetUnpackedts.
+      -- binders to bind, but we still plan to use the results.
       let bs = toNest $ map Ignore $ toList types
       return bs
     _ -> error $ "Unpacking a type that doesn't support unpacking: " ++ pprint (getType expr)

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -675,6 +675,7 @@ reduceBlock scope (Block decls result) = do
 
 reduceAtom :: Scope -> Atom -> Atom
 reduceAtom scope x = case x of
+  Var (Name InferenceName _ _ :> _) -> x
   Var v -> case snd (scope ! v) of
     -- TODO: worry about effects!
     LetBound PlainLet expr -> fromMaybe x $ reduceExpr scope expr

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -15,7 +15,7 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               buildLam, EmbedT, Embed, MonadEmbed, buildScoped, runEmbedT,
               runSubstEmbed, runEmbed, zeroAt, addAt, sumAt, getScope, reduceBlock,
               app, add, mul, sub, neg, div', andE, iadd, imul, isub, idiv, reduceScoped,
-              select, substEmbed, substEmbedR, emitUnpack,
+              select, substEmbed, substEmbedR, emitUnpack, getUnpacked,
               fromPair, getFst, getSnd, naryApp, appReduce,
               emitBlock, unzipTab, buildFor, isSingletonType, emitDecl, withNameHint,
               singletonTypeVal, scopedDecls, embedScoped, extendScope, checkEmbed,
@@ -103,7 +103,7 @@ emitUnpack expr = do
       return bs
     RecordTy (NoExt types) -> do
       -- TODO: is using Ignore here appropriate? We don't have any existing
-      -- binders to bind, but we still plan to use the results.
+      -- binders to bind, but we still plan to use the resulgetUnpackedts.
       let bs = toNest $ map Ignore $ toList types
       return bs
     ty -> error $ "Can't unpack value of type " <> pprint ty

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -541,12 +541,6 @@ traverseExpr def@(_, fAtom) expr = case expr of
   Hof hof -> Hof  <$> traverse fAtom hof
   Case e alts ty ->
     Case <$> fAtom e <*> mapM (traverseAlt def) alts <*> fAtom ty
-  RecordCons    items a -> RecordCons   <$> traverse fAtom items <*> fAtom a
-  RecordSplit   items a -> RecordSplit  <$> traverse fAtom items <*> fAtom a
-  VariantLift types a -> do
-    items' <- traverse fAtom types
-    VariantLift items' <$> fAtom a
-  VariantSplit items a -> VariantSplit <$> traverse fAtom items <*> fAtom a
 
 traverseAlt :: (MonadEmbed m, MonadReader SubstEnv m)
              => TraversalDef m -> Alt -> m Alt

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -129,10 +129,6 @@ toImpExpr env (maybeDest, expr) = case expr of
              void $ toImpBlock (env <> newEnv bs xs) (Just dest, body)
         destToAtom dest
       _ -> error $ "Unexpected scrutinee: " ++ pprint e'
-  RecordCons   _ _ -> error "Unreachable: should have simplified away"
-  RecordSplit  _ _ -> error "Unreachable: should have simplified away"
-  VariantLift  _ _ -> error "Unreachable: should have simplified away"
-  VariantSplit _ _ -> error "Unreachable: should have simplified away"
 
 impSubst :: Subst a => SubstEnv -> a -> ImpM a
 impSubst env x = do
@@ -229,6 +225,10 @@ toImpOp (maybeDest, op) = case op of
     emitSwitch p' [copyAtom dest y, copyAtom dest x]
     destToAtom dest
     where (BaseTy tagBT) = TagRepTy
+  RecordCons   _ _ -> error "Unreachable: should have simplified away"
+  RecordSplit  _ _ -> error "Unreachable: should have simplified away"
+  VariantLift  _ _ -> error "Unreachable: should have simplified away"
+  VariantSplit _ _ -> error "Unreachable: should have simplified away"
   _ -> do
     returnVal . toScalarAtom resultTy =<< emitInstr (IPrimOp $ fmap fromScalarAtom op)
   where

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -24,6 +24,7 @@ import Control.Monad.Writer hiding (Alt)
 import Data.Text.Prettyprint.Doc
 import Data.Foldable (toList)
 import Data.Coerce
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 
 import Embed
@@ -116,7 +117,7 @@ toImpExpr env (maybeDest, expr) = case expr of
         toImpBlock (env <> newEnv bs args) (maybeDest, body)
       Variant (NoExt types) label i x -> do
         let LabeledItems ixtypes = enumerate types
-        let index = fst $ ixtypes M.! label !! i
+        let index = fst $ ixtypes M.! label NE.!! i
         let Abs bs body = alts !! index
         toImpBlock (env <> newEnv bs [x]) (maybeDest, body)
       Con (SumAsProd _ tag xss) -> do
@@ -616,7 +617,7 @@ zipWithDest dest@(Dest destAtom) atom f = case (destAtom, atom) of
     zipWithM_ recDest (payload !! con) x
   (Con (SumAsProd _ tag payload), Variant (NoExt types) label i x) -> do
     let LabeledItems ixtypes = enumerate types
-    let index = fst $ (ixtypes M.! label) !! i
+    let index = fst $ (ixtypes M.! label) NE.!! i
     recDest tag (IntVal index)
     zipWithM_ recDest (payload !! index) [x]
   (Con dcon, Con acon) -> case (dcon, acon) of

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -129,6 +129,10 @@ toImpExpr env (maybeDest, expr) = case expr of
              void $ toImpBlock (env <> newEnv bs xs) (Just dest, body)
         destToAtom dest
       _ -> error $ "Unexpected scrutinee: " ++ pprint e'
+  RecordCons   _ _ -> error "Unreachable: should have simplified away"
+  RecordSplit  _ _ -> error "Unreachable: should have simplified away"
+  VariantLift  _ _ -> error "Unreachable: should have simplified away"
+  VariantSplit _ _ -> error "Unreachable: should have simplified away"
 
 impSubst :: Subst a => SubstEnv -> a -> ImpM a
 impSubst env x = do

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -114,7 +114,7 @@ toImpExpr env (maybeDest, expr) = case expr of
       DataCon _ _ con args -> do
         let Abs bs body = alts !! con
         toImpBlock (env <> newEnv bs args) (maybeDest, body)
-      Variant types label i x -> do
+      Variant (NoExt types) label i x -> do
         let LabeledItems ixtypes = enumerate types
         let index = fst $ ixtypes M.! label !! i
         let Abs bs body = alts !! index
@@ -492,8 +492,8 @@ makeDest nameHint destType = do
               let dcs' = applyDataDefParams def params
               contents <- forM dcs' $ \(DataConDef _ bs) -> forM (toList bs) (rec . binderType)
               return $ Con $ SumAsProd ty tag contents
-        RecordTy types -> Record <$> forM types rec
-        VariantTy types -> do
+        RecordTy (NoExt types) -> Record <$> forM types rec
+        VariantTy (NoExt types) -> do
           tag <- rec IntTy
           contents <- forM (toList types) rec
           return $ Con $ SumAsProd ty tag $ map (\x->[x]) contents
@@ -614,7 +614,7 @@ zipWithDest dest@(Dest destAtom) atom f = case (destAtom, atom) of
   (Con (SumAsProd _ tag payload), DataCon _ _ con x) -> do
     recDest tag (IntVal con)
     zipWithM_ recDest (payload !! con) x
-  (Con (SumAsProd _ tag payload), Variant types label i x) -> do
+  (Con (SumAsProd _ tag payload), Variant (NoExt types) label i x) -> do
     let LabeledItems ixtypes = enumerate types
     let index = fst $ (ixtypes M.! label) !! i
     recDest tag (IntVal index)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -332,6 +332,7 @@ unpackTopPat letAnn (WithSrc _ pat) expr = case pat of
     zipWithM_ (\p x -> unpackTopPat letAnn p (Atom x)) (toList pats) leftVals
     unpackTopPat letAnn tailPat (Atom right)
   UPatVariant _ _ _ -> throw TypeErr "Variant not allowed in can't-fail pattern"
+  UPatVariantLift _ _ -> throw TypeErr "Variant not allowed in can't-fail pattern"
 
 inferUDecl :: Bool -> UDecl -> UInferM SubstEnv
 inferUDecl topLevel (ULet letAnn (p, ann) rhs) = do
@@ -531,6 +532,7 @@ bindPat' (WithSrc pos pat) val = addSrcContext (Just pos) $ case pat of
     env2 <- bindPat' tailPat right
     return $ env1 <> env2
   UPatVariant _ _ _ -> throw TypeErr "Variant not allowed in can't-fail pattern"
+  UPatVariantLift _ _ -> throw TypeErr "Variant not allowed in can't-fail pattern"
 
 -- TODO (BUG!): this should just be a hint but something goes wrong if we don't have it
 patNameHint :: UPat -> Name

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -176,7 +176,7 @@ checkOrInferRho (WithSrc pos expr) reqTy =
               -- Split off the types we don't know about, mapping them to a
               -- runtime error.
               split <- emit $ VariantSplit types scrut'
-              VariantTy (NoExt (Unlabeled (leftTy NE.:| [rightTy]))) <-
+              VariantTy (NoExt (Unlabeled [leftTy, rightTy])) <-
                 return $ getType split
               leftCase <- buildNAbs (toNest [Ignore leftTy])
                                     (\[v] -> buildMonomorphicCase types v)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -746,7 +746,7 @@ unifyExtLabeledItems r1 r2 = do
   r2' <- zonk r2
   vs <- looks solverVars
   case (r1', r2') of
-    _ | r1 == r2 -> return ()
+    _ | r1' == r2' -> return ()
     (r, Ext NoLabeledItems (Just v)) | v `isin` vs ->
       bindQ (v:>LabeledRowKind) (LabeledRow r)
     (Ext NoLabeledItems (Just v), r) | v `isin` vs ->
@@ -770,7 +770,7 @@ unifyEff r1 r2 = do
   r2' <- zonk r2
   vs <- looks solverVars
   case (r1', r2') of
-    _ | r1 == r2 -> return ()
+    _ | r1' == r2' -> return ()
     (r, EffectRow [] (Just v)) | v `isin` vs -> bindQ (v:>EffKind) (Eff r)
     (EffectRow [] (Just v), r) | v `isin` vs -> bindQ (v:>EffKind) (Eff r)
     (EffectRow effs1@(_:_) t1, EffectRow effs2@(_:_) t2) -> do

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -111,15 +111,16 @@ indices ty = case ty of
   TC (IndexRange _ _ _)  -> fmap (Con . Coerce ty . IntVal) [0..n - 1]
   TC (PairType lt rt)    -> [PairVal l r | l <- indices lt, r <- indices rt]
   TC (UnitType)          -> [UnitVal]
-  RecordTy types         -> let
+  RecordTy (NoExt types) -> let
     subindices = map indices (toList types)
     products = foldl (\prevs curs -> [cur:prev | cur <- curs, prev <- prevs]) [[]] subindices
     in map (\idxs -> Record $ restructure idxs types) products
-  VariantTy types        -> let
+  VariantTy (NoExt types) -> let
     subindices = fmap indices types
     reflect = reflectLabels types
     zipped = zip (toList reflect) (toList subindices)
-    in concatMap (\((label, i), args) -> Variant types label i <$> args) zipped
+    in concatMap (\((label, i), args) ->
+      Variant (NoExt types) label i <$> args) zipped
   _ -> error $ "Not implemented: " ++ pprint ty
   where n = indexSetSize ty
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -200,6 +200,7 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
     RefType h a -> atPrec AppPrec $ pAppArg "Ref" [h, a]
     TypeKind -> atPrec ArgPrec "Type"
     EffectRowKind -> atPrec ArgPrec "EffKind"
+    LabeledRowKindTC -> atPrec ArgPrec "Types"
     _ -> prettyExprDefault $ TCExpr con
 
 instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -202,7 +202,7 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
     RefType h a -> atPrec AppPrec $ pAppArg "Ref" [h, a]
     TypeKind -> atPrec ArgPrec "Type"
     EffectRowKind -> atPrec ArgPrec "EffKind"
-    LabeledRowKindTC -> atPrec ArgPrec "Types"
+    LabeledRowKindTC -> atPrec ArgPrec "Fields"
     _ -> prettyExprDefault $ TCExpr con
 
 instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -194,6 +194,7 @@ leafExpr = parens (mayPair $ makeExprParser leafExpr ops)
 containedExpr :: Parser UExpr
 containedExpr =   parens (mayPair $ makeExprParser leafExpr ops)
               <|> uVarOcc
+              <|> uLabeledExprs
               <?> "contained expression"
 
 uType :: Parser UType

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -522,7 +522,7 @@ parseLabeledItems sep bindwith itemparser punner tailDefault =
         Just punFn -> explicitBound <|> pure (punFn pos l)
         Nothing -> explicitBound
       rest <- beforeSep
-      return $ joinExtLabeledItems (labeledSingleton l itemVal) rest
+      return $ prefixExtLabeledItems (labeledSingleton l itemVal) rest
 
 -- === infix ops ===
 

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -209,12 +209,12 @@ prettyVal val = case val of
       where
         DataConDef conName _ = dataCons !! i
         args = payload !! i
-    SumAsProd (VariantTy types) (IntVal i) payload ->
+    SumAsProd (VariantTy (NoExt types)) (IntVal i) payload ->
       pretty variant
       where
         [value] = payload !! i
         (theLabel, repeatNum) = toList (reflectLabels types) !! i
-        variant = Variant types theLabel repeatNum value
+        variant = Variant (NoExt types) theLabel repeatNum value
     _           -> pretty con
   atom -> prettyPrec atom LowestPrec
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -174,7 +174,7 @@ simplifyExpr expr = case expr of
       DataCon _ _ con args -> do
         let Abs bs body = alts !! con
         extendR (newEnv bs args) $ simplifyBlock body
-      Variant types label i value -> do
+      Variant (NoExt types) label i value -> do
         let LabeledItems ixtypes = enumerate types
         let index = fst $ (ixtypes M.! label) !! i
         let Abs bs body = alts !! index

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -189,9 +189,10 @@ simplifyExpr expr = case expr of
   RecordCons left right -> case getType right of
     RecordTy (NoExt rightTys) -> do
       -- Unpack, then repack with new arguments (possibly in the middle).
+      left' <- mapM simplifyAtom left
       rightList <- getUnpacked =<< simplifyAtom right
       let rightItems = restructure rightList rightTys
-      simplifyAtom $ Record $ left <> rightItems
+      return $ Record $ left' <> rightItems
     _ -> emit =<< RecordCons <$> mapM simplifyAtom left <*> simplifyAtom right
   RecordSplit leftTys@(LabeledItems litems) full -> case getType full of
     RecordTy (NoExt fullTys) -> do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -14,6 +14,7 @@ import Control.Monad.Reader
 import Data.Foldable (toList)
 import Data.Functor
 import Data.List (partition)
+import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 
 import Autodiff
@@ -176,7 +177,7 @@ simplifyExpr expr = case expr of
         extendR (newEnv bs args) $ simplifyBlock body
       Variant (NoExt types) label i value -> do
         let LabeledItems ixtypes = enumerate types
-        let index = fst $ (ixtypes M.! label) !! i
+        let index = fst $ (ixtypes M.! label) NE.!! i
         let Abs bs body = alts !! index
         extendR (newEnv bs [value]) $ simplifyBlock body
       _ -> do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -202,7 +202,7 @@ simplifyExpr expr = case expr of
           left = M.intersectionWith splitLeft fullItems litems
           splitRight fvs ltys = NE.nonEmpty $ NE.drop (length ltys) fvs
           right = M.differenceWith splitRight fullItems litems
-      return $ Record $ Unlabeled $ NE.fromList
+      return $ Record $ Unlabeled $
         [Record (LabeledItems left), Record (LabeledItems right)]
     _ -> emit =<< RecordSplit <$> mapM substEmbedR leftTys <*> simplifyAtom full
   VariantLift leftTys@(LabeledItems litems) right -> case getType right of

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -324,12 +324,19 @@ data PrimOp e =
       | IdxSetSize e
       | ThrowError e
       | CastOp e e                   -- Type, then value. See Type.hs for valid coercions.
-      -- Add/remove fields from a record/variant, always to/from the left.
-      -- (RecordCons expects labeled values, the others expect labeled types.)
-      | RecordCons   (LabeledItems e) e   -- Add fields to a record.
-      | RecordSplit  (LabeledItems e) e   -- Extract subset of fields.
-      | VariantLift  (LabeledItems e) e   -- Extend a variant.
-      | VariantSplit (LabeledItems e) e   -- Partition a variant.
+      -- Extensible record and variant operations:
+      -- Add fields to a record (on the left). Left arg contains values to add.
+      | RecordCons   (LabeledItems e) e
+      -- Split {a:A & b:B & ...rest} into (effectively) {a:A & b:B} & {&...rest}.
+      -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
+      | RecordSplit  (LabeledItems e) e
+      -- Extend a variant with empty alternatives (on the left).
+      -- Left arg contains the types of the empty alternatives to add.
+      | VariantLift  (LabeledItems e) e
+      -- Split {a:A | b:B | ...rest} into (effectively) {a:A & b:B} | {|...rest}
+      -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
+      -- (see https://github.com/google-research/dex-lang/pull/201#discussion_r471591972)
+      | VariantSplit (LabeledItems e) e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimHof e =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -333,7 +333,7 @@ data PrimOp e =
       -- Extend a variant with empty alternatives (on the left).
       -- Left arg contains the types of the empty alternatives to add.
       | VariantLift  (LabeledItems e) e
-      -- Split {a:A | b:B | ...rest} into (effectively) {a:A & b:B} | {|...rest}
+      -- Split {a:A | b:B | ...rest} into (effectively) {a:A | b:B} | {|...rest}.
       -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
       -- (see https://github.com/google-research/dex-lang/pull/201#discussion_r471591972)
       | VariantSplit (LabeledItems e) e

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -1351,14 +1351,17 @@ pattern NoExt a = Ext a Nothing
 pattern InternalSingletonLabel :: Label
 pattern InternalSingletonLabel = "%UNLABELED%"
 
-_getUnlabeled :: LabeledItems a -> Maybe (NE.NonEmpty a)
-_getUnlabeled (LabeledItems items) = do
-  guard $ length items == 1
-  M.lookup InternalSingletonLabel items
+_getUnlabeled :: LabeledItems a -> Maybe [a]
+_getUnlabeled (LabeledItems items) = case (length items) of
+  0 -> Just []
+  1 -> NE.toList <$> M.lookup InternalSingletonLabel items
+  _ -> Nothing
 
-pattern Unlabeled :: (NE.NonEmpty a) -> LabeledItems a
+pattern Unlabeled :: [a] -> LabeledItems a
 pattern Unlabeled as <- (_getUnlabeled -> Just as)
-  where Unlabeled as = LabeledItems (M.singleton InternalSingletonLabel as)
+  where Unlabeled as = case NE.nonEmpty as of
+          Just ne -> LabeledItems (M.singleton InternalSingletonLabel ne)
+          Nothing -> NoLabeledItems
 
   -- TODO: Enable once https://gitlab.haskell.org//ghc/ghc/issues/13363 is fixed...
 -- {-# COMPLETE TypeVar, ArrowType, TabTy, Forall, TypeAlias, Effect, NoAnn, TC #-}

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -647,7 +647,7 @@ instance HasUVars UExpr' where
     UPrimExpr _ -> mempty
     UCase e alts -> freeUVars e <> foldMap freeUVars alts
     URecord ulr -> freeUVars ulr
-    UVariant skip _ val -> freeUVars skip <> freeUVars val
+    UVariant types _ val -> freeUVars types <> freeUVars val
     URecordTy ulr -> freeUVars ulr
     UVariantTy ulr -> freeUVars ulr
     UVariantLift skip val -> freeUVars skip <> freeUVars val

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -48,6 +48,7 @@ module Syntax (
     pattern TabTy, pattern TabTyAbs, pattern TabVal, pattern TabValA,
     pattern Pure, pattern BinaryFunTy, pattern BinaryFunVal, pattern Unlabeled,
     pattern NoExt, pattern LabeledRowKind, pattern NoLabeledItems,
+    pattern InternalSingletonLabel,
     pattern EffKind, pattern JArrayTy, pattern ArrayTy, pattern IDo)
   where
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -21,7 +21,7 @@ module Syntax (
     ImpProg (..), ImpStatement, ImpInstr (..), IExpr (..), IVal, IPrimOp,
     IVar, IBinder, IType (..), ArrayType, SetVal (..), MonMap (..), LitProg,
     UAlt (..), Alt, binderBinding, Label, LabeledItems (..), labeledSingleton,
-    reflectLabels, ExtLabeledItems (..), joinExtLabeledItems,
+    reflectLabels, withLabels, ExtLabeledItems (..), joinExtLabeledItems,
     MDImpFunction (..), MDImpProg (..), MDImpInstr (..), MDImpStatement,
     ImpKernel (..), PTXKernel (..), HasIVars (..), IScope,
     ScalarTableType, ScalarTableBinder, BinderInfo (..),Bindings,
@@ -168,6 +168,10 @@ labeledSingleton label value = LabeledItems $ M.singleton label (value NE.:|[])
 reflectLabels :: LabeledItems a -> LabeledItems (Label, Int)
 reflectLabels (LabeledItems items) = LabeledItems $
   flip M.mapWithKey items $ \k xs -> fmap (\(i,_) -> (k,i)) (enumerate xs)
+
+withLabels :: LabeledItems a -> LabeledItems (Label, Int, a)
+withLabels (LabeledItems items) = LabeledItems $
+  flip M.mapWithKey items $ \k xs -> fmap (\(i,a) -> (k,i,a)) (enumerate xs)
 
 instance Semigroup (LabeledItems a) where
   LabeledItems items <> LabeledItems items' =

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -179,7 +179,7 @@ instance HasType Expr where
       RecordTy full <- typeCheck record
       diff <- labeledRowDifference full (NoExt types)
       return $ RecordTy $ NoExt $
-        Unlabeled $ NE.fromList [ RecordTy $ NoExt types, RecordTy diff ]
+        Unlabeled [ RecordTy $ NoExt types, RecordTy diff ]
     VariantLift types record -> do
       mapM_ (|: TyKind) types
       VariantTy rest <- typeCheck record
@@ -189,7 +189,7 @@ instance HasType Expr where
       VariantTy full <- typeCheck variant
       diff <- labeledRowDifference full (NoExt types)
       return $ VariantTy $ NoExt $
-        Unlabeled $ NE.fromList [ VariantTy $ NoExt types, VariantTy diff ]
+        Unlabeled [ VariantTy $ NoExt types, VariantTy diff ]
 
 checkApp :: Type -> Atom -> TypeM Type
 checkApp fTy x = do

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -177,12 +177,10 @@ instance HasType Expr where
       diff <- labeledRowDifference full (NoExt types)
       return $ RecordTy $ NoExt $
         Unlabeled [ RecordTy $ NoExt types, RecordTy diff ]
-    VariantLift liftedType variant -> do
-      VariantTy rest <- typeCheck variant
-      _ <- labeledRowDifference liftedType rest
-      let ty = VariantTy liftedType
-      ty |: TyKind
-      return ty
+    VariantLift types record -> do
+      mapM_ (|: TyKind) types
+      VariantTy rest <- typeCheck record
+      return $ VariantTy $ joinExtLabeledItems types rest
     VariantSplit types variant -> do
       mapM_ (|: TyKind) types
       VariantTy full <- typeCheck variant
@@ -525,7 +523,7 @@ typeCheckTyCon tc = case tc of
   RefType r a      -> r|:TyKind >> a|:TyKind >> return TyKind
   TypeKind         -> return TyKind
   EffectRowKind    -> return TyKind
-  LabeledRowKind_  -> return TyKind
+  LabeledRowKindTC -> return TyKind
   JArrayType _ _   -> undefined
 
 typeCheckCon :: Con -> TypeM Type

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -656,7 +656,7 @@ typeCheckOp op = case op of
       RecordTy rest -> return rest
       _ -> throw TypeErr $ "Can't add fields to a non-record object "
                         <> pprint record <> " (of type " <> pprint rty <> ")"
-    return $ RecordTy $ joinExtLabeledItems types rest
+    return $ RecordTy $ prefixExtLabeledItems types rest
   RecordSplit types record -> do
     mapM_ (|: TyKind) types
     fullty <- typeCheck record
@@ -674,7 +674,7 @@ typeCheckOp op = case op of
       VariantTy rest -> return rest
       _ -> throw TypeErr $ "Can't add alternatives to a non-variant object "
                         <> pprint variant <> " (of type " <> pprint rty <> ")"
-    return $ VariantTy $ joinExtLabeledItems types rest
+    return $ VariantTy $ prefixExtLabeledItems types rest
   VariantSplit types variant -> do
     mapM_ (|: TyKind) types
     fullty <- typeCheck variant


### PR DESCRIPTION
Implements extensible records and variants, in the style of Daan Leijen's ["Extensible records with scoped labels."](https://www.microsoft.com/en-us/research/wp-content/uploads/2016/02/scopedlabels.pdf)

On a high level, we can now do stuff like:
```haskell
-- Records

:p
  x = {a=5.0, b=2}
  y : {a:Int & b:Int & ..._} = {a=3, a=4, ...x}
  y
> {a = 3, a = 4, a = 5.0, b = 2}

def getTwoFoosAndABar (rest : Types)?->
                      (x : {foo:a & foo:b & bar:c & ...rest}) : (a&b&c) =
  ({foo=f1, foo=f2, bar=b, ...}) = x
  (f1, f2, b)

:p getTwoFoosAndABar {foo=1, bar=2, foo=0.0, foo=4, baz=3.0, bar=7}
> (1, (0.0, 2))

:p
  foo = 1
  bar = 2.0
  {foo, bar}
> {bar = 2.0, foo = 1}

:p
  ({foo, ...}) = {foo=1, bar=2.0}
  foo
> 1

-- Variants

def splitTwoFoosOrABar (rest:Types)?-> 
                       (x : {foo:a | foo:b | bar:c | ...rest})
                       : ({x:a | y:b | z:c} | {|...rest}) =
  case x of
    {| foo=x |}                 -> Left {| x=x |}
    {| foo | foo=y |}           -> Left {| y=y |}
    {| bar=z |}                 -> Left {| z=z |}
    {|foo|foo|bar| ...other |}  -> Right other

myStuff = [ {| foo=1 |},
            {| bar=2 |},
            {| foo | foo=3 |},
            {| baz=4 |},
            {| foo | foo | foo=5 |}
          ]:(Fin 5 => {foo:_ | foo:_ | foo:_ | bar:_ | baz:_})

:p for i. splitTwoFoosOrABar myStuff.i
> [ (Left {| x = 1 |})
> , (Left {| z = 2 |})
> , (Left {| y = 3 |})
> , (Right {| baz = 4 |})
> , (Right {| foo = 5 |}) ]
```

Individual fields can be extracted by pattern-matching with `...`. It should also be possible to implement field accessor functions, but I'll leave that for another PR (probably will look something like `get #foo record : {foo:a, ...r} -> a`)

## Some more details

I've modified the syntax for variants with repeated labels, to make it more consistent with Leijen's work and also to make it possible to write down variant lifting/destructuring operations in a straightforward way. Variant literals can now have a bunch of labels with no values on the left side, which indicate the alternatives that were skipped over. So for instance, setting the second `a` field is done with `{| a | a = value |}`, and adding (empty) cases for `a` and `b` to an existing variant is done with `{|a|b| ...existing |}`. I'm not sure there's much use for repeated labels in variants anyway, at least at the user level, but we can add back something like the old syntax if we need to at some point.

In the core IR, extensibility is represented using a new kind `LabeledRowKind` (aliased to `Types` in the prelude for ease-of-use) and a new ADT `ExtLabeledItems a b` which represents some labeled items of type `a` along with possibly an extension of type `b`. Record and variant types are then written in terms of this. Concrete records, since they have to contain actual values, don't have an extensible tail. However, there are four new `Expr` types that allow constructing and breaking down records and variants, which all have special syntax in the parser.

Notably, those four `Expr` types exist only between parsing and simplification. As soon as we know the monomorphic type, they get simplified away into normal record unpacking and variant pattern-matching. This means that `Imp` doesn't have to change at all.

I've gone ahead and implemented an `Unlabeled` helper pattern, also, which can be used to construct records and variants that don't have a label (well, technically, they have one label, but it is a special singleton that can't be written in userspace). This can be used as an internal anonymous product or sum type (and I use it to split up records and variants when matching patterns that have a `...rest` tail).

Side change: I've made it so that inference doesn't put solver variables into the Embed scope, since there's no particular need for them to be there, and it's a bit nicer to keep the two scopes separate. This also helps because we need to be able to create variables at unification time but we don't have a scope when we are unifying things.

