### PR TITLE
Make the kernel language more flexible

### DIFF
--- a/makefile
+++ b/makefile
@@ -106,11 +106,11 @@ update-%: examples/%.dx build
 	mv $<.tmp $<
 
 run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
-run-gpu-tests: examples/gpu-tests.dx
+run-gpu-tests: examples/gpu-tests.dx build
 	misc/check-quine $< $(dex) --backend LLVM-CUDA script --allow-errors
 
 update-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0
-update-gpu-tests: examples/gpu-tests.dx
+update-gpu-tests: examples/gpu-tests.dx build
 	$(dex) --backend LLVM-CUDA script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -314,6 +314,7 @@ linearizePrimCon con = case con of
   TabRef _       -> error "Unexpected ref"
   ConRef _       -> error "Unexpected ref"
   RecordRef _    -> error "Unexpected ref"
+  ParIndexCon   _ _ -> error "Unexpected ParIndexCon"
   ClassDictHole _ _ -> error "Unexpected ClassDictHole"
   where emitWithZero = LinA $ return $ withZeroTangent $ Con con
 
@@ -709,9 +710,10 @@ transposeCon con ct = case con of
   SumAsProd _ _ _   -> notImplemented
   CharCon _         -> notTangent
   ClassDictHole _ _ -> notTangent
-  IntRangeVal _ _ _     -> notImplemented
-  IndexRangeVal _ _ _ _ -> notImplemented
-  IndexSliceVal _ _ _   -> notImplemented
+  IntRangeVal _ _ _     -> notTangent
+  IndexRangeVal _ _ _ _ -> notTangent
+  IndexSliceVal _ _ _   -> notTangent
+  ParIndexCon _ _       -> notTangent
   BaseTypeRef _  -> notTangent
   TabRef _       -> notTangent
   ConRef _       -> notTangent

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -14,7 +14,10 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               getAllowedEffects, withEffects, modifyAllowedEffects,
               buildLam, EmbedT, Embed, MonadEmbed, buildScoped, runEmbedT,
               runSubstEmbed, runEmbed, getScope, embedLook,
-              app, add, mul, sub, neg, div', iadd, imul, isub, idiv, fpow, flog, fLitLike,
+              app,
+              add, mul, sub, neg, div',
+              iadd, imul, isub, idiv, ilt, ieq,
+              fpow, flog, fLitLike,
               select, substEmbed, substEmbedR, emitUnpack, getUnpacked,
               fromPair, getFst, getSnd, naryApp, appReduce, appTryReduce, buildAbs,
               buildFor, buildForAux, buildForAnn, buildForAnnAux,
@@ -283,6 +286,10 @@ flog x = emitOp $ ScalarUnOp Log x
 ilt :: MonadEmbed m => Atom -> Atom -> m Atom
 ilt x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (<) x y
 ilt x y = emitOp $ ScalarBinOp (ICmp Less) x y
+
+ieq :: MonadEmbed m => Atom -> Atom -> m Atom
+ieq x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (==) x y
+ieq x y = emitOp $ ScalarBinOp (ICmp Equal) x y
 
 getFst :: MonadEmbed m => Atom -> m Atom
 getFst (PairVal x _) = return x

--- a/src/lib/Imp/Embed.hs
+++ b/src/lib/Imp/Embed.hs
@@ -7,10 +7,13 @@
 module Imp.Embed ( ISubstEmbedT, ISubstEnv (..)
                  , runISubstEmbedT, liftSE
                  , emit, freshIVar, extendValSubst
+                 , buildScoped
                  -- embedding
-                 , ptrOffset, imul, alloc
+                 , iadd, imul
+                 , alloc, ptrOffset
                  -- traversal
-                 , traverseImpModule, traverseImpFunction, traverseImpBlock
+                 , traverseImpModule, traverseImpFunction
+                 , traverseImpBlock, evalImpBlock
                  , traverseImpDecl, traverseImpInstr
                  , traverseIExpr, traverseIFunVar
                  , ITraversalDef, substTraversalDef
@@ -82,6 +85,9 @@ ptrOffset ptr off = liftM head $ emit $ IPrimOp $ PtrOffset ptr off
 
 imul :: Monad m => IExpr -> IExpr -> IEmbedT m IExpr
 imul x y = liftM head $ emit $ IPrimOp $ ScalarBinOp IMul x y
+
+iadd :: Monad m => IExpr -> IExpr -> IEmbedT m IExpr
+iadd x y = liftM head $ emit $ IPrimOp $ ScalarBinOp IAdd x y
 
 alloc :: Monad m => AddressSpace -> IType -> IExpr -> IEmbedT m IExpr
 alloc addrSpc ty size = liftM head $ emit $ Alloc addrSpc ty size

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -105,30 +105,29 @@ compileFunction logger fun@(ImpFunction f bs body) = case cc of
     let strFun = constStringFunction (asLLVMName name) str
     return ([L.GlobalDefinition strFun], S.singleton mallocFun)
   MCThreadLaunch -> return $ runCompile CPU $ do
-    (threadIdParam, threadId) <- freshParamOpPair [] i64
-    (startIdxParam, startIdx) <- freshParamOpPair [] i64
-    (endIdxParam, endIdx)     <- freshParamOpPair [] i64
-    -- TODO: Preserve pointer attributes??
+    -- Set up arguments
     (argArrayParam, argArray) <- freshParamOpPair [] $ hostPtrTy hostVoidp
     args <- unpackArgs argArray argTypes
     let argEnv = foldMap (uncurry (@>)) $ zip argBinders args
-    niter <- (`asIntWidth` idxType) =<< endIdx `sub` startIdx
-    compileLoop Fwd idxBinder niter $ do
-      idxEnv <- case idxBinder of
-        Ignore _ -> return mempty
-        Bind v -> do
-          innerIdx <- lookupImpVar v
-          idx64 <- add startIdx =<< (innerIdx `asIntWidth` i64)
-          idx <- idx64 `asIntWidth` idxType
-          return $ idxBinder @> idx
-      void $ extendOperands (tidBinder @> threadId <> idxEnv <> argEnv) $ compileBlock body
+    -- Set up thread info
+    wid                       <- compileExpr $ IIdxRepVal 0
+    (threadIdParam, tidArg  ) <- freshParamOpPair [] i32
+    (nThreadParam , nthrArg ) <- freshParamOpPair [] i32
+    tid  <- tidArg  `asIntWidth` idxRepTy
+    nthr <- nthrArg `asIntWidth` idxRepTy
+    let threadInfoEnv =  tidBinder  @> tid
+                      <> widBinder  @> wid
+                      <> wszBinder  @> nthr
+                      <> nthrBinder @> nthr
+    -- Emit the body
+    void $ extendOperands (argEnv <> threadInfoEnv) $ compileBlock body
     kernel <- makeFunction (asLLVMName name)
-                [threadIdParam, startIdxParam, endIdxParam, argArrayParam] Nothing
+                [threadIdParam, nThreadParam, argArrayParam] Nothing
     extraSpecs <- gets funSpecs
     return ([L.GlobalDefinition kernel], extraSpecs)
     where
-      (tidBinder:idxBinder:argBinders) = bs
-      idxType = scalarTy $ binderAnn idxBinder
+      idxRepTy = scalarTy $ IIdxRepTy
+      (tidBinder:widBinder:wszBinder:nthrBinder:argBinders) = bs
       argTypes = map (scalarTy . binderAnn) argBinders
   where
     name :> IFunType cc argTys retTys = f
@@ -145,10 +144,24 @@ compileInstr instr = case instr of
     compileIf p' (compileVoidBlock cons) (compileVoidBlock alt)
   IQueryParallelism f s -> do
     let IFunType cc _ _ = varAnn f
+    let kernelFuncName = asLLVMName $ varName f
+    n <- (`asIntWidth` i64) =<< compileExpr s
     case cc of
-      MCThreadLaunch   -> error "Not implemented yet"
-      -- TODO: Use the occupancy calculator and emit a loop inside the kernel
-      CUDAKernelLaunch -> (:[]) <$> ((`asIntWidth` i32) =<< compileExpr s)
+      MCThreadLaunch -> do
+        numThreads <- emitExternCall queryParallelismMCFun [n]
+        return [i32Lit 1, numThreads]
+        where queryParallelismMCFun = ExternFunSpec "dex_queryParallelismMC" i32 [] [] [i64]
+      CUDAKernelLaunch -> do
+        let ptxPtrFun = callableOperand (funTy (hostPtrTy i8) []) kernelFuncName
+        ptxPtr <- emitInstr (hostPtrTy i8) $ callInstr ptxPtrFun []
+        numWorkgroupsPtr <- alloca 1 i32
+        workgroupSizePtr <- alloca 1 i32
+        emitVoidExternCall queryParallelismCUDAFun [ptxPtr, n, numWorkgroupsPtr, workgroupSizePtr]
+        traverse load [numWorkgroupsPtr, workgroupSizePtr]
+        where
+          queryParallelismCUDAFun = ExternFunSpec "dex_queryParallelismCUDA" L.VoidType [] []
+                                                  [hostPtrTy i8, i64, hostPtrTy i32, hostPtrTy i32]
+      _                -> error $ "Unsupported calling convention: " ++ show cc
   ILaunch f size args -> [] <$ do
     let IFunType cc _ _ = varAnn f
     size' <- (`asIntWidth` i64) =<< compileExpr size
@@ -163,7 +176,7 @@ compileInstr instr = case instr of
       CUDAKernelLaunch -> do
         let ptxPtrFun = callableOperand (funTy (hostPtrTy i8) []) kernelFuncName
         ptxPtr <- emitInstr (hostPtrTy i8) $ callInstr ptxPtrFun []
-        kernelParams <- packArgs $ size' : args'
+        kernelParams <- packArgs args'
         launchCUDAKernel ptxPtr size' kernelParams
       _ -> error $ "Not a valid calling convention for a launch: " ++ pprint cc
   IThrowError   -> do
@@ -235,6 +248,7 @@ compileInstr instr = case instr of
         resultPtr <- makeMultiResultAlloc resultTys'
         emitVoidExternCall (makeFunSpec f) (resultPtr : args')
         loadMultiResultAlloc resultTys' resultPtr
+      _ -> error $ "Unsupported calling convention: " ++ show cc
 
 makeFunSpec :: IFunVar -> ExternFunSpec
 makeFunSpec (Name _ name _ :> IFunType FFIFun argTys [resultTy]) =
@@ -383,32 +397,35 @@ cuMemFree ptr = do
   where spec = ExternFunSpec "dex_cuMemFree" L.VoidType [] [] [deviceVoidp]
 
 -- === GPU Kernel compilation ===
+-- Useful docs:
+-- * NVVM IR specification: https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html
+-- * PTX docs: https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html
 
 impKernelToLLVMGPU :: ImpFunction -> LLVMKernel
-impKernelToLLVMGPU (ImpFunction _ ~(tidvar:lidxvar:args) body) = runCompile GPU $ do
+impKernelToLLVMGPU ~(ImpFunction _ ~(tidVar:widVar:wszVar:nthrVar:args) body) = runCompile GPU $ do
   (argParams, argOperands) <- unzip <$> mapM (freshParamOpPair ptrParamAttrs) argTypes
-  (sizeParam, sizeOperand) <- freshParamOpPair [] lidxType
-  tidx <- threadIdxX
-  bidx <- blockIdxX
-  bsz  <- blockDimX
-  lidx <- mul bidx bsz >>= (add tidx) >>= (`asIntWidth` lidxType)
-  let tid = lidx
-  outOfBounds <- emitInstr i1 $ L.ICmp IP.UGE lidx sizeOperand []
-  compileIf outOfBounds (return ()) $ do
-    let paramEnv = foldMap (uncurry (@>)) $ zip args argOperands
-    -- TODO: Use a restricted form of compileBlock that e.g. never emits FFI calls!
-    void $ extendOperands (paramEnv <> lidxvar @> lidx <> tidvar @> tid) $ compileBlock body
-  kernel <- makeFunction "kernel" (sizeParam : argParams) Nothing
+  tidx <- threadIdxX >>= (`asIntWidth` idxRepTy)
+  bidx <- blockIdxX  >>= (`asIntWidth` idxRepTy)
+  bsz  <- blockDimX  >>= (`asIntWidth` idxRepTy)
+  gsz  <- gridDimX   >>= (`asIntWidth` idxRepTy)
+  nthr <- mul bsz gsz
+  let threadInfoEnv =  tidVar  @> tidx
+                    <> widVar  @> bidx
+                    <> wszVar  @> bsz
+                    <> nthrVar @> nthr
+  let paramEnv = foldMap (uncurry (@>)) $ zip args argOperands
+  void $ extendOperands (paramEnv <> threadInfoEnv) $ compileBlock body
+  kernel <- makeFunction "kernel" argParams Nothing
   LLVMKernel <$> makeModuleEx ptxDataLayout ptxTargetTriple
                    [L.GlobalDefinition kernel, kernelMeta, nvvmAnnotations]
   where
-    lidxType = scalarTy $ binderAnn lidxvar
+    idxRepTy = scalarTy $ IIdxRepTy
     ptrParamAttrs = [L.NoAlias, L.NoCapture, L.NonNull, L.Alignment 256]
     argTypes = fmap (scalarTy . binderAnn) args
     kernelMetaId = L.MetadataNodeID 0
     kernelMeta = L.MetadataNodeDefinition kernelMetaId $ L.MDTuple
       [ Just $ L.MDValue $ L.ConstantOperand $ C.GlobalReference
-          (funTy L.VoidType (lidxType : argTypes)) "kernel"
+          (funTy L.VoidType argTypes) "kernel"
       , Just $ L.MDString "kernel"
       , Just $ L.MDValue $ L.ConstantOperand $ C.Int 32 1
       ]
@@ -425,6 +442,10 @@ blockIdxX = emitExternCall spec []
 blockDimX :: Compile Operand
 blockDimX = emitExternCall spec []
   where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.ntid.x"
+
+gridDimX :: Compile Operand
+gridDimX = emitExternCall spec []
+  where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.nctaid.x"
 
 ptxSpecialReg :: L.Name -> ExternFunSpec
 ptxSpecialReg name = ExternFunSpec name i32 [] [FA.ReadNone, FA.NoUnwind] []
@@ -465,6 +486,20 @@ gpuBinaryIntrinsic op x y = case L.typeOf x of
       _    -> error $ "Unsupported GPU operation: " ++ show op
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty, ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x, y]
+
+_gpuDebugPrint :: Operand -> Compile ()
+_gpuDebugPrint i32Val = do
+  let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) "%d\n" ++ [0]
+  let formatStrArr = L.ConstantOperand $ C.Array i8 chars
+  formatStrPtr <- alloca (length chars) i8
+  castLPtr (L.typeOf formatStrArr) formatStrPtr >>= (`store` formatStrArr)
+  valPtr <- alloca 1 i32
+  store valPtr i32Val
+  valPtri8 <- castLPtr i8 valPtr
+  void $ emitExternCall vprintfSpec [formatStrPtr, valPtri8]
+  where
+    genericPtrTy ty = L.PointerType ty $ L.AddrSpace 0
+    vprintfSpec = ExternFunSpec "vprintf" i32 [] [] [genericPtrTy i8, genericPtrTy i8]
 
 compileBlock :: ImpBlock -> Compile [Operand]
 compileBlock (ImpBlock Empty result) = traverse compileExpr result
@@ -507,7 +542,7 @@ unpackArgs argArrayPtr types =
 makeMultiResultAlloc :: [L.Type] -> Compile Operand
 makeMultiResultAlloc tys = do
   resultsPtr <- alloca (length tys) hostVoidp
-  forM (zip [0..] tys) $ \(i, ty) -> do
+  forM_ (zip [0..] tys) $ \(i, ty) -> do
     ptr <- alloca 1 ty >>= castVoidPtr
     resultsPtrOffset <- gep resultsPtr $ i32Lit i
     store resultsPtrOffset ptr
@@ -519,10 +554,10 @@ loadMultiResultAlloc tys ptr =
     gep ptr (i32Lit i) >>= load >>= castLPtr ty >>= load
 
 runMCKernel :: ExternFunSpec
-runMCKernel = ExternFunSpec "dex_parallel_for" L.VoidType [] [] [hostVoidp, i64, hostPtrTy hostVoidp]
+runMCKernel = ExternFunSpec "dex_launchKernelMC" L.VoidType [] [] [hostVoidp, i64, hostPtrTy hostVoidp]
 
 mcKernelPtrType :: L.Type
-mcKernelPtrType = hostPtrTy $ L.FunctionType L.VoidType [i64, i64, i64, hostPtrTy $ hostVoidp] False
+mcKernelPtrType = hostPtrTy $ L.FunctionType L.VoidType [i32, i32, hostPtrTy $ hostVoidp] False
 
 -- === LLVM embedding ===
 
@@ -743,8 +778,8 @@ cpuBinaryIntrinsic op x y = case L.typeOf x of
 constStringFunction :: L.Name -> B.ByteString -> Function
 constStringFunction name str = runCompile CPU $ do
   let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) (B.unpack str) ++ [0]
-  ptr <- malloc i8 $ i64Lit $ length chars
   let strVal = L.ConstantOperand $ C.Array i8 chars
+  ptr <- malloc i8 $ i64Lit $ length chars
   tyPtr <- castLPtr (L.typeOf strVal) ptr
   store tyPtr strVal
   makeFunction name [] (Just ptr)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -214,6 +214,7 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
         high' = case high of InclusiveLim x -> pApp x
                              ExclusiveLim x -> "<" <> pApp x
                              Unlimited      -> ""
+    ParIndexRange d _ _ n -> atPrec LowestPrec $ parens (p $ show d) <> pApp n
     RefType (Just h) a -> atPrec AppPrec $ pAppArg "Ref" [h, a]
     RefType Nothing a  -> atPrec AppPrec $ pAppArg "Ref" [a]
     TypeKind -> atPrec ArgPrec "Type"
@@ -244,6 +245,8 @@ prettyPrecPrimCon con = case con of
   ClassDictHole _ _ -> atPrec ArgPrec "_"
   IntRangeVal     l h i -> atPrec LowestPrec $ pApp i <> "@" <> pApp (IntRange     l h)
   IndexRangeVal t l h i -> atPrec LowestPrec $ pApp i <> "@" <> pApp (IndexRange t l h)
+  ParIndexCon ty i ->
+    atPrec LowestPrec $ pApp i <> "@" <> pApp ty
   IndexSliceVal ty n i ->
     atPrec LowestPrec $ "IndexSlice" <+> pApp ty <+> pApp n <+> pApp i
   BaseTypeRef ptr -> atPrec ArgPrec $ "Ref" <+> pApp ptr

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -49,11 +49,11 @@ module Syntax (
     varType, binderType, isTabTy, LogLevel (..), IRVariant (..),
     applyIntBinOp, applyIntCmpOp, applyFloatBinOp, applyFloatUnOp,
     getIntLit, getFloatLit, sizeOf, vectorWidth, pattern CharLit,
-    pattern IdxRepTy, pattern IdxRepVal, pattern IIdxRepVal,
+    pattern IdxRepTy, pattern IdxRepVal, pattern IIdxRepVal, pattern IIdxRepTy,
     pattern TagRepTy, pattern TagRepVal,
     pattern IntLitExpr, pattern FloatLitExpr,
     pattern UnitTy, pattern PairTy, pattern FunTy,
-    pattern FixedIntRange, pattern RefTy, pattern RawRefTy,
+    pattern FixedIntRange, pattern Fin, pattern RefTy, pattern RawRefTy,
     pattern BaseTy, pattern PtrTy, pattern UnitVal,
     pattern PairVal, pattern PureArrow,
     pattern TyKind, pattern LamVal,
@@ -284,6 +284,7 @@ data PrimTC e =
       | TypeKind
       | EffectRowKind
       | LabeledRowKindTC
+      | ParIndexRange Device e e e  -- Global thread id, thread count, full index set
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimCon e =
@@ -301,6 +302,7 @@ data PrimCon e =
       | TabRef e
       | ConRef (PrimCon e)
       | RecordRef (LabeledItems e)
+      | ParIndexCon e e        -- Type, value
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimOp e =
@@ -1291,13 +1293,16 @@ pattern CharLit x = Con (CharCon (Con (Lit (Int8Lit x))))
 
 -- Type used to represent indices at run-time
 pattern IdxRepTy :: Type
-pattern IdxRepTy = TC (BaseType (Scalar Int32Type))
+pattern IdxRepTy = TC (BaseType IIdxRepTy)
 
 pattern IdxRepVal :: Int32 -> Atom
 pattern IdxRepVal x = Con (Lit (Int32Lit x))
 
 pattern IIdxRepVal :: Int32 -> IExpr
 pattern IIdxRepVal x = ILit (Int32Lit x)
+
+pattern IIdxRepTy :: IType
+pattern IIdxRepTy = Scalar Int32Type
 
 -- Type used to represent sum type tags at run-time
 pattern TagRepTy :: Type
@@ -1344,6 +1349,9 @@ pattern LabeledRowKind = TC LabeledRowKindTC
 
 pattern FixedIntRange :: Int32 -> Int32 -> Type
 pattern FixedIntRange low high = TC (IntRange (IdxRepVal low) (IdxRepVal high))
+
+pattern Fin :: Atom -> Type
+pattern Fin n = TC (IntRange (IdxRepVal 0) n)
 
 pattern PureArrow :: Arrow
 pattern PureArrow = PlainArrow Pure


### PR DESCRIPTION
This exposes a number of important variables in the kernel language,
which expose the concept of a workgroup to the Imp representation. While
this does not come with any significant upsides at the moment, it is a
necessary prerequisite for the efficient parallel reductions that I am
hoping to submit soon (I have most of the implementation ready).

Here's a summary of the changes:
* It is no longer the responsibility of `ILaunch` to actually cover the
  iteration domain with threads. `ILaunch` is supposed to launch as many
  threads as can concurrently execute on the given accelerator, and it is
  the responsibility of each thread to figure out its iteration domain
  (which might involve multiple points of the full domain).
* Kernel threads now expose a number of useful variables such as
  (intra-workgroup) thread id, workgroup id, workgroup size, total number
  of threads.
* Given those constraints, CUDA kernels are now using grid-stride loops,
  while CPU kernels still iterate over the domain in contiguous chunks.
  This required an addition of an Imp-lowering-specific index range type
  called `ParIndexRange` and the corresponding constructor `ParIndexCon`.