### PR TITLE
NFC: gardening.

### DIFF
--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -135,7 +135,7 @@ indices ty = do
       lt' <- indices lt
       rt' <- indices rt
       return $ [PairVal l r | l <- lt', r <- rt']
-    TC (UnitType)          -> return $ [UnitVal]
+    TC UnitType            -> return [UnitVal]
     RecordTy (NoExt types) -> do
       subindices <- mapM indices (toList types)
       -- Earlier indices change faster than later ones, so we need to first

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -229,7 +229,7 @@ instance PrettyPrec e => PrettyPrec (PrimCon e) where
   prettyPrec = prettyPrecPrimCon
 
 instance {-# OVERLAPPING #-} PrettyPrec (PrimCon Atom) where
-  prettyPrec con = case (Con con) of
+  prettyPrec con = case Con con of
     CharLit c -> atPrec ArgPrec $ p $ show $ toEnum @Char $ fromIntegral c
     _         -> prettyPrecPrimCon con
 

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -48,7 +48,7 @@ parseTopDeclRepl s = case sbContents b of
 parseExpr :: String -> Maybe UExpr
 parseExpr s = case parseit s (expr <* eof) of
   Right ans -> Just ans
-  Left  e   -> Nothing
+  Left  _   -> Nothing
 
 parseit :: String -> Parser a -> Except a
 parseit s p = case runTheParser s (p <* (optional eol >> eof)) of
@@ -117,16 +117,16 @@ sourceBlock' :: Parser SourceBlock'
 sourceBlock' =
       proseBlock
   <|> topLevelCommand
-  <|> liftM (declsToModule . (:[])) (topDecl <* eolf)
-  <|> liftM (declsToModule . (:[])) (interfaceInstance <* eolf)
-  <|> liftM declsToModule (interfaceDef <* eolf)
-  <|> liftM (Command (EvalExpr Printed) . exprAsModule) (expr <* eol)
+  <|> fmap (declsToModule . (:[])) (topDecl <* eolf)
+  <|> fmap (declsToModule . (:[])) (interfaceInstance <* eolf)
+  <|> fmap declsToModule (interfaceDef <* eolf)
+  <|> fmap (Command (EvalExpr Printed) . exprAsModule) (expr <* eol)
   <|> hidden (some eol >> return EmptyLines)
   <|> hidden (sc >> eol >> return CommentLine)
   where declsToModule = RunModule . UModule . toNest
 
 proseBlock :: Parser SourceBlock'
-proseBlock = label "prose block" $ char '\'' >> liftM (ProseBlock . fst) (withSource consumeTillBreak)
+proseBlock = label "prose block" $ char '\'' >> fmap (ProseBlock . fst) (withSource consumeTillBreak)
 
 loadData :: Parser SourceBlock'
 loadData = do
@@ -278,12 +278,12 @@ interfaceDef = do
   keyWord WhereKW
   recordFieldsWithSrc <- withSrc $ interfaceRecordFields ":"
   let (UConDef interfaceName uAnnBinderNest) = tyCon
-      record = (URecordTy . NoExt) <$> recordFieldsWithSrc
+      record = URecordTy . NoExt <$> recordFieldsWithSrc
       consName = mkInterfaceConsName interfaceName
       varNames = fmap (\(Bind v) -> varName v) uAnnBinderNest
       (WithSrc _ recordFields) = recordFieldsWithSrc
       funDefs = mkFunDefs (pos, varNames, interfaceName) recordFields
-  return $ (UData tyCon [UConDef consName (toNest [Ignore record])]) : funDefs
+  return $ UData tyCon [UConDef consName (toNest [Ignore record])] : funDefs
   where
     -- From an interface
     --   interface I a:Type b:Type where

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -985,8 +985,7 @@ absArgType :: Abs Binder a -> Type
 absArgType (Abs b _) = binderType b
 
 toNest :: [a] -> Nest a
-toNest (x:xs) = Nest x $ toNest xs
-toNest [] = Empty
+toNest = foldr Nest Empty
 
 instance HasVars Arrow where
   freeVars arrow = case arrow of
@@ -1392,10 +1391,10 @@ isTabTy (TabTy _ _) = True
 isTabTy _ = False
 
 mkConsListTy :: [Type] -> Type
-mkConsListTy tys = foldr PairTy UnitTy tys
+mkConsListTy = foldr PairTy UnitTy
 
 mkConsList :: [Atom] -> Atom
-mkConsList xs = foldr PairVal UnitVal xs
+mkConsList = foldr PairVal UnitVal
 
 fromConsListTy :: MonadError Err m => Type -> m [Type]
 fromConsListTy ty = case ty of
@@ -1435,7 +1434,7 @@ pattern InternalSingletonLabel :: Label
 pattern InternalSingletonLabel = "%UNLABELED%"
 
 _getUnlabeled :: LabeledItems a -> Maybe [a]
-_getUnlabeled (LabeledItems items) = case (length items) of
+_getUnlabeled (LabeledItems items) = case length items of
   0 -> Just []
   1 -> NE.toList <$> M.lookup InternalSingletonLabel items
   _ -> Nothing

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -18,7 +18,7 @@ import Prelude hiding (pi)
 import Control.Monad
 import Control.Monad.Except hiding (Except)
 import Control.Monad.Reader
-import Data.Foldable (toList)
+import Data.Foldable (toList, traverse_)
 import Data.Functor
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -394,7 +394,7 @@ instance CoreVariant Expr where
 instance CoreVariant Decl where
   -- let annotation restrictions?
   checkVariant (Let _ b e) = checkVariant b >> checkVariant e
-  checkVariant (Unpack bs e) = mapM checkVariant bs >> checkVariant e
+  checkVariant (Unpack bs e) = mapM_ checkVariant bs >> checkVariant e
 
 instance CoreVariant Block where
   checkVariant (Block ds e) = mapM_ checkVariant ds >> checkVariant e
@@ -558,7 +558,7 @@ typeCheckTyCon tc = case tc of
   IndexSlice n l   -> n|:TyKind >> l|:TyKind >> return TyKind
   PairType a b     -> a|:TyKind >> b|:TyKind >> return TyKind
   UnitType         -> return TyKind
-  RefType r a      -> mapM (|: TyKind) r  >> a|:TyKind >> return TyKind
+  RefType r a      -> mapM_ (|: TyKind) r >> a|:TyKind >> return TyKind
   TypeKind         -> return TyKind
   EffectRowKind    -> return TyKind
   LabeledRowKindTC -> return TyKind
@@ -933,8 +933,8 @@ checkDataLike :: MonadError Err m => String -> Type -> m ()
 checkDataLike msg ty = case ty of
   Var _ -> error "Not implemented"
   TabTy _ b -> recur b
-  RecordTy (NoExt items)  -> void $ traverse recur items
-  VariantTy (NoExt items) -> void $ traverse recur items
+  RecordTy (NoExt items)  -> traverse_ recur items
+  VariantTy (NoExt items) -> traverse_ recur items
   TypeCon def params ->
     mapM_ checkDataLikeDataCon $ applyDataDefParams def params
   TC con -> case con of


### PR DESCRIPTION
Minor stylistic fixes according to hlint:
- Remove redundant `$`.
- Remove redundant parentheses in various expressions.
- Rewrite `liftM` as `fmap`.
- Use `foldr` instead of manual implementation.
- Eta-reduce some functions (make them point-free).

---

Use discarding functions instead of accumulating ones. This is NFC but may result in better performance.
Rename where possible:
- `mapM` -> `mapM_`
- `void $ traverse` -> `traverse_`