### PR TITLE
Make it possible to use ptxas instead of the CUDA driver for SASS compilation

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -36,7 +36,7 @@ library
                        blaze-html, cmark, diagrams-lib, ansi-terminal,
                        diagrams-rasterific, JuicyPixels, transformers,
                        base64-bytestring, vector, directory, mmap, unix,
-                       process, primitive, store, dex-resources
+                       process, primitive, store, dex-resources, temporary
   if !os(darwin)
     exposed-modules:   Resources
     hs-source-dirs:    src/resources

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -10,7 +10,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module LLVMExec (LLVMFunction (..), LLVMKernel (..),
-                 callLLVM, compilePTX) where
+                 callLLVM, compileCUDAKernel) where
 
 import qualified LLVM.Analysis as L
 import qualified LLVM.AST as L
@@ -31,17 +31,22 @@ import qualified LLVM.OrcJIT as JIT
 import LLVM.Internal.OrcJIT.CompileLayer as JIT
 import LLVM.Context
 import Data.Time.Clock (getCurrentTime, diffUTCTime)
+import System.IO
 import System.IO.Unsafe
+import System.IO.Temp
 import System.Directory (listDirectory)
+import System.Process
+import System.Environment
+import System.Exit
 
 import Foreign.Marshal.Alloc
 import Foreign.Ptr
 import Foreign.Storable hiding (alignment)
 import Control.Monad
 import Control.Exception hiding (throw)
-import Data.ByteString.Char8 (unpack)
+import Data.ByteString.Char8 (unpack, pack)
 import Data.IORef
-import qualified Data.ByteString as BS
+import qualified Data.ByteString.Char8 as B
 import qualified Data.Map as M
 
 import Logging
@@ -49,22 +54,42 @@ import Syntax
 import JIT (LLVMFunction (..), LLVMKernel (..), ptxTargetTriple, ptxDataLayout)
 import Resources
 
-type ExitCode = Int
+type DexExitCode = Int
 
 foreign import ccall "dynamic"
-  callFunPtr :: FunPtr (Ptr () -> IO ExitCode) -> Ptr () -> IO ExitCode
+  callFunPtr :: FunPtr (Ptr () -> IO DexExitCode) -> Ptr () -> IO DexExitCode
 
-compilePTX :: Logger [Output] -> LLVMKernel -> IO PTXKernel
-compilePTX logger (LLVMKernel ast) = do
+compileCUDAKernel :: Logger [Output] -> LLVMKernel -> IO CUDAKernel
+compileCUDAKernel logger (LLVMKernel ast) = do
   T.initializeAllTargets
   withContext $ \ctx ->
     Mod.withModuleFromAST ctx ast $ \m -> do
-      withGPUTargetMachine "sm_60" $ \tm -> do
+      withGPUTargetMachine (pack arch) $ \tm -> do
         linkLibdevice ctx           m
         linkDexrt     ctx           m
         internalize   ["kernel"]    m
         compileModule ctx logger tm m
-        PTXKernel . unpack <$> Mod.moduleTargetAssembly tm m
+        ptx <- Mod.moduleTargetAssembly tm m
+        usePTXAS <- maybe False (=="1") <$> lookupEnv "DEX_USE_PTXAS"
+        if usePTXAS
+          then do
+            withSystemTempFile "kernel.ptx" $ \ptxPath ptxH -> do
+              B.hPut ptxH ptx
+              hClose ptxH
+              withSystemTempFile "kernel.sass" $ \sassPath sassH -> do
+                let cmd = proc ptxasPath [ptxPath, "-o", sassPath, "-arch=" ++ arch, "-O3"]
+                withCreateProcess cmd $ \_ _ _ ptxas -> do
+                  code <- waitForProcess ptxas
+                  case code of
+                    ExitSuccess   -> return ()
+                    ExitFailure _ -> error "ptxas invocation failed"
+                -- TODO: B.readFile might be faster, but withSystemTempFile seems to lock the file...
+                CUDAKernel <$> B.hGetContents sassH
+          else return $ CUDAKernel ptx
+  where
+    ptxasPath = "/usr/local/cuda/bin/ptxas"
+    arch = "sm_60"
+
 
 callLLVM :: Logger [Output] -> LLVMFunction -> [Ptr ()] -> IO [Ptr ()]
 callLLVM logger (LLVMFunction numOutputs ast) inArrays = do
@@ -82,7 +107,7 @@ callLLVM logger (LLVMFunction numOutputs ast) inArrays = do
     numInputs = length inArrays
     ptrSize = 8 -- TODO: Get this from LLVM instead of hardcoding!
 
-evalLLVM :: Logger [Output] -> L.Module -> Ptr () -> IO ExitCode
+evalLLVM :: Logger [Output] -> L.Module -> Ptr () -> IO DexExitCode
 evalLLVM logger ast argPtr = do
   resolvers <- newIORef M.empty
   withContext $ \c -> do
@@ -187,7 +212,7 @@ internalize names m = runPasses [P.InternalizeFunctions names, P.GlobalDeadCodeE
 instance Show LLVMKernel where
   show (LLVMKernel ast) = unsafePerformIO $ withContext $ \c -> Mod.withModuleFromAST c ast showModule
 
-withGPUTargetMachine :: BS.ByteString -> (T.TargetMachine -> IO a) -> IO a
+withGPUTargetMachine :: B.ByteString -> (T.TargetMachine -> IO a) -> IO a
 withGPUTargetMachine computeCapability next = do
   (tripleTarget, _) <- T.lookupTarget Nothing ptxTargetTriple
   T.withTargetOptions $ \topt ->
@@ -241,7 +266,7 @@ libdevice = unsafePerformIO $ do
     let libdeviceDirectory = "/usr/local/cuda/nvvm/libdevice"
     [libdeviceFileName] <- listDirectory libdeviceDirectory
     let libdevicePath = libdeviceDirectory ++ "/" ++ libdeviceFileName
-    libdeviceBC <- BS.readFile libdevicePath
+    libdeviceBC <- B.readFile libdevicePath
     m <- Mod.withModuleFromBitcode ctx (libdevicePath, libdeviceBC) Mod.moduleAST
     -- Override the data layout and target triple to avoid warnings when linking
     return $ m { L.moduleDataLayout = Just ptxDataLayout

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -24,7 +24,7 @@ module Syntax (
     UAlt (..), Alt, binderBinding, Label, LabeledItems (..), labeledSingleton,
     reflectLabels, withLabels, ExtLabeledItems (..), prefixExtLabeledItems,
     MDImpFunction (..), MDImpProgram, MDImpInstr (..), MDImpStatement,
-    ImpKernel (..), PTXKernel (..), IScope,
+    ImpKernel (..), CUDAKernel (..), IScope,
     ScalarTableType, ScalarTableBinder, BinderInfo (..),Bindings,
     SrcCtx, Result (..), Output (..), OutFormat (..), DataFormat (..),
     Err (..), ErrType (..), Except, throw, throwIf, modifyErr, addContext,
@@ -62,7 +62,8 @@ import Control.Monad.Fail
 import Control.Monad.Identity
 import Control.Monad.Writer hiding (Alt)
 import Control.Monad.Except hiding (Except)
-import qualified Data.Vector.Storable as V
+import qualified Data.Vector.Storable  as V
+import qualified Data.ByteString.Char8 as B
 import Data.List (sort)
 import qualified Data.List.NonEmpty as NE
 import Data.Store (Store)
@@ -508,7 +509,7 @@ data MDImpInstr k = MDLaunch Size [IVar] k
 -- Parameters, linear thread index, kernel body
 data ImpKernel = ImpKernel [IBinder] IBinder ImpProgram
                  deriving (Show)
-newtype PTXKernel = PTXKernel String deriving (Show)
+newtype CUDAKernel = CUDAKernel B.ByteString deriving (Show)
 
 -- === some handy monoids ===
 

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -251,10 +251,7 @@ evalBackend block = do
         isScalarRef (_ :> ArrayTy (BaseTy _)) = True
         isScalarRef _ = False
 
-        compileKernel :: ImpKernel -> IO PTXKernel
-        compileKernel k = do
-          let llvmKernel = impKernelToLLVM k
-          compilePTX logger llvmKernel
+        compileKernel = compileCUDAKernel logger . impKernelToLLVM
     -- JaxServer server -> do
     --   -- callPipeServer (psPop (psPop server)) $ arrayFromScalar (IntLit 123)
     --   let jfun = toJaxFunction (inVars, block)


### PR DESCRIPTION
This is just to make sure that we're not missing out on any SASS
optimizations that the driver might be considering as too expensive. I
don't really see any difference when it comes to the ray tracer example,
so the path is disabled by default (to enable set `DEX_USE_PTXAS=1` in
your env). In any case, it will probably come in handy for a future AOT
mode, so that we can speed up CUDA module load times.