### PR TITLE
A batch of AD fixes and improvements

### DIFF
--- a/examples/ad-tests.dx
+++ b/examples/ad-tests.dx
@@ -254,3 +254,12 @@ vec = [1.]
   (r, lin) = linearize f 2.0
   (r, lin 4.0)
 > (30.0, 96.0)
+
+:p
+  f : Float -> Float = \x.
+    snd $ withState x \xr.
+      for i:(Fin 4).
+        xr := get xr * get xr
+  (r, lin) = linearize f 2.0
+  (r, lin 1.0)
+> (65536.0, 524288.0)

--- a/examples/ad-tests.dx
+++ b/examples/ad-tests.dx
@@ -244,3 +244,13 @@ vec = [1.]
       a += y
   grad f 1.0
 > 4.0
+
+:p
+  f : Float -> Float = \x.
+    x2 = x * x
+    withReader x \xr.
+      withReader x2 \x2r.
+        5.0 * (ask x2r) + 4.0 * (ask xr) + 2.0
+  (r, lin) = linearize f 2.0
+  (r, lin 4.0)
+> (30.0, 96.0)

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -20,7 +20,7 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               emitBlock, unzipTab, buildFor, isSingletonType, emitDecl, withNameHint,
               singletonTypeVal, scopedDecls, embedScoped, extendScope, checkEmbed,
               embedExtend, reduceAtom,
-              unpackConsList, emitRunWriter, emitRunReader, tabGet,
+              unpackConsList, emitRunWriter, emitRunReader, tabGet, buildNestedLam,
               SubstEmbedT, SubstEmbed, runSubstEmbedT,
               TraversalDef, traverseDecls, traverseDecl, traverseBlock, traverseExpr,
               traverseAtom, arrOffset, arrLoad, evalBlockE, substTraversalDef,
@@ -328,6 +328,11 @@ buildFor d i body = do
   eff <- getAllowedEffects
   lam <- buildLam i (PlainArrow eff) body
   emit $ Hof $ For d lam
+
+buildNestedLam :: MonadEmbed m => [Binder] -> ([Atom] -> m Atom) -> m Atom
+buildNestedLam [] f = f []
+buildNestedLam (b:bs) f =
+  buildLam b PureArrow $ \x -> buildNestedLam bs $ \xs -> f (x:xs)
 
 tabGet :: MonadEmbed m => Atom -> Atom -> m Atom
 tabGet x i = emit $ App x i

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -24,6 +24,7 @@ import Data.Functor
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Text.Prettyprint.Doc
+import GHC.Stack
 
 import Array
 import Syntax
@@ -41,7 +42,7 @@ type TypeM = ReaderT TypeCheckEnv Except
 class Pretty a => HasType a where
   typeCheck :: a -> TypeM Type
 
-getType :: HasType a => a -> Type
+getType :: (HasCallStack, HasType a) => a -> Type
 getType x = ignoreExcept $ ctx $ runTypeCheck SkipChecks $ typeCheck x
   where ctx = addContext $ "Querying:\n" ++ pprint x
 


### PR DESCRIPTION
* Added linearization rules for `RunReader` and `RunState`
* Changed the data structures used for linearization to get O(log n) lookups instead of O(n)
* Added field names for linearization environments to improve documentation and make access easier
* Fixed all warnings inside linearization
