### PR TITLE
Improved linear algebra example.

### DIFF
--- a/examples/linear_algebra.dx
+++ b/examples/linear_algebra.dx
@@ -3,69 +3,79 @@
 def identity_matrix (_:Eq n) ?=> (_:Add a) ?=> (_:Mul a) ?=> : n=>n=>a =
   for i j. select (i == j) one zero
 
-
 '### Triangular matrices
 
-def LowerTriMat (n:Type) : Type = i:n=>(..i)=>Float
-def UpperTriMat (n:Type) : Type = i:n=>(i..)=>Float
+def LowerTriMat (n:Type) (v:Type) : Type = i:n=>(..i)=>v
+def UpperTriMat (n:Type) (v:Type) : Type = i:n=>(i..)=>v
 
-def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n) (b:n=>v) : n=>v =
+def upperTriDiag (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
+def lowerTriDiag (l:LowerTriMat n v) : n=>v = for i. l.i.((ordinal i)@_)
+
+def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n Float) (b:n=>v) : n=>v =
   -- Solves lower triangular linear system (inverse a) **. b
   snd $ withState zero \sRef.
     for i:n.
       s = sum for k:(..<i).  -- dot product
-        a.i.((ordinal k)@_) .* (get sRef).(%inject k)
+        a.i.((ordinal k)@_) .* get sRef!(%inject k)
       sRef!i := (b.i - s) / a.i.((ordinal i)@_)
 
-def backward_substitute (_:VSpace v) ?=> (a:UpperTriMat n) (b:n=>v) : n=>v =
+def backward_substitute (_:VSpace v) ?=> (a:UpperTriMat n Float) (b:n=>v) : n=>v =
   -- Solves upper triangular linear system (inverse a) **. b
   snd $ withState zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
-        a.i.((ordinal k)@_) .* (get sRef).(%inject k)
+        a.i.((ordinal k)@_) .* get sRef!(%inject k)
       sRef!i := (b.i - s) / a.i.(0@_) -- 0 is the diagonal index
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
-def lowerTriIndex (ref:Ref h (LowerTriMat n)) (i:n) : Ref h ((..i)=>Float) =
+def lowerTriIndex (ref:Ref h (LowerTriMat n v)) (i:n) : Ref h ((..i)=>v) =
   %indexRef ref i
-def upperTriIndex (ref:Ref h (UpperTriMat n)) (i:n) : Ref h ((i..)=>Float) =
+def upperTriIndex (ref:Ref h (UpperTriMat n v)) (i:n) : Ref h ((i..)=>v) =
   %indexRef ref i
 
 
 '### Permutations
 
-def Permutation (n:Type) : Type = n=>n
-def apply_permutation (permutation: n=>n) (array: n=>t) : n=>t =
-  for i. array.(permutation.i)
-def identity_permutation (n:Type) ?-> : Permutation n =
-  for i. i
+-- The sign of the determinant of a permutation is either 1.0 or -1.0
+PermutationSign = Float
+
+def Permutation (n:Type) : Type = (perm:n=>n & PermutationSign)
+
+def apply_permutation ((perm, _):Permutation n) (xs: n=>t) : n=>t =
+  for i. xs.(perm.i)
+
+def identity_permutation : Permutation n =
+  (for i. i, 1.0)
+
+def swapInPlace (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
+  (permRef, signRef) = (fstRef pRef, sndRef pRef)
+  tempj = get permRef!j
+  permRef!j := get permRef!i
+  permRef!i := tempj
+  signRef := -(get signRef)
+
+def perToTable ((perm, _):Permutation n) : n=>n = perm
+def permSign   ((_, sign):Permutation n) : PermutationSign = sign
+
 
 
 '### LU decomposition functions
 
-Sign = Float  -- Either 1.0 or -1.0
-
-def pivotize (_:Eq n) ?=> (a:n=>n=>Float) : (Permutation n & Sign) =
-  -- Permutes rows of a matrix to make Gaussian elimination more stable.
-  -- Returns permutation and the sign of its determinant.
-  snd $ withState (identity_permutation, 1.0) \stateRef.
-    (pRef, signRef) = (fstRef stateRef, sndRef stateRef)
+def pivotize (_:Eq n) ?=> (a:n=>n=>Float) : Permutation n =
+  -- Gives a row permutation that makes Gaussian elimination more stable.
+  snd $ withState identity_permutation \permRef.
     for j:n.
-      row_with_largest = argmin for i:(j..). (-(abs a.(%inject i).j))
-      row_with_largest = %inject row_with_largest
+      row_with_largest' = argmin for i:(j..). (-(abs a.(%inject i).j))
+      row_with_largest = %inject row_with_largest'
       case (j == row_with_largest) of
         True -> ()
-        False -> 
-          tempj = get pRef!j  -- Is there a refSwap?
-          pRef!j := get pRef!row_with_largest
-          pRef!row_with_largest := tempj
-          signRef := -(get signRef)
+        False -> swapInPlace permRef j row_with_largest
 
 def lu (_:Eq n) ?=> (a: n=>n=>Float) :
-       (LowerTriMat n & UpperTriMat n & Permutation n & Sign) =
+       (LowerTriMat n Float & UpperTriMat n Float & Permutation n) =
   -- Computes lower, upper, and permuntation matrices from a square matrix,
   -- such that apply_permutation permutation a == lower ** upper.
-  (permutation, swapcount) = pivotize a
+  permutation = pivotize a
   a = apply_permutation permutation a
 
   init_lower = for i:n. for j':(..i).
@@ -120,7 +130,7 @@ def lu (_:Eq n) ?=> (a: n=>n=>Float) :
         ujj = get (upperTriIndex uRef j)!(0@_)
         lijRef = (lowerTriIndex lRef i'')!((ordinal j)@_)
         lijRef := (a.i'.j - s) / ujj
-  (lower, upper, permutation, swapcount)
+  (lower, upper, permutation)
 
 
 '### General linear algebra functions.
@@ -130,7 +140,7 @@ def solve (_:Eq n) ?=> (_:VSpace v) ?=> (a:n=>n=>Float) (b:n=>v) : n=>v =
   -- that l always has ones on the diagonal.  It would just require a
   -- custom forward_substitute routine that doesn't divide
   -- by the diagonal entries.
-  (l, u, perm, _) = lu a
+  (l, u, perm) = lu a
   b' = apply_permutation perm b
   y = forward_substitute l b'
   backward_substitute u y
@@ -139,15 +149,13 @@ def invert (_:Eq n) ?=> (a:n=>n=>Float) : n=>n=>Float =
   solve a identity_matrix
 
 def determinant (_:Eq n) ?=> (a:n=>n=>Float) : Float =
-  (l, u, perm, permutation_sign) = lu a
-  -- formerly u.i.i * l.i.i
-  (prod for i. u.i.(0@_) * l.i.((ordinal i)@_)) * permutation_sign
+  (l, u, perm) = lu a
+  prod (for i. (upperTriDiag u).i * (lowerTriDiag l).i) * permSign perm
 
 def sign_and_log_determinant (_:Eq n) ?=> (a:n=>n=>Float) : (Float & Float) =
-  (l, u, perm, permutation_sign) = lu a
-  -- formerly u.i.i * l.i.i
-  diags = for i. u.i.(0@_) * l.i.((ordinal i)@_)
-  sign = permutation_sign * prod for i. sign diags.i
+  (l, u, perm) = lu a
+  diags = for i. (upperTriDiag u).i * (lowerTriDiag l).i
+  sign = (permSign perm) * prod for i. sign diags.i
   sum_of_log_abs = sum for i. log (abs diags.i) 
   (sign, sum_of_log_abs)
 


### PR DESCRIPTION
 - Generalized some of the types.  Could make things more general still when multi-param `interface`s work so the scalar field of `VSpace` becomes a parameter.
 - Got rid of an unnecessary copy in the triangular solves.
 - Made the permutation logic more self-contained.  I couldn't use a typeclass because I don't think there's an equivalent of `fstRef` and `sndRef` that lets one index into fields of a typeclass given a reference to it.
 - Started moving some of the unsafe indexing logic into smaller functions.