### PR TITLE
Execute `%bench`ed blocks multiple times

### DIFF
--- a/benchmarks/prepare-executables.py
+++ b/benchmarks/prepare-executables.py
@@ -78,7 +78,7 @@ def prepare_rodinia_backprop():
   exe_path.mkdir(parents=True, exist_ok=True)
   exe_path_ad = RODINIA_EXE_ROOT / 'backprop-ad'
   exe_path_ad.mkdir(parents=True, exist_ok=True)
-  in_features = [512, 123]
+  in_features = [128, 1048576]
 
   for inf, use_ad in product(in_features, (False, True)):
     outf = 1

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -148,7 +148,6 @@ parseEvalOpts = EvalConfig
   <*> (optional $ strOption $ long "logto"
                     <> metavar "FILE"
                     <> help "File to log to" <> showDefault)
-  <*> pure (error "Logging not initialized")
 
 main :: IO ()
 main = do

--- a/src/foreign/API.hs
+++ b/src/foreign/API.hs
@@ -34,7 +34,7 @@ data Context = Context EvalConfig TopEnv
 
 dexCreateContext :: IO (Ptr ())
 dexCreateContext = do
-    let evalConfig = EvalConfig LLVM Nothing (error "Logging not initialized")
+    let evalConfig = EvalConfig LLVM Nothing
     maybePreludeEnv <- evalPrelude evalConfig preludeSource
     case maybePreludeEnv of
       Right preludeEnv -> castStablePtrToPtr <$> newStablePtr (Context evalConfig preludeEnv)

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -32,7 +32,7 @@ module Syntax (
     IFunType (..), IFunVar, CallingConvention (..),
     UAlt (..), AltP, Alt, Label, LabeledItems (..), labeledSingleton,
     reflectLabels, withLabels, ExtLabeledItems (..), prefixExtLabeledItems,
-    IScope, BinderInfo (..), Bindings, CUDAKernel (..),
+    IScope, BinderInfo (..), Bindings, CUDAKernel (..), BenchStats,
     SrcCtx, Result (..), Output (..), OutFormat (..), DataFormat (..),
     Err (..), ErrType (..), Except, throw, throwIf, modifyErr, addContext,
     addSrcContext, catchIOExcept, liftEitherIO, (-->), (--@), (==>),
@@ -579,14 +579,15 @@ type LitProg = [(SourceBlock, Result)]
 type SrcCtx = Maybe SrcPos
 data Result = Result [Output] (Except ())  deriving (Show, Eq)
 
+type BenchStats = Int -- number of runs
 data Output = TextOut String
             | HtmlOut String
             | HeatmapOut Bool Int Int (V.Vector Double)  -- Bool indicates if color
             | ScatterOut (V.Vector Double) (V.Vector Double)
             | PassInfo PassName String
-            | EvalTime  Double
+            | EvalTime  Double (Maybe BenchStats)
             | TotalTime Double
-            | BenchResult String Double Double  -- name, compile time, eval time
+            | BenchResult String Double Double (Maybe BenchStats) -- name, compile time, eval time
             | MiscLog String
               deriving (Show, Eq, Generic)
 


### PR DESCRIPTION
To get more accurate results, especially when they're very cheap. One
interesting finding is that for some reason any (!) trival computation
seems to cost at least ~3us, which is pretty high. The LLVM program
shouldn't take this long to execute and I don't know where does that
come from. Maybe the Haskell -> C dispatch?