### PR TITLE
Cleanup the interface parsing code.

### DIFF
--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -361,25 +361,6 @@ def triRefIndex (ref:Ref h (i':n=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
 id (for i:(Fin 2). for j:(..i). 1.0)
 > [[1.0]@(..(0@Fin 2)), [1.0, 1.0]@(..(1@Fin 2))]
 
-interface InterfaceTest1 a:Type where
-  InterfaceTest1 : a
-> Error: variable already defined: InterfaceTest1
-
-interface InterfaceTest2 typeName:Type where
-  typeName : typeName -> typeName
-
-interface InterfaceTest3 _:Type where
-  att : Int32
-
-instance instanceTest3 : InterfaceTest3 where
-  att = 1
-> Type error:
-> Expected: Type
->   Actual: (Type -> Type)
->
-> instance instanceTest3 : InterfaceTest3 where
->                          ^^^^^^^^^^^^^^^
-
 def weakerInferenceReduction (l : i:n=>(..i)=>Float) (j:n): Unit =
   for i:(..j).
     i' = %inject i

--- a/examples/typeclass-tests.dx
+++ b/examples/typeclass-tests.dx
@@ -1,21 +1,38 @@
-interface TestInterface where
+interface InterfaceTest1 a:Type where
+  InterfaceTest1 : a
+> Error: variable already defined: InterfaceTest1
+
+interface InterfaceTest2 typeName:Type where
+  typeName : typeName -> typeName
+
+interface InterfaceTest3 _:Type where
+  foo : Int32
+
+> Parse error:8:26:
+>   |
+> 8 | interface InterfaceTest3 _:Type where
+>   |                          ^^^^^
+> unexpected "_:Typ"
+> expecting "where" or named annoted binder
+interface InterfaceTest4 where
   foo : Int
 
-instance TestInstance : TestInterface where
+instance instanceTest4 : InterfaceTest4 where
   foo = 1
 
-> Parse error:4:39:
->   |
-> 4 | instance TestInstance : TestInterface where
->   |                                       ^
-> Interface constructor was not applied to any type and can not be instantiated
-instance tabAdd2 : Add x -> Add a ?=> Add (n=>a) where
-  add = \x y. for i. x.i + y.i
-  sub = \x y. for i. x.i - y.i
-  zero = for _. zero
+instance instanceTest4 : InterfaceTest4 x -> InterfaceTest4 (n=>a) where
+  foo = 1
 
-> Parse error:7:50:
->   |
-> 7 | instance tabAdd2 : Add x -> Add a ?=> Add (n=>a) where
->   |                                                  ^
+> Parse error:23:68:
+>    |
+> 23 | instance instanceTest4 : InterfaceTest4 x -> InterfaceTest4 (n=>a) where
+>    |                                                                    ^
 > Met invalid arrow '->' in type annotation of instance. Only class arrows and implicit arrows are allowed.
+instance instanceTest5 : (..i) where
+  bar = bar
+
+> Parse error:31:32:
+>    |
+> 31 | instance instanceTest5 : (..i) where
+>    |                                ^
+> Could not extract interface name from type annotation.

--- a/examples/typeclass-tests.dx
+++ b/examples/typeclass-tests.dx
@@ -1,0 +1,10 @@
+interface TestInterface where
+  foo : Int
+
+instance TestInstance : TestInterface where
+  foo = 1
+> Parse error:5:10:
+>   |
+> 5 |   foo = 1
+>   |          ^
+> Interface constructor was not applied to any type and can not be instantiated

--- a/examples/typeclass-tests.dx
+++ b/examples/typeclass-tests.dx
@@ -3,8 +3,19 @@ interface TestInterface where
 
 instance TestInstance : TestInterface where
   foo = 1
-> Parse error:5:10:
+
+> Parse error:4:39:
 >   |
-> 5 |   foo = 1
->   |          ^
+> 4 | instance TestInstance : TestInterface where
+>   |                                       ^
 > Interface constructor was not applied to any type and can not be instantiated
+instance tabAdd2 : Add x -> Add a ?=> Add (n=>a) where
+  add = \x y. for i. x.i + y.i
+  sub = \x y. for i. x.i - y.i
+  zero = for _. zero
+
+> Parse error:7:50:
+>   |
+> 7 | instance tabAdd2 : Add x -> Add a ?=> Add (n=>a) where
+>   |                                                  ^
+> Met invalid arrow '->' in type annotation of instance. Only class arrows and implicit arrows are allowed.

--- a/makefile
+++ b/makefile
@@ -80,7 +80,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator parser-tests serialize-tests \
                 mcmc record-variant-tests simple-include-test ctc raytrace \
-                isomorphisms
+                isomorphisms typeclass-tests
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -368,8 +368,8 @@ interfaceInstance = do
   where
     -- Here, we are traversing the type annotation to retrieve the name of
     -- the interface and generate its corresponding constructor.
-    mkConstructorCall (WithSrc _ (UPi _ ClassArrow typ)) record =
-      mkConstructorCall typ record
+    mkConstructorCall (WithSrc _ (UPi _ arr typ)) record
+      | arr `elem` [ClassArrow, ImplicitArrow] = mkConstructorCall typ record
     mkConstructorCall (WithSrc _ (UApp _ (WithSrc _ (UVar v)) _)) record =
       (var . nameToStr . mkInterfaceConsName . varName) v `mkApp` record
     mkConstructorCall (WithSrc _ (UApp _ func _)) record =

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -272,13 +272,14 @@ interfaceDef = do
   keyWord InterfaceKW
   (tyCon, pos) <- withPos tyConDef
   keyWord WhereKW
-  recordFields <- withSrc $ interfaceRecordFields ":"
+  recordFieldsWithSrc <- withSrc $ interfaceRecordFields ":"
   let (UConDef interfaceName uAnnBinderNest) = tyCon
-      record = (URecordTy . NoExt) <$> recordFields
+      record = (URecordTy . NoExt) <$> recordFieldsWithSrc
       consName = mkInterfaceConsName interfaceName
       ((_, varNames), uAnnBinderNest') =
           mapAccumR mkFreeVarTypeName (0, []) uAnnBinderNest
       tyCon' = UConDef interfaceName uAnnBinderNest'
+      (WithSrc _ recordFields) = recordFieldsWithSrc
       funDefs = mkFunDefs (pos, varNames, interfaceName) recordFields
   return $ (UData tyCon' [UConDef consName (toNest [Ignore record])]) : funDefs
   where
@@ -297,8 +298,8 @@ interfaceDef = do
     --     f
     -- where I# is an automatically generated constructor of I.
     mkFunDefs
-      :: (SrcPos, [Name], Name) -> WithSrc (LabeledItems UExpr) -> [UDecl]
-    mkFunDefs meta ~(WithSrc _ (LabeledItems items)) =
+      :: (SrcPos, [Name], Name) -> LabeledItems UExpr -> [UDecl]
+    mkFunDefs meta (LabeledItems items) =
         fmap (\(name, ty :| []) -> mkOneFunDef meta (name, ty)) $ M.toList items
     mkOneFunDef :: (SrcPos, [Name], Name) -> (Label, UExpr) -> UDecl
     mkOneFunDef (pos, typeVarNames, interfaceName) (fLabel, fType) =

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -370,11 +370,19 @@ interfaceInstance = do
     -- the interface and generate its corresponding constructor.
     mkConstructorCall (WithSrc _ (UPi _ arr typ)) record
       | arr `elem` [ClassArrow, ImplicitArrow] = mkConstructorCall typ record
+    -- The innermost UApp is an application of a variable that has the name of
+    -- the interface to a type. We retrieve its name and derive the name of
+    -- its automatically generated constructor, which we apply to the record
+    -- passed as a parameter.
     mkConstructorCall (WithSrc _ (UApp _ (WithSrc _ (UVar v)) _)) record =
       (var . nameToStr . mkInterfaceConsName . varName) v `mkApp` record
+    -- Given the instance "I Int Float" of a multi-parameter interface I, we
+    -- end up with something similar to UApp _ (UApp _ I Int) Float. The below
+    -- traverses UApps to get to the innermost one..
     mkConstructorCall (WithSrc _ (UApp _ func _)) record =
       mkConstructorCall func record
-    -- We let this case through to fail during typechecking
+    -- In this case, the type annotation does not contain any function
+    -- application; this indicates a Kind error.
     mkConstructorCall _ record = record
     var s = WithSrc Nothing $ UVar $ mkName s :> ()
 

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -293,7 +293,7 @@ interfaceDef = do
     --   interface I a:Type b:Type where
     --     f : a -> b
     -- mkFunDefs generates the equivalent of the following function definition:
-    --   def f (instance# : I a b) ?=> a -> b =
+    --   def f (instance# : I a b) ?=> : a -> b =
     --     (I# {f=f,...}) = instance#
     --     f
     -- where I# is an automatically generated constructor of I.

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -370,8 +370,8 @@ interfaceInstance = do
     -- the interface and generate its corresponding constructor. A valid type
     -- annotation for an instance is composed of:
     -- 1) implicit/class arguments
-    -- 2) a function whose name is the name of the interface applied to several
-    --    arguments
+    -- 2) a function whose name is the name of the interface applied to 0 or
+    --    more arguments
     mkConstructorNameVar ann =
       stripArrows ann >>= stripAppliedArgs >>= buildConstructor
 


### PR DESCRIPTION
This applies the comments made post-merge on
google-research/dex-lang#249.

What is *not* done:
- `symName` is still acceptable as an interface name (this is a side-effect of changing the manual parsing for a call to `tyCon`); maybe we want to instead wrap it differently?
- generating better error messages (as described in https://github.com/google-research/dex-lang/pull/249#discussion_r498926205). I admit I am not 100% sure what is the right way to go about it. I wonder if it is enough to call `fail` and indicate a Kind error when falling through the last case?
- adding proper test cases for multi-parameter type classes, and for the error(s) described above