### PR TITLE
Differentiation through inactive cases + misc improvements in AD

### DIFF
--- a/examples/ad-tests.dx
+++ b/examples/ad-tests.dx
@@ -111,22 +111,22 @@ f : Float -> Float = \x. snd $ withAccum \ref. ref += x
 :p checkDeriv cos 1.0
 > True
 
--- :p checkDeriv exp 2.0
--- > True
+:p checkDeriv exp 2.0
+> True
 
--- :p checkDeriv log 2.0
--- > True
+:p checkDeriv log 2.0
+> True
 
--- :p checkDeriv sqrt 2.0
--- > True
-
--- :p checkDeriv (\x. cos (sin (exp x))) 2.0
--- > True
+:p checkDeriv (\x. exp (sin (cos x))) 2.0
+> True
 
 :p checkDeriv (deriv sin) 1.0
 > True
 
 :p checkDeriv (deriv cos) 1.0
+> True
+
+:p checkDeriv sqrt 4.0
 > True
 
 -- badDerivFun : Float -> Float
@@ -281,3 +281,8 @@ vec = [1.]
   (y, df) = linearize f 2.0
   checkDerivBase f 2.0
 > True
+
+:p
+  f = max 0.0
+  (checkDeriv f 1.0, checkDeriv f (-1.0))
+> (True, True)

--- a/examples/ad-tests.dx
+++ b/examples/ad-tests.dx
@@ -269,3 +269,15 @@ vec = [1.]
   f = \x. for i:(Fin 4). { x=x * x * (IToF $ ordinal i) }
   jvp f 2.0 1.0
 > [{x = 0.0}, {x = 4.0}, {x = 8.0}, {x = 12.0}]
+
+:p
+  s : { a : Float | b : Float } = case 2 == 2 of
+    False -> {| a=2.0 |}
+    True -> {| b=5.0 |}
+  f = \x.
+    case s of
+      {| a=a |} -> 2.0 * (a + x)
+      {| b=b |} -> b * x
+  (y, df) = linearize f 2.0
+  checkDerivBase f 2.0
+> True

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -36,15 +36,6 @@ def sampleAveraged (_:VSpace a) ?=> (sample:Key -> a) (n:Int) (k:Key) : a =
 
 def positiveProjection (x:n=>Float) (y:n=>Float) : Bool = dot x y > 0.0
 
-def addAt (_:Eq n) ?=> (_:VSpace a) ?=> (xs:n=>a) (i:n) (x:a) : n=>a =
-  for j. case i == j of
-           True  -> xs.j + x
-           False -> xs.j
-
-def gradNumerical (n:Int) ?-> (f:Vec n -> Float) (xs:Vec n) : Vec n =
-  eps = 0.0001
-  for i. (f (addAt xs i eps) - f (addAt xs i (neg eps))) / (2.0 * eps)
-
 data IterResult a:Type b:Type =
   Continue a
   Done b
@@ -198,10 +189,9 @@ def sdScene (scene:Scene n) (pos:Position) : (Object & Distance) =
   (i, d) = minimumBy snd $ for i. (i, sdObject pos objs.i)
   (objs.i, d)
 
--- TODO: use AD!
 def calcNormal (scene:Scene n) (pos:Position) : Direction =
   dist = \p. snd $ sdScene scene p
-  normalize (gradNumerical dist pos)
+  normalize (grad dist pos)
 
 data RayMarchResult =
   -- incident ray, surface normal, surface properties

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -372,10 +372,12 @@ isSingletonType ty = case singletonTypeVal ty of
   Nothing -> False
   Just _  -> True
 
+-- TODO: TypeCon with a single case?
 singletonTypeVal :: Type -> Maybe Atom
 singletonTypeVal (TabTy v a) = TabValA v <$> singletonTypeVal a
+singletonTypeVal (RecordTy (NoExt items)) = Record <$> traverse singletonTypeVal items
 singletonTypeVal (TC con) = case con of
-  PairType a b -> liftM2 PairVal (singletonTypeVal a) (singletonTypeVal b)
+  PairType a b -> PairVal <$> singletonTypeVal a <*> singletonTypeVal b
   UnitType     -> return UnitVal
   _            -> Nothing
 singletonTypeVal _ = Nothing

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -241,6 +241,12 @@ simplifyExpr expr = case expr of
 -- TODO: come up with a coherent strategy for ordering these various reductions
 simplifyOp :: Op -> SimplifyM Atom
 simplifyOp op = case op of
+  Fst (ACase e alts (PairTy xt _)) -> do
+    let alts' = flip fmap alts $ \(Abs bs a) -> Abs bs $ Block Empty (Op $ Fst a)
+    dropSub $ simplifyExpr $ Case e alts' xt
+  Snd (ACase e alts (PairTy _ yt)) -> do
+    let alts' = flip fmap alts $ \(Abs bs a) -> Abs bs $ Block Empty (Op $ Snd a)
+    dropSub $ simplifyExpr $ Case e alts' yt
   Fst (PairVal x _) -> return x
   Snd (PairVal _ y) -> return y
   RecordCons left right -> case getType right of


### PR DESCRIPTION
#### Differentiate through case expressions with inactive scrutinees

While supporting differentiation for sum/variant types is difficult, it
doesn't mean that we can't differentiate any programs that contain
`case` expressions. If the scrutinee contains no active variables, then
this is equivalent to simply selecting one of the paths through the
program, without any effect on the tangent values.

#### A bunch of AD fixes 

* Make it possible to differentiate through programs that branch on
  comparison results (e.g. `max(0, x)`).
* Fix a bug in transposition of `case` expressions.
* Add linearization formulas for `sqrt`, `exp` and `log`.

This allows us to switch the ray tracer to compute surface normals using
AD instead of doing numerical differentiation.