### PR TITLE
Add table unpacking patterns, deduplicate pattern logic

### DIFF
--- a/examples/record-variant-tests.dx
+++ b/examples/record-variant-tests.dx
@@ -173,6 +173,9 @@ def getTwoFoosAndABar (rest : Fields)?->
 x : {a:Int | a:Float | a:Int} = {| a | a = 3.0 |}
 ({| a | a = a |}) = x
 > Type error:Variant not allowed in can't-fail pattern
+>
+> ({| a | a = a |}) = x
+>  ^^^^^^^^^^^^^^^
 
 'Record puns
 

--- a/examples/type-tests.dx
+++ b/examples/type-tests.dx
@@ -102,6 +102,7 @@ xr = map IToF arr
 > Type error:
 > Expected: Int32
 >   Actual: ((Fin 1) => Int32)
+> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
 >
 > :t [1, [2]]
 >        ^^^
@@ -113,6 +114,7 @@ xr = map IToF arr
 > Type error:
 > Expected: ((Fin 2) => Int32)
 >   Actual: ((Fin 1) => Int32)
+> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
 >
 > :t [[1, 2], [3]]
 >             ^^^

--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -258,3 +258,52 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 
 :p (eitherFloor (Left 1), eitherFloor (Right 2.3))
 > (1, 2)
+
+:p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+> Type error:
+> Expected: ((Fin a & Fin 2) => Int32)
+>   Actual: ((Fin 4) => Int32)
+> (Solving for: [a:Int32])
+> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
+>
+> :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+>    ^^^^^^^^^^^^^
+
+:p
+  [(a, b), c] = [(1, 2), (3, 4)]
+  (a, c)
+> (1, (3, 4))
+
+:p
+  [a, b] = [1, 2, 3]
+  (a, b)
+> Type error:
+> Expected: ((Fin 3) => Int32)
+>   Actual: ((Fin 2) => a)
+> (Solving for: [a:Type])
+>
+>   [a, b] = [1, 2, 3]
+>   ^^^^^^^
+
+:p
+  [[a, _], [_, d]] = [[1, 2], [3, 4]]
+  a + d
+> 5
+
+-- Can only unpack tables indexed by `Fin n`
+:p
+  [a, b, c, d] = [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
+  (a, b, c, d)
+> Type error:
+> Expected: ((Fin 2 & Fin 2) => Int32)
+>   Actual: ((Fin 4) => a)
+> (Solving for: [a:Type])
+>
+>   [a, b, c, d] = [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
+>   ^^^^^^^^^^^^^
+
+:p
+  -- parentheses needed to stop the parser from reading "zero" as a binder name
+  [a, b, c, d] = (zero) : (_ => Int)
+  (a, b, c, d)
+> (0, (0, (0, 0)))

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -614,6 +614,7 @@ instance PrettyPrec UPat' where
     UPatRecord pats -> prettyExtLabeledItems pats (line' <> ",") " ="
     UPatVariant labels label value -> prettyVariant labels label value
     UPatVariantLift labels value -> prettyVariantLift labels value
+    UPatTable pats -> atPrec ArgPrec $ p pats
 
 prettyUBinder :: UPatAnn -> Doc ann
 prettyUBinder (pat, ann) = p pat <> annDoc where

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -793,12 +793,12 @@ ops =
   [ [InfixL $ sym "." $> mkGenApp TabArrow, symOp "!"]
   , [InfixL $ sc $> mkApp]
   , [prefixNegOp]
-  , [annotatedExpr]
   , [anySymOp] -- other ops with default fixity
   , [symOp "+", symOp "-", symOp "||", symOp "&&",
      InfixR $ sym "=>" $> mkArrow TabArrow,
      InfixL $ opWithSrc $ backquoteName >>= (return . binApp),
      symOp "<<<", symOp ">>>", symOp "<<&", symOp "&>>"]
+  , [annotatedExpr]
   , [InfixR $ mayBreak (infixSym "$") $> mkApp]
   , [symOp "+=", symOp ":=", InfixL $ pairingSymOpP "|", InfixR infixArrow]
   , [InfixR $ pairingSymOpP "&", InfixR $ pairingSymOpP ","]

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -255,6 +255,7 @@ data UPat' = UPatBinder UBinder
            | UPatRecord (ExtLabeledItems UPat UPat)     -- {a=x, b=y, ...rest}
            | UPatVariant (LabeledItems ()) Label UPat   -- {|a|b| a=x |}
            | UPatVariantLift (LabeledItems ()) UPat     -- {|a|b| ...rest |}
+           | UPatTable [UPat]
              deriving (Show)
 
 data WithSrc a = WithSrc SrcCtx a
@@ -741,6 +742,7 @@ instance HasUVars UPat' where
     UPatRecord items -> freeUVars items
     UPatVariant _ _ p -> freeUVars p
     UPatVariantLift _ p -> freeUVars p
+    UPatTable ps -> foldMap freeUVars ps
 
 instance BindsUVars UPat' where
   boundUVars pat = case pat of
@@ -751,6 +753,7 @@ instance BindsUVars UPat' where
     UPatRecord items -> boundUVars items
     UPatVariant _ _ p -> boundUVars p
     UPatVariantLift _ p -> boundUVars p
+    UPatTable ps -> foldMap boundUVars ps
 
 instance HasUVars UDecl where
   freeUVars (ULet _ p expr) = freeUVars p <> freeUVars expr


### PR DESCRIPTION
**Deduplicate bindPat and unpackTopPat.**

bindPat and unpackTopPat have almost identical logic; the only difference
(that I can tell) is that bindPat uses a local CatT environment to catch
repeated variables and returns the final set of bindings, whereas unpackTopPat
just emits everything into the global environment. To avoid having to
reimplement complex pattern unpacking logic, this commit refactors unpackTopPat
to just call bindPat, then emit everything it found.

For top-level bindings, the bindings are checked twice: once, locally, to detect
multiple references to the same name inside the same pattern, then again,
globally (after converting the binders to globals), to detect shadowing at the
top level. This is a bit redundant but shouldn't cause any problems.

**Add table unpacking patterns.**

This adds support for unpacking tables in patterns. ~~Similar to literals, users
can unpack concrete non-Fin index types, but if we don't have a concrete type
we assume the index is of the form `Fin n`.~~ For now, only supports tables
indexed by `Fin n`.

Also makes some minor changes to how patterns are used in let expressions; in
particular we allow any leaf pattern to appear in a Let, instead of just
parenthesized patterns.

**Lower precedence of (:)**
To make it more intuitive to use. I haven't lowered it past `$`, though.

There's still some weirdness around this, especially because of ambiguity between
`:` used as a type annotation and `:` used as part of a pi type. But that's probably
out of scope for this PR.