### PR TITLE
Caustic rendering demo

### DIFF
--- a/examples/caustics.dx
+++ b/examples/caustics.dx
@@ -1,0 +1,475 @@
+'Caustic Rendering
+
+Based on https://benedikt-bitterli.me/tantalum/
+
+'## Rendering utilities
+
+AbsPoint = (Int & Int)
+RelPoint = (Float & Float)
+
+def pixel (w:Int)?-> (h:Int)?-> (x:Int) (y:Int) : (Fin w & Fin h) = (x@_, y@_)
+
+def drawIntoCanvas (height:Int) (width:Int)
+                   (f: ref:Type ?-> Ref ref ((Fin width & Fin height) =>out)
+                                ->{Accum ref} Unit)
+                   : Fin height=>Fin width=>out =
+  canvas = snd $ withAccum f
+  for y x. canvas.(x, y)
+
+def checkerboard (height:Int)?-> (width:Int)?-> (ref:Type)?->
+      (canvas:Ref ref ((Fin width & Fin height)=>Float))
+      :{Accum ref} Unit =
+  h_over_two = height `idiv` 2
+  -- note: this works but can't be reduced so it has to be a def (?)
+  for i:(Fin width) j:(Fin h_over_two).
+    canvas!(pixel (ordinal i) ((2 * ordinal j) + (ordinal i `rem` 2))) += 1.0
+  ()
+
+:plotmat drawIntoCanvas 20 20 checkerboard
+
+square = \x:Float. x * x
+
+-- Rasterize a segment of a line in a single logical pixel centered between
+-- four physical pixels.
+def rasterLineSegmentInFourPixels (height:Int)?-> (width:Int)?-> (ref:Type)?->
+      (_: VSpace out)?=>
+      (pixel_x: Int) -- 0 <= pixel_x < width - 1
+      (pixel_y: Int) -- 0 <= pixel_y < height - 1
+      (a: RelPoint) -- First line endpoint
+      (b: RelPoint) -- Second line endpoint
+      (fill: out) -- Fill intensity per relative unit.
+      (canvas:Ref ref ((Fin width & Fin height)=>out)) -- Where to draw to.
+      :{Accum ref} Unit =
+  
+  case (pixel_x >= 0 && pixel_x < (width - 1) && pixel_y >= 0 && pixel_y < (height - 1)) of
+    False -> () -- out of bounds! Don't segfault
+    True ->
+
+      dx = 1.0 / IToF (width - 1)
+      dy = 1.0 / IToF (height - 1)
+      x_lo = dx * IToF pixel_x
+      y_lo = dy * IToF pixel_y
+      x_hi = x_lo + dx
+      y_hi = y_lo + dy
+
+      (x1, y1) = a
+      (x2, y2) = b
+      inf = 1./0.
+
+      -- Clip to the bounds.
+      (t_enter_x, t_exit_x) = case x1 == x2 of
+        True -> case x1 > x_lo && x1 < x_hi of
+          True -> (-inf, inf)
+          False -> (inf, -inf)
+        False ->
+          (lt, ht) = ((x_lo - x1) / (x2 - x1), (x_hi - x1) / (x2 - x1))
+          case x1 < x2 of
+            True -> (lt, ht)
+            False -> (ht, lt)
+
+      (t_enter_y, t_exit_y) = case y1 == y2 of
+        True -> case y1 > y_lo && y1 < y_hi of
+          True -> (-inf, inf)
+          False -> (inf, -inf)
+        False ->
+          (lt, ht) = ((y_lo - y1) / (y2 - y1), (y_hi - y1) / (y2 - y1))
+          case y1 < y2 of
+            True -> (lt, ht)
+            False -> (ht, lt)
+
+      t_enter = maximum [t_enter_x, t_enter_y, 0.]
+      t_exit  = minimum [t_exit_x,  t_exit_y,  1.]
+      case t_enter < t_exit of
+        False -> ()
+        True ->
+          x1_clip = t_enter * x2 + (1.0 - t_enter) * x1
+          y1_clip = t_enter * y2 + (1.0 - t_enter) * y1
+          x2_clip = t_exit * x2 + (1.0 - t_exit) * x1
+          y2_clip = t_exit * y2 + (1.0 - t_exit) * y1
+          segment_len = sqrt (square (x2_clip - x1_clip) + square (y2_clip - y1_clip))
+          c = segment_len .* fill
+
+          -- Rasterize into the four neighboring pixels using bilinear interpolation.
+          -- bilinearFill evaluates the definite integral of the function
+          -- ((1-t) v1 + t v2) * ((1-t) w1 + t w2) from 0 to 1, then scales it
+          -- by the distance between (v1, w1) and (v2, w2).
+          bilinearFill = \v1 v2 w1 w2.
+            ((2.0*v1*w1 + 2.0*v2*w2 + v1*w2 + v2*w1) / 6.0) .* c
+          canvas!(pixel pixel_x pixel_y) += (bilinearFill
+            ((x_hi - x1_clip)/dx) ((x_hi - x2_clip)/dx)
+            ((y_hi - y1_clip)/dy) ((y_hi - y2_clip)/dy))
+          canvas!(pixel (pixel_x+1) pixel_y) += (bilinearFill
+            ((x1_clip - x_lo)/dx) ((x2_clip - x_lo)/dx)
+            ((y_hi - y1_clip)/dy) ((y_hi - y2_clip)/dy))
+          canvas!(pixel pixel_x (pixel_y+1)) += (bilinearFill
+            ((x_hi - x1_clip)/dx) ((x_hi - x2_clip)/dx)
+            ((y1_clip - y_lo)/dy) ((y2_clip - y_lo)/dy))
+          canvas!(pixel (pixel_x+1) (pixel_y+1)) += (bilinearFill
+            ((x1_clip - x_lo)/dx) ((x2_clip - x_lo)/dx)
+            ((y1_clip - y_lo)/dy) ((y2_clip - y_lo)/dy))
+          ()
+
+-- Simple rasterization of two lines by evaluating the fill color at every pixel.
+:plotmat
+  s = 100
+  s2 = s - 1
+  drawIntoCanvas s s $ \canvas.
+    for i:(Fin s2) j:(Fin s2).
+      rasterLineSegmentInFourPixels (ordinal i) (ordinal j) (0.1, 0.3) (0.8, 0.6) 1.0 canvas
+      rasterLineSegmentInFourPixels (ordinal i) (ordinal j) (0.6, 0.8) (0.3, 0.1) 1.0 canvas
+    ()
+
+
+-- Bilinear approximation preserves line integral
+:p sum $ sum $ drawIntoCanvas 100 100 $ \canvas.
+  for i:(Fin 99) j:(Fin 99).
+    rasterLineSegmentInFourPixels (ordinal i) (ordinal j) (0.1, 0.3) (0.8, 0.6) 1.0 canvas
+  ()
+
+:p sqrt (square (0.8 - 0.1) + square (0.6 - 0.3))
+
+-- TODO: This doesn't work because of https://github.com/google-research/dex-lang/issues/267
+-- def forEachBetween (eff:Effects)?-> (lo: Int) (hi: Int) (f: Int ->{|eff} Unit) :{|eff} Unit =
+--  delta = hi - lo + 1
+--  for offset:(Fin delta).
+--    i = lo + ordinal offset
+--    f i
+--  ()
+
+-- Instead of rasterizing every pixel, we can rasterize only those touched by
+-- the line segment.
+def rasterLineSegment (height:Int)?-> (width:Int)?-> (ref:Type)?->
+      (_: VSpace out)?=>
+      (a: RelPoint) -- First line endpoint
+      (b: RelPoint) -- Second line endpoint
+      (fill: out) -- Fill intensity per relative unit.
+      (canvas:Ref ref ((Fin width & Fin height)=>out)) -- Where to draw to.
+      :{Accum ref} Unit =
+  (x1, y1) = a
+  (x2, y2) = b
+  dx = 1.0 / IToF (width - 1)
+  dy = 1.0 / IToF (height - 1)
+
+  x_changes_more = abs (x1 - x2) > abs (y1 - y2)
+  (u1, u2, v1, v2, du, dv) = case x_changes_more of
+    True -> case x1 < x2 of
+      True -> (x1, x2, y1, y2, dx, dy)
+      False -> (x2, x1, y2, y1, dx, dy)
+    False -> case y1 < y2 of
+      True -> (y1, y2, x1, x2, dy, dx)
+      False -> (y2, y1, x2, x1, dy, dx)
+
+  min_u_int = FToI $ floor (u1 / du)
+  max_u_int = FToI $ ceil (u2 / du)
+  delta_u = max_u_int - min_u_int + 1
+  for u_offset:(Fin delta_u).
+    u_int = ordinal u_offset + min_u_int
+    u_rel_lo = IToF u_int * dx
+    v_rel_earlier = v1 + (u_rel_lo - u1)*(v2 - v1)/(u2 - u1)
+    v_int = FToI $ floor (v_rel_earlier / dv)
+    v_int_next = case v2 > v1 of
+      True -> v_int + 1
+      False -> v_int - 1
+    case x_changes_more of
+      True ->
+        rasterLineSegmentInFourPixels u_int v_int a b fill canvas
+        rasterLineSegmentInFourPixels u_int v_int_next a b fill canvas
+      False ->
+        rasterLineSegmentInFourPixels v_int u_int a b fill canvas
+        rasterLineSegmentInFourPixels v_int_next u_int a b fill canvas
+  ()
+
+
+:plotmat
+  s = 100
+  drawIntoCanvas s s $ \canvas.
+    rasterLineSegment (0.1, 0.3) (0.8, 0.6) 1.0 canvas
+    rasterLineSegment (0.6, 0.8) (0.3, 0.1) 1.0 canvas
+
+-- Bilinear approximation preserves line integral
+:p sum $ sum $ drawIntoCanvas 100 100 $
+  rasterLineSegment (0.1, 0.3) (0.8, 0.6) 1.0
+
+'## Light path visualization
+We can visualize light by rasterizing many lines coming from a single point.
+
+def invertAndGammaCorrect (raw : w=>h=>Float) : w=>h=>Float =
+  -for i j. exp $ 0.45 * log raw.i.j
+
+:plotmat
+  s = 100
+  n = 10000
+  invertAndGammaCorrect $ drawIntoCanvas s s $ \canvas.
+    for i:(Fin n).
+      key = ixkey (newKey 42) i
+      angle = 2. * pi * rand key
+      rasterLineSegment (0.5, 0.5) (0.5 + (cos angle), 0.5 + (sin angle)) 1.0 canvas
+    ()
+
+'But it's not very interesting unless the light has something to interact with!
+
+data BoundaryCurve =
+  LineSegment start:RelPoint end:RelPoint
+  ArcSegment center:RelPoint radius:Float theta1:Float theta2:Float  -- smallest theta must be between [-pi, pi)
+
+Ray = { start: RelPoint & dir: RelPoint }
+
+
+def invert2d (m: Fin 2 => Fin 2 => Float) : Fin 2 => Fin 2 => Float =
+  det = m.(0@_).(0@_) * m.(1@_).(1@_) - m.(0@_).(1@_) * m.(1@_).(0@_)
+  (1.0/det) .* [ [m.(1@_).(1@_), -m.(0@_).(1@_)]
+  , [-m.(1@_).(0@_), m.(0@_).(0@_)]
+  ]
+
+-- TODO: add built-in atan2?
+def atan2 (y:Float) (x:Float) :Float =
+  -- https://math.stackexchange.com/questions/1098487/atan2-faster-approximation/1105038
+  a = minimum [abs x, abs y] / maximum [abs x, abs y]
+  s = a * a
+  r = ((-0.0464964749 * s + 0.15931422) * s - 0.327622764) * s * a + a
+  r = case (abs y > abs x) of
+    True -> (pi/2.) - r
+    False -> r
+  r = case x<0. of
+    True -> pi - r
+    False -> r
+  r = case y<0. of
+    True -> -r
+    False -> r
+  r
+
+-- :p for i:(Fin 360).
+--   ratio = 180. / pi
+--   theta = IToF (ordinal i) / ratio
+--   ratio * approx_atan2 (sin theta) (cos theta)
+
+def unitVector (u:RelPoint) : RelPoint =
+  (ux, uy) = u
+  unorm = sqrt (square ux + square uy)
+  (ux / unorm, uy / unorm)
+
+minDistance = 0.00001
+
+-- Intersect a ray with a boundary and return a surface normal
+def testHit (ray:Ray) (boundary:BoundaryCurve) : Maybe Ray =
+  ({start=(sx, sy), dir=dir}) = ray
+  (ux, uy) = unitVector dir
+  case boundary of
+    LineSegment (ax, ay) (bx, by) ->
+      (vx, vy) = (bx - ax, by - ay)
+      soln = (invert2d [[-vx, ux], [-vy, uy]]) **. [ax - sx, ay - sy]
+      interp_a_to_b = soln.(0@_)
+      ray_dist = soln.(1@_)
+      case (interp_a_to_b > 0. && interp_a_to_b <= 1. && ray_dist > minDistance) of
+        True -> Just { start=(sx + ray_dist * ux, sy + ray_dist * uy)
+                     , dir=(-vy, vx)
+                     }
+        False -> Nothing
+    ArcSegment (cx, cy) r theta0 theta1 ->
+      ({start=(sx, sy), dir=dir}) = ray
+      u = [ux, uy]
+      uLeft = [-uy, ux]
+      -- solve in normalized coordinate system
+      sToC = [cx - sx, cy - sy]
+      dAlong = vdot u sToC
+      dPerp = vdot uLeft sToC
+      plusminus = [-1.0, 1.0]
+      distances = for i. dAlong + plusminus.i * sqrt (square r - square dPerp)
+      (normalPointsAway, baseTheta, radians) = case theta1 > theta0 of
+        True -> (False, theta0, theta1 - theta0)
+        False -> (True, theta1, theta0 - theta1)
+      
+      intersects = for i.
+        dist = distances.i
+        cToP_x = sx + ux * dist - cx
+        cToP_y = sy + uy * dist - cy
+        theta = atan2 cToP_y cToP_x
+        valid = (dist > minDistance) && (theta >= baseTheta) && ((theta - baseTheta) < radians)
+        dir = case normalPointsAway of
+          True -> (cToP_x, cToP_y)
+          False -> (-cToP_x, -cToP_y)
+        (valid, {start=(sx + ux * dist, sy + uy * dist), dir=dir})
+
+      (v0, out0) = intersects.(0@_)
+      (v1, out1) = intersects.(1@_)
+
+      case v0 of
+        True -> Just out0
+        False -> case v1 of
+          True -> Just out1
+          False -> Nothing
+
+
+:p testHit {start=(0.,0.), dir=(0., 1.)} (LineSegment (2., 2.) (-2., 2.))
+
+:p testHit {start=(0.,0.), dir=(1., 1.)} (LineSegment (5., 2.) (-5., 1.))
+
+:p testHit {start=(0.,0.), dir=(1., 1.)} (LineSegment (1., 2.) (2., 3.))
+
+:p testHit {start=(0.,0.), dir=(1., 0.)} (ArcSegment (3., 1.) 2. (-pi) pi)
+
+'Now we can draw objects, although they are all opaque:
+
+:plotmat
+  s = 100
+  n = 10000
+  objects = [ LineSegment (0.85, 0.6) (0.6, 0.9)
+            , LineSegment (0.2, 0.7) (0.4, 0.5)
+            , ArcSegment (0.25, 0.25) 0.15 (-pi) (-pi/3.)
+            , ArcSegment (0.6, 0.25) 0.15 (-pi) pi
+            ]
+  invertAndGammaCorrect $ drawIntoCanvas s s $ \canvas.
+    for i:(Fin n).
+      key = ixkey (newKey 42) i
+      angle = 2. * pi * rand key
+      (sx, sy) = (0.5, 0.5)
+      ray = {start=(sx, sy), dir=(cos angle, sin angle)}
+      endpt = snd $ withState (sx + (cos angle), sy + (sin angle)) \ref.
+        for objidx.
+          case testHit ray objects.objidx of
+            Just {start=(nx, ny), ..._} ->
+              (cx, cy) = get ref
+              dc = sqrt (square (cx-sx) + square (cy-sy))
+              dn = sqrt (square (nx-sx) + square (ny-sy))
+              case dn < dc of
+                True -> ref := (nx, ny)
+                False -> ()
+            Nothing -> ()
+
+      rasterLineSegment (getAt #start ray) endpt 1.0 canvas
+    ()
+
+'Let's add some interactions!
+
+data SurfaceType =
+  Black
+  Matte
+  Reflecting
+  Refracting refractionCoeff:Float
+
+Boundary = { curve: BoundaryCurve
+           & surface: SurfaceType
+           }
+
+def reemit (incoming:Ray) (intersect:Ray) (surf:SurfaceType) (rng:Key) : Maybe Ray =
+  pt = getAt #start intersect
+  (ix, iy) = unitVector $ getAt #dir incoming
+  (nx, ny) = unitVector $ getAt #dir intersect
+  case surf of
+    Black -> Nothing
+    Matte ->
+      dotprod = ix * nx + iy * ny
+      xi = rand rng
+      perpendicular = 2.0 * xi - 1.0
+      parallel = sqrt (1.0 - square perpendicular) * select (dotprod > 0.) (-1.0) 1.0
+      reflected = ( parallel * nx + perpendicular * ny
+                  , parallel * ny + perpendicular * (-nx) )
+      Just {start=pt, dir=reflected}
+    Reflecting ->
+      dotprod = ix * nx + iy * ny
+      reflected = (ix - 2. * nx * dotprod, iy - 2. * ny * dotprod)
+      Just {start=pt, dir=reflected}
+    Refracting rCoef ->
+      dotprod = ix * nx + iy * ny
+      perp = ix * ny + iy * (-nx)
+      perpAdj = perp * select (dotprod > 0.) rCoef (1.0/rCoef)
+      parallelSquared = (1.0 - square perpAdj)
+      case parallelSquared > 0.0 of
+        False ->
+          -- Internal reflection
+          reflected = (ix - 2. * nx * dotprod, iy - 2. * ny * dotprod)
+          Just {start=pt, dir=reflected}
+        True ->
+          parallelAdj = sqrt parallelSquared * select (dotprod > 0.) 1.0 (-1.0)
+          refracted = ( parallelAdj * nx + perpAdj * ny
+                      , parallelAdj * ny + perpAdj * (-nx) )
+          Just {start=pt, dir=refracted}
+      
+
+
+def traceLightPaths (height:Int)?-> (width:Int)?-> (ref:Type)?->
+      (boundaries: bidx=>Boundary)
+      (ray:Ray)
+      (maxBounces:Int) 
+      (key:Key) 
+      (canvas:Ref ref ((Fin width & Fin height)=>Float32)) -- Where to draw to.
+      :{Accum ref} Unit =
+  withState {ray, key, stop=False, bounce=0} $ \h ?-> \stateRef:(Ref h _).
+    -- Slightly annoying that we have to write this type signature in order
+    -- for the typechecker to do the right effect inference.
+    cond : Unit ->{State h, Accum ref} Bool = \().
+      ({ray, key, stop, bounce}) = get stateRef
+      not stop && (bounce < maxBounces)
+    while cond $ \().
+      ({ray, key, stop, bounce}) = get stateRef
+      (sx, sy) = getAt #start ray
+      (k1, k2) = splitKey key
+      firstHit = snd $ withState Nothing \hitstate.
+        for i.
+          old = get hitstate
+          case testHit ray (getAt #curve boundaries.i) of
+            Just hit ->
+              ({start=(nx, ny), ...}) = hit
+              case old of
+                Just ({start=(cx, cy), ..._}, _) ->
+                  dc = sqrt (square (cx-sx) + square (cy-sy))
+                  dn = sqrt (square (nx-sx) + square (ny-sy))
+                  case dn < dc of
+                    True -> hitstate := Just (hit, i)
+                    False -> ()
+                Nothing -> hitstate := Just (hit, i)
+            Nothing -> ()
+      case firstHit of
+        Nothing -> stateRef := {ray, key, stop=True, bounce}
+        Just (intersect, idx) ->
+          rasterLineSegment (getAt #start ray) (getAt #start intersect) 1.0 canvas
+          case reemit ray intersect (getAt #surface boundaries.idx) k1 of
+            Nothing ->
+              stateRef := {ray, key, stop=True, bounce}
+            Just newRay ->
+              stateRef := {ray=newRay, key=k2, stop=False, bounce=bounce + 1}
+  ()
+
+:plotmat
+  s = 100
+  n = 10000
+                -- Walls
+  boundaries =  [ { curve=LineSegment (0.0, 0.0) (0.0, 1.0)
+                  , surface=Black
+                  }
+                , { curve=LineSegment (1.0, 1.0) (0.0, 1.0)
+                  , surface=Black
+                  }
+                , { curve=LineSegment (1.0, 1.0) (1.0, 0.0)
+                  , surface=Matte
+                  }
+                , { curve=LineSegment (0.0, 0.0) (1.0, 0.0)
+                  , surface=Black
+                  }
+                -- Scene objects
+                , { curve=LineSegment (0.85, 0.6) (0.3, 0.9)
+                  , surface=Reflecting
+                }
+                , { curve=LineSegment (0.6, 0.8) (0.95, 0.95)
+                  , surface=Black
+                }
+                , { curve=ArcSegment (0.25, 0.25) 0.2 (-pi) (-pi/3.)
+                  , surface=Reflecting
+                }
+                , { curve=ArcSegment (0.5, 0.5) 0.3 (-pi/2.) 0.0
+                  , surface=Refracting 0.5
+                }
+                , { curve=ArcSegment (0.8, 0.2) 0.3 (pi/2.) pi
+                  , surface=Refracting 0.5
+                }
+            ]
+  invertAndGammaCorrect $ drawIntoCanvas s s $ \canvas.
+    for i:(Fin n).
+      key = ixkey (newKey 42) i
+      (k1, k2) = splitKey key
+      angle = 2. * pi * rand k1
+      (sx, sy) = (0.3, 0.7)
+      ray = {start=(sx, sy), dir=(cos angle, sin angle)}
+      maxBounces = 10
+      traceLightPaths boundaries ray maxBounces k2 canvas
+    ()

--- a/static/style.css
+++ b/static/style.css
@@ -48,6 +48,7 @@ code {
 
 .plot-img {
   width: 80%;
+  image-rendering: pixelated;
 }
 
 .comment {


### PR DESCRIPTION
Based on https://benedikt-bitterli.me/tantalum/, this demo generates caustics by tracing the path of light through a 2D scene. All updates are done in the `Accum` writer effect, which should mean that this example can be sped up using parallelism.

Uses a custom antialiasing function that computes line integrals within bilinearly-smoothed pixels, so the rendered outputs correspond fairly accurately to the amount of light passing through each pixel.

Example output:

<img src="https://user-images.githubusercontent.com/4992683/96612628-f996c200-12cb-11eb-925a-4e281ca3c66d.png" width="500px">

Some implementation notes:

- I needed `atan2` but that's not a builtin yet, so I found a cheap approximation. But this should probably be a builtin? I imagine it's just a matter of hooking it up to LLVM in the right way.
- I ran into #267 while trying to write effect-polymorphic helper functions, so right now it's written without those helper functions.
- It's surprisingly annoying to index into small matrices and vectors, and there's a lot of visual noise (e.g. `m.(1@_).(1@_)`). I ended up mostly using tuples instead. Maybe this is another argument toward having a more powerful indexing syntax.