### PR TITLE
Use C++17 flag

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -34,7 +34,7 @@ library
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
   cxx-sources:         src/lib/dexrt.cpp
-  cxx-options:         -std=c++11
+  cxx-options:         -std=c++17
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
   if flag(cuda)

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ STACK_FLAGS = --flag dex:cuda
 CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
 endif
 
-CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti
+CXXFLAGS := $(CFLAGS) -std=c++17 -fno-exceptions -fno-rtti
 CFLAGS := $(CFLAGS) -std=c11
 
 .PHONY: all


### PR DESCRIPTION
I was getting the following error on OS X with Clang 11.0.3.

```bash
$ make
clang++ -fPIC -std=c++11 -fno-exceptions -fno-rtti -c -emit-llvm src/lib/dexrt.cpp -o src/lib/dexrt.bc
src/lib/dexrt.cpp:25:42: error: use of undeclared identifier 'aligned_alloc'
  char* result = reinterpret_cast<char*>(aligned_alloc(alignment, nbytes));
                                         ^
```

Looks like `aligned_alloc` is defined in C++17, so the fix is to change `-std=c++11` to `-std=c++17`. I think only the `makefile` change was strictly needed to avoid the error, but I assumed it's sensible for `dex.cabal` to be consistent and changed that too.