### PR TITLE
Fast Fourier Transform

### DIFF
--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -40,46 +40,45 @@ def nextpow2 (x:Int) : Int = case isPowerOf2 x of
 
 '## Inner FFT functions
 
--- FFT can be called in either forwards mode (for FFT),
--- or backwards mode (for inverse FFT).
-data Direction =
-  Forward
-  Backward
+data FTDirection =
+  ForwardFT
+  InverseFT
 
 -- Todo: Replace with reshaping.
 def butterfly_ixs (j:Int) (pow2:Int) : (n & n) =
   k = ((idiv j pow2) * pow2 * 2) + mod j pow2
   (k@n, (k + pow2)@n)
 
-def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
+def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   -- Input size must be a power of 2.
   -- Could enforce this with tables-as-index-sets like:
   -- (x: (log2n=>(Fin 2))=>Complex)).
   dir_const = case direction of
-    Forward -> -pi
-    Backward -> pi
+    ForwardFT -> -pi
+    InverseFT -> pi
 
   log2n = intlog2 (size n)
   halfn = idiv (size n) 2
   
-  ans = yieldState x \ref.
+  ans = yieldState x \refOuter.
     for i:(Fin log2n).
       pow2 = intpow 2 (ordinal i)
-      copy = get ref
-      for j:(Fin halfn).  -- Todo: Parallelize this loop.
-        j' = ordinal j
+      copy = get refOuter
+      refOuter := yieldAccum (AddMonoid Complex) \ref.
+        for j:(Fin halfn).  -- Executes in parallel.
+          j' = ordinal j
 
-        angle = dir_const * (IToF $ mod j' pow2) / IToF pow2
-        h = (j' + halfn)@n
-        v = copy.h * (MkComplex (cos angle) (sin angle))
-        (a, b) = butterfly_ixs j' pow2
+          angle = dir_const * (IToF $ mod j' pow2) / IToF pow2
+          h = (j' + halfn)@n
+          v = copy.h * (MkComplex (cos angle) (sin angle))
+          (a, b) = butterfly_ixs j' pow2
 
-        ref!a := copy.(j'@n) + v
-        ref!b := copy.(j'@n) - v
+          ref!a += copy.(j'@n) + v
+          ref!b += copy.(j'@n) - v
 
   case direction of
-    Forward -> ans
-    Backward -> ans / (IToF (size n))
+    ForwardFT -> ans
+    InverseFT -> ans / (IToF (size n))
 
 def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Complex) =
   -- Convolve by pointwise multiplication in the Fourier domain.
@@ -87,25 +86,40 @@ def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Co
   working_size = nextpow2 convolved_size
   u_padded = padTo (Fin working_size) zero u
   v_padded = padTo (Fin working_size) zero v
-  spectral_u = power_of_2_fft Forward u_padded
-  spectral_v = power_of_2_fft Forward v_padded
+  spectral_u = power_of_2_fft ForwardFT u_padded
+  spectral_v = power_of_2_fft ForwardFT v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
-  padded_conv = power_of_2_fft Backward spectral_conv
+  padded_conv = power_of_2_fft InverseFT spectral_conv
   slice padded_conv 0 {ovals:n | padding:m }
 
-def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float)  =
+def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float) =
   u' = for i. MkComplex u.i 0.0
   v' = for i. MkComplex v.i 0.0
   ans = convolve_complex u' v'
   for i.
-    (MkComplex re im) = ans.i
-    re
+    (MkComplex real imag) = ans.i
+    real
+
 
 '## FFT Interface
 
+def reflect (i:n) : n =
+  s = size n
+  (s - 1 - ordinal i)@n
+
+def backwards_and_forwards (mid:a) (seq:n=>a) : ({back:n | mid:Unit | zforward:n}=>a) =
+  -- Turns sequence 12345 into 543212345.
+  for i.
+    case i of
+      {|back=i|} -> seq.(reflect i)
+      {|mid=i|} -> mid
+      {|zforward=i|} -> seq.i
+
+def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
+
 def fft (x: n=>Complex): n=>Complex =
   if isPowerOf2 (size n)
-    then power_of_2_fft Forward x
+    then power_of_2_fft ForwardFT x
     else
       -- Bluestein's algorithm for FFT on any size of array.
       im = MkComplex 0.0 1.0
@@ -113,15 +127,8 @@ def fft (x: n=>Complex): n=>Complex =
         i_squared = IToF $ sq $ ordinal i
         exp $ (-im) * (MkComplex (pi * i_squared / (IToF (size n))) 0.0)
 
-      -- Turns sequence 12345 into 543212345.
-      -- I would break this into a helper function, but I don't know
-      -- how to type it.
-      backwards_and_forwards = Fin (2 * (size n) - 1)
-      baf = for i:backwards_and_forwards.
-        case ordinal i < size n of
-          True  -> wks.(((size n) - 1 - ordinal i)@n)
-          False -> wks.(((ordinal i) - (size n) + 1)@n)
-
+      tailList = tail wks 1
+      baf = backwards_and_forwards (head wks) (listToTable tailList)
       xq = for i. x.i * wks.i
       baf_conj = for i. complex_conj baf.i
       conved = convolve_complex xq baf_conj
@@ -130,7 +137,7 @@ def fft (x: n=>Complex): n=>Complex =
 
 def ifft (xs: n=>Complex): n=>Complex =
   if isPowerOf2 (size n)
-    then power_of_2_fft Backward xs
+    then power_of_2_fft InverseFT xs
     else
       fo = fft (for i. complex_conj xs.i)
       for i. (complex_conj fo.i) / (IToF (size n))

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -1,0 +1,95 @@
+'# Fast Fourier Transform
+Using a simple radix-2 algorithm.
+
+
+'## General helper functions
+
+-- Todo: Better algorithms exist for these.
+def intpow (base:Int) (power:Int) : Int =
+  reduce 1 (\i j. j * i) for a:(Fin power). base
+def intlog2 (x:Int) : Int = FToI $ floor (log2 (IToF x))
+
+
+'## FFT functions
+
+-- FFT can be called in either forwards mode (for FFT),
+-- or backwards mode (for inverse FFT).
+data Direction =
+  Forward
+  Backward
+
+def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
+  -- input size must be a power of 2.
+  -- Could enforce this with function-level types like (x: (2^log2n)=>Complex)).
+  dir_const = case direction of
+    Forward -> -pi
+    Backward -> pi
+
+  log2n = intlog2 (size n)
+  iters = idiv (size n) 2
+  
+  snd $ withState x \ref.  
+    for i:(Fin log2n).
+      pow2 = intpow 2 (ordinal i)
+      copy = get ref
+      for j:(Fin iters).  -- Todo: Parallelize this loop.
+        j' = ordinal j
+
+        angle = dir_const * (IToF $ mod j' pow2) / IToF pow2
+        h = (j' + (idiv (size n) 2))@n
+        v = copy.h * (MkComplex (cos angle) (sin angle))
+        k = ((idiv j' pow2) * pow2 * 2) + mod j' pow2
+        
+        ref!(k@n)          := copy.(j'@n) + v
+        ref!((k + pow2)@n) := copy.(j'@n) - v
+
+def fft_ (direction: Direction) (x: n=>Complex): n=>Complex =
+  -- Todo: pad to power of 2
+  power_of_2_fft direction x
+
+def  fft (x: n=>Complex): n=>Complex = fft_ Forward x
+def ifft (x: n=>Complex): n=>Complex =
+  nc = size n
+  (fft_ Backward x) / (IToF nc)
+
+def  fft_real (x: n=>Float): n=>Complex =  fft for i. MkComplex x.i 0.0
+def ifft_real (x: n=>Float): n=>Complex = ifft for i. MkComplex x.i 0.0
+
+def fft2_ (direction: Direction) (x: n=>m=>Complex): n=>m=>Complex =
+  -- todo: pad to power of 2
+  x'  = for i. power_of_2_fft direction x.i
+  x'' = for i. power_of_2_fft direction (transpose x').i
+  transpose x''
+
+def fft2  (x: n=>m=>Complex): n=>m=>Complex = fft2_ Forward x
+def ifft2 (x: n=>m=>Complex): n=>m=>Complex =
+  nc = (size n) * (size m)
+  (fft2_ Backward x) / (IToF nc)
+
+def  fft2_real (x: n=>m=>Float): n=>m=>Complex =  fft2 for i j. MkComplex x.i.j 0.0
+def ifft2_real (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex x.i.j 0.0
+
+
+-------- Tests --------
+
+real = \(MkComplex re im). re
+imag = \(MkComplex re im). im
+
+def realmat (x:n=>m=>Complex) : n=>m=>Float =
+ for i j. real x.i.j
+
+a = [10.1, -2.2, 8.3, 4.5]
+:p a ~~ (map real (ifft $ fft_real a))
+> True
+:p a ~~ (map real (fft $ ifft_real a))
+> True
+
+b = for i:(Fin 8) j:(Fin 8). randn $ ixkey2 (newKey 0) i j
+
+:p b ~~ realmat (ifft2 $ fft2_real b)
+> True
+:p b ~~ realmat (fft2 $ ifft2_real b)
+> True
+
+
+

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -1,6 +1,6 @@
 '# Fast Fourier Transform
-A basic implementation, which uses a radix-2 algorithm for FFT of arrays whose sizes are
-powers of two.
+For arrays whose size is a power of 2, we use a radix-2 algorithm based
+on the [Fhutark demo](https://github.com/diku-dk/fft/blob/master/lib/github.com/diku-dk/fft/stockham-radix-2.fut#L30).
 For non-power-of-2 sized arrays, it uses
 [Bluestein's Algorithm](https://en.wikipedia.org/wiki/Chirp_Z-transform),
 which calls the power-of-2 FFT as a subroutine.
@@ -8,15 +8,21 @@ which calls the power-of-2 FFT as a subroutine.
 
 '## General helper functions
 
-
 def isPowerOf2 (x:Int) : Bool =
   -- A fast trick based on bitwise AND.
+  -- Note: The bitwise and operator (.&.)
+  -- is only defined for Byte, which is why
+  -- I use %and here.
+  -- A test below verifies that this works on
+  -- more than 8 bit integers.
+  -- TODO: Make (.&.) polymorphic.
   if x == 0
     then False
-    else 0 == %and x (x - 1)  -- Make (.&.) polymorphic?
+    else 0 == %and x (x - 1)
 
 def intpow [Mul a] (base:a) (power:Int) : a =
-  -- Todo: Use Knuth's power trick inside of commutative reduce.
+  -- Todo: Use Knuth's power trick,
+  -- which can give an asymptotic speedup.
   reduce one (*) (for a:(Fin power). base)
 
 def intlog2 (x:Int) : Int =
@@ -37,6 +43,21 @@ def nextpow2 (x:Int) : Int = case isPowerOf2 x of
   True -> x
   False -> intpow2 (1 + intlog2 x)
 
+def reflect (i:n) : n =
+  s = size n
+  (s - 1 - ordinal i)@n
+
+def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
+
+def odd_sized_palindrome (mid:a) (seq:n=>a) :
+  ({backward:n | mid:Unit | zforward:n}=>a) =  -- Alphabetical order matters here.
+  -- Turns sequence 12345 into 543212345.
+  for i.
+    case i of
+      {|backward=i|} -> seq.(reflect i)
+      {|mid=i|} -> mid
+      {|zforward=i|} -> seq.i
+
 
 '## Inner FFT functions
 
@@ -44,15 +65,17 @@ data FTDirection =
   ForwardFT
   InverseFT
 
--- Todo: Replace with reshaping.
 def butterfly_ixs (j:Int) (pow2:Int) : (n & n) =
+  -- Re-index at a finer frequency.
+  -- For explanation, see https://en.wikipedia.org/wiki/Butterfly_diagram
+  -- Note: with fancier index sets, this might be replacable by reshapes.
   k = ((idiv j pow2) * pow2 * 2) + mod j pow2
   (k@n, (k + pow2)@n)
 
 def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   -- Input size must be a power of 2.
-  -- Could enforce this with tables-as-index-sets like:
-  -- (x: (log2n=>(Fin 2))=>Complex)).
+  -- Can enforce this with tables-as-index-sets like:
+  -- (x: (log2n=>(Fin 2))=>Complex)) once that's supported.
   dir_const = case direction of
     ForwardFT -> -pi
     InverseFT -> pi
@@ -62,17 +85,19 @@ def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   
   ans = yieldState x \refOuter.
     for i:(Fin log2n).
-      pow2 = intpow 2 (ordinal i)
+      ipow2 = intpow 2 (ordinal i)
       copy = get refOuter
       refOuter := yieldAccum (AddMonoid Complex) \ref.
         for j:(Fin halfn).  -- Executes in parallel.
           j' = ordinal j
 
-          angle = dir_const * (IToF $ mod j' pow2) / IToF pow2
-          h = (j' + halfn)@n
-          v = copy.h * (MkComplex (cos angle) (sin angle))
-          (a, b) = butterfly_ixs j' pow2
-
+          -- Read one element from the last buffer, scaled.
+          ix = (j' + halfn)@n
+          angle = dir_const * (IToF $ mod j' ipow2) / IToF ipow2
+          v = copy.ix * (MkComplex (cos angle) (sin angle))
+          
+          -- Add and subtract it to the relevant places in the new buffer.
+          (a, b) = butterfly_ixs j' ipow2
           ref!a += copy.(j'@n) + v
           ref!b += copy.(j'@n) - v
 
@@ -80,7 +105,8 @@ def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
     ForwardFT -> ans
     InverseFT -> ans / (IToF (size n))
 
-def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Complex) =
+def convolve_complex (u:n=>Complex) (v:m=>Complex) :
+  ({orig_vals:n | padding:m }=>Complex) =  -- Alphabetical order matters here.
   -- Convolve by pointwise multiplication in the Fourier domain.
   convolved_size = (size n) + (size m) - 1
   working_size = nextpow2 convolved_size
@@ -90,9 +116,9 @@ def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Co
   spectral_v = power_of_2_fft ForwardFT v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
   padded_conv = power_of_2_fft InverseFT spectral_conv
-  slice padded_conv 0 {ovals:n | padding:m }
+  slice padded_conv 0 {orig_vals:n | padding:m }
 
-def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float) =
+def convolve (u:n=>Float) (v:m=>Float) : ({orig_vals:n | padding:m }=>Float) =
   u' = for i. MkComplex u.i 0.0
   v' = for i. MkComplex v.i 0.0
   ans = convolve_complex u' v'
@@ -103,44 +129,32 @@ def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float) =
 
 '## FFT Interface
 
-def reflect (i:n) : n =
-  s = size n
-  (s - 1 - ordinal i)@n
-
-def backwards_and_forwards (mid:a) (seq:n=>a) : ({back:n | mid:Unit | zforward:n}=>a) =
-  -- Turns sequence 12345 into 543212345.
-  for i.
-    case i of
-      {|back=i|} -> seq.(reflect i)
-      {|mid=i|} -> mid
-      {|zforward=i|} -> seq.i
-
-def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
-
 def fft (x: n=>Complex): n=>Complex =
   if isPowerOf2 (size n)
     then power_of_2_fft ForwardFT x
     else
-      -- Bluestein's algorithm for FFT on any size of array.
+      -- Bluestein's algorithm.
+      -- Converts the general FFT into a convolution,
+      -- which is then solved with calls to a power-of-2 FFT.
       im = MkComplex 0.0 1.0
       wks = for i.
         i_squared = IToF $ sq $ ordinal i
         exp $ (-im) * (MkComplex (pi * i_squared / (IToF (size n))) 0.0)
 
       tailList = tail wks 1
-      baf = backwards_and_forwards (head wks) (listToTable tailList)
+      back_and_forth = odd_sized_palindrome (head wks) (listToTable tailList)
       xq = for i. x.i * wks.i
-      baf_conj = for i. complex_conj baf.i
-      conved = convolve_complex xq baf_conj
-      convslice = slice conved (size n - 1) n
+      back_and_forth_conj = for i. complex_conj back_and_forth.i
+      convolution = convolve_complex xq back_and_forth_conj
+      convslice = slice convolution (size n - 1) n
       for i. wks.i * convslice.i
 
 def ifft (xs: n=>Complex): n=>Complex =
   if isPowerOf2 (size n)
     then power_of_2_fft InverseFT xs
     else
-      fo = fft (for i. complex_conj xs.i)
-      for i. (complex_conj fo.i) / (IToF (size n))
+      unscaled_fft = fft (for i. complex_conj xs.i)
+      for i. (complex_conj unscaled_fft.i) / (IToF (size n))
 
 def  fft_real (x: n=>Float): n=>Complex =  fft for i. MkComplex x.i 0.0
 def ifft_real (x: n=>Float): n=>Complex = ifft for i. MkComplex x.i 0.0
@@ -159,7 +173,7 @@ def ifft2_real (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex x.i.j 
 -------- Tests --------
 
 a = for i. MkComplex [10.1, -2.2, 8.3, 4.5, 9.3].i 0.0
-b = for i:(Fin 3) j:(Fin 7).
+b = for i:(Fin 20) j:(Fin 70).
   MkComplex (randn $ ixkey2 (newKey 0) i j) 0.0
 
 :p a ~~ (ifft $ fft a)
@@ -170,3 +184,32 @@ b = for i:(Fin 3) j:(Fin 7).
 > True
 :p b ~~ (fft2 $ ifft2 b)
 > True
+
+-- Integer utility tests
+
+:p map isPowerOf2 [0, 1, 2, 3, 256, 1024, 1024*1024, 1024*1024 + 1]
+> [False, True, True, False, True, True, True, False]
+
+:p intpow 0 0
+> 1
+
+:p intpow 0 1
+> 0
+
+:p intpow 1 0
+> 1
+
+:p intpow 1 1
+> 1
+
+:p intpow 2 1
+> 2
+
+:p intpow 2 3
+> 8
+
+:p map intlog2 [-1, 0, 1, 2, 3, 4, 5, 1023, 1024, 1025]
+> [-1, -1, 0, 1, 1, 2, 2, 9, 10, 10]
+
+:p map nextpow2 [-1, 0, 1, 2, 3, 4, 7, 8, 9, 1023, 1024, 1025]
+> [1, 1, 1, 2, 4, 4, 8, 8, 16, 1024, 1024, 2048]

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -1,18 +1,42 @@
 '# Fast Fourier Transform
-Using a radix-2 algorithm as a base,
-then Bluestein on top of that.
+A basic implementation, which uses a radix-2 algorithm for FFT of arrays whose sizes are
+powers of two.
+For non-power-of-2 sized arrays, it uses
+[Bluestein's Algorithm](https://en.wikipedia.org/wiki/Chirp_Z-transform),
+which calls the power-of-2 FFT as a subroutine.
 
 
 '## General helper functions
 
--- Todo: Better algorithms exist for these.
-def intpow (base:Int) (power:Int) : Int =
-  reduce 1 (\i j. j * i) for a:(Fin power). base
-def intlog2 (x:Int) : Int = FToI $ floor (log2 (IToF x))
-def isPowerOf2 (x:Int) : Bool = x == intpow 2 (intlog2 x)
+
+def isPowerOf2 (x:Int) : Bool =
+  -- A fast trick based on bitwise AND.
+  if x == 0
+    then False
+    else 0 == %and x (x - 1)  -- Make (.&.) polymorphic?
+
+def intpow [Mul a] (base:a) (power:Int) : a =
+  -- Todo: Use Knuth's power trick inside of commutative reduce.
+  reduce one (*) (for a:(Fin power). base)
+
+def intlog2 (x:Int) : Int =
+  yieldState (-1) \ansRef.
+    runState 1 \cmpRef.
+      while do
+        if x >= (get cmpRef)
+          then 
+            ansRef := (get ansRef) + 1
+            cmpRef := %shl (get cmpRef) 1
+            True
+          else
+            False
+
+def intpow2 (power:Int) : Int = %shl 1 power
+
 def nextpow2 (x:Int) : Int = case isPowerOf2 x of
   True -> x
-  False -> intpow 2 (1 + intlog2 x)
+  False -> intpow2 (1 + intlog2 x)
+
 
 '## Inner FFT functions
 
@@ -38,7 +62,7 @@ def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
   log2n = intlog2 (size n)
   halfn = idiv (size n) 2
   
-  ans = snd $ withState x \ref.
+  ans = yieldState x \ref.
     for i:(Fin log2n).
       pow2 = intpow 2 (ordinal i)
       copy = get ref

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -1,5 +1,6 @@
 '# Fast Fourier Transform
-Using a simple radix-2 algorithm.
+Using a radix-2 algorithm as a base,
+then Bluestein on top of that.
 
 
 '## General helper functions
@@ -8,15 +9,23 @@ Using a simple radix-2 algorithm.
 def intpow (base:Int) (power:Int) : Int =
   reduce 1 (\i j. j * i) for a:(Fin power). base
 def intlog2 (x:Int) : Int = FToI $ floor (log2 (IToF x))
+def isPowerOf2 (x:Int) : Bool = x == intpow 2 (intlog2 x)
+def nextpow2 (x:Int) : Int = case isPowerOf2 x of
+  True -> x
+  False -> intpow 2 (1 + intlog2 x)
 
-
-'## FFT functions
+'## Inner FFT functions
 
 -- FFT can be called in either forwards mode (for FFT),
 -- or backwards mode (for inverse FFT).
 data Direction =
   Forward
   Backward
+
+-- Todo: Replace with reshaping.
+def butterfly_ixs (j:Int) (pow2:Int) : (n & n) =
+  k = ((idiv j pow2) * pow2 * 2) + mod j pow2
+  (k@n, (k + pow2)@n)
 
 def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
   -- input size must be a power of 2.
@@ -26,70 +35,94 @@ def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
     Backward -> pi
 
   log2n = intlog2 (size n)
-  iters = idiv (size n) 2
+  halfn = idiv (size n) 2
   
   snd $ withState x \ref.  
     for i:(Fin log2n).
       pow2 = intpow 2 (ordinal i)
       copy = get ref
-      for j:(Fin iters).  -- Todo: Parallelize this loop.
+      for j:(Fin halfn).  -- Todo: Parallelize this loop.
         j' = ordinal j
 
         angle = dir_const * (IToF $ mod j' pow2) / IToF pow2
-        h = (j' + (idiv (size n) 2))@n
+        h = (j' + halfn)@n
         v = copy.h * (MkComplex (cos angle) (sin angle))
-        k = ((idiv j' pow2) * pow2 * 2) + mod j' pow2
-        
-        ref!(k@n)          := copy.(j'@n) + v
-        ref!((k + pow2)@n) := copy.(j'@n) - v
+        (a, b) = butterfly_ixs j' pow2
 
-def fft_ (direction: Direction) (x: n=>Complex): n=>Complex =
-  -- Todo: pad to power of 2
-  power_of_2_fft direction x
+        ref!a := copy.(j'@n) + v
+        ref!b := copy.(j'@n) - v
 
-def  fft (x: n=>Complex): n=>Complex = fft_ Forward x
-def ifft (x: n=>Complex): n=>Complex =
-  nc = size n
-  (fft_ Backward x) / (IToF nc)
+def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Complex)  =
+  -- Convolve by pointwise multiplication in the Fourier domain.
+  convolved_size = (size n) + (size m) - 1
+  working_size = nextpow2 convolved_size
+  u_padded = padTo (Fin working_size) zero u
+  v_padded = padTo (Fin working_size) zero v
+  spectral_u = power_of_2_fft Forward u_padded
+  spectral_v = power_of_2_fft Forward v_padded
+  spectral_conv = for i. spectral_u.i * spectral_v.i
+  padded_conv = power_of_2_fft Backward spectral_conv
+  us = slice padded_conv 0 {ovals:n | padding:m }
+  us / (IToF working_size)  -- Todo: move into fft
+
+def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float)  =
+  u' = for i. MkComplex u.i 0.0
+  v' = for i. MkComplex v.i 0.0
+  ans = convolve_complex u' v'
+  for i.
+    (MkComplex re im) = ans.i
+    re
+
+'## FFT Interface
+
+def fft (x: n=>Complex): n=>Complex =
+  -- Bluestein's algorithm for FFT on any size of array.
+  -- Todo: short circuit for powers of two.
+  im = MkComplex 0.0 1.0
+  wks = for i:n.
+    ks = IToF $ ordinal i
+    exp $ (-im) * (MkComplex (pi * (sq ks) / (IToF (size n))) 0.0)
+  xq = for i. x.i * wks.i
+  first = exp (-im * MkComplex (pi * (IToF (size n))) 0.0)
+  sn = (size n)
+  rwks:(Fin sn)=>Complex = for i. wks.(((size n) - 1 - ordinal i)@n)
+  nm1 = (size n) - 1
+  wq' = concat [AsList _ [first], AsList _ rwks, AsList _ (slice wks 1 (Fin nm1))]
+  (AsList _ wq'') = wq'
+  wq = for i. complex_conj wq''.i
+  conved = convolve_complex xq wq
+  convslice = slice conved (size n) n
+  for i. wks.i * convslice.i
+
+def ifft (xs: n=>Complex): n=>Complex =
+  fo = fft (for i. complex_conj xs.i)
+  for i. (complex_conj fo.i) / (IToF (size n))
 
 def  fft_real (x: n=>Float): n=>Complex =  fft for i. MkComplex x.i 0.0
 def ifft_real (x: n=>Float): n=>Complex = ifft for i. MkComplex x.i 0.0
 
-def fft2_ (direction: Direction) (x: n=>m=>Complex): n=>m=>Complex =
-  -- todo: pad to power of 2
-  x'  = for i. power_of_2_fft direction x.i
-  x'' = for i. power_of_2_fft direction (transpose x').i
-  transpose x''
+def fft2 (x: n=>m=>Complex): n=>m=>Complex =
+  x'      = for i. fft x.i
+  transpose for i. fft (transpose x').i
 
-def fft2  (x: n=>m=>Complex): n=>m=>Complex = fft2_ Forward x
 def ifft2 (x: n=>m=>Complex): n=>m=>Complex =
-  nc = (size n) * (size m)
-  (fft2_ Backward x) / (IToF nc)
+  x'      = for i. ifft x.i
+  transpose for i. ifft (transpose x').i
 
 def  fft2_real (x: n=>m=>Float): n=>m=>Complex =  fft2 for i j. MkComplex x.i.j 0.0
 def ifft2_real (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex x.i.j 0.0
 
-
 -------- Tests --------
 
-real = \(MkComplex re im). re
-imag = \(MkComplex re im). im
+a = for i. MkComplex [10.1, -2.2, 8.3, 4.5, 9.3].i 0.0
+b = for i:(Fin 3) j:(Fin 7).
+  MkComplex (randn $ ixkey2 (newKey 0) i j) 0.0
 
-def realmat (x:n=>m=>Complex) : n=>m=>Float =
- for i j. real x.i.j
-
-a = [10.1, -2.2, 8.3, 4.5]
-:p a ~~ (map real (ifft $ fft_real a))
+:p a ~~ (ifft $ fft a)
 > True
-:p a ~~ (map real (fft $ ifft_real a))
+:p a ~~ (fft $ ifft a)
 > True
-
-b = for i:(Fin 8) j:(Fin 8). randn $ ixkey2 (newKey 0) i j
-
-:p b ~~ realmat (ifft2 $ fft2_real b)
+:p b ~~ (ifft2 $ fft2 b)
 > True
-:p b ~~ realmat (fft2 $ ifft2_real b)
+:p b ~~ (fft2 $ ifft2 b)
 > True
-
-
-

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -28,8 +28,9 @@ def butterfly_ixs (j:Int) (pow2:Int) : (n & n) =
   (k@n, (k + pow2)@n)
 
 def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
-  -- input size must be a power of 2.
-  -- Could enforce this with function-level types like (x: (2^log2n)=>Complex)).
+  -- Input size must be a power of 2.
+  -- Could enforce this with tables-as-index-sets like:
+  -- (x: (log2n=>(Fin 2))=>Complex)).
   dir_const = case direction of
     Forward -> -pi
     Backward -> pi
@@ -37,7 +38,7 @@ def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
   log2n = intlog2 (size n)
   halfn = idiv (size n) 2
   
-  snd $ withState x \ref.  
+  ans = snd $ withState x \ref.
     for i:(Fin log2n).
       pow2 = intpow 2 (ordinal i)
       copy = get ref
@@ -52,7 +53,11 @@ def power_of_2_fft (direction: Direction) (x: n=>Complex) : n=>Complex =
         ref!a := copy.(j'@n) + v
         ref!b := copy.(j'@n) - v
 
-def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Complex)  =
+  case direction of
+    Forward -> ans
+    Backward -> ans / (IToF (size n))
+
+def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Complex) =
   -- Convolve by pointwise multiplication in the Fourier domain.
   convolved_size = (size n) + (size m) - 1
   working_size = nextpow2 convolved_size
@@ -62,8 +67,7 @@ def convolve_complex (u:n=>Complex) (v:m=>Complex) : ({ovals:n | padding:m }=>Co
   spectral_v = power_of_2_fft Forward v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
   padded_conv = power_of_2_fft Backward spectral_conv
-  us = slice padded_conv 0 {ovals:n | padding:m }
-  us / (IToF working_size)  -- Todo: move into fft
+  slice padded_conv 0 {ovals:n | padding:m }
 
 def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float)  =
   u' = for i. MkComplex u.i 0.0
@@ -76,27 +80,36 @@ def convolve (u:n=>Float) (v:m=>Float) : ({ovals:n | padding:m }=>Float)  =
 '## FFT Interface
 
 def fft (x: n=>Complex): n=>Complex =
-  -- Bluestein's algorithm for FFT on any size of array.
-  -- Todo: short circuit for powers of two.
-  im = MkComplex 0.0 1.0
-  wks = for i:n.
-    ks = IToF $ ordinal i
-    exp $ (-im) * (MkComplex (pi * (sq ks) / (IToF (size n))) 0.0)
-  xq = for i. x.i * wks.i
-  first = exp (-im * MkComplex (pi * (IToF (size n))) 0.0)
-  sn = (size n)
-  rwks:(Fin sn)=>Complex = for i. wks.(((size n) - 1 - ordinal i)@n)
-  nm1 = (size n) - 1
-  wq' = concat [AsList _ [first], AsList _ rwks, AsList _ (slice wks 1 (Fin nm1))]
-  (AsList _ wq'') = wq'
-  wq = for i. complex_conj wq''.i
-  conved = convolve_complex xq wq
-  convslice = slice conved (size n) n
-  for i. wks.i * convslice.i
+  if isPowerOf2 (size n)
+    then power_of_2_fft Forward x
+    else
+      -- Bluestein's algorithm for FFT on any size of array.
+      im = MkComplex 0.0 1.0
+      wks = for i.
+        i_squared = IToF $ sq $ ordinal i
+        exp $ (-im) * (MkComplex (pi * i_squared / (IToF (size n))) 0.0)
+
+      -- Turns sequence 12345 into 543212345.
+      -- I would break this into a helper function, but I don't know
+      -- how to type it.
+      backwards_and_forwards = Fin (2 * (size n) - 1)
+      baf = for i:backwards_and_forwards.
+        case ordinal i < size n of
+          True  -> wks.(((size n) - 1 - ordinal i)@n)
+          False -> wks.(((ordinal i) - (size n) + 1)@n)
+
+      xq = for i. x.i * wks.i
+      baf_conj = for i. complex_conj baf.i
+      conved = convolve_complex xq baf_conj
+      convslice = slice conved (size n - 1) n
+      for i. wks.i * convslice.i
 
 def ifft (xs: n=>Complex): n=>Complex =
-  fo = fft (for i. complex_conj xs.i)
-  for i. (complex_conj fo.i) / (IToF (size n))
+  if isPowerOf2 (size n)
+    then power_of_2_fft Backward xs
+    else
+      fo = fft (for i. complex_conj xs.i)
+      for i. (complex_conj fo.i) / (IToF (size n))
 
 def  fft_real (x: n=>Float): n=>Complex =  fft for i. MkComplex x.i 0.0
 def ifft_real (x: n=>Float): n=>Complex = ifft for i. MkComplex x.i 0.0

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -44,8 +44,7 @@ def nextpow2 (x:Int) : Int = case isPowerOf2 x of
   False -> intpow2 (1 + intlog2 x)
 
 def reflect (i:n) : n =
-  s = size n
-  (s - 1 - ordinal i)@n
+  unsafeFromOrdinal n ((size n) - 1 - ordinal i)
 
 def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
 
@@ -65,12 +64,19 @@ data FTDirection =
   ForwardFT
   InverseFT
 
-def butterfly_ixs (j:Int) (pow2:Int) : (n & n) =
+def butterfly_ixs (j':halfn) (pow2:Int) : (n & n & n & n) =
   -- Re-index at a finer frequency.
+  -- halfn must have half the size of n.
   -- For explanation, see https://en.wikipedia.org/wiki/Butterfly_diagram
   -- Note: with fancier index sets, this might be replacable by reshapes.
+  j = ordinal j'
   k = ((idiv j pow2) * pow2 * 2) + mod j pow2
-  (k@n, (k + pow2)@n)
+  left_write_ix  = unsafeFromOrdinal n k
+  right_write_ix = unsafeFromOrdinal n (k + pow2)
+
+  left_read_ix  = unsafeFromOrdinal n j
+  right_read_ix = unsafeFromOrdinal n (j + size halfn)
+  (left_read_ix, right_read_ix, left_write_ix, right_write_ix)
 
 def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   -- Input size must be a power of 2.
@@ -83,23 +89,21 @@ def power_of_2_fft (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   log2n = intlog2 (size n)
   halfn = idiv (size n) 2
   
-  ans = yieldState x \refOuter.
+  ans = yieldState x \xRef.
     for i:(Fin log2n).
       ipow2 = intpow 2 (ordinal i)
-      copy = get refOuter
-      refOuter := yieldAccum (AddMonoid Complex) \ref.
+      xRef := yieldAccum (AddMonoid Complex) \bufRef.
         for j:(Fin halfn).  -- Executes in parallel.
-          j' = ordinal j
+          (left_read_ix, right_read_ix,
+           left_write_ix, right_write_ix) = butterfly_ixs j ipow2
 
           -- Read one element from the last buffer, scaled.
-          ix = (j' + halfn)@n
-          angle = dir_const * (IToF $ mod j' ipow2) / IToF ipow2
-          v = copy.ix * (MkComplex (cos angle) (sin angle))
-          
+          angle = dir_const * (IToF $ mod (ordinal j) ipow2) / IToF ipow2
+          v = (get xRef!right_read_ix) * (MkComplex (cos angle) (sin angle))
+
           -- Add and subtract it to the relevant places in the new buffer.
-          (a, b) = butterfly_ixs j' ipow2
-          ref!a += copy.(j'@n) + v
-          ref!b += copy.(j'@n) - v
+          bufRef!left_write_ix  += (get (xRef!left_read_ix)) + v
+          bufRef!right_write_ix += (get (xRef!left_read_ix)) - v
 
   case direction of
     ForwardFT -> ans

--- a/makefile
+++ b/makefile
@@ -89,7 +89,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator mcmc ctc raytrace particle-filter \
                 isomorphisms ode-integrator linear_algebra fluidsim \
-                sgd chol
+                sgd chol fft
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              shadow-tests monad-tests io-tests exception-tests \


### PR DESCRIPTION
The inner loop is now parallelizable by the compiler, since it uses `yieldAccum` over `AddMonoid Complex`.

It would be nice to be able to enforce that the input size is a power of two using the type system.  I worked out how to do this in a way that typechecks: `((Fin pow)=>m)=>a` expresses arrays of size `m^pow`.  But this crashes currently due to #146.  

At some point, I'm hoping to make a blog post comparing it to the [Fhutark FFT example](https://github.com/diku-dk/fft/blob/master/lib/github.com/diku-dk/fft/stockham-radix-2.fut#L30) that I initially based this one off of.  The main emphasis would be on the additional safety that comes from types (and maybe more generality once `Complex` can be parameterized by its floating-point representation).  But the coding style is also very different - just like when writing the fluidsim, I originally started writing lots of helper functions for vectorized operations, like `gather`, `scatter`, and different flavors of `zip` / `unzip`.  But then I realized it would be easier just to write fused for loops.  So the code for the same function ends up looking very different.

Misc notes:
  - Eventually I'm hoping to move all the `@`s to marked unsafe one-liners, following @apaszke 's style, or remove them by using tables as index sets.
  - These functions are linear, but I don't think the compiler will be able to recognize that.
  - I'm open to moving most of the utility functions to the prelude.