### PR TITLE
Improve defunctionalization of case statements

### DIFF
--- a/examples/ad-tests.dx
+++ b/examples/ad-tests.dx
@@ -284,5 +284,5 @@ vec = [1.]
 
 :p
   f = max 0.0
-  (checkDeriv f 1.0, checkDeriv f (-1.0))
+  (checkDerivBase f 1.0, checkDerivBase f (-1.0))
 > (True, True)

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -71,6 +71,8 @@ linearizeBlock env (Block decls result) = case decls of
             (x, boundLin) <- runLinA $ linearizeExpr env expr
             xs <- if isUnpack then emitUnpack (Atom x) else (:[]) <$> emit (Atom x)
             let vs = fmap (\(Var v) -> v) xs
+            -- NB: This can still overestimate the set of active variables (e.g.
+            --     when multiple values are returned from a case statement).
             -- Don't mark variables with trivial tangent types as active. This lets us avoid
             -- pretending that we're differentiating wrt e.g. equality tests which yield discrete results.
             let nontrivialVsMask = [not $ isSingletonType $ tangentType $ varType v | v <- vs]

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -297,9 +297,11 @@ fromPair pair = (,) <$> getFst pair <*> getSnd pair
 unpackConsList :: MonadEmbed m => Atom -> m [Atom]
 unpackConsList xs = case getType xs of
   UnitTy -> return []
-  _ -> do
+  --PairTy _ UnitTy -> (:[]) <$> getFst xs
+  PairTy _ _ -> do
     (x, rest) <- fromPair xs
     liftM (x:) $ unpackConsList rest
+  _ -> error $ "Not a cons list: " ++ pprint (getType xs)
 
 emitRunWriter :: MonadEmbed m => Name -> Type -> (Atom -> m Atom) -> m Atom
 emitRunWriter v ty body = do

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -11,7 +11,7 @@ module Util (group, ungroup, pad, padLeft, delIdx, replaceIdx,
              scanM, composeN, mapMaybe, uncons, repeated,
              showErr, listDiff, splitMap, enumerate, restructure,
              onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3,
-             bindM2, foldMapM, lookupWithIdx, (...), zipWithT) where
+             bindM2, foldMapM, lookupWithIdx, (...), zipWithT, for) where
 
 import Data.Functor.Identity (Identity(..))
 import Data.List (sort)
@@ -212,3 +212,6 @@ lookupWithIdx k vals = lookup k $ [(x, (i, y)) | (i, (x, y)) <- zip [0..] vals]
 zipWithT :: (Traversable t, Monad h, Foldable f) => (a -> b -> h c) -> t a -> f b -> h (t c)
 zipWithT f trav args = flip evalStateT (toList args) $ flip traverse trav $ \e -> getNext >>= lift . f e
   where getNext = get >>= \(h:t) -> put t >> return h
+
+for :: Functor f => f a -> (a -> b) -> f b
+for = flip fmap


### PR DESCRIPTION
The previous method of extracting the closure necessary to rebuild the
atom after a case statement (find the set of free variables, emit an
acase with the same type as the case) was simple, but unfortunately it
caused the code we emitted later to get quite ugly. It made us emit
another case statment for each output of the case, even the
data-conforming ones.

With this patch, we traverse the product type returned from the case and
gather all the leaf values. All the data-conforming leaves are returned
as they are, since their value can be resolved within this single
branch set. All non-data leaves cause us to emit a "closure value"
indicating which case has been taken and capturing all the local values
necessary to reconstruct the non-data atom. This way we only emit extra
case statements at the use-site of non-data values, which generally are
a relatively small subset of the result.

One important property we get from this is that doing AD on data-only
case statements preserves the number of `case` expressions in the primal
function.