### PR TITLE
Inline table builders (`for`s) with a single use site

### DIFF
--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -12,7 +12,7 @@
 
 module Cat (CatT, MonadCat, runCatT, look, extend, scoped, looks, extendLocal,
             extendR, captureW, asFst, asSnd, capture, asCat, evalCatT, evalCat,
-            Cat, runCat, newCatT, catTraverse, evalScoped,
+            Cat, runCat, newCatT, catTraverse, evalScoped, execCat, execCatT,
             catFold, catFoldM, catMap, catMapM) where
 
 -- Monad for tracking monoidal state
@@ -95,7 +95,10 @@ runCatT (CatT m) initEnv = do
   return (ans, newEnv)
 
 evalCatT :: (Monoid env, Monad m) => CatT env m a -> m a
-evalCatT m = liftM fst $ runCatT m mempty
+evalCatT m = fst <$> runCatT m mempty
+
+execCatT :: (Monoid env, Monad m) => CatT env m a -> m env
+execCatT m = snd <$> runCatT m mempty
 
 newCatT :: (Monoid env, Monad m) => (env -> m (a, env)) -> CatT env m a
 newCatT  f = do
@@ -109,6 +112,9 @@ runCat m env = runIdentity $ runCatT m env
 
 evalCat :: Monoid env => Cat env a -> a
 evalCat m = runIdentity $ evalCatT m
+
+execCat :: Monoid env => Cat env a -> env
+execCat m = runIdentity $ execCatT m
 
 looks :: (Monoid env, MonadCat env m) => (env -> a) -> m a
 looks getter = liftM getter look

--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -51,8 +51,8 @@ nameSpace :: Name -> Maybe NameSpace
 nameSpace (Name s _ _) = Just s
 nameSpace _ = Nothing
 
-newEnv :: (Foldable f, HasName a) => f a -> [b] -> Env b
-newEnv bs xs = fold $ zipWith (@>) (toList bs) xs
+newEnv :: (Foldable f, Foldable h, HasName a) => f a -> h b -> Env b
+newEnv bs xs = fold $ zipWith (@>) (toList bs) (toList xs)
 
 varAnn :: VarP a -> a
 varAnn (_:>ann) = ann

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -650,7 +650,7 @@ synthDictTop ctx ty = do
 
 traverseHoles :: (MonadReader SubstEnv m, MonadEmbed m)
               => (SrcCtx -> Type -> m Atom) -> TraversalDef m
-traverseHoles fillHole = (traverseExpr recur, synthPassAtom)
+traverseHoles fillHole = (traverseDecl recur, traverseExpr recur, synthPassAtom)
   where
     synthPassAtom atom = case atom of
       Con (ClassDictHole ctx ty) -> fillHole ctx ty


### PR DESCRIPTION
The idea behind this is that if each element of an array is consumed
at most once, then there is no point in precomputing them ahead of time,
as we could just do it on the fly at the use site. It's essentially loop
fusion.

Now, this patch comes with two caveats, both around the algorithm used
to determine the number of uses:
1. Right now we accumulate the number of occurrences of each binder in
   over the whole program, which might end up overesitmating the number
   of uses, because we tend to reuse names in incomparable scopes.
2. This optimization doesn't duplicate work only if we have a guarantee
   that each array element is used at most once, but the check is a
   little weaker than that at the moment. See the comment in
   `inlineTraverseDecl` for a longer explanation.