### PR TITLE
LLVM cloning + aligned_alloc -> posix_memalign

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -47,7 +47,7 @@ library
   hs-source-dirs:      src/lib
   ghc-options:         -Wall -O0
   cxx-sources:         src/lib/dexrt.cpp
-  cxx-options:         -std=c++17
+  cxx-options:         -std=c++11
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
   if flag(cuda)

--- a/makefile
+++ b/makefile
@@ -32,7 +32,7 @@ STACK_FLAGS = --flag dex:cuda
 CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
 endif
 
-CXXFLAGS := $(CFLAGS) -std=c++17 -fno-exceptions -fno-rtti
+CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti
 CFLAGS := $(CFLAGS) -std=c11
 
 .PHONY: all

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -901,7 +901,7 @@ mathFlags :: L.FastMathFlags
 mathFlags = L.noFastMathFlags { L.allowContract = True }
 
 mallocFun :: ExternFunSpec
-mallocFun = ExternFunSpec "malloc_dex" (L.ptr L.VoidType) [L.NoAlias] [] [i64]
+mallocFun = ExternFunSpec "malloc_dex" (L.ptr i8) [L.NoAlias] [] [i64]
 
 freeFun :: ExternFunSpec
 freeFun = ExternFunSpec "free_dex" L.VoidType [] [] [L.ptr i8]

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -59,10 +59,10 @@ compilePTX logger (LLVMKernel ast) = do
   withContext $ \ctx ->
     Mod.withModuleFromAST ctx ast $ \m -> do
       withGPUTargetMachine "sm_60" $ \tm -> do
-        linkLibdevice ctx        m
-        linkDexrt     ctx        m
-        internalize   ["kernel"] m
-        compileModule logger tm  m
+        linkLibdevice ctx           m
+        linkDexrt     ctx           m
+        internalize   ["kernel"]    m
+        compileModule ctx logger tm m
         PTXKernel . unpack <$> Mod.moduleTargetAssembly tm m
 
 callLLVM :: Logger [Output] -> LLVMFunction -> [Ptr ()] -> IO [Ptr ()]
@@ -98,7 +98,7 @@ evalLLVM logger ast argPtr = do
       T.withHostTargetMachine R.PIC CM.Large CGO.Aggressive $ \tm -> do
         linkDexrt     c            m
         internalize   ["entryFun"] m
-        compileModule logger tm    m
+        compileModule c logger tm  m
         JIT.withExecutionSession $ \exe ->
           JIT.withObjectLinkingLayer exe (\k -> (M.! k) <$> readIORef resolvers) $ \linkLayer ->
             JIT.withIRCompileLayer linkLayer tm $ \compileLayer -> do
@@ -132,13 +132,19 @@ evalLLVM logger ast argPtr = do
                     , JIT.jitSymbolFlags = JIT.defaultJITSymbolFlags { JIT.jitSymbolExported = True, JIT.jitSymbolAbsolute = True }
                     }
 
-compileModule :: Logger [Output] -> T.TargetMachine -> Mod.Module -> IO ()
-compileModule logger tm m = do
+compileModule :: Context -> Logger [Output] -> T.TargetMachine -> Mod.Module -> IO ()
+compileModule ctx logger tm m = do
   showModule          m >>= logPass logger JitPass
   L.verify            m
   runDefaultPasses tm m
   showModule          m >>= logPass logger LLVMOpt
-  showAsm          tm m >>= logPass logger AsmPass
+  showAsm      ctx tm m >>= logPass logger AsmPass
+
+withModuleClone :: Context -> Mod.Module -> (Mod.Module -> IO a) -> IO a
+withModuleClone ctx m f = do
+  -- It would be better to go through bitcode, but apparently that doesn't work...
+  bc <- Mod.moduleLLVMAssembly m
+  Mod.withModuleFromLLVMAssembly ctx (("<string>" :: String), bc) f
 
 logPass :: Logger [Output] -> PassName -> String -> IO ()
 logPass logger passName s = logThis logger [PassInfo passName s]
@@ -168,11 +174,11 @@ runPasses passes mt m = do
   let passSpec = P.PassSetSpec passes dl Nothing mt
   P.withPassManager passSpec $ \pm -> void $ P.runPassManager pm m
 
-showAsm :: T.TargetMachine -> Mod.Module -> IO String
-showAsm t m = do
+showAsm :: Context -> T.TargetMachine -> Mod.Module -> IO String
+showAsm ctx t m' = do
   -- Uncomment this to dump assembly to a file that can be linked to a C benchmark suite:
-  -- Mod.writeObjectToFile t (Mod.File "asm.o") m
-  liftM unpack $ Mod.moduleTargetAssembly t m
+  -- withModuleClone ctx m' $ \m -> Mod.writeObjectToFile t (Mod.File "asm.o") m
+  withModuleClone ctx m' $ \m -> unpack <$> Mod.moduleTargetAssembly t m
 
 internalize :: [String] -> Mod.Module -> IO ()
 internalize names m = runPasses [P.InternalizeFunctions names, P.GlobalDeadCodeElimination] Nothing m

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -20,10 +20,12 @@ extern "C" {
 char* malloc_dex(int64_t nbytes) {
   // XXX: Changes to this value might require additional changes to parameter attributes in LLVM
   static const int64_t alignment = 64;
-  // Round nbytes up to the nearest multiple of alignment, as required by the C11 standard.
-  nbytes = ((nbytes + alignment - 1) / alignment) * alignment;
-  char* result = reinterpret_cast<char*>(aligned_alloc(alignment, nbytes));
-  return result;
+  char *ptr;
+  if (posix_memalign(reinterpret_cast<void**>(&ptr), alignment, nbytes)) {
+    fprintf(stderr, "Failed to allocate %ld bytes", (long)nbytes);
+    std::abort();
+  }
+  return ptr;
 }
 
 void free_dex(char* ptr) {


### PR DESCRIPTION
Apparently emitting a single modules multiple times is a practice that's
frowned upon, because the emitters actually mutate the state of the
module. This sometimes results in miscompilations that are incredibly
hard to debug, so from now on we clone the module before we generate the
assembly for logging...

Fixing those miscompilations allows us to transition from
`aligned_alloc` to `posix_memalign` which allows us to relax the C++17
constraint to just C++11.