### PR TITLE
Break out from checking mode when no useful information is propagated

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -350,3 +350,13 @@ def triRefIndex (ref:Ref h (i':n=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
 >
 > (for i:(Fin 5). for j:(i..). 0.0).(0@_)
 >                                    ^^^
+
+-- Type inference of arguments always happens in checking mode, but the checking
+-- doesn't provide any insight into what the argument is in this case. This checks
+-- that type inference is able to realize that and switch to inference mode, so that
+-- it can correctly infer the full dependent type.
+--
+-- There was a time when this wasn't possible, because checking mode would unify the
+-- input type with a non-dependent function type, leading to a later unification errors.
+id (for i:(Fin 2). for j:(..i). 1.0)
+> [[1.0]@(..(0@Fin 2)), [1.0, 1.0]@(..(1@Fin 2))]


### PR DESCRIPTION
This is a simple workaround that allows us to successfully complete type
inference in both of those expressions:
```
for i:(Fin 2). for j:(..i). 1.0
id (for i:(Fin 2). for j:(..i). 1.0)
```
Previously only the first one would pass it.

The error was caused by the fact that the `UApp` rule always triggered
checking mode of the inference on its argument, but it would not provide
any useful information about its type. Then, the checking rule for
abstraction would find out that the type that has been passed in is not
a Pi-type and would unify the requirement with a non-dependent Pi-type
as a default. However, the actual argument is a dependent Pi-type and
we're even able to correctly infer its type when running in inference
mode!

This patch changes the rule for abstraction checking so that it will
attempt to use the requirement if it was actually a Pi-type and
otherwise it will simply fall back to inference mode. Another workaround
would be to unify the requirement with a type of the form `x:?1 -> ?2 x`
(where `?1` and `?2` are inference variables), but that would require
us to implement some form of higher order unification which might be hard
(or even impossible? I don't really know).

Fixes #244.