### PR TITLE
Cache CUDA kernels on the device

### DIFF
--- a/src/dex.hs
+++ b/src/dex.hs
@@ -126,8 +126,7 @@ parseMode = subparser $
                          <> metavar "STRING" <> help "REPL prompt"))
   <> (command "web"    $ simpleInfo (WebMode    <$> sourceFileInfo ))
   <> (command "watch"  $ simpleInfo (WatchMode  <$> sourceFileInfo ))
-  <> (command "export" $ simpleInfo (ExportMode <$> sourceFileInfo
-    <*> objectFileInfo))
+  <> (command "export" $ simpleInfo (ExportMode <$> sourceFileInfo <*> objectFileInfo))
   <> (command "script" $ simpleInfo (ScriptMode <$> sourceFileInfo
     <*> (option
             (optionList [ ("literate"   , TextDoc)

--- a/src/lib/CUDA.hs
+++ b/src/lib/CUDA.hs
@@ -1,5 +1,5 @@
 
-module CUDA (hasCUDA, loadCUDAArray) where
+module CUDA (hasCUDA, loadCUDAArray, synchronizeCUDA) where
 
 import Data.Int
 import Foreign.Ptr
@@ -7,15 +7,19 @@ import Foreign.Ptr
 hasCUDA :: Bool
 
 #ifdef DEX_CUDA
-foreign import ccall "load_cuda_array"  loadCUDAArrayImpl :: Ptr () -> Ptr () -> Int64 -> IO ()
-
 hasCUDA = True
-#else
-loadCUDAArrayImpl :: Ptr () -> Ptr () -> Int64 -> IO ()
-loadCUDAArrayImpl _ _ = error "Dex built without CUDA support"
 
+foreign import ccall "dex_cuMemcpyDtoH"    cuMemcpyDToH    :: Int64 -> Ptr () -> Ptr () -> IO ()
+foreign import ccall "dex_synchronizeCUDA" synchronizeCUDA :: IO ()
+#else
 hasCUDA = False
+
+cuMemcpyDToH :: Int64 -> Ptr () -> Ptr () -> IO ()
+cuMemcpyDToH = error "Dex built without CUDA support"
+
+synchronizeCUDA :: IO ()
+synchronizeCUDA = return ()
 #endif
 
 loadCUDAArray :: Ptr () -> Ptr () -> Int -> IO ()
-loadCUDAArray hostPtr devicePtr bytes = loadCUDAArrayImpl hostPtr devicePtr (fromIntegral bytes)
+loadCUDAArray hostPtr devicePtr bytes = cuMemcpyDToH (fromIntegral bytes) devicePtr hostPtr


### PR DESCRIPTION
Previously whenever we wanted to launch a CUDA kernel we would emit LLVM
code to load it onto the device, call into it, and unload it again.
While this was a good way to get started, loading the code involves a
JIT and can take hundreds of milliseconds, i.e. orders of magnitude more
than the actual GPU execution. This made it almost impossible to
benchmark our CUDA performance, because the run-time was heavily
dominated by code processing.

This change makes it so that the references to GPU code are lazily
created, but are cached for as long as the object files remain in
memory. The liftime management is mostly automatic, thanks to the
special `llvm.global_dtors` variable, which registers our destructors in
the ELF files. Unfortunately, the JIT interface we use does not support
that option, so we have to emulate it in there, but it's not too
difficult.

Also, now that we have this mechanism worked out, we could consider
caching GPU memory allocations using a technique similar to the one
[used in Futhark](https://futhark-lang.org/blog/2018-01-28-how-futhark-manages-gpu-memory.html).