### PR TITLE
Added syntactic sugar for typeclasses.

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -360,3 +360,22 @@ def triRefIndex (ref:Ref h (i':n=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
 -- input type with a non-dependent function type, leading to a later unification errors.
 id (for i:(Fin 2). for j:(..i). 1.0)
 > [[1.0]@(..(0@Fin 2)), [1.0, 1.0]@(..(1@Fin 2))]
+
+interface InterfaceTest1 a:Type where
+  InterfaceTest1 : a
+> Error: variable already defined: InterfaceTest1
+
+interface InterfaceTest2 typeName:Type where
+  typeName : typeName -> typeName
+
+interface InterfaceTest3 _:Type where
+  att : Int32
+
+instance instanceTest3 : InterfaceTest3 where
+  att = 1
+> Type error:
+> Expected: Type
+>   Actual: (Type -> Type)
+>
+> instance instanceTest3 : InterfaceTest3 where
+>                          ^^^^^^^^^^^^^^^

--- a/prelude.dx
+++ b/prelude.dx
@@ -34,36 +34,78 @@ def IToI8  (x : Int)     : Int8    = internalCast _ x
 def IToF (x:Int) : Float = internalCast _ x
 def FToI (x:Float) : Int = internalCast _ x
 
-data Add a:Type =
-  MkAdd (a->a->a) (a->a->a) a  -- add, sub, zero
+interface Add a:Type where
+  add : a -> a -> a
+  sub : a -> a -> a
+  zero : a
 
-def (+)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd add _   _    -> add
-def (-)  (d:Add a) ?=> : a -> a -> a = case d of MkAdd _   sub _    -> sub
-def zero (d:Add a) ?=> : a           = case d of MkAdd _   _   zero -> zero
+def (+)  (d:Add a) ?=> : a -> a -> a = add
+def (-)  (d:Add a) ?=> : a -> a -> a = sub
 
-@instance float64Add : Add Float64 = MkAdd (\x:Float64 y:Float64. %fadd x y) (\x y. %fsub x y) (FToF64 0.0)
-@instance float32Add : Add Float32 = MkAdd (\x:Float32 y:Float32. %fadd x y) (\x y. %fsub x y) (FToF32 0.0)
-@instance int64Add   : Add Int64   = MkAdd (\x:Int64   y:Int64.   %iadd x y) (\x y. %isub x y) (IToI64 0)
-@instance int32Add   : Add Int32   = MkAdd (\x:Int32   y:Int32.   %iadd x y) (\x y. %isub x y) (IToI32 0)
-@instance int8Add    : Add Int8    = MkAdd (\x:Int8    y:Int8.    %iadd x y) (\x y. %isub x y) (IToI8  0)
-@instance unitAdd    : Add Unit    = MkAdd (\x y. ())                        (\x y. ())        ()
+instance float64Add : Add Float64 where
+  add = \x:Float64 y:Float64. %fadd x y
+  sub = \x:Float64 y:Float64. %fsub x y
+  zero = FToF64 0.0
 
-@instance tabAdd : Add a ?=> Add (n=>a) =
-  (MkAdd ( \xs ys. for i. xs.i + ys.i )
-         ( \xs ys. for i. xs.i - ys.i )
-         ( for _. zero ))
+instance float32Add : Add Float32 where
+  add = \x:Float32 y:Float32. %fadd x y
+  sub = \x:Float32 y:Float32. %fsub x y
+  zero = FToF32 0.0
 
-data Mul a:Type = MkMul (a->a->a) a  -- multiply, one
+instance int64Add : Add Int64 where
+  add = \x:Int64 y:Int64. %iadd x y
+  sub = \x:Int64 y:Int64. %isub x y
+  zero = IToI64 0
 
-def (*) (d:Mul a) ?=> : a -> a -> a = case d of MkMul mul _   -> mul
-def one (d:Mul a) ?=> : a           = case d of MkMul _   one -> one
+instance int32Add : Add Int32 where
+  add = \x:Int32 y:Int32. %iadd x y
+  sub = \x:Int32 y:Int32. %isub x y
+  zero = IToI32 0
 
-@instance float64Mul : Mul Float64 = MkMul (\x:Float64 y:Float64. %fmul x y) (FToF64 1.0)
-@instance float32Mul : Mul Float32 = MkMul (\x:Float32 y:Float32. %fmul x y) (FToF32 1.0)
-@instance int64Mul   : Mul Int64   = MkMul (\x:Int64   y:Int64.   %imul x y) (IToI64 1)
-@instance int32Mul   : Mul Int32   = MkMul (\x:Int32   y:Int32.   %imul x y) (IToI32 1)
-@instance int8Mul    : Mul Int8    = MkMul (\x:Int8    y:Int8.    %imul x y) (IToI8  1)
-@instance unitMul    : Mul Unit    = MkMul (\x y. ()) ()
+instance int8Add : Add Int8 where
+  add = \x:Int8 y:Int8. %iadd x y
+  sub = \x:Int8 y:Int8. %isub x y
+  zero = IToI8 0
+
+instance unitAdd : Add Unit where
+  add = \x y. ()
+  sub = \x y. ()
+  zero = ()
+
+instance tabAdd : Add a ?=> Add (n=>a) where
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+interface Mul a:Type where
+  mul : a -> a -> a
+  one : a
+
+def (*) (d:Mul a) ?=> : a -> a -> a = mul
+
+instance float64Mul : Mul Float64 where
+  mul = \x:Float64 y:Float64. %fmul x y
+  one = FToF64 1.0
+
+instance float32Mul : Mul Float32 where
+  mul = \x:Float32 y:Float32. %fmul x y
+  one = FToF32 1.0
+
+instance int64Mul : Mul Int64 where
+  mul = \x:Int64 y:Int64. %imul x y
+  one = IToI64 1
+
+instance int32Mul : Mul Int32 where
+  mul = \x:Int32 y:Int32. %imul x y
+  one = IToI32 1
+
+instance int8Mul : Mul Int8 where
+  mul = \x:Int8 y:Int8. %imul x y
+  one = IToI8 1
+
+instance unitMul : Mul Unit where
+  mul = \x y. ()
+  one = ()
 
 data Integral a:Type =
   MkIntegral (a->a->a) (a->a->a) -- idiv, rem

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -16,6 +16,7 @@ import Text.Megaparsec.Char hiding (space)
 import Data.Char (isLower)
 import Data.Functor
 import Data.List.NonEmpty (NonEmpty (..))
+import qualified Data.Map.Strict as M
 import Data.Void
 import Data.String (fromString)
 import qualified Text.Megaparsec.Char.Lexer as L
@@ -111,10 +112,13 @@ sourceBlock' :: Parser SourceBlock'
 sourceBlock' =
       proseBlock
   <|> topLevelCommand
-  <|> liftM (\d -> RunModule $ UModule (toNest [d])) (topDecl <* eolf)
+  <|> liftM (declsToModule . (:[])) (topDecl <* eolf)
+  <|> liftM (declsToModule . (:[])) (interfaceInstance <* eolf)
+  <|> liftM declsToModule (interfaceDef <* eolf)
   <|> liftM (Command (EvalExpr Printed) . exprAsModule) (expr <* eol)
   <|> hidden (some eol >> return EmptyLines)
   <|> hidden (sc >> eol >> return CommentLine)
+  where declsToModule = RunModule . UModule . toNest
 
 proseBlock :: Parser SourceBlock'
 proseBlock = label "prose block" $ char '\'' >> liftM (ProseBlock . fst) (withSource consumeTillBreak)
@@ -240,17 +244,17 @@ topLet = do
   ~(ULet _ (p, ann) rhs, pos) <- withPos decl
   let (ann', rhs') = addImplicitImplicitArgs pos ann rhs
   return $ ULet lAnn (p, ann') rhs'
+    
+addImplicitImplicitArgs :: SrcPos -> Maybe UType -> UExpr -> (Maybe UType, UExpr)
+addImplicitImplicitArgs _ Nothing e = (Nothing, e)
+addImplicitImplicitArgs sourcePos (Just typ) ex =
+  let (ty', e') = foldr (addImplicitArg sourcePos) (typ, ex) implicitVars
+  in (Just ty', e')
   where
-    addImplicitImplicitArgs :: SrcPos -> Maybe UType -> UExpr -> (Maybe UType, UExpr)
-    addImplicitImplicitArgs _ Nothing e = (Nothing, e)
-    addImplicitImplicitArgs pos (Just ty) e =
-      let (ty', e') = foldr (addImplicitArg pos) (ty,e) implicitVars
-      in (Just ty', e')
-      where
-        implicitVars = filter isLowerCaseName $ envNames $ freeUVars ty
-        isLowerCaseName :: Name -> Bool
-        isLowerCaseName (Name _ tag _) = isLower $ head $ tagToStr tag
-        isLowerCaseName _ = False
+    implicitVars = filter isLowerCaseName $ envNames $ freeUVars typ
+    isLowerCaseName :: Name -> Bool
+    isLowerCaseName (Name _ tag _) = isLower $ head $ tagToStr tag
+    isLowerCaseName _ = False
 
     addImplicitArg :: SrcPos -> Name -> (UType, UExpr) -> (UType, UExpr)
     addImplicitArg pos v (ty, e) =
@@ -259,6 +263,52 @@ topLet = do
       where
         k = if v == mkName "eff" then EffectRowKind else TypeKind
         uTyKind = WithSrc (Just pos) $ UPrimExpr $ TCExpr k
+
+interfaceDef :: Parser [UDecl]
+interfaceDef = do
+  keyWord InterfaceKW
+  -- TODO: allow multi-parameter type classes
+  interfaceName <- upperName <|> symName
+  (oneAnnBinder, pos) <- withPos annBinder
+  keyWord WhereKW
+  record <- withSrc $ URecordTy <$> interfaceRecordFields ":"
+  let consName = mkInterfaceConsName interfaceName
+  let (varTypeName, oneAnnBinder') = case oneAnnBinder of
+        Bind v    -> (varName v, oneAnnBinder)
+        Ignore ty -> let genVar = mkName $ mkNoShadowingStr "gen" in
+            (genVar, Bind (genVar:>ty))
+  let tyCon = UConDef interfaceName $ toNest [oneAnnBinder']
+  let funDefs = mkFunDefs (pos, varTypeName, interfaceName) record
+  return $ (UData tyCon [UConDef consName (toNest [Ignore record])]) : funDefs
+  where
+    mkFunDefs :: (SrcPos, Name, Name) -> UExpr -> [UDecl]
+    mkFunDefs meta ~(WithSrc _ (URecordTy (NoExt (LabeledItems items)))) =
+        fmap (\(name, ty :| []) -> mkOneFunDef meta (name, ty)) $ M.toList items
+    mkOneFunDef :: (SrcPos, Name, Name) -> (Label, UExpr) -> UDecl
+    mkOneFunDef (pos, varTypeName, interfaceName) (fLabel, fType) =
+      let (p, ann) = lhs
+      in let (ann', rhs') = addImplicitImplicitArgs pos ann rhs
+      in ULet PlainLet (p, ann') rhs'
+      where
+        lhs = let uAnnBinder = Bind $ instanceName :> ns (UApp
+                    (PlainArrow ()) (var interfaceName) (var varTypeName))
+          in (patb fLabel, Just $ ns $ UPi uAnnBinder ClassArrow fType)
+        rhs =
+          let recordStr = mkNoShadowingStr "recordVar"
+              recordPat = ns $ UPatRecord $ Ext (labeledSingleton fLabel (patb
+                fLabel)) $ Just (ns (UPatBinder (Ignore ())))
+              conPat = ns $ UPatCon (mkInterfaceConsName interfaceName)
+                $ toNest [patb recordStr]
+              let1 = ULet PlainLet (conPat, Nothing) $ var instanceName
+              let2 = ULet PlainLet (recordPat, Nothing) $ var $ mkName recordStr
+              body = ns $ UDecl let1 (ns $ UDecl let2 (var (mkName fLabel)))
+          in ns $ ULam (patb instanceStr, Nothing) ClassArrow body
+        
+        ns = WithSrc Nothing
+        patb s = ns $ UPatBinder $ Bind $ mkName s :> ()
+        instanceStr = mkNoShadowingStr "instance"
+        instanceName = mkName instanceStr
+        var name = ns $ UVar $ name :> ()
 
 dataDef :: Parser UDecl
 dataDef = do
@@ -284,6 +334,41 @@ decl = do
   lhs <- simpleLet <|> funDefLet
   rhs <- sym "=" >> blockOrExpr
   return $ lhs rhs
+
+interfaceInstance :: Parser UDecl
+interfaceInstance = do
+  keyWord InstanceKW
+  (p, pos) <- withPos letPat
+  ann <- annot uType
+  keyWord WhereKW
+  rhs <- mkRhs ann <$> (withSrc $ URecord <$> interfaceRecordFields "=")
+  let (ann', rhs') = addImplicitImplicitArgs pos (Just ann) rhs
+  return $ ULet InstanceLet (p, ann') rhs'
+  where
+    -- Here, we are traversing the type annotation to retrieve the name of
+    -- the interface and generate its corresponding constructor.
+    mkRhs (WithSrc _ (UPi _ _ lrhs))      rhs = mkRhs lrhs rhs
+    mkRhs (WithSrc _ (UApp _ (WithSrc _ (UVar v)) _)) rhs =
+      (var . nameToStr . mkInterfaceConsName . varName) v `mkApp` rhs
+    -- We let this case through to fail during type checking.
+    mkRhs _ rhs = rhs
+    var s = WithSrc Nothing $ UVar $ mkName s :> ()
+
+oneLabeledItem
+  :: String -> Parser a -> Maybe (SrcPos -> Label -> a)
+  -> Parser (LabeledItems a)
+oneLabeledItem bindwith itemparser punner = do
+  (l, pos) <- withPos fieldLabel
+  let explicitBound = symbol bindwith *> itemparser
+  itemVal <- case punner of
+    Just punFn -> explicitBound <|> pure (punFn pos l)
+    Nothing -> explicitBound
+  return $ labeledSingleton l itemVal
+
+interfaceRecordFields :: String -> Parser (ExtLabeledItems UExpr UExpr)
+interfaceRecordFields bindwith =
+  fuse <$> onePerLine (oneLabeledItem bindwith expr (Just varPun))
+  where fuse = foldr prefixExtLabeledItems (NoExt NoLabeledItems)
 
 simpleLet :: Parser (UExpr -> UDecl)
 simpleLet = label "let binding" $ do
@@ -470,7 +555,7 @@ uPrim = withSrc $ do
       retTy <- baseType
       args <- some lowerName
       return $ UPrimExpr $ OpExpr $ FFICall f retTy args
-    _ -> case strToName s of
+    _ -> case strToPrimName s of
       Just prim -> UPrimExpr <$> traverse (const lowerName) prim
       Nothing -> fail $ "Unrecognized primitive: " ++ s
 
@@ -622,13 +707,9 @@ parseLabeledItems sep bindwith itemparser punner tailDefault =
     beforeSep = (symbol sep >> afterSep) <|> stopWithoutExtend
     afterSep = someItems <|> stopAndExtend <|> stopWithoutExtend
     someItems = do
-      (l, pos) <- withPos $ fieldLabel
-      let explicitBound = symbol bindwith *> itemparser
-      itemVal <- case punner of
-        Just punFn -> explicitBound <|> pure (punFn pos l)
-        Nothing -> explicitBound
+      oneItem <- oneLabeledItem bindwith itemparser punner
       rest <- beforeSep
-      return $ prefixExtLabeledItems (labeledSingleton l itemVal) rest
+      return $ prefixExtLabeledItems oneItem rest
 
 -- Combine two parsers such that if the first fails, we try the second one.
 -- If both fail, consume the same amount of input as the parser that
@@ -784,13 +865,27 @@ inpostfix' p op = Postfix $ do
 mkName :: String -> Name
 mkName s = Name SourceName (fromString s) 0
 
+nameToStr :: Name -> String
+nameToStr = tagToStr . nameTag
+
+-- This function is used to generate a string that is guaranteed to never shadow
+-- any user-defined name, as "#" is an invalid identifier character in normal
+-- source code.
+mkNoShadowingStr :: String -> String
+mkNoShadowingStr = (++ "#")
+
+mkInterfaceConsName :: Name -> Name
+mkInterfaceConsName =
+  GlobalName . fromString . mkNoShadowingStr . nameToStr
+
 -- === lexemes ===
 
 -- These `Lexer` actions must be non-overlapping and never consume input on failure
 type Lexer = Parser
 
 data KeyWord = DefKW | ForKW | RofKW | CaseKW | OfKW
-             | ReadKW | WriteKW | StateKW | DataKW | WhereKW
+             | ReadKW | WriteKW | StateKW | DataKW | InterfaceKW
+             | InstanceKW | WhereKW
 
 upperName :: Lexer Name
 upperName = liftM mkName $ label "upper-case name" $ lexeme $
@@ -819,11 +914,14 @@ keyWord kw = lexeme $ try $ string s >> notFollowedBy nameTailChar
       WriteKW -> "Accum"
       StateKW -> "State"
       DataKW -> "data"
+      InterfaceKW -> "interface"
+      InstanceKW -> "instance"
       WhereKW -> "where"
 
 keyWordStrs :: [String]
 keyWordStrs = ["def", "for", "rof", "case", "of", "llam",
-               "Read", "Write", "Accum", "data", "where"]
+               "Read", "Write", "Accum", "data", "interface",
+               "instance", "where"]
 
 fieldLabel :: Lexer Label
 fieldLabel = label "field label" $ lexeme $

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -31,7 +31,7 @@ module Syntax (
     addSrcContext, catchIOExcept, liftEitherIO, (-->), (--@), (==>),
     boundUVars, PassName (..), boundVars, bindingsAsVars,
     freeVars, freeUVars, Subst, HasVars, BindsVars,
-    strToName, nameToStr, showPrimName,
+    strToPrimName, primNameToStr, showPrimName,
     monMapSingle, monMapLookup, Direction (..), ArrayRef, Array, Limit (..),
     UExpr, UExpr' (..), UType, UPatAnn, UAnnBinder, UVar,
     UPat, UPat' (..), UModule (..), UDecl (..), UArrow, arrowEff,
@@ -389,16 +389,16 @@ data TyQual = TyQual Var ClassName  deriving (Show, Eq, Generic)
 
 type PrimName = PrimExpr ()
 
-strToName :: String -> Maybe PrimName
-strToName s = M.lookup s builtinNames
+strToPrimName :: String -> Maybe PrimName
+strToPrimName s = M.lookup s builtinNames
 
-nameToStr :: PrimName -> String
-nameToStr prim = case lookup prim $ map swap $ M.toList builtinNames of
+primNameToStr :: PrimName -> String
+primNameToStr prim = case lookup prim $ map swap $ M.toList builtinNames of
   Just s  -> s
   Nothing -> show prim
 
 showPrimName :: PrimExpr e -> String
-showPrimName prim = nameToStr $ fmap (const ()) prim
+showPrimName prim = primNameToStr $ fmap (const ()) prim
 
 -- === effects ===
 


### PR DESCRIPTION
It is now possible to define single parameter type classes using
the syntax
```
interface <Class name> <type name>:Type where
   <function name> : <type signature>
   ...
```

To instantiate it for a given type, we use the syntax
```
instance <instance name> : <Class name> <type name> where
  <function name> = <function body>
  ...
```

I only open as a draft right now since I believe this is good for commenting but potentially missing:
- proper tests – what exactly do we expect those to contain?
- namespacing for interface names (I believe that is desirable?)