### PR TITLE
Implement allocation lifting for CUDA kernels

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -30,8 +30,9 @@ library dex-resources
 
 library
   exposed-modules:     Env, Syntax, Type, Inference, JIT, LLVMExec,
-                       Parser, Util, Imp, PPrint, Algebra, Parallelize,
-                       Actor, Cat, Flops, Embed, Serialize, Optimize,
+                       Parser, Util, Imp, Imp.Embed, Imp.Optimize,
+                       PPrint, Algebra, Parallelize, Optimize, Serialize
+                       Actor, Cat, Flops, Embed,
                        RenderHtml, Plot, LiveOutput, Simplify, TopLevel,
                        Autodiff, Interpreter, Logging, PipeRPC, CUDA
   build-depends:       base, containers, mtl, binary, bytestring,

--- a/examples/gpu-tests.dx
+++ b/examples/gpu-tests.dx
@@ -1,0 +1,33 @@
+
+x = for i:(Fin 5). IToF $ ordinal i
+x
+> [0.0, 1.0, 2.0, 3.0, 4.0]
+
+x + x
+> [0.0, 2.0, 4.0, 6.0, 8.0]
+
+-- TODO: Make it a FileCheck test
+testNestedParallelism =
+  for i:(Fin 10).
+    x = ordinal i
+    q = for j:(Fin 2000). IToF $ x * ordinal j
+    (2.0 .* q, 4.0 .* q)
+(fst testNestedParallelism.(2@_)).(5@_)
+> 20.0
+
+-- TODO: Make it a FileCheck test
+testNestedLoops =
+  for i:(Fin 10).
+    for j:(Fin 20).
+      ordinal i * ordinal j
+testNestedLoops.(4@_).(5@_)
+> 20
+
+-- The state is large enough such that it shouldn't fit on the stack of a
+-- single GPU thread. It should get lifted to a top-level allocation instead.
+allocationLiftingTest =
+  for i:(Fin 100).
+    snd $ withState (for j:(Fin 1000). ordinal i) $ \s.
+      s!(0@_) := get s!(0@_) + 1
+(allocationLiftingTest.(4@_).(0@_), allocationLiftingTest.(4@_).(1@_))
+> (5, 4)

--- a/makefile
+++ b/makefile
@@ -105,6 +105,15 @@ update-%: examples/%.dx build
 	$(dex) script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 
+run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
+run-gpu-tests: examples/gpu-tests.dx
+	misc/check-quine $< $(dex) --backend LLVM-CUDA script --allow-errors
+
+update-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0
+update-gpu-tests: examples/gpu-tests.dx
+	$(dex) --backend LLVM-CUDA script --allow-errors $< > $<.tmp
+	mv $<.tmp $<
+
 export-tests: export-test-scalar export-test-array
 
 export-test-%: build

--- a/src/lib/Imp/Embed.hs
+++ b/src/lib/Imp/Embed.hs
@@ -1,0 +1,188 @@
+-- Copyright 2020 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Imp.Embed ( ISubstEmbedT, ISubstEnv (..)
+                 , runISubstEmbedT, liftSE
+                 , emit, freshIVar, extendValSubst
+                 -- embedding
+                 , ptrOffset, imul, alloc
+                 -- traversal
+                 , traverseImpModule, traverseImpFunction, traverseImpBlock
+                 , traverseImpDecl, traverseImpInstr
+                 , traverseIExpr, traverseIFunVar
+                 , ITraversalDef, substTraversalDef
+                 ) where
+
+import Control.Monad.Reader
+
+import Env
+import Cat
+import Syntax
+import Imp
+import Util (bindM2)
+
+-- XXX: Scope is actually global within each function
+data IEmbedEnv = IEmbedEnv
+  { scope :: Env ()
+  , blockDecls :: Nest ImpDecl
+  }
+data ISubstEnv = ISubstEnv
+  { valSubst  :: Env IExpr
+  , funcSubst :: Env IFunVar
+  }
+
+type IEmbedT      m = CatT IEmbedEnv m
+type ISubstT      m = ReaderT ISubstEnv m
+type ISubstEmbedT m = IEmbedT (ISubstT m)
+
+runIEmbedT :: Monad m => IEmbedT m a -> m a
+runIEmbedT m = fst <$> runCatT m mempty
+
+runISubstT :: Monad m => ISubstEnv -> ISubstT m a -> m a
+runISubstT env m = runReaderT m env
+
+runISubstEmbedT :: Monad m => ISubstEnv -> ISubstEmbedT m a -> m a
+runISubstEmbedT env = (runISubstT env) . runIEmbedT
+
+liftSE :: Monad m => m a -> ISubstEmbedT m a
+liftSE = lift . lift
+
+extendScope :: Monad m => Env a -> IEmbedT m ()
+extendScope s = extend $ IEmbedEnv (fmap (const ()) s) mempty
+
+emit :: Monad m => ImpInstr -> IEmbedT m [IExpr]
+emit instr = do
+  vs <- traverse (freshIVar . Ignore) $ impInstrTypes instr
+  emitTo vs instr
+
+emitTo :: Monad m => [IVar] -> ImpInstr -> IEmbedT m [IExpr]
+emitTo bs instr = do
+  extend $ mempty { blockDecls = (Nest (ImpLet (fmap Bind bs) instr) Empty) }
+  return $ fmap IVar bs
+
+instance Semigroup IEmbedEnv where
+  (IEmbedEnv s d) <> (IEmbedEnv s' d') = IEmbedEnv (s <> s') (d <> d')
+
+instance Monoid IEmbedEnv where
+  mempty = IEmbedEnv mempty mempty
+
+instance Semigroup ISubstEnv where
+  (ISubstEnv v f) <> (ISubstEnv v' f') = ISubstEnv (v <> v') (f <> f')
+
+instance Monoid ISubstEnv where
+  mempty = ISubstEnv mempty mempty
+
+-- === Imp embedding ===
+
+ptrOffset :: Monad m => IExpr -> IExpr -> IEmbedT m IExpr
+ptrOffset ptr off = liftM head $ emit $ IPrimOp $ PtrOffset ptr off
+
+imul :: Monad m => IExpr -> IExpr -> IEmbedT m IExpr
+imul x y = liftM head $ emit $ IPrimOp $ ScalarBinOp IMul x y
+
+alloc :: Monad m => AddressSpace -> IType -> IExpr -> IEmbedT m IExpr
+alloc addrSpc ty size = liftM head $ emit $ Alloc addrSpc ty size
+
+-- === Imp IR traversal ===
+
+type ITraversalDef m = ( ImpDecl  -> ISubstEmbedT m (Env IExpr)
+                       , ImpInstr -> ISubstEmbedT m ImpInstr
+                       )
+
+substTraversalDef :: Monad m => ITraversalDef m
+substTraversalDef = ( traverseImpDecl  substTraversalDef
+                    , traverseImpInstr substTraversalDef )
+
+traverseImpModule :: forall m. Monad m
+                  => (Env IFunVar -> ImpFunction -> m ImpFunction) -> ImpModule -> m ImpModule
+traverseImpModule fTrav (ImpModule funcs) = ImpModule . fst <$> runCatT (traverse go funcs) mempty
+  where
+    go :: ImpFunction -> CatT (Env IFunVar) m ImpFunction
+    go f = do
+      fenv <- look
+      f' <- lift $ fTrav fenv f
+      extend $ impFunVar f @> impFunVar f'
+      return f'
+
+traverseImpFunction :: Monad m => ITraversalDef m -> Env IFunVar -> ImpFunction -> m ImpFunction
+traverseImpFunction _   _    (FFIFunction f             ) = return $ FFIFunction f
+traverseImpFunction def fenv (ImpFunction name args body) = runISubstEmbedT env $ do
+  extendScope $ foldMap binderAsEnv args
+  body' <- extendValSubst (foldMap argSub args) $ traverseImpBlock def body
+  return $ ImpFunction name args body'
+  where
+    argSub b = case b of
+      Ignore _ -> mempty
+      Bind   v -> v @> IVar v
+    env = ISubstEnv mempty fenv
+
+traverseImpBlock :: Monad m => ITraversalDef m -> ImpBlock -> ISubstEmbedT m ImpBlock
+traverseImpBlock def block = buildScoped $ evalImpBlock def block
+
+evalImpBlock :: Monad m => ITraversalDef m -> ImpBlock -> ISubstEmbedT m [IExpr]
+evalImpBlock def@(fDecl, _) (ImpBlock decls results) = do
+  case decls of
+    Nest decl rest -> do
+      env' <- fDecl decl
+      extendValSubst env' $ evalImpBlock def $ ImpBlock rest results
+    Empty -> traverse traverseIExpr results
+
+traverseImpDecl :: Monad m => ITraversalDef m -> ImpDecl -> ISubstEmbedT m (Env IExpr)
+traverseImpDecl (_, fInstr) (ImpLet bs instr) = do
+  vs <- bindM2 emitTo (traverse freshIVar bs) (fInstr instr)
+  return $ newEnv bs vs
+
+traverseImpInstr :: Monad m => ITraversalDef m -> ImpInstr -> ISubstEmbedT m ImpInstr
+traverseImpInstr def instr = case instr of
+  IFor dir b size body -> do
+    b' <- freshIVar b
+    IFor dir (Bind b') <$> traverseIExpr size
+                       <*> (extendValSubst (b @> IVar b') $ traverseImpBlock def body)
+  IWhile cond body ->
+    IWhile <$> traverseImpBlock def cond <*> traverseImpBlock def body
+  ICond cond tb fb -> ICond <$> traverseIExpr cond
+                            <*> traverseImpBlock def tb
+                            <*> traverseImpBlock def fb
+  IQueryParallelism f s -> IQueryParallelism <$> traverseIFunVar f
+                                             <*> traverseIExpr s
+  ILaunch f s args -> ILaunch <$> traverseIFunVar f
+                              <*> traverseIExpr s
+                              <*> traverse traverseIExpr args
+  ICall f args  -> ICall <$> traverseIFunVar f <*> traverse traverseIExpr args
+  Store dst val -> Store <$> traverseIExpr dst <*> traverseIExpr val
+  Alloc addrSpace ty size -> Alloc addrSpace ty <$> traverseIExpr size
+  MemCopy dst src n       -> MemCopy <$> traverseIExpr dst
+                                     <*> traverseIExpr src
+                                     <*> traverseIExpr n
+  Free dst       -> Free <$> traverseIExpr dst
+  IThrowError    -> return IThrowError
+  ICastOp ty val -> ICastOp ty <$> traverseIExpr val
+  IPrimOp op     -> IPrimOp <$> traverse traverseIExpr op
+
+traverseIExpr :: Monad m => IExpr -> ISubstEmbedT m IExpr
+traverseIExpr (ILit l) = return $ ILit l
+traverseIExpr (IVar v) = (!v) <$> asks valSubst
+
+traverseIFunVar :: Monad m => IFunVar -> ISubstEmbedT m IFunVar
+traverseIFunVar fv = (!fv) <$> asks funcSubst
+
+freshIVar :: Monad m => IBinder -> IEmbedT m IVar
+freshIVar b = do
+  let nameHint = case b of
+                   Bind (name:>_) -> name
+                   Ignore _       -> "v"
+  name <- genFresh nameHint <$> looks scope
+  extendScope $ name @> ()
+  return $ name :> binderAnn b
+
+buildScoped :: Monad m => IEmbedT m [IExpr] -> IEmbedT m ImpBlock
+buildScoped m = do
+  (results, IEmbedEnv scopeExt decls) <- scoped m
+  extend $ IEmbedEnv scopeExt mempty  -- Names are global in Imp IR
+  return $ ImpBlock decls results
+
+extendValSubst :: Monad m => Env IExpr -> ISubstEmbedT m a -> ISubstEmbedT m a
+extendValSubst s = local (\env -> env { valSubst = valSubst env <> s })

--- a/src/lib/Imp/Optimize.hs
+++ b/src/lib/Imp/Optimize.hs
@@ -1,0 +1,79 @@
+-- Copyright 2020 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Imp.Optimize (liftCUDAAllocations) where
+
+import Control.Monad
+
+import PPrint
+import Env
+import Cat
+import Syntax
+import Imp.Embed
+
+type AllocInfo    = (BaseType, Int)
+type FuncAllocEnv = [(IBinder, AllocInfo)]
+type ModAllocEnv  = Env [AllocInfo]
+
+liftCUDAAllocations :: ImpModule -> ImpModule
+liftCUDAAllocations m =
+    fst $ runCat (traverseImpModule liftFunc m) mempty
+  where
+    liftFunc :: Env IFunVar -> ImpFunction -> Cat ModAllocEnv ImpFunction
+    liftFunc fenv f = case f of
+      FFIFunction _ -> return f
+      ImpFunction (fname:>IFunType cc argTys retTys) argBs' body' -> case cc of
+        CUDAKernelLaunch -> do
+          let ((argBs, body), fAllocEnv) =
+                flip runCat mempty $ runISubstEmbedT (ISubstEnv mempty fenv) $ do
+                  ~args@(tid:_) <- traverse freshIVar argBs'
+                  newBody <- extendValSubst (newEnv argBs' $ fmap IVar args) $
+                      traverseImpBlock (liftAlloc $ IVar tid) body'
+                  return (fmap Bind args, newBody)
+          let (allocBs, allocs) = unzip fAllocEnv
+          extend $ fname @> allocs
+          let newFunTy = IFunType cc (argTys ++ fmap binderAnn allocBs) retTys
+          return $ ImpFunction (fname :> newFunTy) (argBs ++ allocBs) body
+        _ -> traverseImpFunction amendLaunch fenv f
+
+    liftAlloc :: IExpr -> ITraversalDef (Cat FuncAllocEnv)
+    liftAlloc tid = (liftAllocDecl, traverseImpInstr rec)
+      where
+        rec = liftAlloc tid
+        liftAllocDecl decl = case decl of
+          ImpLet [b] (Alloc addrSpace ty (IIdxRepVal size)) ->
+            case addrSpace of
+              Stack    -> traverseImpDecl rec decl
+              Heap CPU -> error "Unexpected CPU allocation in a CUDA kernel"
+              Heap GPU -> do
+                bArg <- freshIVar b
+                liftSE $ extend $ [(Bind bArg, (ty, fromIntegral size))]
+                ptr <- ptrOffset (IVar bArg) =<< imul tid (IIdxRepVal size)
+                return $ b @> ptr
+          ImpLet _ (Alloc _ _ _) ->
+            error $ "Failed to lift an allocation out of a CUDA kernel: " ++ pprint decl
+          ImpLet _ (Free _) -> return mempty
+          _                 -> traverseImpDecl rec decl
+
+    amendLaunch :: ITraversalDef (Cat ModAllocEnv)
+    amendLaunch = (traverseImpDecl amendLaunch, amendLaunchInstr)
+      where
+        amendLaunchInstr :: ImpInstr -> ISubstEmbedT (Cat ModAllocEnv) ImpInstr
+        amendLaunchInstr instr = case instr of
+          ILaunch f' s' args' -> do
+            s <- traverseIExpr s'
+            args <- traverse traverseIExpr args'
+            liftedAllocs <- liftSE $ looks (!f')
+            f <- traverseIFunVar f'
+            extraArgs <- case null liftedAllocs of
+              True -> return []
+              False -> do
+                ~[nthreads] <- emit $ IQueryParallelism f s
+                forM liftedAllocs $ \(ty, size) -> do
+                  totalSize <- imul (IIdxRepVal $ fromIntegral size) nthreads
+                  alloc (Heap GPU) ty totalSize
+            return $ ILaunch f s (args ++ extraArgs)
+          _ -> traverseImpInstr amendLaunch instr

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -449,6 +449,7 @@ instance Pretty ImpInstr where
   pretty (ICond predicate cons alt) =
     "if" <+> p predicate <+> "then" <> nest 2 (hardline <> p cons) <>
     hardline <> "else" <> nest 2 (hardline <> p alt)
+  pretty (IQueryParallelism f s) = "query_parallelism" <+> p (varName f) <+> p s
   pretty (ILaunch f size args) =
     "launch_kernel" <+> p (varName f) <+> p size <+> spaced args
   pretty (IPrimOp op)     = pLowest op

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -139,7 +139,7 @@ double randunif(uint64_t keypair) {
 }
 
 void dex_parallel_for(char *function_ptr, int64_t size, char **args) {
-  auto function = reinterpret_cast<void (*)(int64_t, int64_t, char**)>(function_ptr);
+  auto function = reinterpret_cast<void (*)(int64_t, int64_t, int64_t, char**)>(function_ptr);
   int64_t nthreads = std::thread::hardware_concurrency();
   if (size < nthreads) {
     nthreads = size;
@@ -149,8 +149,8 @@ void dex_parallel_for(char *function_ptr, int64_t size, char **args) {
   for (int64_t t = 0; t < nthreads; ++t) {
     int64_t start = t * chunk_size;
     int64_t end = t == nthreads - 1 ? size : (t + 1) * chunk_size;
-    threads[t] = std::thread([function, args, start, end]() {
-      function(start, end, args);
+    threads[t] = std::thread([function, args, t, start, end]() {
+      function(t, start, end, args);
     });
   }
   for (auto& thread : threads) {


### PR DESCRIPTION
GPUs don't support dynamic memory allocation from inside the kernels, so
any non-stack allocations should be lifted to the host. This is an
initial version of this transformation, which only works for allocations
of statically known size. Extending it to arbitrary (loop-independent)
arithmetic would require us to lift whole blocks out of the loops, which
is a form of loop invariant code motion (size calculation would have to
happen on the host), and that seems like a natural next step now.

Here's an example program which would previously fail to compile (due to
the large intermediate state allocated in each thread), but should work
just fine now:
```
allocationLiftingTest =
  for i:(Fin 100).
    snd $ withState (for j:(Fin 1000). ordinal i) $ \s.
      s!(0@_) := get s!(0@_) + 1
```

Now that we stop treating Imp IR as a temporary stop along the way to
LLVM, I've figured out that it makes sense to start splitting the
directory structure of our compiler. The tooling we'll need for each of
our IRs is similar (e.g. we now have an Embed monad for both Core and
Imp), and organizing it into submodules can make the code a bit clearer.
Some TODOs here are:
* Lift the Imp IR definition from Syntax;
* Make the Core -> Imp translation use the new Embed monad;
* Implement a `MonadIEmbed` typeclass, similarly to Core's `MonadEmbed`.