### PR TITLE
Add an initial version of the multicore backend

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -1,10 +1,11 @@
+cabal-version:       2.2
+
 -- Copyright 2019 Google LLC
 --
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-cabal-version:       2.0
 name:                dex
 version:             0.1.0.0
 author:              Dougal Maclaurin
@@ -32,14 +33,14 @@ library
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
-  c-sources:           src/lib/dexrt.c
-  cc-options:          -std=c11
+  cxx-sources:         src/lib/dexrt.cpp
+  cxx-options:         -std=c++11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
   if flag(cuda)
     include-dirs:      /usr/local/cuda/include
     extra-libraries:   cuda
-    cc-options:        -DDEX_CUDA
+    cxx-options:       -DDEX_CUDA
     cpp-options:       -DDEX_CUDA
 
 executable dex

--- a/makefile
+++ b/makefile
@@ -25,10 +25,15 @@ endif
 
 # --- building Dex ---
 
+CFLAGS := -fPIC
+
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
 STACK_FLAGS = --flag dex:cuda
-CFLAGS = -std=c11 -I/usr/local/cuda/include -DDEX_CUDA -fPIC
+CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
 endif
+
+CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti
+CFLAGS := $(CFLAGS) -std=c11
 
 .PHONY: all
 all: build
@@ -45,8 +50,8 @@ build-prof: dexrt-llvm
 
 dexrt-llvm: src/lib/dexrt.bc
 
-%.bc: %.c
-	clang $(CFLAGS) -c -emit-llvm $^ -o $@
+%.bc: %.cpp
+	clang++ $(CXXFLAGS) -c -emit-llvm $^ -o $@
 
 # --- running tets ---
 
@@ -113,3 +118,4 @@ doc/%.css: static/%.css
 
 clean:
 	$(STACK) clean
+	rm -rf src/lib/dexrt.bc

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -138,6 +138,7 @@ parseEvalOpts = EvalConfig
   <$> (option
          (optionList [ ("LLVM", LLVM)
                      , ("LLVM-CUDA", LLVMCUDA)
+                     , ("LLVM-MC", LLVMMC)
                      , ("JAX", JAX)
                      , ("interp", Interp)])
          (long "backend" <> value LLVM <> help "Backend (LLVM|LLVM-CUDA|JAX|interp)"))

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE Rank2Types #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module JIT (impToLLVM, mdImpToLLVM, impKernelToLLVM,
+module JIT (impToLLVM, mdImpToMulticore, mdImpToCUDA, impKernelToLLVM,
             LLVMFunction (..), LLVMKernel (..),
             ptxTargetTriple, ptxDataLayout) where
 
@@ -60,9 +60,9 @@ data CompileState = CompileState { curBlocks   :: [BasicBlock]
                                  -- TODO: Make progOutputs part of an extra reader monad
                                  --       that's specific to CPU codegen
                                  , progOutputs :: Env Operand  -- Maps Imp values to the output pointer operands
+                                 , allocas     :: S.Set L.Name
                                  , funSpecs    :: S.Set ExternFunSpec
                                  , globalDefs  :: [L.Definition]
-                                 , allocas     :: S.Set L.Name
                                  }
 data CompileEnv m = CompileEnv { operandEnv :: OperandEnv
                                , uiFunc     :: UIFunc m
@@ -108,9 +108,8 @@ compileImpInstr isLocal instr = case instr of
   _ -> compileGenericInstr compileBlock instr
   where compileBlock (ImpProg stmts) = compileProg compileImpInstr stmts
 
-compileLoop :: Direction -> IBinder -> IExpr -> Compile () -> Compile ()
-compileLoop d iBinder n' compileBody = do
-  n <- compileExpr n'
+compileLoop :: Direction -> IBinder -> Operand -> Compile () -> Compile ()
+compileLoop d iBinder n compileBody = do
   let loopName = "loop_" ++ (showName $ binderNameHint iBinder)
   loopBlock <- freshName $ fromString $ loopName
   nextBlock <- freshName $ fromString $ "cont_" ++ loopName
@@ -218,19 +217,76 @@ compileBinOp op x y = case op of
       GreaterEqual -> IP.SGE
       Equal        -> IP.EQ
 
--- === MDImp to LLVM ===
+-- === MDImp to multicore LLVM ===
+
+mdImpToMulticore :: MDImpFunction ImpKernel -> LLVMFunction
+mdImpToMulticore (MDImpFunction outVars inVars (MDImpProg prog)) =
+  runIdentity $ compileFunction [] compileMDImpInstrMC outVars inVars prog
+
+compileMDImpInstrMC :: Bool -> MDImpInstr ImpKernel -> Compile (Maybe Operand)
+compileMDImpInstrMC isLocal instr =
+  case instr of
+    MDLaunch size args kernel -> do
+      -- Generate the kernel
+      kernelFuncName <- freshName "kernel"
+      let (kernelFunSpecs, kernelDefs) = impKernelToMC kernelFuncName kernel
+      modify $ (\s -> s { globalDefs = kernelDefs ++ (globalDefs s) })
+      modify $ (\s -> s { funSpecs = kernelFunSpecs <> (funSpecs s) })
+      -- Run the kernel using the dex_parallel_for runtime function
+      kernelParams <- packArgs =<< traverse lookupImpVar args
+      s <- (`asIntWidth` i64) =<< compileExpr size
+      emitVoidExternCall runKernelSpec [
+          L.ConstantOperand $ C.BitCast (C.GlobalReference kernelPtrType kernelFuncName) (L.ptr L.VoidType),
+          s,
+          kernelParams
+        ]
+      return Nothing
+      where
+        runKernelSpec = ExternFunSpec "dex_parallel_for" L.VoidType [] [] [L.ptr L.VoidType, i64, L.ptr $ L.ptr L.VoidType]
+        kernelPtrType = L.ptr $ L.FunctionType L.VoidType [i64, i64, L.ptr $ L.ptr L.VoidType] False
+    MDAlloc  t s           -> compileImpInstr isLocal (Alloc t s)
+    MDFree   v             -> compileImpInstr isLocal (Free v)
+    MDHostInstr impInstr   -> compileImpInstr isLocal impInstr
+
+impKernelToMC :: L.Name -> ImpKernel -> (S.Set ExternFunSpec, [L.Definition])
+impKernelToMC funcName (ImpKernel argBinders idxBinder (ImpProg prog)) = runCompile cpuInitCompileEnv $ do
+  (startIdxParam, startIdx) <- freshParamOpPair [] i64
+  (endIdxParam, endIdx) <- freshParamOpPair [] i64
+  -- TODO: Preserve pointer attributes??
+  (argArrayParam, argArray) <- freshParamOpPair [] (L.ptr $ L.ptr $ L.VoidType)
+  args <- unpackArgs argArray argTypes
+  let argEnv = foldMap (uncurry (@>)) $ zip argBinders args
+
+  niter <- endIdx `sub` startIdx
+  compileLoop Fwd idxBinder niter $ do
+    idxEnv <- case idxBinder of
+      Ignore _ -> return mempty
+      Bind v -> do
+        innerIdx <- lookupImpVar v
+        idx64 <- add startIdx =<< (innerIdx `asIntWidth` i64)
+        idx <- idx64 `asIntWidth` (L.typeOf innerIdx)
+        return $ idxBinder @> idx
+    extendOperands (argEnv <> idxEnv) $ compileProg compileImpInstr prog
+  kernel <- makeFunction funcName [startIdxParam, endIdxParam, argArrayParam] Nothing
+  extraSpecs <- gets funSpecs
+  extraDefs <- gets globalDefs
+  return $ (extraSpecs, L.GlobalDefinition kernel : extraDefs)
+  where
+    argTypes = fmap ((fromIType $ L.AddrSpace 0) . binderAnn) argBinders
+
+-- === MDImp to LLVM CUDA ===
 
 type MDHostCompile   = Compile
 data MDImpInstrCG    = EnsureHasContext -- code generation specific instructions
 type MDImpInstrExt k = Either MDImpInstrCG (MDImpInstr k)
 
-mdImpToLLVM :: MDImpFunction PTXKernel -> LLVMFunction
-mdImpToLLVM (MDImpFunction outVars inVars (MDImpProg prog)) =
-  runIdentity $ compileFunction [] compileMDImpInstr outVars inVars prog'
+mdImpToCUDA :: MDImpFunction PTXKernel -> LLVMFunction
+mdImpToCUDA (MDImpFunction outVars inVars (MDImpProg prog)) =
+  runIdentity $ compileFunction [] compileMDImpInstrCUDA outVars inVars prog'
   where prog' = (IDo, Left EnsureHasContext) : [(d, Right i) | (d, i) <- prog]
 
-compileMDImpInstr :: Bool -> MDImpInstrExt PTXKernel -> MDHostCompile (Maybe Operand)
-compileMDImpInstr isLocal instrExt = do
+compileMDImpInstrCUDA :: Bool -> MDImpInstrExt PTXKernel -> MDHostCompile (Maybe Operand)
+compileMDImpInstrCUDA isLocal instrExt = do
   case instrExt of
     Left ext -> case ext of
       EnsureHasContext -> ensureHasContext >> return Nothing
@@ -342,7 +398,7 @@ cuModuleGetFunction cuMod name = do
 
 cuLaunchKernel :: Operand -> (Operand, Operand, Operand) -> (Operand, Operand, Operand) -> [Operand] -> MDHostCompile ()
 cuLaunchKernel fun grid block args = do
-  kernelParams <- packArray args
+  kernelParams <- packArgs args
   gridI32  <- makeDimArgs grid
   blockI32 <- makeDimArgs block
   checkCuResult "cuLaunchKernel" =<< emitExternCall spec
@@ -365,16 +421,6 @@ cuLaunchKernel fun grid block args = do
              , L.ptr $ L.ptr L.VoidType ]
 
     makeDimArgs (x, y, z) = mapM (`asIntWidth` i32) [x, y, z]
-
-    packArray :: Monad m => [Operand] -> CompileT m Operand
-    packArray elems = do
-      arr <- alloca (length elems) (L.ptr $ L.VoidType)
-      forM_ (zip [0..] elems) $ \(i, e) -> do
-        eptr <- alloca 1 $ L.typeOf e
-        store eptr e
-        earr <- gep arr $ i `withWidth` 32
-        store earr =<< castLPtr L.VoidType eptr
-      return arr
 
 cuMemAlloc :: L.Type -> Operand -> MDHostCompile Operand
 cuMemAlloc ty bytes = do
@@ -427,7 +473,7 @@ impKernelToLLVM (ImpKernel args lvar (ImpProg prog)) = runCompile gpuInitCompile
   LLVMKernel <$> makeModuleEx ptxDataLayout ptxTargetTriple [L.GlobalDefinition kernel, kernelMeta, nvvmAnnotations]
   where
     ptrParamAttrs = [L.NoAlias, L.NoCapture, L.NonNull, L.Alignment 256]
-    argTypes = fmap ((fromIType $ L.AddrSpace 1). binderAnn) args
+    argTypes = fmap ((fromIType $ L.AddrSpace 1) . binderAnn) args
     kernelMetaId = L.MetadataNodeID 0
     kernelMeta = L.MetadataNodeDefinition kernelMetaId $ L.MDTuple
       [ Just $ L.MDValue $ L.ConstantOperand $ C.GlobalReference (funTy L.VoidType (longTy : argTypes)) "kernel"
@@ -561,7 +607,9 @@ compileGenericInstr compileBlock instr = case instr of
   Store dest val   -> Nothing <$  bindM2 store (compileExpr dest) (compileExpr val)
   IOffset x off _  -> Just    <$> bindM2 gep   (compileExpr x)    (compileExpr off)
   IWhile cond body -> Nothing <$  compileWhile cond (compileBlock body)
-  Loop d i n body  -> Nothing <$  compileLoop d i n (compileBlock body)
+  Loop d i n body  -> Nothing <$  do
+    n' <- compileExpr n
+    compileLoop d i n' (compileBlock body)
   ICastOp idt ix   -> Just    <$> do
     x <- compileExpr ix
     let (xt, dt) = (L.typeOf x, fromIType undefined idt)
@@ -580,6 +628,23 @@ compileGenericInstr compileBlock instr = case instr of
                  (compileBlock alt)
     return Nothing
   _ -> error $ "Not a generic instruction: " ++ pprint instr
+
+packArgs :: Monad m => [Operand] -> CompileT m Operand
+packArgs elems = do
+  arr <- alloca (length elems) (L.ptr $ L.VoidType)
+  forM_ (zip [0..] elems) $ \(i, e) -> do
+    eptr <- alloca 1 $ L.typeOf e
+    store eptr e
+    earr <- gep arr $ i `withWidth` 32
+    store earr =<< castLPtr L.VoidType eptr
+  return arr
+
+unpackArgs :: Monad m => Operand -> [L.Type] -> CompileT m [Operand]
+unpackArgs argArrayPtr types =
+  forM (zip [0..] types) $ \(i, ty) -> do
+    argVoidPtr <- gep argArrayPtr $ i `withWidth` 64
+    argPtr <- castLPtr (L.ptr ty) argVoidPtr
+    load =<< load argPtr
 
 -- === LLVM embedding ===
 
@@ -898,10 +963,11 @@ makeModule defs = do
 
 makeModuleEx :: Monad m => L.DataLayout -> ShortByteString -> [L.Definition] -> CompileT m L.Module
 makeModuleEx dataLayout triple defs = do
-  specs <- gets funSpecs
+  specs     <- gets funSpecs
+  extraDefs <- gets globalDefs
   return $ L.defaultModule
       { L.moduleName = "dexModule"
-      , L.moduleDefinitions = defs ++ fmap externDecl (toList specs)
+      , L.moduleDefinitions = extraDefs ++ defs ++ fmap externDecl (toList specs)
       , L.moduleDataLayout = Just dataLayout
       , L.moduleTargetTriple = Just triple }
 


### PR DESCRIPTION
Turns out, that having MDImp in place, we can reuse a lot of the
CUDA-related infrastructure for generating multicore CPU code. With this
patch (and some hacks to make MDImp less restrictive) the ray tracer
example takes 98s to generate a 250x250 image using 16 threads, as opposed
to 584s when running with the single-threaded backend.