### PR TITLE
Change the precision of Float and Int to 32 bits

### DIFF
--- a/examples/adt-tests.dx
+++ b/examples/adt-tests.dx
@@ -16,7 +16,7 @@ z = MkMyPair 1 2.3
 > MkMyPair 1 2.3
 
 :t z
-> (MyPair Int64 Float64)
+> (MyPair Int32 Float32)
 
 :p
   case z of

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -118,7 +118,7 @@ labels = for i:position. randIdxNoZero vocab (newKey (ordinal i))
 
 -- Evaluate marginal probability of labels given logits
 :p exp $ ctc blank logits labels
-> 1.0398494e-3
+> 1.0398488e-3
 
 
 
@@ -132,12 +132,12 @@ labels = for i:position. randIdxNoZero vocab (newKey (ordinal i))
 
 :p sum for i:vocab.
   exp $ ctc blank logits [i]
-> 0.14146832
+> 0.14146839
 
 :p sum for (i, j):(vocab & vocab).
   exp $ ctc blank logits [i, j]
-> 0.7091231
+> 0.7091234
 
 :p sum for (i, j, k):(vocab & vocab & vocab).
   exp $ ctc blank logits [i, j, k]
-> 0.9251014
+> 0.9251011

--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -105,13 +105,13 @@ fun = \y. sum (map IToF arr) + y
 > 1.4142135
 
 :p sin 3.14159
-> 2.6535897e-6
+> 2.5351817e-6
 
 :p cos 0.0
 > 1.0
 
 :p tan 1.57079
-> 158057.9
+> 159378.27
 
 :p FToI $ floor 3.6
 > 3
@@ -214,12 +214,12 @@ litArr = [10, 5, 3]
 :p
    k = newKey 0
    mean for i:(Fin 100). randn (ixkey k i)
-> -0.115799494
+> -0.1157995
 
 :p
    k = newKey 0
    mean for i:(Fin 100). sq $ randn (ixkey k i)
-> 1.2581897
+> 1.2581898
 
 :p for i:(Fin 3) j:(Fin 2). rand $ ixkey2 (newKey 11) i j
 > [[0.47415292, 0.9145164], [0.7944602, 0.27679908], [0.58958626, 0.7116251]]
@@ -754,9 +754,9 @@ hard = [(-1000.0), 1000.0, 1000.0, 0.1, 0.0]
 > True
 
 :p sum for i. exp $ (logsoftmax hard).i
-> 1.0
+> 0.9999709
 
-:p all for i. abs ((softmax hard).i - exp (logsoftmax hard).i) < 0.0000001
+:p all for i. abs ((softmax hard).i - exp (logsoftmax hard).i) < 0.0001
 > True
 
 :p evalpoly [2.0, 3.0, 4.0] 10.0

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -92,14 +92,14 @@ hmcSamples = runChain randnVec (hmcStep hmcParams myLogProb) numSamples k0
 mhSamples  = runChain randnVec (mhStep  mhParams  myLogProb) numSamples k0
 
 :p meanAndCovariance hmcSamples
-> ( [1.4468334, 2.4944708]
-> , [[1.0656763, 2.0475943e-2], [2.0475943e-2, 5.2884966e-2]] )
+> ( [1.4468338, 2.4944727]
+> , [[1.0656759, 2.0475952e-2], [2.0475952e-2, 5.2884985e-2]] )
 
 :plot for i. (IToF (ordinal i), hmcSamples.i.(0@_))
 > <graphical output>
 
 :p meanAndCovariance mhSamples
-> ([0.64555407, 2.4140553], [[0.38236168, 0.1794119], [0.1794119, 0.22895665]])
+> ([0.6455552, 2.4140577], [[0.38236213, 0.1794126], [0.1794126, 0.228957]])
 
 :plot for i. (IToF (ordinal i), mhSamples.i.(0@_))
 > <graphical output>

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -50,7 +50,7 @@ t1 = [1.0]
 dt = 0.001
 
 :p odeint myDyn z0 t0 t1 dt
-> [[2.716924]]
+> [[2.7170746]]
 
 :plot
   xs = linspace (Fin 100) 0.0 1.0

--- a/examples/parser-tests.dx
+++ b/examples/parser-tests.dx
@@ -30,8 +30,8 @@ f = \x. x + 10.
 
 :p f -1.0   -- parses as (-) f (-1.0)
 > Type error:
-> Expected: (Float64 -> Float64)
->   Actual: Float64
+> Expected: (Float32 -> Float32)
+>   Actual: Float32
 >
 > :p f -1.0   -- parses as (-) f (-1.0)
 >       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -22,10 +22,10 @@ rosenbrock2 : ((Fin 2)=>Float) -> Float =
 > 0.0
 
 :p rosenbrock 1.0 1.02
-> 3.2e-2
+> 3.199994e-2
 
 :p rosenbrock2 [1.0, 1.02]
-> 3.2e-2
+> 3.199994e-2
 
 
 ' ## Helper functions
@@ -43,7 +43,7 @@ randBounded : Key -> (d=>Float)->(d=>Float)->(d=>Float) =
     for i. lb.i + ((rand $ ixkey key i) * (ub.i - lb.i))
 
 :p randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
-> [-0.3510105, 1.4935503]
+> [-0.35101044, 1.4935503]
 
 ' ## The Optimizer itself.
 We have **arguments**:
@@ -103,13 +103,13 @@ Run it for more iterations and result should improve.
 Which it indeed does.
 
 :p optimize 50 10 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [3.7902775, 14.911414]
+> [3.7902741, 14.911411]
 
 :p optimize 50 20 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [1.737736, 3.1227164]
+> [1.737732, 3.1227102]
 
 :p optimize 50 100 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [1.0062338, 1.0128839]
+> [1.0062308, 1.0128763]
 
 :p optimize 50 1000 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [1.0, 1.0]

--- a/examples/pi.dx
+++ b/examples/pi.dx
@@ -22,4 +22,4 @@ numSamps = 1000000
 > (3.143452, 1.6408893)
 
 :p meanAndStdDev numSamps estimatePiAvgVal (newKey 0)
-> (3.1412401, 0.89244914)
+> (3.1437902, 0.8864992)

--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -8,13 +8,13 @@ Syntax for records, variants, and their types.
 > { &}
 
 :p {a:Int & b:Float}
-> {a: Int64 & b: Float64}
+> {a: Int32 & b: Float32}
 
 :p {a:Int & b:Float &}
-> {a: Int64 & b: Float64}
+> {a: Int32 & b: Float32}
 
 :p {a:Int & a:Float}
-> {a: Int64 & a: Float64}
+> {a: Int32 & a: Float32}
 
 
 'Records
@@ -32,17 +32,17 @@ Syntax for records, variants, and their types.
 :p {a=3, b=4}
 > {a = 3, b = 4}
 :t {a=3, b=4}
-> {a: Int64 & b: Int64}
+> {a: Int32 & b: Int32}
 
 :p {a=3, b=4,}
 > {a = 3, b = 4}
 :t {a=3, b=4,}
-> {a: Int64 & b: Int64}
+> {a: Int32 & b: Int32}
 
 :p {a=3, a=4}
 > {a = 3, a = 4}
 :t {a=3, a=4}
-> {a: Int64 & a: Int64}
+> {a: Int32 & a: Int32}
 
 :p
   x = {a=5.0, b=2}
@@ -56,13 +56,13 @@ Syntax for records, variants, and their types.
 > { |}
 
 :p {a:Int | b:Float}
-> {a: Int64 | b: Float64}
+> {a: Int32 | b: Float32}
 
 :p {a:Int | b:Float |}
-> {a: Int64 | b: Float64}
+> {a: Int32 | b: Float32}
 
 :p {a:Int | a:Float}
-> {a: Int64 | a: Float64}
+> {a: Int32 | a: Float32}
 
 
 'Variants (enums)
@@ -81,7 +81,7 @@ Syntax for records, variants, and their types.
 :t
   x : {a:Int | a:Float | a:Int} = {| a | a = 3.0 |}
   x
-> {a: Int64 | a: Float64 | a: Int64}
+> {a: Int32 | a: Float32 | a: Int32}
 
 :p
   x : {a:Int | b:Float} = {| a=3 |}
@@ -161,7 +161,7 @@ def getTwoFoosAndABar (rest : Fields)?->
   (a1, a2, b)
 > Type error:
 > Expected: {a: a & a: b & b: c}
->   Actual: {a: Int64 & b: Int64}
+>   Actual: {a: Int32 & b: Int32}
 > (Solving for: [a:Type, b:Type, c:Type])
 >
 >   ({b=b, a=a1, a=a2}) = {a=1, b=2}
@@ -263,7 +263,7 @@ myVal =
 :p myVal
 > {| b = 4 |}
 :t myVal
-> {a: Float64 | b: Int64 | c: Int64}
+> {a: Float32 | b: Int32 | c: Int32}
 
 -- Badly written tail pattern
 :p

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -61,4 +61,4 @@ rmsErr : n=>Float -> n=>Float -> Float =
   \truth pred. sqrt $ mean for i. sq (pred.i - truth.i)
 
 :p rmsErr ys (map predict xs)
-> 9.46494e-2
+> 0.25608182

--- a/examples/serialize-tests.dx
+++ b/examples/serialize-tests.dx
@@ -22,7 +22,7 @@
 'Values without a pretty-printer (currently shows warning message):
 
 :p Int
-> Int64
+> Int32
 
 :p Fin 10
 > Fin 10

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -53,18 +53,18 @@ help make the errors more local.
 :t
    myid : a:Type ?-> a -> a = \x. x
    myid (myid) (myid 1)
-> Int64
+> Int32
 
 :t
    x = iota (Fin 10)
    sum x
-> Int64
+> Int32
 
 :t
    x = iota (Fin 10)
    y = iota (Fin 3)
    IToF (sum for i. x.i) + IToF (sum for j. y.j)
-> Float64
+> Float32
 
 :t
    x = iota (Fin 10)
@@ -84,19 +84,19 @@ arr  = iota Narr
 xr = map IToF arr
 
 :t arr
-> ((Fin 10) => Int64)
+> ((Fin 10) => Int32)
 
 :t (\(x, y). x + y) (1.0, 2.0)
-> Float64
+> Float32
 
 :t
    f = \(x, y). x + 2.0 * y
    z = for i. (xr.i, xr.i * xr.i)
    sum (for i. f z.i)
-> Float64
+> Float32
 
 :t [1, 2, 3]
-> ((Fin 3) => Int64)
+> ((Fin 3) => Int32)
 
 :t []
 > Type error:Empty table constructor must have type annotation
@@ -106,19 +106,19 @@ xr = map IToF arr
 
 :t [1, [2]]
 > Type error:
-> Expected: Int64
->   Actual: ((Fin 1) => Int64)
+> Expected: Int32
+>   Actual: ((Fin 1) => Int32)
 >
 > :t [1, [2]]
 >        ^^^
 
 :t [[1, 2], [3, 4]]
-> ((Fin 2) => (Fin 2) => Int64)
+> ((Fin 2) => (Fin 2) => Int32)
 
 :t [[1, 2], [3]]
 > Type error:
-> Expected: ((Fin 2) => Int64)
->   Actual: ((Fin 1) => Int64)
+> Expected: ((Fin 2) => Int32)
+>   Actual: ((Fin 1) => Int32)
 >
 > :t [[1, 2], [3]]
 >             ^^^
@@ -128,8 +128,8 @@ f : Int -> Float =
    z = x + 1.0
    x
 > Type error:
-> Expected: Int64
->   Actual: Float64
+> Expected: Int32
+>   Actual: Float32
 >
 >    z = x + 1.0
 >            ^^^
@@ -217,14 +217,14 @@ g : a -> a = \x. x
 :t
   f = \x:Int. x
   f 1
-> Int64
+> Int32
 
 :t
    f = \x:Float. x
    f 1
 > Type error:
-> Expected: Float64
->   Actual: Int64
+> Expected: Float32
+>   Actual: Int32
 >
 >    f 1
 >      ^
@@ -232,7 +232,7 @@ g : a -> a = \x. x
 g1 : (a -> Int) -> (a -> Int) = \x. x
 
 :t g1
-> ((a:Type) ?-> (a -> Int64) -> a -> Int64)
+> ((a:Type) ?-> (a -> Int32) -> a -> Int32)
 
 g2 : a -> a = \x. idiv x x
 > Type error:Couldn't synthesize a class dictionary for: (Integral a)
@@ -260,7 +260,7 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 :p fst newPair
 > Type error:
 > Expected: (a & b)
->   Actual: (NewPair Int64 Float64)
+>   Actual: (NewPair Int32 Float32)
 > (Solving for: [a:Type, b:Type])
 >
 > :p fst newPair
@@ -294,7 +294,7 @@ good_range : Type = (1@Fin 3)..(2@_)
 
 bad_range : Int = (1@Fin 3)..(2@_)
 > Type error:
-> Expected: Int64
+> Expected: Int32
 >   Actual: Type
 >
 > bad_range : Int = (1@Fin 3)..(2@_)
@@ -325,7 +325,7 @@ bad_range : Int = (1@Fin 3)..(2@_)
 > ()
 
 :p (\x:Int. x) == (\x:Int. x)
-> Type error:Couldn't synthesize a class dictionary for: (Eq (Int64 -> Int64))
+> Type error:Couldn't synthesize a class dictionary for: (Eq (Int32 -> Int32))
 >
 > :p (\x:Int. x) == (\x:Int. x)
 >                ^^^

--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -43,24 +43,24 @@ idImplicit2 : (a:Type ?-> a -> a) = \x. x
 
 :p 1.0 + 1
 > Type error:
-> Expected: Float64
->   Actual: Int64
+> Expected: Float32
+>   Actual: Int32
 >
 > :p 1.0 + 1
 >          ^
 
 :p 1 + (1.0 + 2.0)
 > Type error:
-> Expected: Int64
->   Actual: Float64
+> Expected: Int32
+>   Actual: Float32
 >
 > :p 1 + (1.0 + 2.0)
 >         ^^^^^^^^^
 
 :p 1.0 + (2 + 3)
 > Type error:
-> Expected: Float64
->   Actual: Int64
+> Expected: Float32
+>   Actual: Int32
 >
 > :p 1.0 + (2 + 3)
 >           ^^^^^
@@ -141,7 +141,7 @@ myPair = (1, 2.3)
   ((x,y),z)
 > Type error:
 > Expected: (a & b)
->   Actual: Int64
+>   Actual: Int32
 > (Solving for: [a:Type, b:Type])
 >
 >   ((x,y),z) = (1,2,3)
@@ -157,7 +157,7 @@ myPair = (1, 2.3)
   (x,y)
 > Type error:
 > Expected: (a & b)
->   Actual: Int64
+>   Actual: Int32
 > (Solving for: [a:Type, b:Type])
 >
 >   (x,y) = 1

--- a/prelude.dx
+++ b/prelude.dx
@@ -16,8 +16,8 @@ Int8  = %Int8
 Float64 = %Float64
 Float32 = %Float32
 
-Int = Int64
-Float = Float64
+Int = Int32
+Float = Float32
 
 def internalCast (b:Type) (x:a) : b = %cast b x
 
@@ -107,7 +107,7 @@ def (.*)  (d:VSpace a) ?=> : Float -> a -> a = case d of MkVSpace _ scale -> sca
 def (/) (_:VSpace a) ?=> (v:a) (s:Float) : a = (fdiv 1.0 s) .* v
 def neg (_:VSpace a) ?=> (v:a) : a = (-1.0) .* v
 
-@instance floatVS : VSpace Float = MkVSpace float64Add (*)
+@instance floatVS : VSpace Float = MkVSpace float32Add (*)
 @instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i
 @instance unitVS : VSpace Unit = MkVSpace unitAdd \s u. ()
 
@@ -161,8 +161,8 @@ def select (p:Bool) (x:a) (y:a) : a = case p of
 
 def BToI (x:Bool) : Int  =
   case x of
-    False -> (I64ToI 0)
-    True  -> (I64ToI 1)
+    False -> 0
+    True  -> 1
 
 def BToF (x:Bool) : Float = IToF (BToI x)
 def todo (a:Type) ?-> : a = %throwError a
@@ -317,7 +317,7 @@ def finOrd (n:Int) ?-> : Ord (Fin n) =
 
 'Misc
 
-pi : Float = (F64ToF 3.141592653589793)
+pi : Float = 3.141592653589793
 
 def id (x:a) : a = x
 def dup (x:a) : (a & a) = (x, x)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -250,8 +250,8 @@ checkOrInferRho (WithSrc pos expr) reqTy =
     value' <- zonk =<< (checkRho value $ VariantTy $ Ext NoLabeledItems $ Just row)
     prev <- mapM (\() -> freshType TyKind) labels
     matchRequirement =<< emit (Op $ VariantLift prev value')
-  UIntLit  x  -> matchRequirement $ Con $ Lit  $ Int64Lit $ fromIntegral x
-  UFloatLit x -> matchRequirement $ Con $ Lit  $ Float64Lit x
+  UIntLit  x  -> matchRequirement $ Con $ Lit  $ Int32Lit $ fromIntegral x
+  UFloatLit x -> matchRequirement $ Con $ Lit  $ Float32Lit $ realToFrac x
   -- TODO: Make sure that this conversion is not lossy!
   UCharLit x  -> matchRequirement $ CharLit $ fromIntegral $ fromEnum x
   where

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -124,7 +124,7 @@ instance PrettyPrec LitVal where
   prettyPrec (Int32Lit   x) = atPrec ArgPrec $ p x
   prettyPrec (Int8Lit    x) = atPrec ArgPrec $ p x
   prettyPrec (Float64Lit x) = atPrec ArgPrec $ printDouble x
-  prettyPrec (Float32Lit x) = atPrec ArgPrec $ printDouble $ realToFrac x
+  prettyPrec (Float32Lit x) = atPrec ArgPrec $ p x
   prettyPrec (VecLit  l) = atPrec ArgPrec $ encloseSep "<" ">" ", " $ fmap p l
 
 instance Pretty Block where

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -1259,10 +1259,10 @@ pattern CharLit x = Con (CharCon (Con (Lit (Int8Lit x))))
 
 -- Type used to represent indices at run-time
 pattern IdxRepTy :: Type
-pattern IdxRepTy = TC (BaseType (Scalar Int64Type))
+pattern IdxRepTy = TC (BaseType (Scalar Int32Type))
 
-pattern IdxRepVal :: Int64 -> Atom
-pattern IdxRepVal x = Con (Lit (Int64Lit x))
+pattern IdxRepVal :: Int32 -> Atom
+pattern IdxRepVal x = Con (Lit (Int32Lit x))
 
 -- Type used to represent sum type tags at run-time
 pattern TagRepTy :: Type
@@ -1307,7 +1307,7 @@ pattern EffKind = TC EffectRowKind
 pattern LabeledRowKind :: Kind
 pattern LabeledRowKind = TC LabeledRowKindTC
 
-pattern FixedIntRange :: Int64 -> Int64 -> Type
+pattern FixedIntRange :: Int32 -> Int32 -> Type
 pattern FixedIntRange low high = TC (IntRange (IdxRepVal low) (IdxRepVal high))
 
 pattern PureArrow :: Arrow


### PR DESCRIPTION
This should help us make more meaningful comparisons to other systems
and languages, which usually use 32 bit types (many accelerators don't
even implement 64-bit math so it has to be emulated). In the future
we'll probably want to make this configurable by a command line flag or
some expression in the program, but for now one can always hard-code
`Float64` in the places that do require more precision.