### PR TITLE
Expand the C API and Python bindings

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -71,6 +71,7 @@ foreign-library Dex
   build-depends:       base, dex, file-embed, bytestring, mtl
   hs-source-dirs:      src/foreign
   c-sources:           src/foreign/rts.c
+  ghc-options:         -Wall
   default-language:    Haskell2010
   default-extensions:  TypeApplications, ScopedTypeVariables, LambdaCase
 

--- a/python/dex/__init__.py
+++ b/python/dex/__init__.py
@@ -7,12 +7,35 @@
 import ctypes
 import pathlib
 import atexit
+from enum import Enum
+from typing import List
 
 __all__ = ['execute']
 
 here = pathlib.Path(__file__).parent.absolute()
 
 lib = ctypes.cdll.LoadLibrary(here / 'libDex.so')
+
+def tagged_union(name: str, members: List[type]):
+  named_members = [(f"t{i}", member) for i, member in enumerate(members)]
+  payload = type(name + "Payload", (ctypes.Union,), {"_fields_": named_members})
+  union = type(name, (ctypes.Structure,), {
+    "_fields_": [("tag", ctypes.c_uint64), ("payload", payload)],
+    "value": property(lambda self: getattr(self.payload, f"t{self.tag}")),
+  })
+  return union
+
+class APIErr(Enum):
+  ENotFound = 0
+  EUnsupported = 1
+
+CAPIErr = ctypes.c_uint64
+CLit = tagged_union("Lit", [ctypes.c_int64, ctypes.c_int32, ctypes.c_int8, ctypes.c_double, ctypes.c_float])
+CAtom = tagged_union("CAtom", [CLit])
+WithErr = lambda err, val: tagged_union("WithErr", [err, val])
+
+class HsAtom(ctypes.Structure): pass
+class HsContext(ctypes.Structure): pass
 
 _init = lib.dexInit
 _init.restype = None
@@ -23,23 +46,78 @@ _fini.restype = None
 _fini.argtypes = []
 
 _eval = lib.dexEval
-_eval.restype = None
-_eval.argtypes = [ctypes.c_void_p, ctypes.c_char_p]
+_eval.restype = ctypes.POINTER(HsContext)
+_eval.argtypes = [ctypes.POINTER(HsContext), ctypes.c_char_p]
+
+_print = lib.dexPrint
+_print.restype = ctypes.c_char_p
+_print.argtypes = [ctypes.POINTER(HsAtom)]
+
+_lookup = lib.dexLookup
+_lookup.restype = ctypes.POINTER(WithErr(CAPIErr, ctypes.POINTER(HsAtom)))
+_lookup.argtypes = [ctypes.POINTER(HsContext), ctypes.c_char_p]
+
+_toCAtom = lib.dexToCAtom
+_toCAtom.restype = ctypes.POINTER(WithErr(CAPIErr, CAtom))
+_toCAtom.argtypes = [ctypes.POINTER(HsAtom)]
 
 _create_context = lib.dexCreateContext
-_create_context.restype = ctypes.c_void_p
+_create_context.restype = ctypes.POINTER(HsContext)
 _create_context.argtypes = []
 
 _destroy_context = lib.dexDestroyContext
 _destroy_context.restype = None
-_destroy_context.argtypes = [ctypes.c_void_p]
+_destroy_context.argtypes = [ctypes.POINTER(HsContext)]
 
 _init()
-atexit.register(lambda: _fini())
+_nofree = False
+@atexit.register
+def _teardown():
+  global _nofree
+  _fini()
+  _nofree = True  # Don't destruct any Haskell objects after the RTS has been shutdown
 
 _default_ctx = _create_context()
 atexit.register(lambda: _destroy_context(_default_ctx))
 
-def execute(source):
-  source = source + "\n"
-  _eval(_default_ctx, ctypes.c_char_p(source.encode('ascii')))
+class Module:
+  def __init__(self, source):
+    self._env = _eval(_default_ctx, ctypes.c_char_p(source.encode('ascii')))
+
+  def __del__(self):
+    if _nofree:
+      return
+    _destroy_context(self._env)
+
+  def __getattr__(self, name):
+    result = _lookup(self._env, ctypes.c_char_p(name.encode('ascii'))).contents
+    if result.tag == 0:
+      raise ValueError("Lookup failed: f{APIErr[result.value]}")
+    # TODO: Free the result block
+    return Atom(result.value)
+
+class Atom:
+  def __init__(self, ptr):
+    self._as_parameter_ = ptr
+
+  def __del__(self):
+    # TODO: Free
+    pass
+
+  def __repr__(self):
+    return _print(self).decode('ascii')
+
+  def __int__(self):
+    return int(self._as_scalar())
+
+  def __float__(self):
+    return float(self._as_scalar())
+
+  def _as_scalar(self):
+    result = _toCAtom(self).contents
+    if result.tag == 0:
+      raise ValueError("Can't convert Atom to a Python value")
+    value = result.value.value
+    if not isinstance(value, CLit):
+      raise TypeError("Atom is not a scalar value")
+    return value.value

--- a/python/example.py
+++ b/python/example.py
@@ -6,5 +6,11 @@
 
 import dex
 
-dex.execute("1 + 1")
-dex.execute("2.0 .* [2.0, 3.0, 4.0]")
+m = dex.Module("""
+x = 2.5
+y = [2, 3, 4]
+""")
+
+print(m.x)
+print(m.y)
+print(int(m.x))

--- a/src/foreign/API.hs
+++ b/src/foreign/API.hs
@@ -12,19 +12,26 @@ import Control.Monad.State.Strict
 
 import Foreign.Ptr
 import Foreign.StablePtr
-import Foreign.C.Types
+import Foreign.Storable
+import Foreign.Marshal.Alloc
 import Foreign.C.String
 
-import qualified Data.ByteString.Char8 as B
+import Data.String
+import Data.Word
 import Data.FileEmbed
+import qualified Data.ByteString.Char8 as B
 
 import Syntax
 import TopLevel
-import PPrint
+import Serialize (pprintVal)
+import Env hiding (Tag)
 
 foreign export ccall "dexCreateContext" dexCreateContext :: IO (Ptr ())
 foreign export ccall "dexDestroyContext" dexDestroyContext :: Ptr () -> IO ()
-foreign export ccall "dexEval" dexEval :: Ptr () -> CString -> IO ()
+foreign export ccall "dexPrint"   dexPrint   :: Ptr Atom    -> IO CString
+foreign export ccall "dexEval"    dexEval    :: Ptr Context -> CString -> IO (Ptr Context)
+foreign export ccall "dexLookup"  dexLookup  :: Ptr Context -> CString -> IO (Ptr (WithErr APIErr (Ptr Atom)))
+foreign export ccall "dexToCAtom" dexToCAtom :: Ptr Atom               -> IO (Ptr (WithErr APIErr CAtom))
 
 data Context = Context EvalConfig TopEnv
 
@@ -35,7 +42,7 @@ dexCreateContext = do
     maybePreludeEnv <- evalPrelude evalConfig preludeSource
     case maybePreludeEnv of
       Right preludeEnv -> castStablePtrToPtr <$> newStablePtr (Context evalConfig preludeEnv)
-      Left err         -> return nullPtr
+      Left  _          -> return nullPtr
   where
     preludeSource = B.unpack $ $(embedFile "prelude.dx")
 
@@ -47,18 +54,135 @@ evalPrelude opts fname = flip evalStateT mempty $ do
   where
     unlessError :: TopEnv -> [Result] -> Except TopEnv
     result `unlessError` []                        = Right result
-    result `unlessError` ((Result _ (Left err)):_) = Left err
+    _      `unlessError` ((Result _ (Left err)):_) = Left err
     result `unlessError` (_:t                    ) = result `unlessError` t
 
 dexDestroyContext :: Ptr () -> IO ()
 dexDestroyContext = freeStablePtr . castPtrToStablePtr @Context
 
-dexEval :: Ptr () -> CString -> IO ()
+dexPrint :: Ptr Atom -> IO CString
+dexPrint atomPtr = do
+  atom <- deRefStablePtr $ castPtrToStablePtr $ castPtr atomPtr
+  newCString $ pprintVal (atom :: Atom)
+
+dexEval :: Ptr Context -> CString -> IO (Ptr Context)
 dexEval ctxPtr sourcePtr = do
-  Context evalConfig env <- deRefStablePtr $ castPtrToStablePtr ctxPtr
+  Context evalConfig env <- deRefStablePtr $ castPtrToStablePtr $ castPtr ctxPtr
   source <- peekCString sourcePtr
-  results <- evalStateT (evalSource evalConfig source) env
-  putStr $ foldMap (nonEmptyNewline . pprint . snd) results
+  finalEnv <- execStateT (evalSource evalConfig source) env
+  castPtr . castStablePtrToPtr <$> newStablePtr (Context evalConfig finalEnv)
+
+dexLookup :: Ptr Context -> CString -> IO (Ptr (WithErr APIErr (Ptr Atom)))
+dexLookup ctxPtr namePtr = do
+  Context (EvalConfig _ backend _) env <- deRefStablePtr $ castPtrToStablePtr $ castPtr ctxPtr
+  name <- peekCString namePtr
+  case envLookup env (GlobalName $ fromString name) of
+    Just (_, LetBound _ (Atom atom)) -> do
+      val <- substArrayLiterals backend atom
+      atomPtr <- castPtr . castStablePtrToPtr <$> newStablePtr val
+      packSuccess atomPtr
+    Just _                          -> packErr EUnsupported
+    Nothing                         -> packErr ENotFound
+
+dexToCAtom :: Ptr Atom -> IO (Ptr (WithErr APIErr CAtom))
+dexToCAtom atomPtr = packAtom =<< (deRefStablePtr $ castPtrToStablePtr $ castPtr atomPtr)
+
+packAtom :: Atom -> IO (Ptr (WithErr APIErr CAtom))
+packAtom atom = case atom of
+  Con con -> case con of
+    Lit (VecLit _) -> notSerializable
+    Lit l          -> packSuccess $ CLit l
+    _ -> notSerializable
+  _ -> notSerializable
   where
-    nonEmptyNewline [] = []
-    nonEmptyNewline l  = l ++ ['\n']
+    notSerializable = packErr EUnsupported
+
+unpackAtom :: CAtom -> Atom
+unpackAtom catom = case catom of
+  CLit l           -> Con $ Lit l
+  CRectArray _ _ _ -> error "Unsupported"
+
+data CAtom = CLit LitVal | CRectArray (Ptr ()) [Int] [Int]
+
+data WithErr err val = Fail err | Success val
+data APIErr = ENotFound | EUnsupported deriving (Enum)
+
+packErr :: (Storable err, Storable val) => err -> IO (Ptr (WithErr err val))
+packErr = putOnHeap . Fail
+
+packSuccess :: (Storable err, Storable val) => val -> IO (Ptr (WithErr err val))
+packSuccess = putOnHeap . Success
+
+bitcastWord :: Storable a => a -> IO Word64
+bitcastWord x = do
+  unless (sizeOf    x <= sizeOf    (undefined :: Word64)) $ error "Payload too large"
+  unless (alignment x >= alignment (undefined :: Word64)) $ error "Payload requires stricter alignment"
+  alloca $ \ref -> do
+    poke ref 0
+    poke (castPtr ref) x
+    peek ref
+
+instance Storable CAtom where
+  sizeOf _ = tag + val + val + val
+    where tag = 8; val = 8
+  alignment _ = 8
+  peek addr = do
+    tag <- val @Word64 0
+    case tag of
+      0 -> do
+        litTag <- val @Word64 1
+        CLit <$> case litTag of
+                   0 -> Int64Lit   <$> val 2
+                   1 -> Int32Lit   <$> val 2
+                   2 -> Int8Lit    <$> val 2
+                   3 -> Float64Lit <$> val 2
+                   4 -> Float32Lit <$> val 2
+                   _ -> error "Invalid tag"
+      _ -> error "Invalid tag"
+    where
+      val :: forall a. Storable a => Int -> IO a
+      val i = peekByteOff (castPtr addr) (i * 8)
+  poke addr catom = case catom of
+    CLit lit -> do
+      val @Word64 0 0
+      case lit of
+        Int64Lit   v -> val @Word64 1 0 >> val 2 v
+        Int32Lit   v -> val @Word64 1 1 >> val 2 v
+        Int8Lit    v -> val @Word64 1 2 >> val 2 v
+        Float64Lit v -> val @Word64 1 3 >> val 2 v
+        Float32Lit v -> val @Word64 1 4 >> val 2 v
+        VecLit     _ -> error "Unsupported"
+    CRectArray _ _ _ -> error "Unsupported"
+    where
+      val :: forall a. Storable a => Int -> a -> IO ()
+      val i v = pokeByteOff (castPtr addr) (i * 8) v
+
+instance Storable APIErr where
+  sizeOf    _ = sizeOf    (undefined :: Word64)
+  alignment _ = alignment (undefined :: Word64)
+  peek addr   = toEnum @APIErr . fromIntegral <$> peek (castPtr @_ @Word64 addr)
+  poke addr x = poke (castPtr @_ @Word64 addr) $ fromIntegral $ fromEnum x
+
+instance (Storable err, Storable val) => Storable (WithErr err val) where
+  -- TODO: Assert that alignment of err and val is not more than 8
+  sizeOf    _ = 8 + max (sizeOf (undefined :: err)) (sizeOf (undefined :: val))
+  alignment _ = 8
+  peek ptr    = do
+    tag <- peek (castPtr @_ @Word64 ptr)
+    let payloadPtr = plusPtr ptr 8
+    case tag of
+      0 -> Fail    <$> peek (castPtr payloadPtr)
+      1 -> Success <$> peek (castPtr payloadPtr)
+      _ -> error    $  "Unexpected tag value: " ++ show tag
+  poke ptr x  = do
+    let tagPtr = castPtr @_ @Word64 ptr
+    let payloadPtr = plusPtr ptr 8
+    case x of
+      Fail err    -> poke tagPtr 0 >> poke payloadPtr err
+      Success val -> poke tagPtr 1 >> poke payloadPtr val
+
+putOnHeap :: Storable a => a -> IO (Ptr a)
+putOnHeap x = do
+  addr <- calloc
+  poke addr x
+  return addr

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE OverloadedStrings #-}
 
 module TopLevel (evalSourceBlock, evalDecl, evalSource, evalFile,
-                 EvalConfig (..), Backend (..), initializeBackend) where
+                 EvalConfig (..), Backend (..), initializeBackend,
+                 substArrayLiterals) where
 
 import Control.Concurrent.MVar
 import Control.Monad.State.Strict


### PR DESCRIPTION
Instead of only allowing to evaluate expressions, and always printing
the results, the new version allows defining modules and looking up
their attributes. It also allows to convert scalar Dex values into
scalar Python values.