### PR TITLE
Get rid of AnyValue

### DIFF
--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -304,7 +304,6 @@ linearizePrimCon :: Con -> LinA Atom
 linearizePrimCon con = case con of
   Lit _                 -> emitWithZero
   CharCon _             -> emitWithZero
-  AnyValue _            -> emitWithZero
   PairCon x y           -> PairVal <$> linearizeAtom x <*> linearizeAtom y
   UnitCon               -> emitWithZero
   SumAsProd ty tg elems -> Con . SumAsProd ty tg <$> traverse (traverse linearizeAtom) elems
@@ -709,7 +708,6 @@ transposeCon con ct = case con of
     getSnd ct >>= transposeAtom y
   SumAsProd _ _ _   -> notImplemented
   CharCon _         -> notTangent
-  AnyValue _        -> notTangent
   ClassDictHole _ _ -> notTangent
   IntRangeVal _ _ _     -> notImplemented
   IndexRangeVal _ _ _ _ -> notImplemented

--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -71,7 +71,10 @@ instance (Monoid w, MonadCat env m) => MonadCat env (WriterT w m) where
 instance MonadCat env m => MonadCat env (ExceptT e m) where
   look = lift look
   extend x = lift $ extend x
-  scoped = error "TODO"
+  scoped m = do (xerr, env) <- lift $ scoped $ runExceptT m
+                case xerr of
+                  Left err -> throwError err
+                  Right x  -> return (x, env)
 
 instance (Monoid env, MonadError e m) => MonadError e (CatT env m) where
   throwError = lift . throwError

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -26,7 +26,7 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               TraversalDef, traverseDecls, traverseDecl, traverseBlock, traverseExpr,
               clampPositive, buildNAbs, buildNAbsAux, buildNestedLam, zeroAt,
               transformModuleAsBlock, dropSub, appReduceTraversalDef,
-              indexSetSizeE, indexToIntE, intToIndexE, anyValue, freshVarE) where
+              indexSetSizeE, indexToIntE, intToIndexE, freshVarE) where
 
 import Control.Applicative
 import Control.Monad
@@ -801,11 +801,3 @@ intToIndexE (VariantTy (NoExt types)) i = do
   start <- Variant (NoExt types) l0 0 <$> intToIndexE ty0 i
   foldM go start zs
 intToIndexE ty _ = error $ "Unexpected type " ++ pprint ty
-
-anyValue :: Type -> Atom
-anyValue (BaseTy (Scalar Int64Type  )) = Con $ Lit $ Int64Lit    0
-anyValue (BaseTy (Scalar Int32Type  )) = Con $ Lit $ Int32Lit    0
-anyValue (BaseTy (Scalar Int8Type   )) = Con $ Lit $ Int8Lit     0
-anyValue (BaseTy (Scalar Float64Type)) = Con $ Lit $ Float64Lit  0
-anyValue (BaseTy (Scalar Float32Type)) = Con $ Lit $ Float32Lit  0
-anyValue t = error $ "Expected a scalar type in anyValue, got: " ++ pprint t

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -239,7 +239,6 @@ prettyPrecPrimCon con = case con of
   PairCon x y -> atPrec ArgPrec $ align $ group $
     parens $ flatAlt " " "" <> pApp x <> line' <> "," <+> pApp y
   UnitCon     -> atPrec ArgPrec "()"
-  AnyValue t  -> atPrec AppPrec $ pAppArg "%anyVal" [t]
   SumAsProd ty tag payload -> atPrec LowestPrec $
     "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
   ClassDictHole _ _ -> atPrec ArgPrec "_"

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -118,8 +118,6 @@ simplifyAtom atom = case atom of
   -- We don't simplify body of lam because we'll beta-reduce it soon.
   Lam _ -> substEmbedR atom
   Pi  _ -> substEmbedR atom
-  Con (AnyValue (TabTy v b)) -> TabValA v <$> mkAny b
-  Con (AnyValue (PairTy a b))-> PairVal <$> mkAny a <*> mkAny b
   Con con -> Con <$> mapM simplifyAtom con
   TC tc -> TC <$> mapM substEmbedR tc
   Eff eff -> Eff <$> substEmbedR eff
@@ -146,7 +144,6 @@ simplifyAtom atom = case atom of
         ACase e' alts' <$> (substEmbedR rty)
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _ _ _ _ -> error "Should only occur in Imp lowering"
-  where mkAny t = Con . AnyValue <$> substEmbedR t >>= simplifyAtom
 
 simplifyCase :: Atom -> [AltP a] -> Maybe (SubstEnv, a)
 simplifyCase e alts = case e of

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -288,7 +288,6 @@ data PrimTC e =
 
 data PrimCon e =
         Lit LitVal
-      | AnyValue e        -- Produces an arbitrary value of a given type
       | PairCon e e
       | UnitCon
       | ClassDictHole SrcCtx e   -- Only used during type inference
@@ -1487,7 +1486,6 @@ builtinNames = M.fromList
   , ("snd", OpExpr $ Snd ())
   , ("fstRef", OpExpr $ FstRef ())
   , ("sndRef", OpExpr $ SndRef ())
-  , ("anyVal", ConExpr $ AnyValue ())
   -- TODO: Lift vectors to constructors
   --, ("VectorFloatType",  TCExpr $ BaseType $ Vector FloatType)
   , ("vectorPack", OpExpr $ VectorPack $ replicate vectorWidth ())

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -566,7 +566,6 @@ typeCheckCon :: Con -> TypeM Type
 typeCheckCon con = case con of
   Lit l -> return $ BaseTy $ litType l
   CharCon v -> v |: (BaseTy $ Scalar Int8Type) $> CharTy
-  AnyValue t -> t|:TyKind $> t
   PairCon x y -> PairTy <$> typeCheck x <*> typeCheck y
   UnitCon -> return UnitTy
   SumAsProd ty tag _ -> tag |:TagRepTy >> return ty  -- TODO: check!


### PR DESCRIPTION
We didn't really need it anymore, because in case we know the exact
contructor of an ADT statically, we no longer use the sum-as-product
representation. The only remaining place was in Imp error handling, but
this should be handled differently. We don't need the operation to
produce any result, but instead we abort the code generation for the
current block, and replace its body with just the throwing instruction.

Note that we might want to revisit this strategy if we add debug
instructions. A block that is guaranteed to fail currently
doesn't evaluate anything, but the failure might be only because the
code is incomplete and the user wants to debug something else.