### PR TITLE
Don't decide  about loop parallelization in Imp

### DIFF
--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -248,7 +248,7 @@ linearizeBinOp op x' y' = LinA $ do
 -- abstract over the whole tangent state.
 linearizeHof :: SubstEnv -> Hof -> LinA Atom
 linearizeHof env hof = case hof of
-  For d ~(LamVal i body) -> LinA $ do
+  For ~(RegularFor d) ~(LamVal i body) -> LinA $ do
     i' <- mapM (substEmbed env) i
     (ansWithLinTab, vi'') <- buildForAux d i' $ \i''@(Var vi'') ->
        (,vi'') <$> (willRemat vi'' $ tangentFunAsLambda $ linearizeBlock (env <> i@>i'') body)
@@ -644,7 +644,7 @@ linAtomRef a = error $ "Not a linear var: " ++ pprint a
 
 transposeHof :: Hof -> Atom -> TransposeM ()
 transposeHof hof ct = case hof of
-  For d ~(Lam (Abs b (_, body))) ->
+  For ~(RegularFor d) ~(Lam (Abs b (_, body))) ->
     void $ buildFor (flipDir d) b $ \i -> do
       ct' <- tabGet ct i
       localNonlinSubst (b@>i) $ transposeBlock body ct'

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -346,7 +346,7 @@ buildForAux :: MonadEmbed m => Direction -> Binder -> (Atom -> m (Atom, a)) -> m
 buildForAux d i body = do
   eff <- getAllowedEffects
   (lam, aux) <- buildLamAux i (const $ return $ PlainArrow eff) body
-  (,aux) <$> (emit $ Hof $ For d lam)
+  (,aux) <$> (emit $ Hof $ For (RegularFor d) lam)
 
 buildFor :: MonadEmbed m => Direction -> Binder -> (Atom -> m Atom) -> m Atom
 buildFor d i body = fst <$> buildForAux d i (\x -> (,()) <$> body x)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -116,14 +116,14 @@ checkOrInferRho (WithSrc pos expr) reqTy = do
     let infer = do
           allowedEff <- getAllowedEffects
           lam <- inferULam b (PlainArrow allowedEff) body
-          emitZonked $ Hof $ For dir lam
+          emitZonked $ Hof $ For (RegularFor dir) lam
     case reqTy of
       Check (Pi (Abs n (arr, a))) -> do
         unless (arr == TabArrow) $
           throw TypeErr $ "Not an table arrow type: " ++ pprint arr
         allowedEff <- getAllowedEffects
         lam <- checkULam b body $ Abs n (PlainArrow allowedEff, a)
-        emitZonked $ Hof $ For dir lam
+        emitZonked $ Hof $ For (RegularFor dir) lam
       Check _ -> infer >>= matchRequirement
       Infer   -> infer
   UApp arr f x@(WithSrc xPos _) -> do

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -24,7 +24,7 @@ module Syntax (
     PrimHof (..), LamExpr, PiType, WithSrc (..), srcPos, LetAnn (..),
     BinOp (..), UnOp (..), CmpOp (..), SourceBlock (..),
     ReachedEOF, SourceBlock' (..), SubstEnv, ScopedSubstEnv,
-    Scope, CmdName (..), HasIVars (..),
+    Scope, CmdName (..), HasIVars (..), ForAnn (..),
     Val, TopEnv, Op, Con, Hof, TC, Module (..), DataConRefBinding (..),
     ImpModule (..), ImpBlock (..), ImpFunction (..), ImpDecl (..),
     IExpr (..), IVal, ImpInstr (..), Backend (..), Device (..),
@@ -346,7 +346,7 @@ data PrimOp e =
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimHof e =
-        For Direction e
+        For ForAnn e
       | Tile Int e e          -- dimension number, tiled body, scalar body
       | While e e
       | RunReader e e
@@ -376,6 +376,8 @@ data CmpOp = Less | Greater | Equal | LessEqual | GreaterEqual
              deriving (Show, Eq, Generic)
 
 data Direction = Fwd | Rev  deriving (Show, Eq, Generic)
+data ForAnn = RegularFor Direction | ParallelFor
+                deriving (Show, Eq, Generic)
 
 data Limit a = InclusiveLim a
              | ExclusiveLim a
@@ -1507,6 +1509,7 @@ instance Store a => Store (Limit a)
 instance Store a => Store (PrimEffect a)
 instance Store a => Store (LabeledItems a)
 instance (Store a, Store b) => Store (ExtLabeledItems a b)
+instance Store ForAnn
 instance Store Atom
 instance Store Expr
 instance Store Block


### PR DESCRIPTION
Instead, use the extended for annotation field to tag certain loops as
parallel. Selection of loops to paralellize should happen entirely as
a Core to Core rewrite.