### PR TITLE
Revert the revert of DexRT static linking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ scratch/
 test-scratch/
 dist-newstyle/
 *.cache
+*.bc

--- a/dex.cabal
+++ b/dex.cabal
@@ -28,11 +28,10 @@ library
                        blaze-html, cmark, diagrams-lib, ansi-terminal,
                        diagrams-rasterific, JuicyPixels, transformers,
                        base64-bytestring, vector, directory, mmap, unix,
-                       process, primitive, store
+                       process, primitive, store, file-embed
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
-  ld-options:          -rdynamic
   c-sources:           src/lib/dexrt.c
   cc-options:          -std=c11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,

--- a/makefile
+++ b/makefile
@@ -27,20 +27,26 @@ endif
 
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
 STACK_FLAGS = --flag dex:cuda
+CFLAGS = -std=c11 -I/usr/local/cuda/include -DDEX_CUDA -fPIC
 endif
 
 .PHONY: all
 all: build
 
 # type-check only
-tc:
+tc: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS) --ghc-options -fno-code
 
-build:
+build: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS)
 
-build-prof:
+build-prof: dexrt-llvm
 	$(STACK) build $(PROF)
+
+dexrt-llvm: src/lib/dexrt.bc
+
+%.bc: %.c
+	clang $(CFLAGS) -c -emit-llvm $^ -o $@
 
 # --- running tets ---
 


### PR DESCRIPTION
Stripping function attributes encourages LLVM to do more optimizations
which should make the code generator bugs less likely to appear... This
is not a definite fix, but there's little be we can do other than
upgrade the LLVM version.