### PR TITLE
Fix bug in Atan2

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -956,7 +956,7 @@ def atan2 (y:Float) (x:Float) : Float =
   (min_abs_x_y, max_abs_x_y) = min_and_max abs_x abs_y
   a = atan_inner (min_abs_x_y / max_abs_x_y)
   a = select (abs_x <= abs_y) ((pi / 2.0) -a) a
-  a = select (x < 0.0) pi a
+  a = select (x < 0.0) (pi - a) a
   t = select (x < 0.0) pi 0.0
   a = select (y == 0.0) t a
   t = select (x < 0.0) (3.0 * pi / 4.0) (pi / 4.0)

--- a/tests/trig-tests.dx
+++ b/tests/trig-tests.dx
@@ -20,6 +20,14 @@
 > True
 :p atan2 (-sin (-0.44)) (cos (-0.44)) ~~ (0.44)
 > True
+:p atan2 (-1.0) (-1.0) ~~ (-3.0/4.0*pi)
+> True
+
+-- Test all the way around the circle.
+angles = linspace (Fin 11) (-pi + 0.001) (pi)
+:p all for i:(Fin 11).
+  angles.i ~~ atan2 (sin angles.i) (cos angles.i)
+> True
 
 :p (atan2   infinity  1.0) ~~ ( pi / 2.0)
 > True


### PR DESCRIPTION
Fixes #362

I originally tested 14 different inputs to `atan2`, but somehow managed to miss two quadrants.  I also added a test that goes systematically around the circle.