### PR TITLE
A prototype of Python bindings

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-dex
 *.hi
 *.o
 test.db

--- a/dex.cabal
+++ b/dex.cabal
@@ -45,9 +45,9 @@ library
     build-depends:     dex-resources
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
-  ghc-options:         -Wall -O0
+  ghc-options:         -Wall -O0 -fPIC
   cxx-sources:         src/lib/dexrt.cpp
-  cxx-options:         -std=c++11
+  cxx-options:         -std=c++11 -fPIC
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
                        TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
   if flag(cuda)
@@ -65,6 +65,15 @@ executable dex
   hs-source-dirs:      src
   default-extensions:  CPP
 
+foreign-library Dex
+  type:                native-shared
+  other-modules:       API
+  build-depends:       base, dex, file-embed, bytestring, mtl
+  hs-source-dirs:      src/foreign
+  c-sources:           src/foreign/rts.c
+  default-language:    Haskell2010
+  default-extensions:  TypeApplications, ScopedTypeVariables, LambdaCase
+
 Test-Suite test-dex
   type:                exitcode-stdio-1.0
   main-is:             PropTests.hs
@@ -75,11 +84,3 @@ Test-Suite test-dex
   hs-source-dirs:      tests
   ghc-options:         cbits/libdex.so
                        -Wall
-
--- executable dex2jax.so
---   main-is:             Dex2Jax.hs
---   build-depends:       dex, base, aeson, bytestring, mtl
---   ghc-options:         -no-hs-main -fPIC -shared -dynamic
---   hs-source-dirs:      src/ffi
---   extra-libraries:     HSrts-ghc8.6.5
---   ghc-options:         -Wall

--- a/makefile
+++ b/makefile
@@ -50,6 +50,12 @@ build-prof: dexrt-llvm
 
 dexrt-llvm: src/lib/dexrt.bc
 
+# For some reason stack fails to detect modifications to foreign library files
+build-python: build
+	$(STACK) build $(STACK_FLAGS) --force-dirty
+	$(eval STACK_INSTALL_DIR=$(shell stack path --local-install-root))
+	cp $(STACK_INSTALL_DIR)/lib/libDex.so python/dex/
+
 %.bc: %.cpp
 	clang++ $(CXXFLAGS) -c -emit-llvm $^ -o $@
 

--- a/python/dex/__init__.py
+++ b/python/dex/__init__.py
@@ -1,0 +1,45 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import ctypes
+import pathlib
+import atexit
+
+__all__ = ['execute']
+
+here = pathlib.Path(__file__).parent.absolute()
+
+lib = ctypes.cdll.LoadLibrary(here / 'libDex.so')
+
+_init = lib.dexInit
+_init.restype = None
+_init.argtypes = []
+
+_fini = lib.dexFini
+_fini.restype = None
+_fini.argtypes = []
+
+_eval = lib.dexEval
+_eval.restype = None
+_eval.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+
+_create_context = lib.dexCreateContext
+_create_context.restype = ctypes.c_void_p
+_create_context.argtypes = []
+
+_destroy_context = lib.dexDestroyContext
+_destroy_context.restype = None
+_destroy_context.argtypes = [ctypes.c_void_p]
+
+_init()
+atexit.register(lambda: _fini())
+
+_default_ctx = _create_context()
+atexit.register(lambda: _destroy_context(_default_ctx))
+
+def execute(source):
+  source = source + "\n"
+  _eval(_default_ctx, ctypes.c_char_p(source.encode('ascii')))

--- a/python/example.py
+++ b/python/example.py
@@ -1,0 +1,10 @@
+# Copyright 2020 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import dex
+
+dex.execute("1 + 1")
+dex.execute("2.0 .* [2.0, 3.0, 4.0]")

--- a/src/foreign/API.hs
+++ b/src/foreign/API.hs
@@ -1,0 +1,64 @@
+-- Copyright 2020 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE TemplateHaskell #-}
+
+module API where
+
+import Control.Monad.State.Strict
+
+import Foreign.Ptr
+import Foreign.StablePtr
+import Foreign.C.Types
+import Foreign.C.String
+
+import qualified Data.ByteString.Char8 as B
+import Data.FileEmbed
+
+import Syntax
+import TopLevel
+import PPrint
+
+foreign export ccall "dexCreateContext" dexCreateContext :: IO (Ptr ())
+foreign export ccall "dexDestroyContext" dexDestroyContext :: Ptr () -> IO ()
+foreign export ccall "dexEval" dexEval :: Ptr () -> CString -> IO ()
+
+data Context = Context EvalConfig TopEnv
+
+dexCreateContext :: IO (Ptr ())
+dexCreateContext = do
+    backend <- initializeBackend LLVM
+    let evalConfig = EvalConfig Nothing backend (error "Logging not initialized")
+    maybePreludeEnv <- evalPrelude evalConfig preludeSource
+    case maybePreludeEnv of
+      Right preludeEnv -> castStablePtrToPtr <$> newStablePtr (Context evalConfig preludeEnv)
+      Left err         -> return nullPtr
+  where
+    preludeSource = B.unpack $ $(embedFile "prelude.dx")
+
+evalPrelude :: EvalConfig -> FilePath -> IO (Either Err TopEnv)
+evalPrelude opts fname = flip evalStateT mempty $ do
+  results <- fmap snd <$> evalSource opts fname
+  env <- get
+  return $ env `unlessError` results
+  where
+    unlessError :: TopEnv -> [Result] -> Except TopEnv
+    result `unlessError` []                        = Right result
+    result `unlessError` ((Result _ (Left err)):_) = Left err
+    result `unlessError` (_:t                    ) = result `unlessError` t
+
+dexDestroyContext :: Ptr () -> IO ()
+dexDestroyContext = freeStablePtr . castPtrToStablePtr @Context
+
+dexEval :: Ptr () -> CString -> IO ()
+dexEval ctxPtr sourcePtr = do
+  Context evalConfig env <- deRefStablePtr $ castPtrToStablePtr ctxPtr
+  source <- peekCString sourcePtr
+  results <- evalStateT (evalSource evalConfig source) env
+  putStr $ foldMap (nonEmptyNewline . pprint . snd) results
+  where
+    nonEmptyNewline [] = []
+    nonEmptyNewline l  = l ++ ['\n']

--- a/src/foreign/rts.c
+++ b/src/foreign/rts.c
@@ -1,0 +1,14 @@
+#include <stdlib.h>
+#include "HsFFI.h"
+
+void dexInit() {
+  int argc = 0;
+  char *argv[] = { NULL };
+  char **pargv = argv;
+
+  hs_init(&argc, &pargv);
+}
+
+void dexFini() {
+  hs_exit();
+}

--- a/src/lib/LiveOutput.hs
+++ b/src/lib/LiveOutput.hs
@@ -33,7 +33,7 @@ import Syntax
 import Actor
 import Parser
 import Env
-import TopLevel
+import TopLevel hiding (evalSource)
 import RenderHtml
 import PPrint
 


### PR DESCRIPTION
This adds a new Cabal build target, which creates a shared library that
exposes a C API that allows to evaluate basic Dex expressions. I also
included an example of Python bindings. To try out the example run:
```
make build-python
python python/example.py
```