### PR TITLE
Fix macOS build with Hombrew-installed libpng.

### DIFF
--- a/makefile
+++ b/makefile
@@ -32,9 +32,15 @@ endif
 
 CFLAGS := -fPIC
 
+# CUDA
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
 STACK_FLAGS = --flag dex:cuda
 CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
+endif
+
+# libpng
+ifneq (,$(wildcard /usr/local/include/png.h))
+CFLAGS := $(CFLAGS) -I/usr/local/include
 endif
 
 ifneq (,$(PREFIX))


### PR DESCRIPTION
Add `-I/usr/local/include` to C compiler flags.
Homebrew installs libpng and creates a symlink at `/usr/local/include/png.h`.

There may be a more principled fix using `dex.cabal` and `pkg-config`.