### PR TITLE
Remove unused valuie in parser

### DIFF
--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -48,7 +48,7 @@ parseTopDeclRepl s = case sbContents b of
 parseExpr :: String -> Maybe UExpr
 parseExpr s = case parseit s (expr <* eof) of
   Right ans -> Just ans
-  Left  e   -> Nothing
+  Left  _   -> Nothing
 
 parseit :: String -> Parser a -> Except a
 parseit s p = case runTheParser s (p <* (optional eol >> eof)) of


### PR DESCRIPTION
This should fix the warning

```
[ 9 of 31] Compiling Parser

/Users/oxinabox/dex_building/round7/dex-lang/src/lib/Parser.hs:51:9: warning: [-Wunused-matches]
    Defined but not used: ‘e’
   |
51 |   Left  e   -> Nothing
```

