### PR TITLE
Make it possible to create long-lived LLVM Target objects

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -34,7 +34,8 @@ library
                        PPrint, Algebra, Parallelize, Optimize, Serialize
                        Actor, Cat, Flops, Embed,
                        RenderHtml, LiveOutput, Simplify, TopLevel,
-                       Autodiff, Interpreter, Logging, PipeRPC, CUDA, LLVM.JIT
+                       Autodiff, Interpreter, Logging, PipeRPC, CUDA,
+                       LLVM.JIT, LLVM.Shims
   build-depends:       base, containers, mtl, binary, bytestring,
                        time, tf-random, llvm-hs-pure ==9.*, llvm-hs ==9.*,
                        aeson, megaparsec >=8.0, warp, wai, filepath,

--- a/src/lib/LLVM/Shims.hs
+++ b/src/lib/LLVM/Shims.hs
@@ -1,0 +1,96 @@
+-- Copyright 2020 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module LLVM.Shims (
+  SymbolResolver (..), newSymbolResolver, disposeSymbolResolver,
+  newTargetMachine, newHostTargetMachine, disposeTargetMachine,
+  newTargetOptions, disposeTargetOptions
+  ) where
+
+import qualified Data.Map as M
+import Foreign.C.String
+import Foreign.Ptr
+import qualified Data.ByteString.Char8 as BS
+import qualified Data.ByteString.Short as SBS
+
+import qualified LLVM.Internal.OrcJIT as OrcJIT
+import qualified LLVM.Internal.FFI.OrcJIT as OrcJIT.FFI
+
+import qualified LLVM.Relocation as R
+import qualified LLVM.CodeModel as CM
+import qualified LLVM.CodeGenOpt as CGO
+import qualified LLVM.Internal.Target as Target
+import qualified LLVM.Internal.FFI.Target as Target.FFI
+import LLVM.Prelude (ShortByteString, ByteString)
+import LLVM.Internal.Coding (encodeM, decodeM)
+
+-- llvm-hs doesn't expose any way to manage the symbol resolvers in a non-bracketed way
+
+type FFIResolver = CString -> Ptr OrcJIT.FFI.JITSymbol -> IO ()
+foreign import ccall "wrapper" wrapFFIResolver :: FFIResolver -> IO (FunPtr FFIResolver)
+data SymbolResolver = SymbolResolver (FunPtr FFIResolver) (Ptr OrcJIT.FFI.SymbolResolver)
+
+-- | Create a `FFI.SymbolResolver` that can be used with the JIT.
+newSymbolResolver :: OrcJIT.ExecutionSession -> OrcJIT.SymbolResolver -> IO SymbolResolver
+newSymbolResolver (OrcJIT.ExecutionSession session) (OrcJIT.SymbolResolver resolverFn) = do
+  ffiResolverPtr <- wrapFFIResolver $ \sym res -> do
+    f <- encodeM =<< resolverFn =<< decodeM sym
+    f res
+  lambdaResolver <- OrcJIT.FFI.createLambdaResolver session ffiResolverPtr
+  return $ SymbolResolver ffiResolverPtr lambdaResolver
+
+disposeSymbolResolver :: SymbolResolver -> IO ()
+disposeSymbolResolver (SymbolResolver wrapper resolver) = do
+  OrcJIT.FFI.disposeSymbolResolver resolver
+  freeHaskellFunPtr wrapper
+
+-- llvm-hs doesn't expose any way to manage target machines in a non-bracketed way
+
+newTargetMachine :: Target.Target
+                 -> ShortByteString
+                 -> ByteString
+                 -> M.Map Target.CPUFeature Bool
+                 -> Target.TargetOptions
+                 -> R.Model
+                 -> CM.Model
+                 -> CGO.Level
+                 -> IO Target.TargetMachine
+newTargetMachine (Target.Target targetFFI) triple cpu features
+                 (Target.TargetOptions targetOptFFI)
+                 relocModel codeModel cgoLevel = do
+  SBS.useAsCString triple $ \tripleFFI -> do
+    BS.useAsCString cpu $ \cpuFFI -> do
+      let featuresStr = BS.intercalate "," $ fmap encodeFeature $ M.toList features
+      BS.useAsCString featuresStr $ \featuresFFI -> do
+        relocModelFFI <- encodeM relocModel
+        codeModelFFI <- encodeM codeModel
+        cgoLevelFFI <- encodeM cgoLevel
+        Target.TargetMachine <$> Target.FFI.createTargetMachine
+                targetFFI tripleFFI cpuFFI featuresFFI
+                targetOptFFI relocModelFFI codeModelFFI cgoLevelFFI
+  where encodeFeature (Target.CPUFeature f, on) = (if on then "+" else "-") <> f
+
+newHostTargetMachine :: R.Model -> CM.Model -> CGO.Level -> IO (Target.TargetMachine, Target.TargetOptions)
+newHostTargetMachine relocModel codeModel cgoLevel = do
+  Target.initializeAllTargets
+  triple <- Target.getProcessTargetTriple
+  (target, _) <- Target.lookupTarget Nothing triple
+  cpu <- Target.getHostCPUName
+  features <- Target.getHostCPUFeatures
+  targetOptions <- newTargetOptions
+  tm <- newTargetMachine target triple cpu features targetOptions relocModel codeModel cgoLevel
+  return (tm, targetOptions)
+
+disposeTargetMachine :: Target.TargetMachine -> IO ()
+disposeTargetMachine (Target.TargetMachine tmFFI) = Target.FFI.disposeTargetMachine tmFFI
+
+-- llvm-hs doesn't expose any way to manage target options in a non-bracketed way
+
+newTargetOptions :: IO Target.TargetOptions
+newTargetOptions = Target.TargetOptions <$> Target.FFI.createTargetOptions
+
+disposeTargetOptions :: Target.TargetOptions -> IO ()
+disposeTargetOptions (Target.TargetOptions optsFFI) = Target.FFI.disposeTargetOptions optsFFI

--- a/stack-macos.yaml
+++ b/stack-macos.yaml
@@ -1,10 +1,10 @@
-# Copyright 2020 Google LLC
+# Copyright 2019 Google LLC
 #
 # Use of this source code is governed by a BSD-style
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: lts-14.27
+resolver: lts-16.26
 
 packages:
 - .
@@ -14,6 +14,9 @@ extra-deps:
   - llvm-hs-pure-9.0.0
   - megaparsec-8.0.0
   - prettyprinter-1.6.2
+  - store-0.7.8@sha256:0b604101fd5053b6d7d56a4ef4c2addf97f4e08fe8cd06b87ef86f958afef3ae,8001
+  - store-core-0.4.4.4@sha256:a19098ca8419ea4f6f387790e942a7a5d0acf62fe1beff7662f098cfb611334c,1430
+  - th-utilities-0.2.4.1@sha256:b37d23c8bdabd678aee5a36dd4373049d4179e9a85f34eb437e9cd3f04f435ca,1869
 
 flags:
   llvm-hs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -4,7 +4,7 @@
 # license that can be found in the LICENSE file or at
 # https://developers.google.com/open-source/licenses/bsd
 
-resolver: lts-14.27
+resolver: lts-16.26
 
 packages:
 - .
@@ -14,3 +14,6 @@ extra-deps:
   - llvm-hs-pure-9.0.0
   - megaparsec-8.0.0
   - prettyprinter-1.6.2
+  - store-0.7.8@sha256:0b604101fd5053b6d7d56a4ef4c2addf97f4e08fe8cd06b87ef86f958afef3ae,8001
+  - store-core-0.4.4.4@sha256:a19098ca8419ea4f6f387790e942a7a5d0acf62fe1beff7662f098cfb611334c,1430
+  - th-utilities-0.2.4.1@sha256:b37d23c8bdabd678aee5a36dd4373049d4179e9a85f34eb437e9cd3f04f435ca,1869


### PR DESCRIPTION
llvm-hs is missing a bunch of non-bracketed contructors and destructors
for LLVM objects. This adds them for `llvm::Target` and
`llvm::TargetOptions`. All of the llvm-hs patches that depend on
internal functionality are now isolated in the `LLVM.Shims` module.