### PR TITLE
Isomorphisms and record/variant syntactic sugar

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -1,0 +1,253 @@
+'# Isomorphisms in Dex
+
+'`Iso a b` is the type of an isomorphism between `a` and `b`.
+
+:t MkIso
+> ((a:Type) ?-> (b:Type) ?-> {bwd: b -> a & fwd: a -> b} -> Iso a b)
+
+'This is a normal ADT, and you can construct your own isomorphisms. Note that
+we assume but do not check that the isomorphism is lawful (i.e.
+`appIso iso $ revIso iso x == x` for all `x`, or equivalently
+`iso `chainIsos` (flipIso iso) == idIso`).
+
+cycleThree : Iso (a & b & c) (b & c & a) =
+  MkIso { fwd = \(a, b, c). (b, c, a)
+        , bwd = \(b, c, a). (a, b, c)
+        }
+
+:p appIso cycleThree (1, 2.0, 3)
+> (2.0, (3, 1))
+
+:p appIso (flipIso cycleThree) (1, 2.0, 3)
+> (3, (1, 2.0))
+
+'In addition, Dex will automatically write some useful isomorphisms for you
+to extract fields from records and variants. There are four syntactic forms
+that produce isos. We will start with the first two:
+- `#x` produces a "lens-like" record accessor `Iso {x:a & ...r} (a & {&...r})`
+- `#?x` produces a "prism-like" variant matcher `Iso {x:a | ...r} (a | {|...r})`
+
+%passes parse
+:t astype (Iso {a:Int & b:Float & c:Unit} _) #b
+> (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
+> === parse ===
+> _ans_:() =
+>   astype (Iso {a: Int & b: Float & c: Unit} _)
+>     (MkIso
+>        { bwd = \(x:(), r:()). {b = x, ...r}
+>        , fwd = \{b = x:(), ...r:()}. (,) x r})
+
+%passes parse
+:t astype (Iso {a:Int | b:Float | c:Unit} _) #?b
+> (Iso {a: Int32 | b: Float32 | c: Unit} (Float32 | {a: Int32 | c: Unit}))
+> === parse ===
+> _ans_:() =
+>   astype (Iso {a: Int | b: Float | c: Unit} _)
+>     (MkIso
+>        { bwd = \v:(). case v
+>                    ((Left x:())) -> {| b = x |}
+>                    ((Right r:())) -> {|b| ...r |}
+>                    
+>        , fwd = \v:(). case v
+>                    {| b = x:() |} -> (Left x)
+>                    {|b| ...r:() |} -> (Right r)
+>                    })
+
+'There are also two "zipper" forms, described later on this page:
+- `#&x` produces a "lens-zipper" record isomorphism
+  ```
+  Iso ({&...l} & {x:a & ...r}) ({x:a & ...l} & {&...r})
+  ```
+- `#|x` produces a "prism-zipper" variant isomorphism
+  ```
+  Iso ({|...l} | {x:a | ...r}) ({x:a | ...l} | {|...r})
+  ```
+
+'## Record accessors
+Record accessor isomorphisms can be passed into the helper function `getAt`:
+
+:t getAt
+> ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b & c)) -> a -> b)
+
+:p getAt #foo {foo=1, bar=2.0}
+> 1
+
+'We can also do other types of things:
+
+:p popAt #foo {foo=1, bar=2.0}
+> {bar = 2.0}
+
+:p pushAt #foo 3.0 {foo=1, bar=2.0}
+> {bar = 2.0, foo = 3.0, foo = 1}
+
+:p setAt #foo 2 {foo=1, bar=2.0}
+> {bar = 2.0, foo = 2}
+
+'These helper functions work with any "lens-like" isomorphism. For instance,
+we can select everything except for a particular field:
+
+:t exceptLens
+> ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b & c)) -> Iso a (c & b))
+
+:p getAt (exceptLens #foo) {foo=1, bar=2.0, baz=3}
+> {bar = 2.0, baz = 3}
+
+
+'## Variant prisms
+Similarly, there are prism-like helpers
+
+:t matchWith
+> ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b | c)) -> a -> Maybe b)
+
+:t buildWith
+> ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b | c)) -> b -> a)
+
+'which can be used with variant accessors or any other prism-like isomorphism:
+
+:p matchWith #?foo $ astype {foo:Int | bar:Float} {|foo = 1|}
+> Just 1
+
+:p matchWith #?foo $ astype {foo:Int | bar:Float} {|bar = 1.0|}
+> Nothing
+
+:p astype {foo:Int | bar:Float} $ buildWith #?foo 3
+> {| foo = 3 |}
+
+:p matchWith (exceptPrism #?foo) $ astype {foo:Int | bar:Float} {|bar = 1.0|}
+> Just {| bar = 1.0 |}
+
+'## Zipper lens isomorphisms
+The isomorphisms shown above are specialized for removing a single field from
+an object. As such, they don't compose well when trying to work with more than
+one field at a time. When using multiple fields, a better choice is to use
+a "zipper isomorphism", which moves a subset of fields from one place to
+another. For instance:
+
+%passes parse
+:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) #&a
+> (Iso
+>    ({ &} & {a: Int32 & b: Float32 & c: Unit})
+>    ({a: Int32} & {b: Float32 & c: Unit}))
+> === parse ===
+> _ans_:() =
+>   astype (Iso ((&) { &} {a: Int & b: Float & c: Unit}) _)
+>     (MkIso
+>        { bwd = \({a = x:(), ...l:()}, {, ...r:()}). (,) {, ...l} {a = x, ...r}
+>        , fwd = \({, ...l:()}, {a = x:(), ...r:()}). (,) {a = x, ...l} {, ...r}})
+
+:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) $
+      #&a `chainIsos` #&b
+> (Iso
+>    ({ &} & {a: Int32 & b: Float32 & c: Unit})
+>    ({a: Int32 & b: Float32} & {c: Unit}))
+
+'`#&a` and `#&b` are isomorphisms that move a given field from the record on the
+right to the record on the left; when composed, they move both fields.
+
+'The main use for zipper isomorphisms is to specify multiple named axes when
+using a record type as an index set:
+
+:t overFields
+> ((a:Type)
+>  ?-> (b:Type)
+>  ?-> (c:Type)
+>  ?-> (v:Type) ?-> (Iso ({ &} & a) (b & c)) -> (a => v) -> b => c => v)
+
+:p
+  x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
+    ordinal a * 100 + ordinal b * 10 + ordinal c
+  v1 = x
+  v2 = sum $ overFields (#&b) x
+  v3 = sum $ overFields (#&b `chainIsos` #&c) x
+  v4 = sum $ overFields (#&a `chainIsos` #&b `chainIsos` #&c) x
+  (v1, v2, v3, v4)
+> ( [0, 100, 10, 110, 1, 101, 11, 111]@{a: Fin 2 & b: Fin 2 & c: Fin 2}
+> , ([10, 210, 12, 212]@{a: Fin 2 & c: Fin 2}, ([22, 422]@{a: Fin 2}, [444]@{ &})) )
+
+'Note that `overFields` is just a simple wrapper combining `lensFields` and
+`over`:
+
+:t lensFields
+> ((a:Type)
+>  ?-> (b:Type) ?-> (c:Type) ?-> (Iso ({ &} & a) (b & c)) -> Iso a (b & c))
+
+:t over
+> ((a:Type)
+>  ?-> (b:Type)
+>  ?-> (c:Type) ?-> (v:Type) ?-> (Iso a (b & c)) -> (a => v) -> b => c => v)
+
+'`over` alone can be used with any lens-like isomorphism, for instance an
+ordinary record accessor lens.
+
+:p
+  x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
+    ordinal a * 100 + ordinal b * 10 + ordinal c
+  over #a x
+> [ [0, 10, 1, 11]@{b: Fin 2 & c: Fin 2}
+> , [100, 110, 101, 111]@{b: Fin 2 & c: Fin 2} ]
+
+'`lensFields` can be used if you want to process multiple fields at once:
+
+:p pushAt (lensFields (#&a `chainIsos` #&b)) {a=1, b=2.0} {c=3, d=4.0}
+> {a = 1, b = 2.0, c = 3, d = 4.0}
+
+'Equivalently, you can use `startLZip`:
+
+:p pushAt (startLZip `chainIsos` #&a `chainIsos` #&b) {a=1, b=2.0} {c=3, d=4.0}
+> {a = 1, b = 2.0, c = 3, d = 4.0}
+
+'## Zipper prism isomorphisms
+Just as there are lens-like zipper isomorphisms, there are also prism-like
+zipper isomorphisms:
+
+%passes parse
+:t astype (Iso ({|} | {a:Int | b:Float | c:Unit}) _) #|a
+> (Iso
+>    ({ |} | {a: Int32 | b: Float32 | c: Unit})
+>    ({a: Int32} | {b: Float32 | c: Unit}))
+> === parse ===
+> _ans_:() =
+>   astype (Iso ((|) { |} {a: Int | b: Float | c: Unit}) _)
+>     (MkIso
+>        { bwd = \v:(). case v
+>                    ((Left w:())) -> (case w
+>                                        {| a = x:() |} -> (Right {| a = x |})
+>                                        {|a| ...r:() |} -> (Left r)
+>                                        )
+>                    ((Right l:())) -> (Right {|a| ...l |})
+>                    
+>        , fwd = \v:(). case v
+>                    ((Left l:())) -> (Left {|a| ...l |})
+>                    ((Right w:())) -> (case w
+>                                         {| a = x:() |} -> (Left {| a = x |})
+>                                         {|a| ...r:() |} -> (Right r)
+>                                         )
+>                    })
+
+'`prismFields` makes a prism zipper into an ordinary prism isomorphism:
+
+:p
+  vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
+  for i. matchWith (prismFields (#|a `chainIsos` #|b)) vals.i
+> [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
+
+'or equivalently
+
+:p
+  vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
+  for i. matchWith (startPZip `chainIsos` #|a `chainIsos` #|b) vals.i
+> [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
+
+'`sliceFields` extracts specific named variants from a variant-indexed table:
+
+:p
+  x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}
+  v1 = x
+  v2 = sliceFields (#|b) x
+  v3 = sliceFields (#|a `chainIsos` #|c) x
+  v4 = sliceFields (#|a `chainIsos` #|b `chainIsos` #|c) x
+  (v1, v2, v3, v4)
+> ( [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2}
+> , ( [2, 3]@{b: Fin 2}
+> , ( [0, 1, 4, 5]@{a: Fin 2 | c: Fin 2}
+> , [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2} ) ) )

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -5,21 +5,36 @@
 :t MkIso
 > ((a:Type) ?-> (b:Type) ?-> {bwd: b -> a & fwd: a -> b} -> Iso a b)
 
-'This is a normal ADT, and you can construct your own isomorphisms. Note that
-we assume but do not check that the isomorphism is lawful (i.e.
-`appIso iso $ revIso iso x == x` for all `x`, or equivalently
-`iso `chainIsos` (flipIso iso) == idIso`).
+'This is a normal ADT, and you can construct your own isomorphisms.
 
 cycleThree : Iso (a & b & c) (b & c & a) =
   MkIso { fwd = \(a, b, c). (b, c, a)
         , bwd = \(b, c, a). (a, b, c)
         }
 
+'Isomorphisms can be applied with `appIso`, applied in reverse with `revIso`,
+and flipped with `flipIso`
+
 :p appIso cycleThree (1, 2.0, 3)
 > (2.0, (3, 1))
 
+:p revIso cycleThree (1, 2.0, 3)
+> (3, (1, 2.0))
+
 :p appIso (flipIso cycleThree) (1, 2.0, 3)
 > (3, (1, 2.0))
+
+'They can also be composed with `<>>`:
+
+:p appIso (cycleThree <>> cycleThree) (1, 2.0, 3)
+> (3, (1, 2.0))
+
+:p appIso (cycleThree <>> cycleThree <>> cycleThree) (1, 2.0, 3)
+> (1, (2.0, 3))
+
+'Note that we assume but do not check that the isomorphism is lawful (i.e.
+`appIso iso $ revIso iso x == x` for all `x`, or equivalently
+`iso <>> (flipIso iso) == idIso`).
 
 'In addition, Dex will automatically write some useful isomorphisms for you
 to extract fields from records and variants. There are four syntactic forms
@@ -135,8 +150,7 @@ another. For instance:
 >        { bwd = \({a = x:(), ...l:()}, {, ...r:()}). (,) {, ...l} {a = x, ...r}
 >        , fwd = \({, ...l:()}, {a = x:(), ...r:()}). (,) {a = x, ...l} {, ...r}})
 
-:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) $
-      #&a `chainIsos` #&b
+:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) (#&a <>> #&b)
 > (Iso
 >    ({ &} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32 & b: Float32} & {c: Unit}))
@@ -158,8 +172,8 @@ using a record type as an index set:
     ordinal a * 100 + ordinal b * 10 + ordinal c
   v1 = x
   v2 = sum $ overFields (#&b) x
-  v3 = sum $ overFields (#&b `chainIsos` #&c) x
-  v4 = sum $ overFields (#&a `chainIsos` #&b `chainIsos` #&c) x
+  v3 = sum $ overFields (#&b <>> #&c) x
+  v4 = sum $ overFields (#&a <>> #&b <>> #&c) x
   (v1, v2, v3, v4)
 > ( [0, 100, 10, 110, 1, 101, 11, 111]@{a: Fin 2 & b: Fin 2 & c: Fin 2}
 > , ([10, 210, 12, 212]@{a: Fin 2 & c: Fin 2}, ([22, 422]@{a: Fin 2}, [444]@{ &})) )
@@ -188,12 +202,12 @@ ordinary record accessor lens.
 
 '`lensFields` can be used if you want to process multiple fields at once:
 
-:p pushAt (lensFields (#&a `chainIsos` #&b)) {a=1, b=2.0} {c=3, d=4.0}
+:p pushAt (lensFields (#&a <>> #&b)) {a=1, b=2.0} {c=3, d=4.0}
 > {a = 1, b = 2.0, c = 3, d = 4.0}
 
 'Equivalently, you can use `startLZip`:
 
-:p pushAt (startLZip `chainIsos` #&a `chainIsos` #&b) {a=1, b=2.0} {c=3, d=4.0}
+:p pushAt (startLZip <>> #&a <>> #&b) {a=1, b=2.0} {c=3, d=4.0}
 > {a = 1, b = 2.0, c = 3, d = 4.0}
 
 '## Zipper prism isomorphisms
@@ -228,14 +242,14 @@ zipper isomorphisms:
 
 :p
   vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
-  for i. matchWith (prismFields (#|a `chainIsos` #|b)) vals.i
+  for i. matchWith (prismFields (#|a <>> #|b)) vals.i
 > [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
 
 'or equivalently
 
 :p
   vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
-  for i. matchWith (startPZip `chainIsos` #|a `chainIsos` #|b) vals.i
+  for i. matchWith (startPZip <>> #|a <>> #|b) vals.i
 > [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
 
 '`sliceFields` extracts specific named variants from a variant-indexed table:
@@ -244,8 +258,8 @@ zipper isomorphisms:
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}
   v1 = x
   v2 = sliceFields (#|b) x
-  v3 = sliceFields (#|a `chainIsos` #|c) x
-  v4 = sliceFields (#|a `chainIsos` #|b `chainIsos` #|c) x
+  v3 = sliceFields (#|a <>> #|c) x
+  v4 = sliceFields (#|a <>> #|b <>> #|c) x
   (v1, v2, v3, v4)
 > ( [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2}
 > , ( [2, 3]@{b: Fin 2}

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -69,16 +69,16 @@ that produce isos. We will start with the first two:
 >                    })
 
 'There are also two "zipper" forms, described later on this page:
-- `#&x` produces a "lens-zipper" record isomorphism
+- `#&x` produces a "record-zipper" isomorphism
   ```
   Iso ({&...l} & {x:a & ...r}) ({x:a & ...l} & {&...r})
   ```
-- `#|x` produces a "prism-zipper" variant isomorphism
+- `#|x` produces a "variant-zipper" isomorphism
   ```
   Iso ({|...l} | {x:a | ...r}) ({x:a | ...l} | {|...r})
   ```
 
-'## Record accessors
+'## Record accessors and lens-like helpers
 Record accessor isomorphisms can be passed into the helper function `getAt`:
 
 :t getAt
@@ -108,7 +108,7 @@ we can select everything except for a particular field:
 > {bar = 2.0, baz = 3}
 
 
-'## Variant prisms
+'## Variant accessors and prism-like helpers
 Similarly, there are prism-like helpers
 
 :t matchWith
@@ -131,7 +131,7 @@ Similarly, there are prism-like helpers
 :p matchWith (exceptPrism #?foo) $ astype {foo:Int | bar:Float} {|bar = 1.0|}
 > Just {| bar = 1.0 |}
 
-'## Zipper lens isomorphisms
+'## Record zipper isomorphisms
 The isomorphisms shown above are specialized for removing a single field from
 an object. As such, they don't compose well when trying to work with more than
 one field at a time. When using multiple fields, a better choice is to use
@@ -158,8 +158,8 @@ another. For instance:
 '`#&a` and `#&b` are isomorphisms that move a given field from the record on the
 right to the record on the left; when composed, they move both fields.
 
-'The main use for zipper isomorphisms is to specify multiple named axes when
-using a record type as an index set:
+'The main use for record zipper isomorphisms is to specify multiple named axes
+when using a record type as an index set:
 
 :t overFields
 > ((a:Type)
@@ -178,12 +178,11 @@ using a record type as an index set:
 > ( [0, 100, 10, 110, 1, 101, 11, 111]@{a: Fin 2 & b: Fin 2 & c: Fin 2}
 > , ([10, 210, 12, 212]@{a: Fin 2 & c: Fin 2}, ([22, 422]@{a: Fin 2}, [444]@{ &})) )
 
-'Note that `overFields` is just a simple wrapper combining `lensFields` and
+'Note that `overFields` is just a simple wrapper combining `splitR` and
 `over`:
 
-:t lensFields
-> ((a:Type)
->  ?-> (b:Type) ?-> (c:Type) ?-> (Iso ({ &} & a) (b & c)) -> Iso a (b & c))
+:t splitR
+> ((a:Type) ?-> Iso a ({ &} & a))
 
 :t over
 > ((a:Type)
@@ -200,18 +199,13 @@ ordinary record accessor lens.
 > [ [0, 10, 1, 11]@{b: Fin 2 & c: Fin 2}
 > , [100, 110, 101, 111]@{b: Fin 2 & c: Fin 2} ]
 
-'`lensFields` can be used if you want to process multiple fields at once:
+'`splitR` can be used if you want to process multiple fields at once:
 
-:p pushAt (lensFields (#&a <>> #&b)) {a=1, b=2.0} {c=3, d=4.0}
+:p pushAt (splitR <>> #&a <>> #&b) {a=1, b=2.0} {c=3, d=4.0}
 > {a = 1, b = 2.0, c = 3, d = 4.0}
 
-'Equivalently, you can use `startLZip`:
-
-:p pushAt (startLZip <>> #&a <>> #&b) {a=1, b=2.0} {c=3, d=4.0}
-> {a = 1, b = 2.0, c = 3, d = 4.0}
-
-'## Zipper prism isomorphisms
-Just as there are lens-like zipper isomorphisms, there are also prism-like
+'## Variant zipper isomorphisms
+Just as there are record zipper isomorphisms, there are also variant
 zipper isomorphisms:
 
 %passes parse
@@ -238,21 +232,18 @@ zipper isomorphisms:
 >                                         )
 >                    })
 
-'`prismFields` makes a prism zipper into an ordinary prism isomorphism:
+'`splitV` makes a prism zipper into an ordinary prism isomorphism:
+
+:t splitV
+> ((a:Type) ?-> Iso a ({ |} | a))
 
 :p
   vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
-  for i. matchWith (prismFields (#|a <>> #|b)) vals.i
+  for i. matchWith (splitV <>> #|a <>> #|b) vals.i
 > [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
 
-'or equivalently
-
-:p
-  vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
-  for i. matchWith (startPZip <>> #|a <>> #|b) vals.i
-> [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
-
-'`sliceFields` extracts specific named variants from a variant-indexed table:
+'`sliceFields` uses this to specific named variants from a variant-indexed
+table:
 
 :p
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -24,17 +24,17 @@ and flipped with `flipIso`
 :p appIso (flipIso cycleThree) (1, 2.0, 3)
 > (3, (1, 2.0))
 
-'They can also be composed with `<>>`:
+'They can also be composed with `&>>`:
 
-:p appIso (cycleThree <>> cycleThree) (1, 2.0, 3)
+:p appIso (cycleThree &>> cycleThree) (1, 2.0, 3)
 > (3, (1, 2.0))
 
-:p appIso (cycleThree <>> cycleThree <>> cycleThree) (1, 2.0, 3)
+:p appIso (cycleThree &>> cycleThree &>> cycleThree) (1, 2.0, 3)
 > (1, (2.0, 3))
 
 'Note that we assume but do not check that the isomorphism is lawful (i.e.
 `appIso iso $ revIso iso x == x` for all `x`, or equivalently
-`iso <>> (flipIso iso) == idIso`).
+`iso &>> (flipIso iso) == idIso`).
 
 'In addition, Dex will automatically write some useful isomorphisms for you
 to extract fields from records and variants. There are four syntactic forms
@@ -150,7 +150,7 @@ another. For instance:
 >        { bwd = \({a = x:(), ...l:()}, {, ...r:()}). (,) {, ...l} {a = x, ...r}
 >        , fwd = \({, ...l:()}, {a = x:(), ...r:()}). (,) {a = x, ...l} {, ...r}})
 
-:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) (#&a <>> #&b)
+:t astype (Iso ({&} & {a:Int & b:Float & c:Unit}) _) (#&a &>> #&b)
 > (Iso
 >    ({ &} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32 & b: Float32} & {c: Unit}))
@@ -172,36 +172,36 @@ when using a record type as an index set:
     ordinal a * 100 + ordinal b * 10 + ordinal c
   v1 = x
   v2 = sum $ overFields (#&b) x
-  v3 = sum $ overFields (#&b <>> #&c) x
-  v4 = sum $ overFields (#&a <>> #&b <>> #&c) x
+  v3 = sum $ overFields (#&b &>> #&c) x
+  v4 = sum $ overFields (#&a &>> #&b &>> #&c) x
   (v1, v2, v3, v4)
 > ( [0, 100, 10, 110, 1, 101, 11, 111]@{a: Fin 2 & b: Fin 2 & c: Fin 2}
 > , ([10, 210, 12, 212]@{a: Fin 2 & c: Fin 2}, ([22, 422]@{a: Fin 2}, [444]@{ &})) )
 
 'Note that `overFields` is just a simple wrapper combining `splitR` and
-`over`:
+`overLens`:
 
 :t splitR
 > ((a:Type) ?-> Iso a ({ &} & a))
 
-:t over
+:t overLens
 > ((a:Type)
 >  ?-> (b:Type)
 >  ?-> (c:Type) ?-> (v:Type) ?-> (Iso a (b & c)) -> (a => v) -> b => c => v)
 
-'`over` alone can be used with any lens-like isomorphism, for instance an
+'`overLens` alone can be used with any lens-like isomorphism, for instance an
 ordinary record accessor lens.
 
 :p
   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
     ordinal a * 100 + ordinal b * 10 + ordinal c
-  over #a x
+  overLens #a x
 > [ [0, 10, 1, 11]@{b: Fin 2 & c: Fin 2}
 > , [100, 110, 101, 111]@{b: Fin 2 & c: Fin 2} ]
 
 '`splitR` can be used if you want to process multiple fields at once:
 
-:p pushAt (splitR <>> #&a <>> #&b) {a=1, b=2.0} {c=3, d=4.0}
+:p pushAt (splitR &>> #&a &>> #&b) {a=1, b=2.0} {c=3, d=4.0}
 > {a = 1, b = 2.0, c = 3, d = 4.0}
 
 '## Variant zipper isomorphisms
@@ -239,7 +239,7 @@ zipper isomorphisms:
 
 :p
   vals = [{|a = 1|}, {|b = 2|}, {|c = 3|}]:(Fin 3 => {a:_ | b:_ | c:_})
-  for i. matchWith (splitV <>> #|a <>> #|b) vals.i
+  for i. matchWith (splitV &>> #|a &>> #|b) vals.i
 > [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
 
 '`sliceFields` uses this to specific named variants from a variant-indexed
@@ -249,8 +249,8 @@ table:
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}
   v1 = x
   v2 = sliceFields (#|b) x
-  v3 = sliceFields (#|a <>> #|c) x
-  v4 = sliceFields (#|a <>> #|b <>> #|c) x
+  v3 = sliceFields (#|a &>> #|c) x
+  v4 = sliceFields (#|a &>> #|b &>> #|c) x
   (v1, v2, v3, v4)
 > ( [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2}
 > , ( [2, 3]@{b: Fin 2}

--- a/makefile
+++ b/makefile
@@ -67,7 +67,8 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 ad-tests mandelbrot pi sierpinsky \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator parser-tests serialize-tests \
-                mcmc record-variant-tests simple-include-test ctc raytrace
+                mcmc record-variant-tests simple-include-test ctc raytrace \
+                isomorphisms
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -93,7 +93,8 @@ def swap (p:(a&b)) : (b&a) = (snd p, fst p)
 
 def astype (t:Type) (x:t) : t = x  -- to give hints to type inference
 
-def o (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
+def (<<<) (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
+def (>>>) (g: a -> b) (f: b -> c) : a -> c = \x. f (g x)
 
 flip : (a -> b -> c) -> (b -> a -> c) = \f x y. f y x
 uncurry : (a -> b -> c) -> (a & b) -> c = \f (x,y). f x y
@@ -604,15 +605,17 @@ def revIso (iso: Iso a b) (x:b) : a = appIso (flipIso iso) x
 
 idIso : Iso a a = MkIso {fwd=id, bwd=id}
 
-def chainIsos (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
+def (<>>) (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
   (MkIso {fwd=fwd1, bwd=bwd1}) = iso1
   (MkIso {fwd=fwd2, bwd=bwd2}) = iso2
-  MkIso {fwd=(fwd2 `o` fwd1), bwd=(bwd1 `o` bwd2)}
+  MkIso {fwd=(fwd1 >>> fwd2), bwd=(bwd1 <<< bwd2)}
+
+def (<<>) (iso2: Iso b c) (iso1: Iso a b) : Iso a c = iso1 <>> iso2
 
 -- Lens-like accessors
 -- (note: #foo is an Iso {foo: a, ...b} (a & {...b}))
-def getAt  (iso: Iso a (b & c)) : a -> b = fst `o` appIso iso
-def popAt  (iso: Iso a (b & c)) : a -> c = snd `o` appIso iso
+def getAt  (iso: Iso a (b & c)) : a -> b = fst <<< appIso iso
+def popAt  (iso: Iso a (b & c)) : a -> c = snd <<< appIso iso
 def pushAt (iso: Iso a (b & c)) (x:b) (r:c) : a = revIso iso (x, r)
 def setAt  (iso: Iso a (b & c)) (x:b) (r:a) : a =
   pushAt iso x $ popAt iso r
@@ -628,7 +631,7 @@ swapPairIso : Iso (a & b) (b & a) =
   MkIso {fwd = \(a, b). (b, a), bwd = \(b, a). (a, b)}
 
 -- Complement the focus of a lens-like isomorphism
-exceptLens : Iso a (b & c) -> Iso a (c & b) = \iso. iso `chainIsos` swapPairIso
+exceptLens : Iso a (b & c) -> Iso a (c & b) = \iso. iso <>> swapPairIso
 
 swapEitherIso : Iso (a | b) (b | a) =
   fwd = \x. case x of
@@ -640,7 +643,7 @@ swapEitherIso : Iso (a | b) (b | a) =
   MkIso {fwd, bwd}
 
 -- Complement the focus of a prism-like isomorphism
-exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso `chainIsos` swapEitherIso
+exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso <>> swapEitherIso
 
 -- Use a lens-like iso to split a 1d table into a 2d table
 def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
@@ -650,7 +653,7 @@ def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
 -- Convert a lens zipper isomorphism to a normal lens-like isomorphism
 startLZip : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 def lensFields (iso: Iso ({&} & a) (b & c)) : Iso a (b & c) =
-  startLZip `chainIsos` iso
+  startLZip <>> iso
 
 def overFields (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
   over (lensFields iso) tab
@@ -659,7 +662,7 @@ def overFields (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
 startPZip : Iso a ({|} | a) =
   MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
 def prismFields (iso: Iso ({|} | a) (b | c)) : Iso a (b | c) =
-  startPZip `chainIsos` iso
+  startPZip <>> iso
 
 def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
   reindex (buildWith $ prismFields iso) tab

--- a/prelude.dx
+++ b/prelude.dx
@@ -91,6 +91,10 @@ def fst (p: (a & b)) : a = %fst p
 def snd (p: (a & b)) : b = %snd p
 def swap (p:(a&b)) : (b&a) = (snd p, fst p)
 
+def astype (t:Type) (x:t) : t = x  -- to give hints to type inference
+
+def o (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
+
 flip : (a -> b -> c) -> (b -> a -> c) = \f x y. f y x
 uncurry : (a -> b -> c) -> (a & b) -> c = \f (x,y). f x y
 const : a -> b -> a = \x _. x
@@ -331,6 +335,8 @@ def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
 
 def slice (xs:n=>a) (start:Int) (m:Type) : m=>a =
   for i. xs.(fromOrdinal _ (ordinal i + start))
+
+def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
 def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
   swap $ withState init \s. for i.
@@ -581,3 +587,79 @@ def (<>) (x:List a) (y:List a) : List a =
     case i' < nx of
       True  -> xs.(fromOrdinal _ i')
       False -> ys.(fromOrdinal _ (i' - nx))
+
+'Isomorphisms
+
+data Iso a:Type b:Type = MkIso { fwd: a -> b & bwd: b -> a }
+
+def appIso (iso: Iso a b) (x:a) : b =
+  (MkIso {fwd, bwd}) = iso
+  fwd x
+
+def flipIso (iso: Iso a b) : Iso b a =
+  (MkIso {fwd, bwd}) = iso
+  MkIso {fwd=bwd, bwd=fwd}
+
+def revIso (iso: Iso a b) (x:b) : a = appIso (flipIso iso) x
+
+idIso : Iso a a = MkIso {fwd=id, bwd=id}
+
+def chainIsos (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
+  (MkIso {fwd=fwd1, bwd=bwd1}) = iso1
+  (MkIso {fwd=fwd2, bwd=bwd2}) = iso2
+  MkIso {fwd=(fwd2 `o` fwd1), bwd=(bwd1 `o` bwd2)}
+
+-- Lens-like accessors
+-- (note: #foo is an Iso {foo: a, ...b} (a & {...b}))
+def getAt  (iso: Iso a (b & c)) : a -> b = fst `o` appIso iso
+def popAt  (iso: Iso a (b & c)) : a -> c = snd `o` appIso iso
+def pushAt (iso: Iso a (b & c)) (x:b) (r:c) : a = revIso iso (x, r)
+def setAt  (iso: Iso a (b & c)) (x:b) (r:a) : a =
+  pushAt iso x $ popAt iso r
+
+-- Prism-like accessors
+def matchWith (iso: Iso a (b | c)) (x: a) : Maybe b =
+  case appIso iso x of
+    Left x -> Just x
+    Right _ -> Nothing
+def buildWith (iso: Iso a (b | c)) (x: b) : a = revIso iso $ Left x
+
+swapPairIso : Iso (a & b) (b & a) =
+  MkIso {fwd = \(a, b). (b, a), bwd = \(b, a). (a, b)}
+
+-- Complement the focus of a lens-like isomorphism
+exceptLens : Iso a (b & c) -> Iso a (c & b) = \iso. iso `chainIsos` swapPairIso
+
+swapEitherIso : Iso (a | b) (b | a) =
+  fwd = \x. case x of
+    Left l -> Right l
+    Right r -> Left r
+  bwd = \x. case x of
+    Left r -> Right r
+    Right l -> Left l
+  MkIso {fwd, bwd}
+
+-- Complement the focus of a prism-like isomorphism
+exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso `chainIsos` swapEitherIso
+
+-- Use a lens-like iso to split a 1d table into a 2d table
+def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
+  for i j. tab.(revIso iso (i, j))
+
+-- Zipper isomorphisms to easily specify many record/variant fields
+-- Convert a lens zipper isomorphism to a normal lens-like isomorphism
+startLZip : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
+def lensFields (iso: Iso ({&} & a) (b & c)) : Iso a (b & c) =
+  startLZip `chainIsos` iso
+
+def overFields (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
+  over (lensFields iso) tab
+
+-- Convert a prism zipper isomorphism to a normal prism-like isomorphism
+startPZip : Iso a ({|} | a) =
+  MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
+def prismFields (iso: Iso ({|} | a) (b | c)) : Iso a (b | c) =
+  startPZip `chainIsos` iso
+
+def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
+  reindex (buildWith $ prismFields iso) tab

--- a/prelude.dx
+++ b/prelude.dx
@@ -605,12 +605,12 @@ def revIso (iso: Iso a b) (x:b) : a = appIso (flipIso iso) x
 
 idIso : Iso a a = MkIso {fwd=id, bwd=id}
 
-def (<>>) (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
+def (&>>) (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
   (MkIso {fwd=fwd1, bwd=bwd1}) = iso1
   (MkIso {fwd=fwd2, bwd=bwd2}) = iso2
   MkIso {fwd=(fwd1 >>> fwd2), bwd=(bwd1 <<< bwd2)}
 
-def (<<>) (iso2: Iso b c) (iso1: Iso a b) : Iso a c = iso1 <>> iso2
+def (<<&) (iso2: Iso b c) (iso1: Iso a b) : Iso a c = iso1 &>> iso2
 
 -- Lens-like accessors
 -- (note: #foo is an Iso {foo: a & ...b} (a & {&...b}))
@@ -632,7 +632,7 @@ swapPairIso : Iso (a & b) (b & a) =
   MkIso {fwd = \(a, b). (b, a), bwd = \(b, a). (a, b)}
 
 -- Complement the focus of a lens-like isomorphism
-exceptLens : Iso a (b & c) -> Iso a (c & b) = \iso. iso <>> swapPairIso
+exceptLens : Iso a (b & c) -> Iso a (c & b) = \iso. iso &>> swapPairIso
 
 swapEitherIso : Iso (a | b) (b | a) =
   fwd = \x. case x of
@@ -644,10 +644,10 @@ swapEitherIso : Iso (a | b) (b | a) =
   MkIso {fwd, bwd}
 
 -- Complement the focus of a prism-like isomorphism
-exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso <>> swapEitherIso
+exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso &>> swapEitherIso
 
 -- Use a lens-like iso to split a 1d table into a 2d table
-def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
+def overLens (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
   for i j. tab.(revIso iso (i, j))
 
 -- Zipper isomorphisms to easily specify many record/variant fields:
@@ -655,16 +655,16 @@ def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
 -- #|foo is an Iso ({|...l} | {foo:a | ...r}) ({foo:a | ...l} | {|...r})
 
 -- Convert a record zipper isomorphism to a normal lens-like isomorphism
--- by using splitR <>> iso
+-- by using splitR &>> iso
 splitR : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 
 def overFields (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
-  over (splitR <>> iso) tab
+  overLens (splitR &>> iso) tab
 
 -- Convert a variant zipper isomorphism to a normal prism-like isomorphism
--- by using splitV <>> iso
+-- by using splitV &>> iso
 splitV : Iso a ({|} | a) =
   MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
 
 def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
-  reindex (buildWith $ splitV <>> iso) tab
+  reindex (buildWith $ splitV &>> iso) tab

--- a/prelude.dx
+++ b/prelude.dx
@@ -613,7 +613,7 @@ def (<>>) (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
 def (<<>) (iso2: Iso b c) (iso1: Iso a b) : Iso a c = iso1 <>> iso2
 
 -- Lens-like accessors
--- (note: #foo is an Iso {foo: a, ...b} (a & {...b}))
+-- (note: #foo is an Iso {foo: a & ...b} (a & {&...b}))
 def getAt  (iso: Iso a (b & c)) : a -> b = fst <<< appIso iso
 def popAt  (iso: Iso a (b & c)) : a -> c = snd <<< appIso iso
 def pushAt (iso: Iso a (b & c)) (x:b) (r:c) : a = revIso iso (x, r)
@@ -621,6 +621,7 @@ def setAt  (iso: Iso a (b & c)) (x:b) (r:a) : a =
   pushAt iso x $ popAt iso r
 
 -- Prism-like accessors
+-- (note: #?foo is an Iso {foo: a | ...b} (a | {|...b}))
 def matchWith (iso: Iso a (b | c)) (x: a) : Maybe b =
   case appIso iso x of
     Left x -> Just x
@@ -649,20 +650,21 @@ exceptPrism : Iso a (b | c) -> Iso a (c | b) = \iso. iso <>> swapEitherIso
 def over (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
   for i j. tab.(revIso iso (i, j))
 
--- Zipper isomorphisms to easily specify many record/variant fields
--- Convert a lens zipper isomorphism to a normal lens-like isomorphism
-startLZip : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
-def lensFields (iso: Iso ({&} & a) (b & c)) : Iso a (b & c) =
-  startLZip <>> iso
+-- Zipper isomorphisms to easily specify many record/variant fields:
+-- #&foo is an Iso ({&...l} & {foo:a & ...r}) ({foo:a & ...l} & {&...r})
+-- #|foo is an Iso ({|...l} | {foo:a | ...r}) ({foo:a | ...l} | {|...r})
+
+-- Convert a record zipper isomorphism to a normal lens-like isomorphism
+-- by using splitR <>> iso
+splitR : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 
 def overFields (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
-  over (lensFields iso) tab
+  over (splitR <>> iso) tab
 
--- Convert a prism zipper isomorphism to a normal prism-like isomorphism
-startPZip : Iso a ({|} | a) =
+-- Convert a variant zipper isomorphism to a normal prism-like isomorphism
+-- by using splitV <>> iso
+splitV : Iso a ({|} | a) =
   MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
-def prismFields (iso: Iso ({|} | a) (b | c)) : Iso a (b | c) =
-  startPZip <>> iso
 
 def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
-  reindex (buildWith $ prismFields iso) tab
+  reindex (buildWith $ splitV <>> iso) tab

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -571,7 +571,7 @@ instance PrettyPrec UPat' where
     UPatPair x y -> atPrec ArgPrec $ parens $ p x <> ", " <> p y
     UPatUnit -> atPrec ArgPrec $ "()"
     UPatCon con pats -> atPrec AppPrec $ parens $ p con <+> spaced pats
-    UPatRecord pats -> prettyExtLabeledItems pats (line <> "&") ":"
+    UPatRecord pats -> prettyExtLabeledItems pats (line' <> ",") " ="
     UPatVariant labels label value -> prettyVariant labels label value
     UPatVariantLift labels value -> prettyVariantLift labels value
 

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -674,7 +674,7 @@ ops =
   , [symOp "+", symOp "-", symOp "||", symOp "&&",
      InfixR $ sym "=>" $> mkArrow TabArrow,
      InfixL $ opWithSrc $ backquoteName >>= (return . binApp),
-     symOp "<<<", symOp ">>>", symOp "<<>", symOp "<>>"]
+     symOp "<<<", symOp ">>>", symOp "<<&", symOp "&>>"]
   , [InfixR $ mayBreak (infixSym "$") $> mkApp]
   , [symOp "+=", symOp ":=", InfixL $ pairingSymOpP "|", InfixR infixArrow]
   , [InfixR $ pairingSymOpP "&", InfixR $ pairingSymOpP ","]
@@ -849,7 +849,7 @@ doubleLit = lexeme $
 
 knownSymStrs :: [String]
 knownSymStrs = [".", ":", "!", "=", "-", "+", "||", "&&", "$", "&", "|", ",", "+=", ":=",
-                "->", "=>", "?->", "?=>", "--o", "--", "<<<", ">>>", "<<>", "<>>",
+                "->", "=>", "?->", "?=>", "--o", "--", "<<<", ">>>", "<<&", "&>>",
                 "..", "<..", "..<", "..<", "<..<"]
 
 -- string must be in `knownSymStrs`

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -673,7 +673,8 @@ ops =
   , [anySymOp] -- other ops with default fixity
   , [symOp "+", symOp "-", symOp "||", symOp "&&",
      InfixR $ sym "=>" $> mkArrow TabArrow,
-     InfixL $ opWithSrc $ backquoteName >>= (return . binApp)]
+     InfixL $ opWithSrc $ backquoteName >>= (return . binApp),
+     symOp "<<<", symOp ">>>", symOp "<<>", symOp "<>>"]
   , [InfixR $ mayBreak (infixSym "$") $> mkApp]
   , [symOp "+=", symOp ":=", InfixL $ pairingSymOpP "|", InfixR infixArrow]
   , [InfixR $ pairingSymOpP "&", InfixR $ pairingSymOpP ","]
@@ -848,7 +849,7 @@ doubleLit = lexeme $
 
 knownSymStrs :: [String]
 knownSymStrs = [".", ":", "!", "=", "-", "+", "||", "&&", "$", "&", "|", ",", "+=", ":=",
-                "->", "=>", "?->", "?=>", "--o", "--",
+                "->", "=>", "?->", "?=>", "--o", "--", "<<<", ">>>", "<<>", "<>>",
                 "..", "<..", "..<", "..<", "<..<"]
 
 -- string must be in `knownSymStrs`

--- a/src/lib/RenderHtml.hs
+++ b/src/lib/RenderHtml.hs
@@ -84,10 +84,12 @@ syntaxSpan s c = H.span (toHtml s) ! class_ (stringValue className)
       CommandStr  -> "command"
       SymbolStr   -> "symbol"
       TypeNameStr -> "type-name"
+      IsoSugarStr -> "iso-sugar"
       NormalStr -> error "Should have been matched already"
 
 data StrClass = NormalStr
               | CommentStr | KeywordStr | CommandStr | SymbolStr | TypeNameStr
+              | IsoSugarStr
 
 classify :: Parser StrClass
 classify =
@@ -96,6 +98,8 @@ classify =
    <|> (do s <- lowerWord
            return $ if s `elem` keyWordStrs then KeywordStr else NormalStr)
    <|> (upperWord >> return TypeNameStr)
+   <|> (char '#' >> (char '?' <|> char '&' <|> char '|' <|> pure ' ')
+        >> lowerWord >> return IsoSugarStr)
    <|> (some symChar >> return SymbolStr)
    <|> (anySingle >> return NormalStr)
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -167,6 +167,8 @@ simplifyExpr expr = case expr of
       DataCon def params con xs -> return $ DataCon def params' con xs'
          where DataDef _ paramBs _ = def
                (params', xs') = splitAt (length paramBs) $ params ++ xs ++ [x']
+      TypeCon def params -> return $ TypeCon def params'
+         where params' = params ++ [x']
       _ -> emit $ App f' x'
   Op  op  -> mapM simplifyAtom op >>= simplifyOp
   Hof hof -> simplifyHof hof

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -186,6 +186,9 @@ instance Semigroup (LabeledItems a) where
   LabeledItems items <> LabeledItems items' =
     LabeledItems $ M.unionWith (<>) items items'
 
+instance Monoid (LabeledItems a) where
+  mempty = NoLabeledItems
+
 -- Extensible version of LabeledItems, which allows an optional object in tail
 -- position. The items of the tail object will always be interpreted as a
 -- "suffix" in the sense that for any field label, the object represented by

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -250,10 +250,10 @@ data UPat' = UPatBinder UBinder
            | UPatVariantLift (LabeledItems ()) UPat     -- {|a|b| ...rest |}
              deriving (Show)
 
-data WithSrc a = WithSrc SrcPos a
+data WithSrc a = WithSrc SrcCtx a
                  deriving (Show, Functor, Foldable, Traversable)
 
-srcPos :: WithSrc a -> SrcPos
+srcPos :: WithSrc a -> SrcCtx
 srcPos (WithSrc pos _) = pos
 
 -- === primitive constructors and operators ===

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -190,7 +190,9 @@ checkApp fTy x = do
 -- TODO: replace with something more precise (this is too cautious)
 blockEffs :: Block -> EffectSummary
 blockEffs (Block decls result) =
-  foldMap (\(Let _ _ expr) -> exprEffs expr) decls <> exprEffs result
+  foldMap declEffs decls <> exprEffs result
+  where declEffs (Let _ _ expr) = exprEffs expr
+        declEffs (Unpack _ expr) = exprEffs expr
 
 isPure :: Expr -> Bool
 isPure expr = case exprEffs expr of

--- a/static/style.css
+++ b/static/style.css
@@ -69,3 +69,7 @@ code {
 .type-name {
   color: #A80000;
 }
+
+.iso-sugar {
+  color: #25BBA7;
+}


### PR DESCRIPTION
Adds an `Iso a b` ADT to the prelude, which corresponds to an isomorphism between two types. Also implements four syntax constructs for constructing isomorphisms based on record and variant fields:

- `#foo` extracts the value from field foo of a record
- `#?foo` tries to extract the value from field foo of a variant
- `#&foo` moves field foo from one record to another (loosely inspired by the "zipper" pattern in functional programming)
- `#|foo` moves field foo from one variant to another

Together, these four forms make it possible to reference either single fields of records/variants or combinations of fields.

Additionally, adds some new helper functions to the prelude to work with these new isomorphisms. In particular, lens-like helper functions allow treating values of type `Iso a (b & c)` like lenses, and prism-like helper functions allow treating values of type `Iso a (b | c)` like prisms. There are also "zipper" helper functions that help with moving fields around.

Also add operators `<<<`, `>>>`, `<>>`, `<<>`. The first two are for function composition; the second two are for isomorphism composition. Eventually, we might be able to use a `Category` typeclass and just have `<<<` and `>>>`, but I don't think we can be polymorphic over `(->)` vs `Iso` in the current type system. (Also, `.` is already reserved for table application!)

Desugaring is done inside the parser; to support this, I've made the `SrcPos` in `WithSrc` optional.

---

Misc notes:

This PR supersedes #205. Having a more general `Iso` type seems like a simpler and more generally useful abstraction than the specific isomorphism lens/prism hybrid ADT. Direct isomorphisms don't compose in exactly the same ways as lenses and prisms, but it should be possible to adapt some of the combinators from #205 to work on `Iso`s if they end up being useful. I also think that the "zipper" isomorphisms are easier to use than the lens combinator forms in #205, because they compose using ordinary isomorphism composition, and they also preserve field names.

It's slightly annoying to have four different syntax forms for the four different types of isomorphism. I briefly considered having a single `#foo` form that would be resolved using a typeclass, similar to Haskell's `OverloadedLabels`, but I don't think Dex's type system is powerful enough to do that yet. I've prefixed all the syntax forms with `#` so that they don't clutter up the symbol namespace too much.

I went through a few iterations of this before settling on this one. In an earlier version, I did the desugaring inside inference instead of in the parser. That ended up being a lot more complicated, though, because it had to directly build something in the core IR, and thus ended up partially duplicating some stuff in the type inference logic.

A weird property of the "zipper" forms is that they reverse the order of repeated field names. But I'm not sure how often that would come up in practice; it seems like usually when referencing fields by name you would want to have unique names.