### PR TITLE
Fix fluid simulation example.

### DIFF
--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -109,14 +109,16 @@ def advect (dict:VSpace a) ?=> (n:Type) ?-> (m:Type) ?-> (f: n=>m=>a) (v: n=>m=>
 
     -- Relative weight of right-hand and bottom cells.
     -- TODO: clipping shouldn't be necessary here, find out why it is.
-    right_weight  = clip $ center_xs - IToF source_col
-    bottom_weight = clip $ center_ys - IToF source_row
+    right_weight  = clip $ center_xs - source_col
+    bottom_weight = clip $ center_ys - source_row
 
     -- Cast back to indices, wrapping around edges.
-    l = wrapidx n  source_col
-    r = wrapidx n (source_col + 1)
-    t = wrapidx m  source_row
-    b = wrapidx m (source_row + 1)
+    source_col_int = FToI source_col
+    source_row_int = FToI source_row
+    l = wrapidx n source_col_int
+    r = wrapidx n (source_col_int + 1)
+    t = wrapidx m  source_row_int
+    b = wrapidx m (source_row_int + 1)
 
     -- A convex weighting of the 4 surrounding cells.
     bilinear_interp right_weight bottom_weight f.l.t f.l.b f.r.t f.r.b
@@ -141,7 +143,7 @@ v = for i:N j:M k:(Fin 2). 3.0 * (randn $ ixkey3 (newKey 0) i j k)
 
 -- Create diagonally-striped color pattern.
 init_color = for i:N j:M.
-  b2r $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
+  BToF $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
 
 -- Run fluid sim and plot it.
 num_steps = 50

--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -148,5 +148,8 @@ init_color = for i:N j:M.
 -- Run fluid sim and plot it.
 num_steps = 50
 final_color = fluidsim num_steps init_color v
-:plotmat final_color
-> <graphical output>
+
+-- FIXME(https://github.com/google-research/dex-lang/issues/173):
+-- Uncomment when plotting is fixed.
+-- :plotmat final_color
+-- > <graphical output>

--- a/makefile
+++ b/makefile
@@ -71,7 +71,7 @@ build-python: build
 %.bc: %.cpp
 	clang++ $(CXXFLAGS) -c -emit-llvm $^ -o $@
 
-# --- running tets ---
+# --- running tests ---
 
 # TODO: re-enable linear-tests ad-tests include-test chol
 example-names = uexpr-tests adt-tests type-tests eval-tests \
@@ -81,7 +81,7 @@ example-names = uexpr-tests adt-tests type-tests eval-tests \
                 ode-integrator parser-tests serialize-tests \
                 mcmc record-variant-tests simple-include-test ctc raytrace \
                 isomorphisms typeclass-tests complex-tests trig-tests \
-                ode-integrator linear_algebra
+                ode-integrator linear_algebra fluidsim
 
 quine-test-targets = $(example-names:%=run-%)
 

--- a/misc/check-no-diff
+++ b/misc/check-no-diff
@@ -1,5 +1,15 @@
 #!/bin/bash
 
+# This script checks whether two input files have a diff.
+#
+# Usage:
+#
+#   check-no-diff <first file> <second file>
+#
+# If there is no diff, the script exits with a zero success status.
+# If there is a diff, the script prints the diff to stdout and exits with a
+# non-zero error status.
+
 tmpdiff=$(mktemp)
 diff --left-column -y $1 $2 > $tmpdiff \
        && echo OK || (cat $tmpdiff; false)

--- a/misc/check-quine
+++ b/misc/check-quine
@@ -1,5 +1,24 @@
 #!/bin/bash
 
+# This script checks quine programs.
+# https://en.wikipedia.org/wiki/Quine_(computing)
+#
+# Usage:
+#
+#   check-quine <input file> <command>
+#   check-quine foo.dx dex -- script --allow-errors
+#
+# Technically, quines are programs that take no input and produce their own
+# source as output. This script instead runs a command with an input file and
+# checks whether the output has no diff with the input file.
+#
+# If the output of the command applied to the input file has no diff with the
+# input file, then the input file is a quine and the script exits with a zero
+# success status.
+#
+# Otherwise, if the input file is not a quine, the script prints the diff to
+# stdout and exits with a non-zero error status.
+
 tmpout=$(mktemp)
 errout=$(mktemp)
 


### PR DESCRIPTION
Fix `examples/fluidsim.dx` on dev branch.

---

Before (errors due to deprecation):

<details>
<p>

```
$ dex script examples/fluidsim.dx
'## Fluid sim
Fluid simulation code based on
[Real-Time Fluid Dynamics for Games](https://www.josstam.com/publications) by Jos Stam

def zeroedges (dict:VSpace a) ?=> (n:Type) ?-> (m:Type) ?-> (x: n=>m=>a) : n=>m=>a =
  -- Todo: update in place without starting with a copy.
  snd $ withState x \buf.
    for i j.
      edge = i==0 || j==0 || i==ordinal n || i==ordinal m
      select edge (buf!(i@n)!(j@m) := zero) ()

def wrapidx (n:Type) -> (i:Int) : n =
  -- Index wrapping around at ends.
  asidx $ mod i $ size n

def incwrap (n:Type) ?-> (i:n) : n =
  -- Increments index, wrapping around at ends.
  asidx $ mod ((ordinal i) + 1) $ size n

def decwrap (n:Type) ?-> (i:n) : n =
  -- Decrements index, wrapping around at ends.
  asidx $ mod ((ordinal i) - 1) $ size n

def finite_difference_neighbours (n:Type) ?-> (x:n=>Float) : n=>Float =
  for i. x.(incwrap i) - x.(decwrap i)

def add_neighbours (n:Type) ?-> (x:n=>Float) : n=>Float =
  for i. x.(incwrap i) + x.(decwrap i)

def apply_along_axis1 (f : b=>Float -> b=>Float) (x : b=>c=>Float) : b=>c=>Float =
  transpose for j. f for i. x.i.j

def apply_along_axis2 (f : c=>Float -> c=>Float) (x : b=>c=>Float) : b=>c=>Float =
  for i. f x.i

def fdx (x : n=>m=>Float) : (n=>m=>Float) =
  apply_along_axis1 finite_difference_neighbours x

def fdy (x : n=>m=>Float) : (n=>m=>Float) =
  apply_along_axis2 finite_difference_neighbours x

def divergence (vx : n=>m=>Float) (vy : n=>m=>Float) : (n=>m=>Float) =
  fdx vx + fdy vy

def add_neighbours_2d (x : n=>m=>Float) : (n=>m=>Float) =
  ax1 = apply_along_axis1 add_neighbours x
  ax2 = apply_along_axis2 add_neighbours x
  ax1 + ax2

def project (v: n=>m=>(Fin 2)=>Float) : n=>m=>(Fin 2)=>Float =
  -- Project the velocity field to be approximately mass-conserving,
  -- using a few iterations of Gauss-Seidel.
  h = 0.01  -- todo: work out units

  -- unpack into two scalar fields
  vx = for i j. v.i.j.(fromOrdinal _ 0)
  vy = for i j. v.i.j.(fromOrdinal _ 1)

  div = -0.5 .* h .* (divergence vx vy)

  p_init = for i. for j. 0.0
  p = snd $ withState p_init \state.
    for i:(Fin 10).
      p = get state
      state := (1.0 / 4.0) .* (div + add_neighbours_2d p)

  vx = vx - (0.5 / h) .* fdx(p)
  vy = vy - (0.5 / h) .* fdy(p)

  for i j. [vx.i.j, vy.i.j]  -- pack back into a vector field

  -- zeroedges v  -- BUG: Crashes with "Not implemented Int"

def bilinear_interp (dict:VSpace a) ?=> (right_weight:Float) --o (bottom_weight:Float) --o
  (topleft: a) --o (bottomleft: a) --o (topright: a) --o (bottomright: a) --o : a =
  left  = (1.0 - right_weight) .* ((1.0 - bottom_weight) .* topleft  + bottom_weight .* bottomleft)
  right =        right_weight  .* ((1.0 - bottom_weight) .* topright + bottom_weight .* bottomright)
  left + right


N = Fin 100
M = Fin 100

def clip (x:Float):Float = max 0.0 (min 1.0 x)

-- BUG: Changing the order of implicit arguments causes an error further down.
-- i.e. it doesn't work to start the next line with
-- (n:Type) ?-> (m:Type) ?-> (dict:VSpace a) ?=>
def advect (dict:VSpace a) ?=> (n:Type) ?-> (m:Type) ?-> (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
  -- Move field f according to x and y velocities (u and v)
  -- using an implicit Euler integrator.

  -- Create table of cell locations.
  -- BUG: using n and m below causes a crash, so I hardcoded it for now.
  numrows = 100.0 -- IToF $ ordinal n
  numcols = 100.0 -- IToF $ ordinal m

  cell_xs = linspace n 0.0 numrows
  cell_ys = linspace m 0.0 numcols

  for i j.
    -- Location of source of flow for this cell.  No meshgrid!
    center_xs = cell_xs.i - v.i.j.(fromOrdinal _ 0)
    center_ys = cell_ys.j - v.i.j.(fromOrdinal _ 1)

    -- Index of source cell.
    source_col = floor center_xs
    source_row = floor center_ys

    -- Relative weight of right-hand and bottom cells.
    -- TODO: clipping shouldn't be necessary here, find out why it is.
    right_weight  = clip $ center_xs - IToF source_col
    bottom_weight = clip $ center_ys - IToF source_row

    -- Cast back to indices, wrapping around edges.
    l = wrapidx n  source_col
    r = wrapidx n (source_col + 1)
    t = wrapidx m  source_row
    b = wrapidx m (source_row + 1)

    -- A convex weighting of the 4 surrounding cells.
    bilinear_interp right_weight bottom_weight f.l.t f.l.b f.r.t f.r.b
> Type error:
> Expected: Int32
>   Actual: Float32
>
>     right_weight  = clip $ center_xs - IToF source_col
>                                             ^^^^^^^^^^

def fluidsim (dict: VSpace a) ?=> (num_steps: Int) (color_init: n=>m=>a)
  (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
  (color_final, v) = snd $ withState (color_init, v) \state.
    for i:(Fin num_steps).
      (color, v) = get state
      v = advect v v          -- Move velocities
      v = project v           -- Project to be volume-preserving
      color = advect color v  -- Move color
      state := (color, v)
  color_final
> Error: variable not in scope: advect
>
>       v = advect v v          -- Move velocities
>           ^^^^^^^

'### Demo

-- Create random velocity field.
def ixkey3 (k:Key) (i:n) (j:m) (k2:o) : Key =
  hash (hash (hash k (ordinal i)) (ordinal j)) (ordinal k2)
v = for i:N j:M k:(Fin 2). 3.0 * (randn $ ixkey3 (newKey 0) i j k)

-- Create diagonally-striped color pattern.
init_color = for i:N j:M.
  b2r $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
> Error: variable not in scope: b2r
>
>   b2r $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
>   ^^^^

-- Run fluid sim and plot it.
num_steps = 50
final_color = fluidsim num_steps init_color v
> Error: variable not in scope: fluidsim
>
> final_color = fluidsim num_steps init_color v
>               ^^^^^^^^^
:plotmat final_color
> Error: variable not in scope: final_color
>
> :plotmat final_color
>          ^^^^^^^^^^^
```

</p>
</details>

After: everything exceeds except the final `:plotmat` command. Perhaps support for that is being added at [dex-plot-library](https://github.com/google-research/dex-lang/tree/dex-plot-library).

```dex
$ dex script examples/fluidsim.dx
...

-- Run fluid sim and plot it.
num_steps = 50
final_color = fluidsim num_steps init_color v
:plotmat final_color
> Compiler bug!
> Please report this at github.com/google-research/dex-lang/issues
>
> not implemented
> CallStack (from HasCallStack):
>   error, called at src/lib/TopLevel.hs:100:25 in dex-0.1.0.0-CA4uXQ86C1yKMObiJn1rPk:TopLevel
```