### PR TITLE
Remove built in fst and snd

### DIFF
--- a/prelude.dx
+++ b/prelude.dx
@@ -138,9 +138,9 @@ instance float32Fractional : Fractional Float32 where
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
 def (,) (x:a) (y:b) : (a & b) = %pair x y
-def fst (p: (a & b)) : a = %fst p
-def snd (p: (a & b)) : b = %snd p
-def swap (p:(a&b)) : (b&a) = (snd p, fst p)
+def fst ((f,s): (a & b)) : a = f
+def snd ((f,s): (a & b)) : b = s
+def swap ((f,s):(a&b)) : (b&a) = (s, f)
 
 def (<<<) (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
 def (>>>) (g: a -> b) (f: b -> c) : a -> c = \x. f (g x)

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -132,8 +132,6 @@ linearizeOp op = case op of
          MTell x -> liftA MTell $ la x
          MGet    -> pure MGet
          MPut  x -> liftA MPut $ la x) `bindLin` emitOp
-  Fst x                  -> (Fst <$> la x) `bindLin` emitOp
-  Snd x                  -> (Snd <$> la x) `bindLin` emitOp
   IndexRef ref i         -> (IndexRef <$> la ref <*> pure i) `bindLin` emitOp
   FstRef   ref           -> (FstRef   <$> la ref           ) `bindLin` emitOp
   SndRef   ref           -> (SndRef   <$> la ref           ) `bindLin` emitOp
@@ -582,8 +580,6 @@ transposeExpr expr ct = case expr of
 
 transposeOp :: Op -> Atom -> TransposeM ()
 transposeOp op ct = case op of
-  Fst x                 -> flip emitCTToRef ct =<< (traverse $ emitOp . FstRef) =<< linAtomRef x
-  Snd x                 -> flip emitCTToRef ct =<< (traverse $ emitOp . SndRef) =<< linAtomRef x
   ScalarUnOp  FNeg x    -> transposeAtom x =<< neg ct
   ScalarUnOp  _    _    -> notLinear
   ScalarBinOp FAdd x y  -> transposeAtom x ct >> transposeAtom y ct

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -198,8 +198,6 @@ toImpOp (maybeDest, op) = case op of
       ithDest <- destGet dest =<< intToIndex (binderType b) (IIdxRepVal i)
       copyAtom ithDest row
     destToAtom dest
-  Fst ~(PairVal x _) -> returnVal x
-  Snd ~(PairVal _ y) -> returnVal y
   PrimEffect refDest m -> do
     case m of
       MAsk    -> returnVal =<< destToAtom refDest

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -115,8 +115,6 @@ evalOp expr = case expr of
     Con (IntRangeVal   _ _   i) -> return i
     Con (IndexRangeVal _ _ _ i) -> return i
     _ -> evalEmbed (indexToIntE idxArg)
-  Fst p -> return x  where (PairVal x _) = p
-  Snd p -> return y  where (PairVal _ y) = p
   _ -> error $ "Not implemented: " ++ pprint expr
 
 -- We can use this when we know we won't be dereferencing pointers. A better

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -367,8 +367,6 @@ simplifyExpr expr = case expr of
 -- TODO: come up with a coherent strategy for ordering these various reductions
 simplifyOp :: Op -> SimplifyM Atom
 simplifyOp op = case op of
-  Fst (PairVal x _) -> return x
-  Snd (PairVal _ y) -> return y
   RecordCons left right -> case getType right of
     RecordTy (NoExt rightTys) -> do
       -- Unpack, then repack with new arguments (possibly in the middle).

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -307,7 +307,7 @@ data PrimCon e =
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimOp e =
-      | TabCon e [e]                 -- table type elements
+        TabCon e [e]                 -- table type elements
       | ScalarBinOp BinOp e e
       | ScalarUnOp UnOp e
       | Select e e e                 -- predicate, val-if-true, val-if-false

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -307,8 +307,6 @@ data PrimCon e =
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data PrimOp e =
-        Fst e
-      | Snd e
       | TabCon e [e]                 -- table type elements
       | ScalarBinOp BinOp e e
       | ScalarUnOp UnOp e

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -652,8 +652,6 @@ typeCheckOp op = case op of
     mapM_ (uncurry (|:)) $ zip xs (fmap (snd . applyAbs a) idxs)
     assertEq (length idxs) (length xs) "Index set size mismatch"
     return ty
-  Fst p -> do { PairTy x _ <- typeCheck p; return x}
-  Snd p -> do { PairTy _ y <- typeCheck p; return y}
   ScalarBinOp binop x y -> bindM2 (checkBinOp binop) (typeCheck x) (typeCheck y)
   ScalarUnOp  unop  x   -> checkUnOp unop =<< typeCheck x
   Select p x y -> do


### PR DESCRIPTION
AFAICT `fst` and `snd` can be implemented in pure dex, using pattern matching.
So it should be possible to delete all the code for handling them as a built-in operator.
Code that doesn't exist has no bugs.

Though, I think it's been possible for quite a while to do this, because tuple destructuring was implemented long ago.
So perhaps they are still here for a reason?