### PR TITLE
Added Quicksort example

### DIFF
--- a/examples/sort.dx
+++ b/examples/sort.dx
@@ -1,15 +1,40 @@
 '## Stack operations.
+This is a fake stack for now until Dex gets dependent dereferencing,
+or can handle nested references.
 
-def push (x:a) (xs:List a) --o : List a =
-  xs <> (AsList 1 [x])
+bufsize = 1000
 
-def pop (list: List a) --o : (Maybe a & List a) =
-  (AsList nx xs) = list
-  case nx == 0 of
-    True -> (Nothing, list)
+data Stack a:Type h:Type =
+  AsStack size: (Ref h Int) buf: (Ref h ((Fin bufsize)=>a))
+
+def pop (stack:Stack a h) : {State h} Maybe a =
+  (AsStack size buf) = stack
+  case get size == 0 of
+    True -> Nothing
     False ->
-      newLength = nx - 1
-      (Just xs.((nx-1)@_), AsList newLength (for i. xs.((ordinal i)@_)))
+      size := (get size) - 1
+      Just (get buf!((get size)@_))
+
+def push (stack:Stack b h) (x:b) : {State h} Unit =
+  (AsStack size buf) = stack
+  buf!((get size)@_) := x
+  size := (get size) + 1
+
+def empty (stack:Stack b h) : {State h} Bool =
+  (AsStack size buf) = stack
+  (get size) <= 0
+
+-- This will be a nice helper function, but for now it doesn't
+-- typecheck due to a unification bug.
+def withStack
+      (eff:Effects) ?->
+      (init:t)
+      (action: (Stack t h -> {State h |eff} Unit))
+      : {|eff} Unit =
+  withState (1, for i:(Fin bufsize). init) \pairref.
+    stack = AsStack (fstRef pairref) (sndRef pairref)
+    action stack
+  ()
 
 
 '## Generic helper functions
@@ -19,7 +44,7 @@ def swapInRef (xsRef: Ref h (n=>t)) (a:n) (b:n) : {State h} Unit =
   xsRef!a := get xsRef!b
   xsRef!b := temp
 
-def unMaybe (maybeA: Maybe a) : a =
+def fromJust (maybeA: Maybe a) : a =
   case maybeA of
     Just x -> x
     Nothing -> throw
@@ -32,15 +57,10 @@ def (+|) (i:n) (delta:Int) : n =
   i' = ordinal i + delta
   fromOrdinal _ $ select (i' >= size n) (size n - 1) i'
 
-def notEmpty ((AsList n xs):List a) : Bool = n > 0
 def firstIx (n:Type) : n = 0@n
 def lastIx  (n:Type) : n = ((size n) - 1)@n
 
-def sorted (_:Ord a) ?=> (xs:n=>a) : Bool =
-  all for i. (xs.i <= xs.(i +| 1))
 
--- Right now the Range type doesn't support unpacking,
--- so this is a temporary workaround.
 data MyRange a:Type =
   MkRange low:a high:a
 
@@ -50,8 +70,7 @@ def rangeSize (MkRange low high:MyRange a) : Int =
 
 '# Sort functions
 
-def partition (_:Ord a) ?=>
-  (xsRef: Ref h (n=>a))
+def partition (_:Ord a) ?=> (xsRef: Ref h (n=>a))
   (MkRange low high:MyRange n) : {State h} n = 
   -- Chooses the last element as the pivot, then
   -- moves all elements smaller than the pivot to its left,
@@ -60,42 +79,42 @@ def partition (_:Ord a) ?=>
     pivotval = get xsRef!high
     
     final_pivot_ix = snd $ withState low \pivotIxRef.
-      low'  = ordinal low  -- can't inline these two.
-      high' = ordinal high  
-      for j':(Range low' high').
-        j = (low' + ordinal j')@n 
+      for j':(low..<high).
+        j = %inject j'
         case get xsRef!j < pivotval of
           True ->
             swapInRef xsRef (get pivotIxRef) j
             pivotIxRef := (get pivotIxRef) +| 1
           False -> ()
-      ()
     swapInRef xsRef final_pivot_ix high 
     final_pivot_ix
 
-def sort (_:Ord a) ?=> (xs:n=>a) --o : n=>a =
-  -- In-place iterative quicksort.
-  init_stack = AsList _ [MkRange (first n) (last n)]
-  snd $ withState xs \xsRef.
-    withState init_stack \stackRef.
-      while (\(). notEmpty (get stackRef)) \().
-        (maybe_cur_range, remaining_stack) = pop (get stackRef)
-        stackRef := remaining_stack
-        cur_range = unMaybe maybe_cur_range
-        case rangeSize cur_range > 1 of
-          False -> ()
-          True ->
-            pivot_ix = partition xsRef cur_range
-            (MkRange low high) = cur_range
+def quickSortInPlace (_:Ord a) ?=> (xsRef: Ref h (n=>a)) : {State h} Unit =
+  initrange = MkRange (firstIx n) (lastIx n)
+  withState (1, for i:(Fin bufsize). initrange) \pairref.
+    stack = AsStack (fstRef pairref) (sndRef pairref)
+    while (\(). not (empty stack)) \().
+      cur_range = fromJust $ pop stack
+      case rangeSize cur_range <= 1 of
+        True -> ()
+        False ->
+          pivot_ix = partition xsRef cur_range
+          (MkRange low high) = cur_range
 
-            left_range  = MkRange low (pivot_ix -| 1)
-            stackRef := push left_range (get stackRef)
+          left_range  = MkRange low (pivot_ix -| 1)
+          right_range = MkRange (pivot_ix +| 1) high
 
-            right_range = MkRange (pivot_ix +| 1) high
-            stackRef := push right_range (get stackRef)
-          
-        
+          push stack left_range
+          push stack right_range
+  ()
+
+def sort (_:Ord a) ?=> (xs:n=>a) : n=>a =
+  snd $ withState xs quickSortInPlace
+
+def isSorted (_:Ord a) ?=> (xs:n=>a) : Bool =
+  all for i. xs.i <= xs.(i +| 1)
+
 ---------- Tests -----------
 
-:p sorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
+:p isSorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
 > True

--- a/examples/sort.dx
+++ b/examples/sort.dx
@@ -27,7 +27,6 @@ def empty (stack:Stack b h) : {State h} Bool =
 -- This will be a nice helper function, but for now it doesn't
 -- typecheck due to a unification bug.
 def withStack
-      (eff:Effects) ?->
       (init:t)
       (action: (Stack t h -> {State h |eff} Unit))
       : {|eff} Unit =
@@ -43,11 +42,6 @@ def swapInRef (xsRef: Ref h (n=>t)) (a:n) (b:n) : {State h} Unit =
   temp     = get xsRef!a
   xsRef!a := get xsRef!b
   xsRef!b := temp
-
-def fromJust (maybeA: Maybe a) : a =
-  case maybeA of
-    Just x -> x
-    Nothing -> throw
 
 def (-|) (i:n) (delta:Int) : n =
   i' = ordinal i - delta
@@ -70,7 +64,7 @@ def rangeSize (MkRange low high:MyRange a) : Int =
 
 '# Sort functions
 
-def partition (_:Ord a) ?=> (xsRef: Ref h (n=>a))
+def partition [Ord a] (xsRef: Ref h (n=>a))
   (MkRange low high:MyRange n) : {State h} n = 
   -- Chooses the last element as the pivot, then
   -- moves all elements smaller than the pivot to its left,
@@ -78,7 +72,7 @@ def partition (_:Ord a) ?=> (xsRef: Ref h (n=>a))
   -- and returns the final location of the pivot.
     pivotval = get xsRef!high
     
-    final_pivot_ix = snd $ withState low \pivotIxRef.
+    final_pivot_ix = yieldState low \pivotIxRef.
       for j':(low..<high).
         j = %inject j'
         case get xsRef!j < pivotval of
@@ -89,29 +83,32 @@ def partition (_:Ord a) ?=> (xsRef: Ref h (n=>a))
     swapInRef xsRef final_pivot_ix high 
     final_pivot_ix
 
-def quickSortInPlace (_:Ord a) ?=> (xsRef: Ref h (n=>a)) : {State h} Unit =
+def quickSortInPlace [Ord a] (xsRef: Ref h (n=>a)) : {State h} Unit =
   initrange = MkRange (firstIx n) (lastIx n)
-  withState (1, for i:(Fin bufsize). initrange) \pairref.
+  runState (1, for i:(Fin bufsize). initrange) \pairref.
     stack = AsStack (fstRef pairref) (sndRef pairref)
-    while (\(). not (empty stack)) \().
-      cur_range = fromJust $ pop stack
-      case rangeSize cur_range <= 1 of
-        True -> ()
-        False ->
-          pivot_ix = partition xsRef cur_range
-          (MkRange low high) = cur_range
+    while do 
+      case pop stack of
+        Nothing -> False
+        Just cur_range -> 
+          case rangeSize cur_range <= 1 of
+            True -> ()
+            False ->
+              pivot_ix = partition xsRef cur_range
+              (MkRange low high) = cur_range
 
-          left_range  = MkRange low (pivot_ix -| 1)
-          right_range = MkRange (pivot_ix +| 1) high
+              left_range  = MkRange low (pivot_ix -| 1)
+              right_range = MkRange (pivot_ix +| 1) high
 
-          push stack left_range
-          push stack right_range
+              push stack left_range
+              push stack right_range
+          True
   ()
 
-def sort (_:Ord a) ?=> (xs:n=>a) : n=>a =
-  snd $ withState xs quickSortInPlace
+def sort [Ord a] (xs:n=>a) : n=>a =
+  yieldState xs quickSortInPlace
 
-def isSorted (_:Ord a) ?=> (xs:n=>a) : Bool =
+def isSorted [Ord a] (xs:n=>a) : Bool =
   all for i. xs.i <= xs.(i +| 1)
 
 ---------- Tests -----------

--- a/examples/sort.dx
+++ b/examples/sort.dx
@@ -1,0 +1,101 @@
+'## Stack operations.
+
+def push (x:a) (xs:List a) --o : List a =
+  xs <> (AsList 1 [x])
+
+def pop (list: List a) --o : (Maybe a & List a) =
+  (AsList nx xs) = list
+  case nx == 0 of
+    True -> (Nothing, list)
+    False ->
+      newLength = nx - 1
+      (Just xs.((nx-1)@_), AsList newLength (for i. xs.((ordinal i)@_)))
+
+
+'## Generic helper functions
+
+def swapInRef (xsRef: Ref h (n=>t)) (a:n) (b:n) : {State h} Unit =
+  temp     = get xsRef!a
+  xsRef!a := get xsRef!b
+  xsRef!b := temp
+
+def unMaybe (maybeA: Maybe a) : a =
+  case maybeA of
+    Just x -> x
+    Nothing -> throw
+
+def (-|) (i:n) (delta:Int) : n =
+  i' = ordinal i - delta
+  fromOrdinal _ $ select (i' < 0) 0 i'
+
+def (+|) (i:n) (delta:Int) : n =
+  i' = ordinal i + delta
+  fromOrdinal _ $ select (i' >= size n) (size n - 1) i'
+
+def notEmpty ((AsList n xs):List a) : Bool = n > 0
+def firstIx (n:Type) : n = 0@n
+def lastIx  (n:Type) : n = ((size n) - 1)@n
+
+def sorted (_:Ord a) ?=> (xs:n=>a) : Bool =
+  all for i. (xs.i <= xs.(i +| 1))
+
+-- Right now the Range type doesn't support unpacking,
+-- so this is a temporary workaround.
+data MyRange a:Type =
+  MkRange low:a high:a
+
+def rangeSize (MkRange low high:MyRange a) : Int =
+  1 + ordinal high - ordinal low
+
+
+'# Sort functions
+
+def partition (_:Ord a) ?=>
+  (xsRef: Ref h (n=>a))
+  (MkRange low high:MyRange n) : {State h} n = 
+  -- Chooses the last element as the pivot, then
+  -- moves all elements smaller than the pivot to its left,
+  -- and all elements greater to the right.  Operates in place
+  -- and returns the final location of the pivot.
+    pivotval = get xsRef!high
+    
+    final_pivot_ix = snd $ withState low \pivotIxRef.
+      low'  = ordinal low  -- can't inline these two.
+      high' = ordinal high  
+      for j':(Range low' high').
+        j = (low' + ordinal j')@n 
+        case get xsRef!j < pivotval of
+          True ->
+            swapInRef xsRef (get pivotIxRef) j
+            pivotIxRef := (get pivotIxRef) +| 1
+          False -> ()
+      ()
+    swapInRef xsRef final_pivot_ix high 
+    final_pivot_ix
+
+def sort (_:Ord a) ?=> (xs:n=>a) --o : n=>a =
+  -- In-place iterative quicksort.
+  init_stack = AsList _ [MkRange (first n) (last n)]
+  snd $ withState xs \xsRef.
+    withState init_stack \stackRef.
+      while (\(). notEmpty (get stackRef)) \().
+        (maybe_cur_range, remaining_stack) = pop (get stackRef)
+        stackRef := remaining_stack
+        cur_range = unMaybe maybe_cur_range
+        case rangeSize cur_range > 1 of
+          False -> ()
+          True ->
+            pivot_ix = partition xsRef cur_range
+            (MkRange low high) = cur_range
+
+            left_range  = MkRange low (pivot_ix -| 1)
+            stackRef := push left_range (get stackRef)
+
+            right_range = MkRange (pivot_ix +| 1) high
+            stackRef := push right_range (get stackRef)
+          
+        
+---------- Tests -----------
+
+:p sorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
+> True


### PR DESCRIPTION
Due to missing features there are still a few  opportunities for taking advantage of Dex's type system that, when fixed, should make it faster, shorter, and safer:
 1. Writing a stack that allows in-place replacement of its underlying buffer with a larger one seems to be beyond the capabilities of Dex right now.  After conversations with @dougalm, it seems that adding dependent deferencing is all that's needed.   After conversations with @apaszke, I think supporting nested references would also be enough.  For now I just used a fixed-sized buffer.
 2. The `partition` function I wrote looks similar to the existing implementations I found online.  There is a shorter and less error-prone way to write it, which operates only on entire tables (having its caller implicitly specify `high` and `low` in the index set).  I wrote it that way first, but couldn't figure out how to create a reference to an in-place slice of an existing table.  I think I want something like this signature:
```
def sliceRef (xsRef: Ref h (n=>t)) (low:Int) (high:Int) :
  {State h} Ref h ((Range low high)=>t) =
    todo
```
this typechecks, but I don't know how to write the body.

Writing this also raised some style questions for Dex code:
3. For in-place updates, should we prefer relying on linearity, or the `State` effect?  My current feeling is that linearity would be preferable if we can count on it, since it's much less obtrusive.  It also keeps function signatures simpler.  However it's also much less flexible.
4. I understand that partial functions are declasse, so I wrote e.g. `pop` to return a `Maybe`.  But I ended up needed to call unsafe functions on the output of `pop` when I knew the stack wasn't empty.  @apaszke suggested we might want to make the condition function of `while` return a `Maybe`, where the value is passed into the body, which would remove one unnecessary unsafe check.
5. Should `sort` go in the prelude?

Fixes #292.
