### PR TITLE
Add support for simple parallel reductions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -46,6 +46,9 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
         restore-keys: ${{ runner.os }}-
 
+    - name: Remove cached Setup executables
+      run: rm -rf ~/.stack/setup-exe-cache
+
     - name: Build
       run: make
 

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -264,6 +264,7 @@ linearizeHof env hof = case hof of
   While _ _   -> notImplemented
   Linearize _ -> error "Unexpected linearization"
   Transpose _ -> error "Unexpected transposition"
+  PTileReduce _ _ -> error "Unexpected PTileReduce"
   where
     linearizeEff maybeInit lam hasResult hofMaker emitter eff = LinA $ do
       (valHofMaker, maybeLinInit) <- case maybeInit of
@@ -666,10 +667,11 @@ transposeHof hof ct = case hof of
       localLinRegion h $ localLinRefSubst (b@>ref) $ transposeBlock body ctBody
       return UnitVal
     transposeAtom s cts
-  Tile   _ _ _ -> notImplemented
-  While    _ _ -> notImplemented
-  Linearize  _ -> error "Unexpected linearization"
-  Transpose  _ -> error "Unexpected transposition"
+  Tile      _ _ _ -> notImplemented
+  While       _ _ -> notImplemented
+  Linearize     _ -> error "Unexpected linearization"
+  Transpose     _ -> error "Unexpected transposition"
+  PTileReduce _ _ -> error "Unexpected PTileReduce"
 
 transposeAtom :: Atom -> Atom -> TransposeM ()
 transposeAtom atom ct = case atom of

--- a/src/lib/Imp/Embed.hs
+++ b/src/lib/Imp/Embed.hs
@@ -154,6 +154,7 @@ traverseImpInstr def instr = case instr of
                             <*> traverseImpBlock def fb
   IQueryParallelism f s -> IQueryParallelism <$> traverseIFunVar f
                                              <*> traverseIExpr s
+  ISyncWorkgroup   -> return ISyncWorkgroup
   ILaunch f s args -> ILaunch <$> traverseIFunVar f
                               <*> traverseIExpr s
                               <*> traverse traverseIExpr args

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -162,6 +162,12 @@ compileInstr instr = case instr of
           queryParallelismCUDAFun = ExternFunSpec "dex_queryParallelismCUDA" L.VoidType [] []
                                                   [hostPtrTy i8, i64, hostPtrTy i32, hostPtrTy i32]
       _                -> error $ "Unsupported calling convention: " ++ show cc
+  ISyncWorkgroup -> do
+    dev <- asks curDevice
+    case dev of
+      CPU -> error "Not yet implemented"
+      GPU -> [] <$ emitVoidExternCall barrierSpec []
+        where barrierSpec = ExternFunSpec "llvm.nvvm.barrier0" L.VoidType [] [] []
   ILaunch f size args -> [] <$ do
     let IFunType cc _ _ = varAnn f
     size' <- (`asIntWidth` i64) =<< compileExpr size

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -214,7 +214,7 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
         high' = case high of InclusiveLim x -> pApp x
                              ExclusiveLim x -> "<" <> pApp x
                              Unlimited      -> ""
-    ParIndexRange d _ _ n -> atPrec LowestPrec $ parens (p $ show d) <> pApp n
+    ParIndexRange n _ _ -> atPrec ArgPrec $ "{" <> pLowest n <> "}"
     RefType (Just h) a -> atPrec AppPrec $ pAppArg "Ref" [h, a]
     RefType Nothing a  -> atPrec AppPrec $ pAppArg "Ref" [a]
     TypeKind -> atPrec ArgPrec "Type"
@@ -451,17 +451,18 @@ instance Pretty ImpInstr where
   pretty (ICond predicate cons alt) =
     "if" <+> p predicate <+> "then" <> nest 2 (hardline <> p cons) <>
     hardline <> "else" <> nest 2 (hardline <> p alt)
-  pretty (IQueryParallelism f s) = "query_parallelism" <+> p (varName f) <+> p s
+  pretty (IQueryParallelism f s) = "queryParallelism" <+> p (varName f) <+> p s
   pretty (ILaunch f size args) =
-    "launch_kernel" <+> p (varName f) <+> p size <+> spaced args
+    "launch" <+> p (varName f) <+> p size <+> spaced args
   pretty (IPrimOp op)     = pLowest op
   pretty (ICastOp t x)    = "cast"  <+> p x <+> "to" <+> p t
   pretty (Store dest val) = "store" <+> p dest <+> p val
   pretty (Alloc _ t s)    = "alloc" <+> p t <> "[" <> p s <> "]"
   pretty (MemCopy dest src numel) = "memcopy" <+> p dest <+> p src <+> p numel
   pretty (Free ptr)       = "free"  <+> p ptr
-  pretty IThrowError = "throwError"
-  pretty (ICall f args) = "call" <+> p f <+> p args
+  pretty ISyncWorkgroup   = "syncWorkgroup"
+  pretty IThrowError      = "throwError"
+  pretty (ICall f args)   = "call" <+> p f <+> p args
 
 forStr :: ForAnn -> Doc ann
 forStr (RegularFor Fwd) = "for"

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -437,6 +437,7 @@ simplifyHof hof = case hof of
     ~(fT', Nothing) <- simplifyLam fT
     ~(fS', Nothing) <- simplifyLam fS
     emit $ Hof $ Tile d fT' fS'
+  PTileReduce _ _ -> error "Unexpected PTileReduce"
   While cond body -> do
     ~(cond', Nothing) <- simplifyLam cond
     ~(body', Nothing) <- simplifyLam body

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -11,7 +11,7 @@
 
 module Type (
   getType, checkType, HasType (..), Checkable (..), litType,
-  isPure, exprEffs, blockEffs, extendEffect, isData, checkBinOp, checkUnOp,
+  isPure, functionEffs, exprEffs, blockEffs, extendEffect, isData, checkBinOp, checkUnOp,
   checkIntBaseType, checkFloatBaseType, withBinder, isDependent,
   indexSetConcreteSize, checkNoShadow, traceCheckM, traceCheck) where
 
@@ -263,6 +263,7 @@ exprEffs expr = case expr of
     RunReader _ f   -> handleRunner Reader f
     RunWriter   f   -> handleRunner Writer f
     RunState  _ f   -> handleRunner State  f
+    PTileReduce _ _ -> mempty
   Case _ alts _ -> foldMap (\(Abs _ block) -> blockEffs block) alts
   where
     handleRunner effName ~(BinaryFunVal (Bind (h:>_)) _ (EffectRow effs Nothing) _) =
@@ -430,6 +431,7 @@ instance CoreVariant (PrimHof a) where
     Linearize _   -> goneBy Simp
     Transpose _   -> goneBy Simp
     Tile _ _ _    -> alwaysAllowed
+    PTileReduce _ _ -> absentUntil Simp -- really absent until parallelization
 
 -- TODO: namespace restrictions?
 alwaysAllowed :: VariantM ()
@@ -561,7 +563,7 @@ typeCheckTyCon tc = case tc of
   TypeKind         -> return TyKind
   EffectRowKind    -> return TyKind
   LabeledRowKindTC -> return TyKind
-  ParIndexRange _ gtid nthr t -> gtid|:IdxRepTy >> nthr|:IdxRepTy >> t|:TyKind >> return TyKind
+  ParIndexRange t gtid nthr -> gtid|:IdxRepTy >> nthr|:IdxRepTy >> t|:TyKind >> return TyKind
 
 typeCheckCon :: Con -> TypeM Type
 typeCheckCon con = case con of
@@ -674,7 +676,7 @@ typeCheckOp op = case op of
     TC tc <- typeCheck i
     case tc of
       IndexRange ty _ _ -> return ty
-      ParIndexRange _ _ _ ty -> return ty
+      ParIndexRange ty _ _ -> return ty
       _ -> throw TypeErr $ "Unsupported inject argument type: " ++ pprint (TC tc)
   PrimEffect ref m -> do
     TC (RefType h s) <- typeCheck ref
@@ -806,6 +808,15 @@ typeCheckHof hof = case hof of
       replaceDim 0 (TabTy _ b) n  = TabTy (Ignore n) b
       replaceDim d (TabTy dv b) n = TabTy dv $ replaceDim (d-1) b n
       replaceDim _ _ _ = error "This should be checked before"
+  PTileReduce n mapping -> do
+    -- mapping : gtid:IdxRepTy -> nthr:IdxRepTy -> ((ParIndexRange n gtid nthr)=>a, r)
+    BinaryFunTy (Bind gtid) (Bind nthr) Pure mapResultTy <- typeCheck mapping
+    PairTy tiledArrTy accTy <- return mapResultTy
+    let threadRange = TC $ ParIndexRange n (Var gtid) (Var nthr)
+    TabTy threadRange' tileElemTy <- return tiledArrTy
+    checkEq threadRange (binderType threadRange')
+    -- PTileReduce n mapping : (n=>a, ro)
+    return $ PairTy (TabTy (Ignore n) tileElemTy) accTy
   While cond body -> do
     Pi (Abs (Ignore UnitTy) (arr , condTy)) <- typeCheck cond
     Pi (Abs (Ignore UnitTy) (arr', bodyTy)) <- typeCheck body

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -193,9 +193,9 @@ void dex_queryParallelismCUDA(const void* _, int64_t iters,
     return;
   }
   // TODO: Use the occupancy calculator, or at least use a fixed number of blocks?
-  const int32_t fixedWgSize = 256;
+  const int64_t fixedWgSize = 1024;
   *workgroupSize = fixedWgSize;
-  *numWorkgroups = (iters + fixedWgSize - 1) / fixedWgSize;
+  *numWorkgroups = std::min((iters + fixedWgSize - 1) / fixedWgSize, fixedWgSize);
 }
 
 void dex_cuLaunchKernel(const void* kernel_text, int64_t iters, char** args) {


### PR DESCRIPTION
This implements a basic two-level reduction kernel for CUDA. Nothing
particularly fancy, but it allows us to at least start experimenting
with basic reductions and already presents some really nice speedups
over single-threaded CPU (adding 1e10 numbers on a P100 in 2.8ms vs 2s).

Anyway, the current implementation leaves a lot on the table. For
example, we carelessly replicate the accumulator over all threads which
might be very wasteful for segmented reductions. Also, we never explot
the paralellism that is present in the `+=` operator (and there might be
plenty, when the accumulator represents e.g. a large matrix).

Finally, the way we deal with the problem right now is a little
unsatisfactory in that the lowering step from Core to Imp involves a
pretty big hand-written kernel template. I would very much like to lift
more of the low-level concepts into the core representation and start
deriving the big thing as an application of multiple, hopefully
straightforward, rewrite rules.