### PR TITLE
Two fixes for inference

### DIFF
--- a/examples/uexpr-tests.dx
+++ b/examples/uexpr-tests.dx
@@ -307,3 +307,13 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
   [a, b, c, d] = (zero) : (_ => Int)
   (a, b, c, d)
 > (0, (0, (0, 0)))
+
+def bug (n : Type) : Unit =
+  for w':n.
+    w : n = todo
+    for i:(w..). ()
+  ()
+> Type error:Leaked local variable `w` in result type ((w..) => Unit)
+>
+>   for w':n.
+>   ^^^^

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -670,7 +670,7 @@ traverseHoles :: (MonadReader SubstEnv m, MonadEmbed m)
 traverseHoles fillHole = (traverseDecl recur, traverseExpr recur, synthPassAtom)
   where
     synthPassAtom atom = case atom of
-      Con (ClassDictHole ctx ty) -> fillHole ctx ty
+      Con (ClassDictHole ctx ty) -> fillHole ctx =<< substEmbedR ty
       _ -> traverseAtom recur atom
     recur = traverseHoles fillHole
 


### PR DESCRIPTION
* Add a missing substitution application in dictionary synthesis
* Give a reasonable error message when leaking a local in type