### PR TITLE
Add export mode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,4 @@ dist-newstyle/
 benchmarks/exe/**/*
 benchmarks/parboil/data
 benchmarks/rodinia/rodinia
+examples/export/scalar

--- a/dex.cabal
+++ b/dex.cabal
@@ -74,7 +74,7 @@ executable dex
     build-depends:     dex-resources
   default-language:    Haskell2010
   hs-source-dirs:      src
-  default-extensions:  CPP
+  default-extensions:  CPP, LambdaCase
   if flag(optimized)
     ghc-options:       -O3
   else

--- a/examples/export/scalar.cpp
+++ b/examples/export/scalar.cpp
@@ -1,0 +1,37 @@
+#include <cstdint>
+#include <cassert>
+#include <iostream>
+#include <array>
+
+extern "C" {
+extern int addi32(int32_t* result, int32_t x, int32_t y);
+extern int addf32(float*   result, float   x, float   y);
+}
+
+int32_t add(int32_t x, int32_t y) {
+  int32_t result = 0;
+  assert(addi32(&result, x, y) == 0);
+  return result;
+}
+
+float add(float x, float y) {
+  float result = 0;
+  assert(addf32(&result, x, y) == 0);
+  return result;
+}
+
+int main() {
+  std::array<int32_t, 5> i32_examples = {0, 1, 2, 3, 4};
+  std::array<float, 5> f32_examples = {1.23, 4.12, 6.21, 9.64, 3.61};
+  for (int32_t x : i32_examples) {
+    for (int32_t y : i32_examples) {
+      assert(add(x, y) == x + y);
+    }
+  }
+  for (float x : f32_examples) {
+    for (float y : f32_examples) {
+      assert(add(x, y) == x + y);
+    }
+  }
+  return EXIT_SUCCESS;
+}

--- a/examples/export/scalar.dx
+++ b/examples/export/scalar.dx
@@ -1,0 +1,5 @@
+addi32 : Int32 -> Int32 -> Int32 = (+)
+:export addi32 addi32
+
+addf32 : Float32 -> Float32 -> Float32 = (+)
+:export addf32 addf32

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ quine-test-targets = $(example-names:%=run-%)
 
 doc-names = $(example-names:%=doc/%.html)
 
-tests: quine-tests repl-test
+tests: quine-tests repl-test export-tests
 
 quine-tests: $(quine-test-targets)
 
@@ -104,6 +104,11 @@ update-%: export DEX_ALLOW_CONTRACTIONS=0
 update-%: examples/%.dx build
 	$(dex) script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
+
+export-tests: build
+	$(dex) export examples/export/scalar.dx examples/export/scalar.o
+	$(CXX) -std=c++11 examples/export/scalar.o examples/export/scalar.cpp -o examples/export/scalar
+	examples/export/scalar
 
 jax-tests: build
 	misc/check-quine examples/jax-tests.dx $(dex) --backend JAX script

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -31,6 +31,7 @@ data DocFmt = ResultOnly | TextDoc | HTMLDoc | JSONDoc
 data EvalMode = ReplMode String
               | WebMode    FilePath
               | WatchMode  FilePath
+              | ExportMode FilePath FilePath -- Dex path, .o path
               | ScriptMode FilePath DocFmt ErrorHandling
 
 data CmdOpts = CmdOpts EvalMode (Maybe FilePath) EvalConfig
@@ -50,8 +51,15 @@ runMode evalMode preludeFile opts = do
       printLitProg fmt results
     -- These are broken if the prelude produces any arrays because the blockId
     -- counter restarts at zero. TODO: make prelude an implicit import block
-    WebMode   fname -> runWeb      fname opts env
-    WatchMode fname -> runTerminal fname opts env
+    WebMode    fname -> runWeb      fname opts env
+    WatchMode  fname -> runTerminal fname opts env
+    ExportMode dexPath objPath -> do
+      results <- fmap snd <$> (runEnv $ evalFile opts dexPath)
+      let outputs = foldMap (\(Result outs _) -> outs) results
+      let errors = foldMap (\case (Result _ (Left err)) -> [err]; _ -> []) results
+      putStr $ foldMap (nonEmptyNewline . pprint) errors
+      let exportedFuns = foldMap (\case (ExportedFun name f) -> [(name, f)]; _ -> []) outputs
+      exportFunctions objPath exportedFuns env opts
 
 evalPrelude :: EvalConfig -> Maybe FilePath -> IO TopEnv
 evalPrelude opts fname = flip execStateT mempty $ do
@@ -93,9 +101,6 @@ simpleInfo p = info (p <**> helper) mempty
 
 printLitProg :: DocFmt -> LitProg -> IO ()
 printLitProg ResultOnly prog = putStr $ foldMap (nonEmptyNewline . pprint . snd) prog
-  where
-    nonEmptyNewline [] = []
-    nonEmptyNewline l  = l ++ ['\n']
 printLitProg HTMLDoc prog = putStr $ progHtml prog
 printLitProg TextDoc prog = do
   isatty <- queryTerminal stdOutput
@@ -104,6 +109,9 @@ printLitProg JSONDoc prog =
   forM_ prog $ \(_, result) -> case toJSONStr result of
     "{}" -> return ()
     s -> putStrLn s
+
+nonEmptyNewline [] = []
+nonEmptyNewline l  = l ++ ['\n']
 
 parseOpts :: ParserInfo CmdOpts
 parseOpts = simpleInfo $ CmdOpts
@@ -118,6 +126,8 @@ parseMode = subparser $
                          <> metavar "STRING" <> help "REPL prompt"))
   <> (command "web"    $ simpleInfo (WebMode    <$> sourceFileInfo ))
   <> (command "watch"  $ simpleInfo (WatchMode  <$> sourceFileInfo ))
+  <> (command "export" $ simpleInfo (ExportMode <$> sourceFileInfo
+    <*> objectFileInfo))
   <> (command "script" $ simpleInfo (ScriptMode <$> sourceFileInfo
     <*> (option
             (optionList [ ("literate"   , TextDoc)
@@ -131,6 +141,7 @@ parseMode = subparser $
                <> help "Evaluate programs containing non-fatal type errors")))
   where
     sourceFileInfo = argument str (metavar "FILE" <> help "Source program")
+    objectFileInfo = argument str (metavar "OBJFILE" <> help "Output path (.o file)")
 
 optionList :: [(String, a)] -> ReadM a
 optionList opts = eitherReader $ \s -> case lookup s opts of

--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -14,6 +14,7 @@ module Env (Name (..), Tag, Env (..), NameSpace (..), envLookup, isin, envNames,
             tagToStr, isGlobal, isGlobalBinder, asGlobal, envFilter, binderAsEnv,
             fromBind, newEnv, HasName, getName, InlineHint (..), pattern Bind) where
 
+import Data.Maybe
 import Data.Store
 import Data.String
 import qualified Data.Text as T
@@ -149,10 +150,10 @@ isin x env = case getName x of
 envMaxName :: Env a -> Maybe Name
 envMaxName (Env m) = if M.null m then Nothing else Just $ fst $ M.findMax m
 
-(!) :: HasCallStack => Env a -> VarP ann -> a
+(!) :: (HasCallStack, HasName b) => Env a -> b -> a
 env ! v = case envLookup env v of
   Just x -> x
-  Nothing -> error $ "Lookup of " ++ show (varName v) ++ " failed"
+  Nothing -> error $ "Lookup of " ++ show (fromMaybe "<no name>" $ getName v) ++ " failed"
 
 isGlobal :: VarP ann -> Bool
 isGlobal (GlobalName _ :> _) = True

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -13,10 +13,11 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
 {-# LANGUAGE DerivingVia #-}
+{-# LANGUAGE BlockArguments #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
-module Imp (toImpModule, getIType, impBlockType, impFunType, getMainFun,
-            toScalarType, fromScalarType, impMainFunName) where
+module Imp (toImpModule, getIType, impBlockType, impFunType,
+            toScalarType, fromScalarType) where
 
 import Prelude hiding (pi, abs)
 import Control.Monad.Reader
@@ -25,9 +26,9 @@ import Control.Monad.State.Strict
 import Control.Monad.Writer hiding (Alt)
 import Data.Text.Prettyprint.Doc
 import Data.Functor
+import Data.Maybe
 import Data.Foldable (toList)
 import Data.Int
-import Data.Maybe (fromJust)
 import Data.String (fromString)
 import GHC.Stack
 import qualified Data.List.NonEmpty as NE
@@ -70,33 +71,37 @@ data ImpCatEnv = ImpCatEnv
 type ImpM = ReaderT ImpCtx (Cat ImpCatEnv)
 type AtomRecon = Abs (Nest Binder) Atom
 
-toImpModule :: Backend -> Block -> (ImpModule, [LitVal], AtomRecon)
-toImpModule backend block = runImpMBinders initOpts argBinders $ do
-  (reconAtom, impBlock) <- scopedBlock $ translateTopLevel block'
-  functions <- toList <$> looks envFunctions
-  let requiresCUDA = case backend of LLVMCUDA -> True
-                                     _        -> False
-  let ty = IFunType (EntryFun requiresCUDA) (map binderAnn argBinders) (impBlockType impBlock)
-  let mainFunction = ImpFunction (impMainFunName:>ty) argBinders impBlock
-  return (ImpModule (functions ++ [mainFunction]), argVals, reconAtom)
-  where
-    (argBinders, argVals, block') = abstractPtrLiterals block
-    initOpts = ImpCtx backend CPU TopLevel
-
-runImpMBinders :: ImpCtx -> [IBinder] -> ImpM a -> a
-runImpMBinders opts inBinders m = runImpM opts inVarScope m
+toImpModule :: Backend -> CallingConvention -> Name
+            -> [IBinder] -> Maybe Dest -> Block
+            -> (ImpFunction, ImpModule, AtomRecon)
+toImpModule backend cc entryName argBinders maybeDest block =
+  runImpM initOpts inVarScope $ do
+    (reconAtom, impBlock) <- scopedBlock $ translateTopLevel (maybeDest, block)
+    functions <- toList <$> looks envFunctions
+    let ty = IFunType cc (map binderAnn argBinders) (impBlockType impBlock)
+    let mainFunction = ImpFunction (entryName:>ty) argBinders impBlock
+    return (mainFunction, ImpModule (functions ++ [mainFunction]), reconAtom)
   where
     inVarScope :: Scope  -- TODO: fix (shouldn't use UnitTy)
-    inVarScope = foldMap binderAsEnv $ fmap (fmap $ const (UnitTy, UnknownBinder)) inBinders
+    inVarScope = binderScope <> destScope
+    binderScope = foldMap binderAsEnv $ fmap (fmap $ const (UnitTy, UnknownBinder)) argBinders
+    destScope = fromMaybe mempty $ fmap freeVars maybeDest
+    initOpts = ImpCtx backend CPU TopLevel
 
-translateTopLevel :: Block -> ImpM (AtomRecon, [IExpr])
-translateTopLevel block = do
-  outDest <- allocKind Unmanaged $ getType block
+-- We don't emit any results when a destination is provided, since they are already
+-- going to be available through the dest.
+translateTopLevel :: WithDest Block -> ImpM (AtomRecon, [IExpr])
+translateTopLevel (maybeDest, block) = do
+  outDest <- case maybeDest of
+        Nothing   -> allocKind Unmanaged $ getType block
+        Just dest -> return dest
   void $ translateBlock mempty (Just outDest, block)
   resultAtom <- destToAtom outDest
   let vsOut = envAsVars $ freeVars resultAtom
   let reconAtom = Abs (toNest $ [Bind (v:>ty) | (v:>(ty, _)) <- vsOut]) resultAtom
-  let resultIExprs = [IVar (v:>fromScalarType ty) | (v:>(ty, _)) <- vsOut]
+  let resultIExprs = case maybeDest of
+        Nothing -> [IVar (v:>fromScalarType ty) | (v:>(ty, _)) <- vsOut]
+        Just _  -> []
   return (reconAtom, resultIExprs)
 
 runImpM :: ImpCtx -> Scope -> ImpM a -> a
@@ -185,9 +190,6 @@ launchKernel env (maybeDest, ~hof@(For _ (LamVal b body))) = do
   f <- emitFunction cc (map Bind (i:args)) kernelBody
   emitStatement $ ILaunch f n $ map IVar args
   destToAtom dest
-
-impMainFunName :: Name
-impMainFunName = Name TopFunctionName "impMain" 0
 
 emitFunction :: CallingConvention -> [IBinder] -> ImpBlock -> ImpM IFunVar
 emitFunction cc bs body = do
@@ -357,40 +359,6 @@ toImpHof env (maybeDest, hof) = do
       void $ translateBlock (env <> ref @> sDest) (Just aDest, body)
       PairVal <$> destToAtom aDest <*> destToAtom sDest
     _ -> error $ "Invalid higher order function primitive: " ++ pprint hof
-
-abstractPtrLiterals :: Block -> ([IBinder], [LitVal], Block)
-abstractPtrLiterals block = flip evalState initState $ do
-  block' <- traverseLiterals block $ \val -> case val of
-    PtrLit ty ptr -> do
-      ptrName <- gets $ M.lookup (ty, ptr). fst
-      case ptrName of
-        Just v -> return $ Var $ v :> getType (Con $ Lit val)
-        Nothing -> do
-          (varMap, usedNames) <- get
-          let name = genFresh (Name AbstractedPtrName "ptr" 0) usedNames
-          put ( varMap    <> M.insert (ty, ptr) name varMap
-              , usedNames <> (name @> ()))
-          return $ Var $ name :> BaseTy (PtrType ty)
-    _ -> return $ Con $ Lit val
-  valsAndNames <- gets $ M.toAscList . fst
-  let impBinders = [Bind (name :> PtrType ty ) | ((ty, _), name) <- valsAndNames]
-  let vals = map (uncurry PtrLit . fst) valsAndNames
-  return (impBinders, vals, block')
-  where
-    initState :: (M.Map (PtrType, Ptr ()) Name, Env ())
-    initState = mempty
-
-traverseLiterals :: forall m . Monad m => Block -> (LitVal -> m Atom) -> m Block
-traverseLiterals block f =
-  liftM fst $ flip runSubstEmbedT  mempty $ traverseBlock def block
-  where
-    def :: TraversalDef (SubstEmbedT m)
-    def = (traverseDecl def, traverseExpr def, traverseAtomLiterals)
-
-    traverseAtomLiterals :: Atom -> SubstEmbedT m Atom
-    traverseAtomLiterals atom = case atom of
-      Con (Lit x) -> lift $ lift $ f x
-      _ -> traverseAtom def atom
 
 -- === Destination type ===
 
@@ -724,7 +692,7 @@ allocateBuffer addrSpace mustFree b numel = do
 -- TODO: separate these concepts in IFunType?
 deviceFromCallingConvention :: CallingConvention -> Device
 deviceFromCallingConvention cc = case cc of
-  OrdinaryFun      -> CPU
+  CEntryFun        -> CPU
   EntryFun _       -> CPU
   FFIFun           -> CPU
   MCThreadLaunch   -> CPU
@@ -1107,10 +1075,6 @@ instance HasIType IExpr where
   getIType x = case x of
     ILit val -> litType val
     IVar v   -> varAnn v
-
-getMainFun :: HasCallStack => ImpModule -> ImpFunction
-getMainFun (ImpModule fs) = fromJust $
-  lookup impMainFunName [(name, f) | f@(ImpFunction (name:>_) _ _) <- fs]
 
 impFunType :: ImpFunction -> IFunType
 impFunType (ImpFunction (_:>ty) _ _) = ty

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -67,12 +67,11 @@ type Function = L.Global
 
 -- === Imp to LLVM ===
 
-impToLLVM :: Logger [Output] -> ImpModule -> IO LLVMModule
-impToLLVM logger m@(ImpModule fs) = do
+impToLLVM :: Logger [Output] -> ImpModule -> IO L.Module
+impToLLVM logger (ImpModule fs) = do
   (defns, externSpecs) <- unzip <$> mapM (compileFunction logger) fs
   let externDefns = map externDecl $ toList $ fold externSpecs
-  let IFunType _ argTypes resultTypes = impFunType $ getMainFun m
-  return $ LLVMModule argTypes resultTypes $ L.defaultModule
+  return $ L.defaultModule
     { L.moduleName = "dexModule"
     , L.moduleDefinitions = concat defns ++ externDefns }
 
@@ -80,7 +79,13 @@ compileFunction :: Logger [Output] -> ImpFunction
                 -> IO ([L.Definition], S.Set ExternFunSpec)
 compileFunction _ (FFIFunction f) = return ([], S.singleton (makeFunSpec f))
 compileFunction logger fun@(ImpFunction f bs body) = case cc of
-  OrdinaryFun -> error "not implemented"
+  CEntryFun -> return $ runCompile CPU $ do
+    (argParams   , argOperands   ) <- unzip <$> traverse (freshParamOpPair [] . scalarTy) argTys
+    unless (null retTys) $ error "CEntryFun doesn't support returning values"
+    void $ extendOperands (newEnv bs argOperands) $ compileBlock body
+    mainFun <- makeFunction (asLLVMName name) argParams (Just $ i64Lit 0)
+    extraSpecs <- gets funSpecs
+    return ([L.GlobalDefinition mainFun], extraSpecs)
   EntryFun requiresCUDA -> return $ runCompile CPU $ do
     (argPtrParam   , argPtrOperand   ) <- freshParamOpPair attrs $ hostPtrTy i64
     (resultPtrParam, resultPtrOperand) <- freshParamOpPair attrs $ hostPtrTy i64
@@ -125,7 +130,7 @@ compileFunction logger fun@(ImpFunction f bs body) = case cc of
       idxType = scalarTy $ binderAnn idxBinder
       argTypes = map (scalarTy . binderAnn) argBinders
   where
-    name :> IFunType cc argTys _ = f
+    name :> IFunType cc argTys retTys = f
 
 compileInstr :: ImpInstr -> Compile [Operand]
 compileInstr instr = case instr of
@@ -624,10 +629,8 @@ callableOperand :: L.Type -> L.Name -> L.CallableOperand
 callableOperand ty name = Right $ L.ConstantOperand $ C.GlobalReference ty name
 
 asLLVMName :: Name -> L.Name
-asLLVMName name@(Name TopFunctionName _ _)
-  | name == impMainFunName = "entryFun"
-  | otherwise = fromString $ pprint name
-asLLVMName _ = error "Should only only top-level function names directly"
+asLLVMName name@(Name TopFunctionName _ _) = fromString $ pprint name
+asLLVMName name = error $ "Expected a top function name: " ++ show name
 
 showName :: Name -> String
 showName (Name GenName tag counter) = asStr $ pretty tag <> "." <> pretty counter

--- a/src/lib/Logging.hs
+++ b/src/lib/Logging.hs
@@ -4,7 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Logging (Logger, runLogger, logThis, readLog) where
+module Logging (Logger, runLogger, execLogger, logThis, readLog) where
 
 import Control.Monad
 import Control.Monad.IO.Class
@@ -24,6 +24,9 @@ runLogger maybePath m = do
   ans <- m $ Logger log logFile
   logged <- liftIO $ readMVar log
   return (ans, logged)
+
+execLogger :: (Monoid l, MonadIO m) => Maybe FilePath -> (Logger l -> m a) -> m a
+execLogger maybePath m = fst <$> runLogger maybePath m
 
 logThis :: (Pretty l, Monoid l, MonadIO m) => Logger l -> l -> m ()
 logThis (Logger log maybeLogHandle) x = liftIO $ do

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -472,6 +472,7 @@ prettyDuration d = p (showFFloat (Just 3) (d * mult) "") <+> unit
 instance Pretty Output where
   pretty (TextOut s) = pretty s
   pretty (HtmlOut _) = "<html output>"
+  pretty (ExportedFun _ _) = ""
   pretty (BenchResult name compileTime runTime stats) =
     benchName <> hardline <>
     "Compile time: " <> prettyDuration compileTime <> hardline <>

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -165,6 +165,7 @@ explicitCommand = do
     "p"       -> return $ EvalExpr Printed
     "t"       -> return $ GetType
     "html"    -> return $ EvalExpr RenderHtml
+    "export"  -> ExportFun <$> nameString
     "plot"    -> return $ EvalExpr Scatter
     "plotmat"      -> return $ EvalExpr (Heatmap False)
     "plotmatcolor" -> return $ EvalExpr (Heatmap True)

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -444,7 +444,7 @@ data SourceBlock' = RunModule UModule
                   | UnParseable ReachedEOF String
                     deriving (Show, Generic)
 
-data CmdName = GetType | EvalExpr OutFormat | Dump DataFormat String
+data CmdName = GetType | EvalExpr OutFormat | ExportFun String | Dump DataFormat String
                deriving  (Show, Generic)
 
 data LogLevel = LogNothing | PrintEvalTime | PrintBench String
@@ -467,7 +467,7 @@ type Size = IExpr
 type IFunVar = VarP IFunType
 data IFunType = IFunType CallingConvention [IType] [IType] -- args, results
                 deriving (Show)
-data CallingConvention = OrdinaryFun
+data CallingConvention = CEntryFun
                        | EntryFun Bool  -- flag indicates whether CUDA required
                        | FFIFun
                        | CUDAKernelLaunch
@@ -589,6 +589,7 @@ data Output = TextOut String
             | TotalTime Double
             | BenchResult String Double Double (Maybe BenchStats) -- name, compile time, eval time
             | MiscLog String
+            | ExportedFun String Atom
               deriving (Show, Eq, Generic)
 
 data OutFormat = Printed | RenderHtml | Heatmap Bool | ColorHeatmap | Scatter


### PR DESCRIPTION
This adds a new directive `:export name expr`, which can be used to
declare a C interface of a Dex file. `expr` should evaluate to a
function type which doesn't close over any tables in the environment (we
can't serialize those at the moment).

When the file is evaluated in one of the existing modes, the `:export`
directive is ignored. Using the `dex export source.dx functions.o`
command will work similarly to `script` mode, except that it will
compile and link together all exported functions, and emit their object
code into the specified `.o` file.