### PR TITLE
Defunctionalize through case expressions

### DIFF
--- a/examples/eval-tests.dx
+++ b/examples/eval-tests.dx
@@ -771,3 +771,12 @@ s1 = "hello world"
 
 :p s1
 > ['h', 'e', 'l', 'l', 'o', ' ', 'w', 'o', 'r', 'l', 'd']
+
+:p
+  x = 2 + 2
+  y = 2 + 4
+  f = \z. case z == 4 of
+            True  -> (\w. w + 2)
+            False -> (\w. w)
+  (f x 4, f y 4)
+> (6, 4)

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -327,7 +327,6 @@ linearizeAtom atom = case atom of
     wrt <- ask
     return (atom, buildLam i TabArrow $ \i' ->
                     rematPrimal wrt $ linearizeBlock (i@>i') body)
-  Lam _ -> error "Unexpected non-table lambda"
   DataCon _ _ _ _ -> notImplemented  -- Need to synthesize or look up a tangent ADT
   Record elems    -> Record <$> traverse linearizeAtom elems
   Variant t l i e -> Variant t l i <$> linearizeAtom e
@@ -338,6 +337,9 @@ linearizeAtom atom = case atom of
   Pi _            -> emitWithZero
   TC _            -> emitWithZero
   Eff _           -> emitWithZero
+  -- Those should be gone after simplification
+  Lam _           -> error "Unexpected non-table lambda"
+  ACase _ _ _     -> error "Unexpected ACase"
   where
     emitWithZero = LinA $ return $ withZeroTangent atom
     rematPrimal wrt m = do
@@ -630,6 +632,7 @@ transposeAtom atom ct = case atom of
   Pi _            -> notTangent
   TC _            -> notTangent
   Eff _           -> notTangent
+  ACase _ _ _     -> error "Unexpected ACase"
   where notTangent = error $ "Not a tangent atom: " ++ pprint atom
 
 transposeCon :: Con -> Atom -> TransposeM ()

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -146,10 +146,13 @@ instance PrettyPrec Expr where
   prettyPrec (Hof (For dir (Lam lamExpr))) =
     atPrec LowestPrec $ dirStr dir <+> prettyLamHelper lamExpr (PrettyFor dir)
   prettyPrec (Hof hof) = prettyPrec hof
-  prettyPrec (Case e alts _) = atPrec LowestPrec $ "case" <+> p e <+> "of" <>
-    nest 2 (hardline <> foldMap (\alt -> prettyAlt alt <> hardline) alts)
+  prettyPrec (Case e alts _) = prettyPrecCase "case" e alts
 
-prettyAlt :: Alt -> Doc ann
+prettyPrecCase :: Pretty b => Doc ann -> Atom -> [AltP b] -> DocPrec ann
+prettyPrecCase name e alts = atPrec LowestPrec $ name <+> p e <+> "of" <>
+  nest 2 (hardline <> foldMap (\alt -> prettyAlt alt <> hardline) alts)
+
+prettyAlt :: Pretty b => AltP b -> Doc ann
 prettyAlt (Abs bs body) =
   hsep (map prettyBinderNoAnn $ toList bs) <+> "->" <> nest 2 (p body)
 
@@ -334,6 +337,7 @@ instance PrettyPrec Atom where
             _ -> M.singleton label $ NE.fromList $ fmap (const ()) [1..i]
     RecordTy items -> prettyExtLabeledItems items (line <> "&") ":"
     VariantTy items -> prettyExtLabeledItems items (line <> "|") ":"
+    ACase e alts _ -> prettyPrecCase "acase" e alts
 
 fromInfix :: Text -> Maybe Text
 fromInfix t = do

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -31,6 +31,7 @@ import Data.List (transpose)
 
 import Array
 import Interpreter
+import Simplify
 import Type hiding (indexSetConcreteSize)
 import Syntax
 import PPrint
@@ -208,6 +209,9 @@ prettyVal val = case val of
             asStr $ prettyVal $ evalBlock mempty $ snd $ applyAbs abs idx
           idxSetStr = case idxSet of FixedIntRange l _ | l == 0 -> mempty
                                      _                          -> "@" <> pretty idxSet
+  ACase e alts _ -> case simplifyCase e alts of
+    Just (env, atom) -> prettyVal $ subst (env, mempty) atom
+    Nothing          -> error $ "Failed to reduce an acase: " ++ pprint val
   Con con -> case con of
     PairCon x y -> pretty (asStr $ prettyVal x, asStr $ prettyVal y)
     Coerce t i  -> pretty i <> "@" <> pretty t

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -6,7 +6,7 @@
 
 {-# LANGUAGE FlexibleContexts #-}
 
-module Simplify (simplifyModule, evalSimplified) where
+module Simplify (simplifyModule, simplifyCase, evalSimplified) where
 
 import Control.Monad
 import Control.Monad.Identity
@@ -107,7 +107,34 @@ simplifyAtom atom = case atom of
     substEmbedR types <*> pure label <*> pure i <*> simplifyAtom value
   VariantTy items -> VariantTy <$> substEmbedR items
   LabeledRow items -> LabeledRow <$> substEmbedR items
+  ACase e alts rty   -> do
+    e' <- substEmbedR e
+    case simplifyCase e' alts of
+      Just (env, result) -> extendR env $ simplifyAtom result
+      Nothing -> do
+        alts' <- forM alts $ \(Abs bs a) -> do
+          bs' <- mapM (mapM substEmbedR) bs
+          (Abs bs'' b) <- buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ simplifyAtom a
+          case b of
+            Block Empty (Atom r) -> return $ Abs bs'' r
+            _                    -> error $ "Nontrivial block in ACase simplification"
+        ACase e' alts' <$> (substEmbedR rty)
   where mkAny t = Con . AnyValue <$> substEmbedR t >>= simplifyAtom
+
+simplifyCase :: Atom -> [AltP a] -> Maybe (SubstEnv, a)
+simplifyCase e alts = case e of
+  DataCon _ _ con args -> do
+    let Abs bs result = alts !! con
+    Just (newEnv bs args, result)
+  Variant (NoExt types) label i value -> do
+    let LabeledItems ixtypes = enumerate types
+    let index = fst $ (ixtypes M.! label) NE.!! i
+    let Abs bs result = alts !! index
+    Just (newEnv bs [value], result)
+  Con (SumAsProd _ (TagRepVal tag) vals) -> do
+    let Abs bs result = alts !! (fromIntegral tag)
+    Just (newEnv bs (vals !! fromIntegral tag), result)
+  _ -> Nothing
 
 -- `Nothing` is equivalent to `Just return` but we can pattern-match on it
 type Reconstruct m a = Maybe (a -> m a)
@@ -122,35 +149,37 @@ simplifyBinaryLam = simplifyLams 2
 simplifyLams :: Int -> Atom -> SimplifyM (Atom, Reconstruct SimplifyM Atom)
 simplifyLams numArgs lam = do
   lam' <- substEmbedR lam
-  dropSub $ simplifyLams' numArgs mempty $ Block Empty $ Atom lam'
+  dropSub $ go numArgs mempty $ Block Empty $ Atom lam'
+  where
+    go 0 scope block = do
+      result <- defunBlock scope block
+      return $ case result of
+        Left  res        -> (res         , Nothing)
+        Right (f, recon) -> (mkConsList f, Just $ unpackConsList >=> recon)
+    go n scope ~(Block Empty (Atom (Lam (Abs b (arr, body))))) = do
+      b' <- mapM substEmbedR b
+      buildLamAux b' (\x -> extendR (b@>x) $ substEmbedR arr) $ \x@(Var v) -> do
+        let scope' = scope <> v @> (varType v, LamBound (void arr))
+        extendR (b@>x) $ go (n-1) scope' body
 
-simplifyLams' :: Int -> Scope -> Block
-              -> SimplifyM (Atom, Reconstruct SimplifyM Atom)
-simplifyLams' 0 scope block = do
+defunBlock :: MonadEmbed m => Scope -> Block -> SimplifyM (Either Atom ([Atom], [Atom] -> m Atom))
+defunBlock localScope block = do
   topScope <- getScope
   if isData topScope (getType block)
-    then liftM (,Nothing) $ simplifyBlock block
+    then Left <$> simplifyBlock block
     else do
-      (block', (scope', decls)) <- embedScoped $ simplifyBlock block
+      (result, (localScope', decls)) <- embedScoped $ simplifyBlock block
       mapM_ emitDecl decls
-      let (dataVals, recon) = separateDataComponent (scope <> scope') block'
-      return (dataVals, Just recon)
-simplifyLams' n scope (Block Empty (Atom (Lam (Abs b (arr, body))))) = do
-  b' <- mapM substEmbedR b
-  buildLamAux b' (\x -> extendR (b@>x) $ substEmbedR arr) $ \x@(Var v) -> do
-    let scope' = scope <> v @> (varType v, LamBound (void arr))
-    extendR (b@>x) $ simplifyLams' (n-1) scope' body
-simplifyLams' _ _ _ = error "Expected n lambdas"
+      let (dataVals, recon) = separateDataComponent (localScope <> localScope') result
+      return $ Right (dataVals, recon)
 
-separateDataComponent :: MonadEmbed m => Scope -> Atom -> (Atom, Atom -> m Atom)
-separateDataComponent localVars atom = (mkConsList $ map Var vs, recon)
+separateDataComponent :: MonadEmbed m => Scope -> Atom -> ([Atom], [Atom] -> m Atom)
+separateDataComponent localVars atom = (map Var vs, recon)
   where
     vs = bindingsAsVars $ localVars `envIntersect` freeVars atom
-    recon :: MonadEmbed m => Atom -> m Atom
     recon xs = do
-      xs' <- unpackConsList xs
       scope <- getScope
-      return $ subst (newEnv vs xs', scope) atom
+      return $ subst (newEnv vs xs, scope) atom
 
 applyRecon :: MonadEmbed m => Maybe (Atom -> m Atom) -> Atom -> m Atom
 applyRecon Nothing x = return x
@@ -167,6 +196,10 @@ simplifyExpr expr = case expr of
       DataCon def params con xs -> return $ DataCon def params' con xs'
          where DataDef _ paramBs _ = def
                (params', xs') = splitAt (length paramBs) $ params ++ xs ++ [x']
+      ACase e alts ~(Pi ab) -> do
+        let rty' = snd $ applyAbs ab $ getType x'
+        let alts' = flip fmap alts $ \(Abs bs a) -> Abs bs $ Block Empty (App a x')
+        dropSub $ simplifyExpr $ Case e alts' rty'
       _ -> emit $ App f' x'
   Op  op  -> mapM simplifyAtom op >>= simplifyOp
   Hof hof -> simplifyHof hof
@@ -174,20 +207,36 @@ simplifyExpr expr = case expr of
   Case e alts resultTy -> do
     e' <- simplifyAtom e
     resultTy' <- substEmbedR resultTy
-    case e' of
-      DataCon _ _ con args -> do
-        let Abs bs body = alts !! con
-        extendR (newEnv bs args) $ simplifyBlock body
-      Variant (NoExt types) label i value -> do
-        let LabeledItems ixtypes = enumerate types
-        let index = fst $ (ixtypes M.! label) NE.!! i
-        let Abs bs body = alts !! index
-        extendR (newEnv bs [value]) $ simplifyBlock body
-      _ -> do
-        alts' <- forM alts $ \(Abs bs body) -> do
-          bs' <-  mapM (mapM substEmbedR) bs
-          buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ simplifyBlock body
-        emit $ Case e' alts' resultTy'
+    case simplifyCase e' alts of
+      Just (env, body) -> extendR env $ simplifyBlock body
+      Nothing -> do
+        topScope <- getScope
+        if isData topScope resultTy'
+          then do
+            alts' <- forM alts $ \(Abs bs body) -> do
+              bs' <-  mapM (mapM substEmbedR) bs
+              buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ simplifyBlock body
+            emit $ Case e' alts' resultTy'
+          else do
+            altsWithRecons <- forM (enumerate alts) $ \(i, Abs bs body) -> do
+              bs' <-  mapM (mapM substEmbedR) bs
+              buildNAbsAux bs' $ \xs -> do
+                ~(Right (res, recon)) <- extendR (newEnv bs' xs) $ defunBlock (boundVars bs') body
+                return (mkConsList res, Just (\ddef -> DataCon ddef [] i res, fmap getType res, recon))
+            let altResultTypes = fmap (\(_, Just (_, t, _)) -> t) altsWithRecons
+            -- TODO: Handle dependency once separateDataComponent supports it
+            let dcons = fmap (DataConDef "Case" . toNest . fmap Ignore) altResultTypes
+            let ddef = DataDef "DefunCase" Empty dcons
+            let alts' = flip fmap altsWithRecons $
+                  \(Abs bs (Block decls _), Just (rval, _, _)) ->
+                    Abs bs $ Block decls $ Atom $ rval ddef
+            caseResult <- emit $ Case e' alts' (TypeCon ddef [])
+            aalts <- forM altsWithRecons $ \(_, Just (_, tys, rec)) -> do
+              (Abs bs' b) <- buildNAbs (toNest $ fmap Ignore tys) $ \free -> rec free
+              case b of
+                Block Empty (Atom r) -> return $ Abs bs' r
+                _ -> error $ "Reconstruction function emitted a nontrivial block: " ++ pprint b
+            return $ ACase caseResult aalts resultTy'
 
 -- TODO: come up with a coherent strategy for ordering these various reductions
 simplifyOp :: Op -> SimplifyM Atom


### PR DESCRIPTION
Current implementation of the simplification pass was unable to
defunctionalize through case expressions, which made it impossible to
return functions from those. This adds support for that, and marks an
important step towards implementing AD for sum types.