### PR TITLE
Improve the benchmark harness

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -37,7 +37,7 @@ library
                        RenderHtml, LiveOutput, Simplify, TopLevel,
                        Autodiff, Interpreter, Logging, CUDA,
                        LLVM.JIT, LLVM.Shims
-  build-depends:       base, containers, mtl, bytestring, time,
+  build-depends:       base, containers, mtl, bytestring,
                        llvm-hs-pure, llvm-hs,
                        -- Parsing
                        megaparsec, parser-combinators,

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -521,8 +521,8 @@ instance Pretty Output where
     benchName <> hardline <>
     "Compile time: " <> prettyDuration compileTime <> hardline <>
     "Run time:     " <> prettyDuration runTime <+>
-    (case stats of Just runs -> "\t" <> parens ("based on" <+> p runs <+> "runs")
-                   Nothing   -> "")
+    (case stats of Just (runs, _) -> "\t" <> parens ("based on" <+> p runs <+> "runs")
+                   Nothing        -> "")
     where benchName = case name of "" -> ""
                                    _  -> "\n" <> p name
   pretty (PassInfo name s) = "===" <+> p name <+> "===" <> hardline <> p s

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -614,7 +614,7 @@ type LitProg = [(SourceBlock, Result)]
 type SrcCtx = Maybe SrcPos
 data Result = Result [Output] (Except ())  deriving (Show, Eq)
 
-type BenchStats = Int -- number of runs
+type BenchStats = (Int, Double) -- number of runs, total benchmarking time
 data Output = TextOut String
             | HtmlOut String
             | PassInfo PassName String

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -12,6 +12,7 @@ module Util (IsBool (..), group, ungroup, pad, padLeft, delIdx, replaceIdx,
              scanM, composeN, mapMaybe, uncons, repeated, transitiveClosure,
              showErr, listDiff, splitMap, enumerate, restructure,
              onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3,
+             measureSeconds,
              bindM2, foldMapM, lookupWithIdx, (...), zipWithT, for) where
 
 import Data.Functor.Identity (Identity(..))
@@ -21,6 +22,7 @@ import Prelude
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as M
 import Control.Monad.State.Strict
+import System.CPUTime
 
 import Cat
 
@@ -232,3 +234,10 @@ transitiveClosure getParents seeds =
       unless (x `Set.member` visited) $ do
         extend $ Set.singleton x
         mapM_ go $ getParents x
+
+measureSeconds :: MonadIO m => m a -> m (a, Double)
+measureSeconds m = do
+  t1 <- liftIO $ getCPUTime
+  ans <- m
+  t2 <- liftIO $ getCPUTime
+  return (ans, (fromIntegral $ t2 - t1) / 1e12)


### PR DESCRIPTION
Use a stable timer, and take a single measurement for a whole bunch of
runs, to amortize the measurement cost (~1us).

Thanks to this, the lowest numbers we can possibly benchmark are ~150ns
on my machine (this is for running a `1 + 1` program). This is still
suspiciously high, but I think it might be connected to the fact that
the program we emit actually does contain a call to `posix_memalign`,
and so it might just be the cost of memory allocation (especially that
we never free the result!).