### PR TITLE
remove unneeded transpose in matmul

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,8 +21,8 @@ or these example programs:
   * [Basis function regression](https://google-research.github.io/dex-lang/regression.html)
   * [Brownian bridge](https://google-research.github.io/dex-lang/brownian_motion.html)
 
-Please note that Dex is an experimental research project at an early stage of
-development. Contributions welcome!
+⚠️ Dex is an experimental research project at an early stage of
+development. Expect monstrous bugs and razor-sharp edges. Contributions welcome! ⚠️
 
 ## Dependencies
 

--- a/prelude.dx
+++ b/prelude.dx
@@ -470,8 +470,7 @@ def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
 (**) : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
-  y' = transpose y
-  for i k. fsum \j. x.i.j * y'.k.j
+  for i k. fsum \j. x.i.j * y.j.k
 
 (**.) : (n=>m=>Float) -> (m=>Float) -> (n=>Float) = \mat v. for i. vdot mat.i v
 (.**) : (m=>Float) -> (n=>m=>Float) -> (n=>Float) = flip (**.)

--- a/prelude.dx
+++ b/prelude.dx
@@ -470,7 +470,7 @@ def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
 (**) : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
-  for i k. fsum \j. x.i.j * y.j.k
+  for i k. sum \j. x.i.j * y.j.k
 
 (**.) : (n=>m=>Float) -> (m=>Float) -> (n=>Float) = \mat v. for i. vdot mat.i v
 (.**) : (m=>Float) -> (n=>m=>Float) -> (n=>Float) = flip (**.)


### PR DESCRIPTION
I suspect I am doing something silly here, but i can't see why we would want a transpose when we can just change the order of the indexes.
