### PR TITLE
Use custom IsCUDARequired ADT instead of Bool.

### DIFF
--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -47,6 +47,7 @@ import PPrint
 import Imp
 import Logging
 import LLVMExec
+import Util (IsBool (..))
 
 type OperandEnv = Env Operand
 data CompileState = CompileState { curBlocks   :: [BasicBlock]
@@ -94,7 +95,7 @@ compileFunction logger fun@(ImpFunction f bs body) = case cc of
     (resultPtrParam, resultPtrOperand) <- freshParamOpPair attrs $ hostPtrTy i64
     argOperands <- forM (zip [0..] argTys) $ \(i, ty) ->
       gep argPtrOperand (i64Lit i) >>= castLPtr (scalarTy ty) >>= load
-    when requiresCUDA ensureHasCUDAContext
+    when (toBool requiresCUDA) ensureHasCUDAContext
     results <- extendOperands (newEnv bs argOperands) $ compileBlock body
     forM_ (zip [0..] results) $ \(i, x) ->
       gep resultPtrOperand (i64Lit i) >>= castLPtr (L.typeOf x) >>= flip store x

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -29,7 +29,7 @@ module Syntax (
     ImpModule (..), ImpBlock (..), ImpFunction (..), ImpDecl (..),
     IExpr (..), IVal, ImpInstr (..), Backend (..), Device (..),
     IPrimOp, IVar, IBinder, IType, SetVal (..), MonMap (..), LitProg,
-    IFunType (..), IFunVar, CallingConvention (..),
+    IFunType (..), IFunVar, CallingConvention (..), IsCUDARequired (..),
     UAlt (..), AltP, Alt, Label, LabeledItems (..), labeledSingleton,
     reflectLabels, withLabels, ExtLabeledItems (..), prefixExtLabeledItems,
     IScope, BinderInfo (..), Bindings, CUDAKernel (..), BenchStats,
@@ -82,7 +82,7 @@ import Foreign.Ptr
 import GHC.Generics
 
 import Env
-import Util (enumerate, (...))
+import Util (IsBool (..), enumerate, (...))
 
 -- === core IR ===
 
@@ -482,8 +482,15 @@ type Size = IExpr
 type IFunVar = VarP IFunType
 data IFunType = IFunType CallingConvention [IType] [IType] -- args, results
                 deriving (Show)
+
+data IsCUDARequired = CUDARequired | CUDANotRequired  deriving (Eq, Show)
+
+instance IsBool IsCUDARequired where
+  toBool CUDARequired = True
+  toBool CUDANotRequired = False
+
 data CallingConvention = CEntryFun
-                       | EntryFun Bool  -- flag indicates whether CUDA required
+                       | EntryFun IsCUDARequired
                        | FFIFun
                        | FFIMultiResultFun
                        | CUDAKernelLaunch

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -200,8 +200,8 @@ evalBackend block = do
   let (ptrBinders, ptrVals, block') = abstractPtrLiterals block
   let funcName = "entryFun"
   let mainName = Name TopFunctionName (fromString funcName) 0
-  let cc = case backend of LLVMCUDA -> EntryFun True
-                           _        -> EntryFun False
+  let cc = case backend of LLVMCUDA -> EntryFun CUDARequired
+                           _        -> EntryFun CUDANotRequired
   let (mainFunc, impModuleUnoptimized, reconAtom) =
         toImpModule backend cc mainName ptrBinders Nothing block'
   -- TODO: toImpModule might generate invalid Imp code, because GPU allocations

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -6,7 +6,7 @@
 
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
-module Util (group, ungroup, pad, padLeft, delIdx, replaceIdx,
+module Util (IsBool (..), group, ungroup, pad, padLeft, delIdx, replaceIdx,
              insertIdx, mvIdx, mapFst, mapSnd, splitOn, scan,
              scanM, composeN, mapMaybe, uncons, repeated,
              showErr, listDiff, splitMap, enumerate, restructure,
@@ -20,6 +20,9 @@ import Prelude
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as M
 import Control.Monad.State.Strict
+
+class IsBool a where
+  toBool :: a -> Bool
 
 swapAt :: Int -> a -> [a] -> [a]
 swapAt _ _ [] = error "swapping to empty list"


### PR DESCRIPTION
`IsCUDARequired` is explicit and easier to understand than `Bool`.
Add auxiliary `IsBool` typeclass.

No Imp test added because pretty-printed Imp is too unstable: https://github.com/google-research/dex-lang/pull/344#discussion_r542013084.

---

Before:

```
%passes imp
:p [1, 2, 3]
> [1, 2, 3]
> === imp ===
> def entryFun EntryFun False [] -- the meaning of False is unclear
>   ...
```

After:

```
%passes imp
:p [1, 2, 3]
> [1, 2, 3]
> === imp ===
> def entryFun EntryFun CUDANotRequired [] -- meaning is clear
>   ...
```