### PR TITLE
Check that dependent functions are only applied to reducible expressions

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -344,3 +344,9 @@ def getFst3 (b:Type) ?-> (n:Type) ?-> (xs:n=>b) : b =
 
 def triRefIndex (ref:Ref h (i':n=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
   %indexRef ref i
+
+(for i:(Fin 5). for j:(i..). 0.0).(0@_)
+> Type error:Dependent functions can only be applied to fully evaluated expressions. Bind the argument to a name before you apply the function.
+>
+> (for i:(Fin 5). for j:(i..). 0.0).(0@_)
+>                                    ^^^


### PR DESCRIPTION
Previously we would happily lift variables bound to the results of
evaluating argument expressions into our types, without checking that
their names might be internally generated. This meant that it was
impossible to specify their type annotations, and has also led to some
ordering issues that have caused #245.

Fixes #245.