### PR TITLE
Create a self-contained abstraction for LLVM JIT infrastructure

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -34,7 +34,7 @@ library
                        PPrint, Algebra, Parallelize, Optimize, Serialize
                        Actor, Cat, Flops, Embed,
                        RenderHtml, LiveOutput, Simplify, TopLevel,
-                       Autodiff, Interpreter, Logging, PipeRPC, CUDA
+                       Autodiff, Interpreter, Logging, PipeRPC, CUDA, LLVM.JIT
   build-depends:       base, containers, mtl, binary, bytestring,
                        time, tf-random, llvm-hs-pure ==9.*, llvm-hs ==9.*,
                        aeson, megaparsec >=8.0, warp, wai, filepath,

--- a/examples/serialize-tests.dx
+++ b/examples/serialize-tests.dx
@@ -20,7 +20,7 @@
 > ()
 
 x = "ab"
-:p for i,j. [x.i, x.j]
+:p for (i,j). [x.i, x.j]
 > ["aa", "ab", "ba", "bb"]@(Fin 2 & Fin 2)
 
 'Records and variants

--- a/src/lib/LLVM/JIT.hs
+++ b/src/lib/LLVM/JIT.hs
@@ -1,0 +1,170 @@
+-- Copyright 2019 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+--
+{-# LANGUAGE RecordWildCards #-}
+{-# LANGUAGE DuplicateRecordFields #-}
+{-# LANGUAGE OverloadedStrings #-}
+
+module LLVM.JIT (
+  JIT, createJIT, destroyJIT, withJIT,
+  NativeModule, compileModule, unloadNativeModule, withNativeModule,
+  getFunctionPtr
+  ) where
+
+import Control.Monad
+import Control.Exception
+import Foreign.C.String
+import Foreign.Ptr
+import Data.IORef
+import Data.String
+import Data.List (sortBy)
+import qualified Data.Map as M
+import qualified Data.ByteString.Char8 as C8BS
+import qualified Data.ByteString.Short as SBS
+
+import qualified LLVM.OrcJIT as OrcJIT
+import qualified LLVM.Internal.OrcJIT.CompileLayer as OrcJIT
+import qualified LLVM.Internal.OrcJIT as OrcJIT
+import qualified LLVM.Internal.FFI.OrcJIT as OrcJIT.FFI
+import qualified LLVM.Internal.Coding as OrcJIT.FFI
+import qualified LLVM.Target as T
+import qualified LLVM.Linking as Linking
+
+import qualified LLVM.Module as Mod
+import qualified LLVM.AST as L
+import qualified LLVM.AST.Global as L
+import qualified LLVM.AST.Constant as C
+
+data JIT =
+    JIT { execSession  :: OrcJIT.ExecutionSession
+        , linkLayer    :: OrcJIT.ObjectLinkingLayer
+        , compileLayer :: OrcJIT.IRCompileLayer OrcJIT.ObjectLinkingLayer
+        , resolvers    :: IORef (M.Map OrcJIT.ModuleKey SymbolResolver)
+        }
+
+-- TODO: This leaks resources if we fail halfway
+createJIT :: T.TargetMachine -> IO JIT
+createJIT tm = do
+  void $ Linking.loadLibraryPermanently Nothing
+  resolvers    <- newIORef M.empty
+  execSession  <- OrcJIT.createExecutionSession
+  let lookupResolver = \k -> do
+        SymbolResolver _ ffiResolver <- (M.! k) <$> readIORef resolvers
+        return ffiResolver
+  linkLayer    <- OrcJIT.newObjectLinkingLayer execSession lookupResolver
+  compileLayer <- OrcJIT.newIRCompileLayer linkLayer tm
+  return JIT{..}
+
+-- TODO: This might not release everything if it fails halfway
+destroyJIT :: JIT -> IO ()
+destroyJIT JIT{..} = do
+  OrcJIT.disposeCompileLayer compileLayer
+  OrcJIT.disposeLinkingLayer linkLayer
+  OrcJIT.disposeExecutionSession execSession
+
+withJIT :: T.TargetMachine -> (JIT -> IO a) -> IO a
+withJIT tm = bracket (createJIT tm) destroyJIT
+
+data NativeModule =
+  NativeModule { moduleJIT      :: JIT
+               , moduleKey      :: OrcJIT.ModuleKey
+               , moduleDtors    :: [FunPtr (IO ())]
+               }
+
+-- XXX: This destroys the passed in module!
+-- TODO: This leaks resources if we fail halfway
+compileModule :: JIT -> (L.Module, Mod.Module) -> IO NativeModule
+compileModule moduleJIT@JIT{..} (ast, m) = do
+  moduleKey <- OrcJIT.allocateModuleKey execSession
+  resolver <- newSymbolResolver execSession (makeResolver compileLayer)
+  modifyIORef resolvers (M.insert moduleKey resolver)
+  OrcJIT.addModule compileLayer moduleKey m
+  moduleDtors <- forM dtorNames $ \dtorName -> do
+    dtorSymbol <- OrcJIT.mangleSymbol compileLayer (fromString dtorName)
+    Right (OrcJIT.JITSymbol dtorAddr _) <- OrcJIT.findSymbol compileLayer dtorSymbol False
+    return $ castPtrToFunPtr $ wordPtrToPtr dtorAddr
+  return NativeModule{..}
+  where
+    makeResolver :: OrcJIT.IRCompileLayer OrcJIT.ObjectLinkingLayer -> OrcJIT.SymbolResolver
+    makeResolver cl = OrcJIT.SymbolResolver $ \sym -> do
+      rsym <- OrcJIT.findSymbol cl sym False
+      -- We look up functions like malloc in the current process
+      -- TODO: Use JITDylibs to avoid inlining addresses as constants:
+      -- https://releases.llvm.org/9.0.0/docs/ORCv2.html#how-to-add-process-and-library-symbols-to-the-jitdylibs
+      case rsym of
+        Right _ -> return rsym
+        Left  _ -> do
+          ptr <- Linking.getSymbolAddressInProcess sym
+          if ptr == 0
+            then error $ "Missing symbol: " ++ show sym
+            else return $ Right $ externSym ptr
+    externSym ptr =
+      OrcJIT.JITSymbol { OrcJIT.jitSymbolAddress = ptr
+                       , OrcJIT.jitSymbolFlags = OrcJIT.defaultJITSymbolFlags
+                           { OrcJIT.jitSymbolExported = True
+                           , OrcJIT.jitSymbolAbsolute = True }
+                       }
+    -- Unfortunately the JIT layers we use here don't handle the destructors properly,
+    -- so we have to find and call them ourselves.
+    dtorNames = do
+      let dtorStructs = flip foldMap (L.moduleDefinitions ast) $ \case
+            L.GlobalDefinition
+              L.GlobalVariable{name="llvm.global_dtors",
+                               initializer=Just (C.Array _ elems),
+                               ..} -> elems
+            _ -> []
+      -- Sort in the order of decreasing priority!
+      fmap snd $ sortBy (flip compare) $ flip fmap dtorStructs $
+        \(C.Struct _ _ [C.Int _ n, C.GlobalReference _ (L.Name dname), _]) ->
+          (n, C8BS.unpack $ SBS.fromShort dname)
+
+foreign import ccall "dynamic"
+  callDtor :: FunPtr (IO ()) -> IO ()
+
+-- TODO: This might not release everything if it fails halfway
+unloadNativeModule :: NativeModule -> IO ()
+unloadNativeModule NativeModule{..} = do
+  let JIT{..} = moduleJIT
+  forM_ moduleDtors callDtor
+  resolver <- (M.! moduleKey) <$> readIORef resolvers
+  disposeSymbolResolver resolver
+  modifyIORef resolvers (M.delete moduleKey)
+  OrcJIT.removeModule compileLayer moduleKey
+  OrcJIT.releaseModuleKey execSession moduleKey
+
+withNativeModule :: JIT -> (L.Module, Mod.Module) -> (NativeModule -> IO a) -> IO a
+withNativeModule jit m = bracket (compileModule jit m) unloadNativeModule
+
+getFunctionPtr :: NativeModule -> String -> IO (FunPtr a)
+getFunctionPtr NativeModule{..} funcName = do
+  let JIT{..} = moduleJIT
+  symbol <- OrcJIT.mangleSymbol compileLayer $ fromString funcName
+  Right (OrcJIT.JITSymbol funcAddr _) <- OrcJIT.findSymbol compileLayer symbol False
+  return $ castPtrToFunPtr $ wordPtrToPtr funcAddr
+
+
+-- === llvm-hs shims ===
+
+-- llvm-hs doesn't expose any way to manage the symbol resolvers in a non-bracketed
+-- way, so we have to use some internal APIs to do that.
+
+type FFIResolver = CString -> Ptr OrcJIT.FFI.JITSymbol -> IO ()
+foreign import ccall "wrapper" wrapFFIResolver :: FFIResolver -> IO (FunPtr FFIResolver)
+data SymbolResolver = SymbolResolver (FunPtr FFIResolver) (Ptr OrcJIT.FFI.SymbolResolver)
+
+-- | Create a `FFI.SymbolResolver` that can be used with the JIT.
+newSymbolResolver :: OrcJIT.ExecutionSession -> OrcJIT.SymbolResolver -> IO SymbolResolver
+newSymbolResolver (OrcJIT.ExecutionSession session) (OrcJIT.SymbolResolver resolverFn) = do
+  ffiResolverPtr <- wrapFFIResolver $ \sym res -> do
+    f <- OrcJIT.FFI.encodeM =<< resolverFn =<< OrcJIT.FFI.decodeM sym
+    f res
+  lambdaResolver <- OrcJIT.FFI.createLambdaResolver session ffiResolverPtr
+  return $ SymbolResolver ffiResolverPtr lambdaResolver
+
+disposeSymbolResolver :: SymbolResolver -> IO ()
+disposeSymbolResolver (SymbolResolver wrapper resolver) = do
+  OrcJIT.FFI.disposeSymbolResolver resolver
+  freeHaskellFunPtr wrapper

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -214,7 +214,7 @@ evalBackend block = do
   checkPass ImpPass impModule
   llvmAST <- liftIO $ impToLLVM logger impModule
   let IFunType _ _ resultTypes = impFunType $ mainFunc
-  let llvmEvaluate = if bench then benchLLVM else callLLVM
+  let llvmEvaluate = if bench then compileAndBench else compileAndEval
   resultVals <- liftM (map (Con . Lit)) $ liftIO $
     llvmEvaluate logger llvmAST funcName ptrVals resultTypes
   return $ applyNaryAbs reconAtom resultVals
@@ -281,7 +281,7 @@ exportFunctions objPath funcs env opts = do
     let (_, impModule, _) = toImpModule backend CEntryFun name cargs (Just dest) block
     llvmAST <- execLogger Nothing $ flip impToLLVM impModule
     return (llvmAST, [nameStr])
-  exportLLVM objPath modules
+  exportObjectFile objPath modules
   where
     outputName = GlobalName "_ans_"
 


### PR DESCRIPTION
Previously, our JIT code was heavily specialized to one-shot
evaluation which is fine when all we care about is interpretation.
But one interesting use case I would like us to support is surfacing
JIT-compiled reentrant (in the sense that they can be called multiple
times) kernels in Python, which will require us to keep the compiled
code around for a while longer.

The new abstractions all live in `LLVM.JIT`. First, there's the `JIT`
ADT which represents an instance of the LLVM JIT objects. There's not
much you can do with that one except for creating and destroying it.
However, its real purpose is so that one can use it to compile and
register `NativeModule`s (potentially multiple at the same time). Such
compiled modules can be queried for function pointers and won't be
unloaded until explicitly asked to do so.

Note that this is also a useful step for compilation caching. While the
current implementation does not support linking accross modules, it
would be a straightforward extension to the symbol resolvers.