### PR TITLE
Make the reduction used in Inference stronger

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -379,3 +379,11 @@ instance instanceTest3 : InterfaceTest3 where
 >
 > instance instanceTest3 : InterfaceTest3 where
 >                          ^^^^^^^^^^^^^^^
+
+def weakerInferenceReduction (l : i:n=>(..i)=>Float) (j:n): Unit =
+  for i:(..j).
+    i' = %inject i
+    for k:(..i').
+      l.i'.k
+    ()
+  ()

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -26,7 +26,6 @@ import Array
 import Syntax
 import Cat
 import Env
-import Embed
 import Type
 import Inference
 import Simplify
@@ -175,7 +174,7 @@ evalUModuleVal env v m = do
   liftIO $ substArrayLiterals backend val
 
 lookupBindings :: Scope -> VarP ann -> Atom
-lookupBindings scope v = reduceAtom scope x
+lookupBindings scope v = x
   where (_, LetBound PlainLet (Atom x)) = scope ! v
 
 -- TODO: extract only the relevant part of the env we can check for module-level


### PR DESCRIPTION
So far it would fail to e.g. substitute variables buried inside type
constructors, leading to some very surprising type errors.