### PR TITLE
Improve DCE and inliner

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -214,7 +214,7 @@ litArr = [10, 5, 3]
 :p
    k = newKey 0
    mean for i:(Fin 100). randn (ixkey k i)
-> -0.1157995
+> -0.115799494
 
 :p
    k = newKey 0

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -93,7 +93,7 @@ mhSamples  = runChain randnVec (mhStep  mhParams  myLogProb) numSamples k0
 
 :p meanAndCovariance hmcSamples
 > ( [1.4468338, 2.4944727]
-> , [[1.0656759, 2.0475952e-2], [2.0475952e-2, 5.2884985e-2]] )
+> , [[1.0656759, 2.0475952e-2], [2.0475952e-2, 5.288498e-2]] )
 
 :plot for i. (IToF (ordinal i), hmcSamples.i.(0@_))
 > <graphical output>

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -103,13 +103,13 @@ Run it for more iterations and result should improve.
 Which it indeed does.
 
 :p optimize 50 10 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [3.7902741, 14.911411]
+> [3.7902741, 14.911415]
 
 :p optimize 50 20 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [1.737732, 3.1227102]
+> [1.7377326, 3.1227152]
 
 :p optimize 50 100 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
-> [1.0062308, 1.0128763]
+> [1.0062307, 1.012882]
 
 :p optimize 50 1000 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [1.0, 1.0]

--- a/examples/pi.dx
+++ b/examples/pi.dx
@@ -22,4 +22,4 @@ numSamps = 1000000
 > (3.143452, 1.6408893)
 
 :p meanAndStdDev numSamps estimatePiAvgVal (newKey 0)
-> (3.1437902, 0.8864992)
+> (3.1437902, 0.88649863)

--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -12,7 +12,7 @@ module Env (Name (..), Tag, Env (..), NameSpace (..), envLookup, isin, envNames,
             envIntersect, varAsEnv, envDiff, envMapMaybe, fmapNames, envAsVars,
             rawName, nameSpace, nameTag, envMaxName, genFresh,
             tagToStr, isGlobal, isGlobalBinder, asGlobal, envFilter, binderAsEnv,
-            fromBind, newEnv, HasName, getName) where
+            fromBind, newEnv, HasName, getName, InlineHint (..), pattern Bind) where
 
 import Data.Store
 import Data.String
@@ -36,8 +36,17 @@ data NameSpace = GenName | SourceName | JaxIdx | Skolem | InferenceName | SumNam
 
 type Tag = T.Text
 data VarP a = (:>) Name a  deriving (Show, Ord, Generic, Functor, Foldable, Traversable)
-data BinderP a = Ignore a | Bind (VarP a)
+data BinderP a = Ignore a | BindWithHint InlineHint (VarP a)
                  deriving (Show, Generic, Functor, Foldable, Traversable)
+
+data InlineHint = NoHint | CanInline | NoInline
+                  deriving (Show, Generic)
+
+pattern Bind :: VarP a -> BinderP a
+pattern Bind v <- BindWithHint _ v
+  where Bind v = BindWithHint NoHint v
+
+{-# COMPLETE Ignore, Bind #-}
 
 rawName :: NameSpace -> Tag -> Name
 rawName s t = Name s t 0
@@ -104,8 +113,10 @@ envPairs (Env m) = M.toAscList m
 fmapNames :: (Name -> a -> b) -> Env a -> Env b
 fmapNames f (Env m) = Env $ M.mapWithKey f m
 
-envDelete :: Name -> Env a -> Env a
-envDelete v (Env m) = Env (M.delete v m)
+envDelete :: HasName a => a -> Env b -> Env b
+envDelete x (Env m) = Env $ case getName x of
+  Nothing -> m
+  Just n  -> M.delete n m
 
 envSubset :: [Name] -> Env a -> Env a
 envSubset vs (Env m) = Env $ M.intersection m (M.fromList [(v,()) | v <- vs])
@@ -215,6 +226,7 @@ tagToStr s = T.unpack s
 
 instance Store Name
 instance Store NameSpace
+instance Store InlineHint
 instance Store a => Store (VarP a)
 instance Store a => Store (Env a)
 instance Store a => Store (BinderP a)


### PR DESCRIPTION
#### Track liveness more accurately in DCE

The previous implementation would fail to optimize many case
expressions, because the liveness information from one branch would get
propagated into the other branch. Also, names of top-level decls used in
module binders are allowed to appear in those sub-blocks, which has
invalidated some more optimization opportunities.

#### Make the inliner use aggregation more accurate 
The previous approach was quite eager to overestimate the number of uses
of each binder, because we tend to aggressively reuse names in
incomparable scopes. This patch adds an extra slot in each binder, which
can be filled in with inlining hints. The whole procedure is very
similar to DCE and the approach is heavily inspired by the "Secrets of
the GHC inliner" paper.