### PR TITLE
Support %indexRef with dependent references

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -347,3 +347,6 @@ def getFst3 (b:Type) ?-> (n:Type) ?-> (xs:n=>b) : b =
 
 :p getFst3 [1,2,3]
 > 1
+
+def triRefIndex (ref:Ref h (i':n=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
+  %indexRef ref i

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -624,9 +624,9 @@ typeCheckOp op = case op of
       MAsk    ->         declareEff (Reader, h) $> s
       MTell x -> x|:s >> declareEff (Writer, h) $> UnitTy
   IndexRef ref i -> do
-    RefTy h (TabTy b a) <- typeCheck ref
-    i |: (binderType b)
-    return $ RefTy h a
+    RefTy h (TabTyAbs a) <- typeCheck ref
+    i |: (absArgType a)
+    return $ RefTy h $ snd $ applyAbs a i
   FstRef ref -> do
     RefTy h (PairTy a _) <- typeCheck ref
     return $ RefTy h a


### PR DESCRIPTION
Partial fix for #239 (`lowerrefindex` type checks now).

cc @duvenaud 