### PR TITLE
Minor fixes for record/variant parsing and printing

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -24,7 +24,7 @@ library
                        Autodiff, Interpreter, Logging, PipeRPC, CUDA
   build-depends:       base, containers, mtl, binary, bytestring,
                        time, tf-random, llvm-hs-pure ==9.*, llvm-hs ==9.*,
-                       aeson, megaparsec, warp, wai,
+                       aeson, megaparsec >=8.0, warp, wai,
                        parser-combinators, http-types, prettyprinter, text,
                        blaze-html, cmark, diagrams-lib, ansi-terminal,
                        diagrams-rasterific, JuicyPixels, transformers,

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -99,7 +99,25 @@ Syntax for records, variants, and their types.
 > 95 | :p {a:Int & b:Float | c:Int }
 >    |                     ^
 > unexpected '|'
-> expecting "..", "..<", expression, or negation
+> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', '}', arrow, backquoted name, expression, or infix operator
+
+:p {a:Int,}
+
+> Parse error:104:10:
+>     |
+> 104 | :p {a:Int,}
+>     |          ^
+> unexpected ','
+> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', ''', '.', '_', '|', '}', alphanumeric character, arrow, backquoted name, expression, or infix operator
+
+:p {|3}
+
+> Parse error:113:6:
+>     |
+> 113 | :p {|3}
+>     |      ^
+> unexpected '3'
+> expecting "...", '}', or field label
 
 
 'Unpacking

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -323,11 +323,11 @@ myStuff = [ {| foo=1 |},
 recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 :p recordsAsIndices
 > [ {a = 0@Fin 2, b = 0@Fin 3}
-> , {a = 0@Fin 2, b = 1@Fin 3}
 > , {a = 1@Fin 2, b = 0@Fin 3}
-> , {a = 1@Fin 2, b = 1@Fin 3}
 > , {a = 0@Fin 2, b = 1@Fin 3}
-> , {a = 0@Fin 2, b = 2@Fin 3} ]@{a: Fin 2 & b: Fin 3}
+> , {a = 1@Fin 2, b = 1@Fin 3}
+> , {a = 0@Fin 2, b = 2@Fin 3}
+> , {a = 1@Fin 2, b = 2@Fin 3} ]@{a: Fin 2 & b: Fin 3}
 
 -- TODO: this still causes an error
 -- :p for i:(Fin 6). recordsAsIndices.((ordinal i) @ _)

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -321,8 +321,16 @@ myStuff = [ {| foo=1 |},
 > {a = 4@Fin 10, b = 1@Fin 3}
 
 recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
+:p recordsAsIndices
+> [ {a = 0@Fin 2, b = 0@Fin 3}
+> , {a = 0@Fin 2, b = 1@Fin 3}
+> , {a = 1@Fin 2, b = 0@Fin 3}
+> , {a = 1@Fin 2, b = 1@Fin 3}
+> , {a = 0@Fin 2, b = 1@Fin 3}
+> , {a = 0@Fin 2, b = 2@Fin 3} ]@{a: Fin 2 & b: Fin 3}
 
--- TODO: error when printing a table indexed by records
+-- TODO: this still causes an error
+-- :p for i:(Fin 6). recordsAsIndices.((ordinal i) @ _)
 
 :p size {a:Fin 10 | b:Fin 3}
 > 13
@@ -339,5 +347,17 @@ recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 > {| b = 1@Fin 3 |}
 
 variantsAsIndices : {a:Fin 10 | b:Fin 3}=>{a:Fin 10 | b:Fin 3} = for i. i
-
--- TODO: error when printing a table indexed by variants
+:p variantsAsIndices
+> [ {| a = 0@Fin 10 |}
+> , {| a = 1@Fin 10 |}
+> , {| a = 2@Fin 10 |}
+> , {| a = 3@Fin 10 |}
+> , {| a = 4@Fin 10 |}
+> , {| a = 5@Fin 10 |}
+> , {| a = 6@Fin 10 |}
+> , {| a = 7@Fin 10 |}
+> , {| a = 8@Fin 10 |}
+> , {| a = 9@Fin 10 |}
+> , {| b = 0@Fin 3 |}
+> , {| b = 1@Fin 3 |}
+> , {| b = 2@Fin 3 |} ]@{a: Fin 10 | b: Fin 3}

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -10,6 +10,8 @@ module Interpreter (evalBlock, indices, indexSetSize, evalEmbed) where
 
 import Data.Foldable
 import Data.Int
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
 
 import Array
 import Cat
@@ -18,7 +20,7 @@ import Env
 import PPrint
 import Embed
 import Type
-import Util (restructure)
+import Util (enumerate, restructure)
 
 -- TODO: can we make this as dynamic as the compiled version?
 foreign import ccall "randunif"      c_unif     :: Int64 -> Double
@@ -32,7 +34,13 @@ evalBlock env (Block decls result) = do
 evalDecl :: SubstEnv -> Decl -> SubstEnv
 evalDecl env (Let _ v rhs) = v @> evalExpr env rhs'
   where rhs' = subst (env, mempty) rhs
-evalDecl _ (Unpack _ _) = error "Not implemented"
+evalDecl env (Unpack vs rhs) = let
+  rhs' = subst (env, mempty) rhs
+  atoms = case evalExpr env rhs' of
+    DataCon _ _ _ atoms' -> atoms'
+    Record atoms' -> toList atoms'
+    _ -> error $ "Can't unpack: " <> pprint rhs'
+  in fold $ map (uncurry (@>)) $ zip (toList vs) atoms
 
 evalExpr :: SubstEnv -> Expr -> Atom
 evalExpr env expr = case expr of
@@ -41,7 +49,19 @@ evalExpr env expr = case expr of
     _     -> error $ "Expected a fully evaluated function value: " ++ pprint f
   Atom atom -> atom
   Op op     -> evalOp op
-  _         -> error $ "Not implemented: " ++ pprint expr
+  Case e alts _ -> case e of
+    DataCon _ _ con args ->
+      evalBlock env $ applyNaryAbs (alts !! con) args
+    Variant (NoExt types) label i x -> do
+      let LabeledItems ixtypes = enumerate types
+      let index = fst $ ixtypes M.! label NE.!! i
+      evalBlock env $ applyNaryAbs (alts !! index) [x]
+    Con (SumAsProd _ tag xss) -> case tag of
+      Con (Lit x) -> let i = getIntLit x in
+        evalBlock env $ applyNaryAbs (alts !! i) (xss !! i)
+      _ -> error $ "Not implemented: SumAsProd with tag " ++ pprint expr
+    _ -> error $ "Unexpected scrutinee: " ++ pprint e
+  _ -> error $ "Not implemented: " ++ pprint expr
 
 evalOp :: Op -> Atom
 evalOp expr = case expr of

--- a/stack.yaml
+++ b/stack.yaml
@@ -12,3 +12,4 @@ packages:
 extra-deps:
   - llvm-hs-9.0.1
   - llvm-hs-pure-9.0.0
+  - megaparsec-8.0.0


### PR DESCRIPTION
Adds a new combinator to `Parser.hs` to get better error messages when records and variants don't parse. The new combinator is kind of like a "scoped try": when the first parser fails, even if it consumes input, we still try the second one, but if both fail we take whichever made the most progress instead of simply ignoring the first parser. This is useful because records, variants, record types, and variant types all look very similar at the beginning, and we want to make sure not to greedily commit to one of those before we know which one it should be.

Also, makes it possible to print tables indexed by records or variants by adding some missing `Unpack` and `Case` logic to `Interpreter.hs`, and fixing a related indexing bug.