### PR TITLE
Refactor diagram.dx

### DIFF
--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -112,8 +112,8 @@ def quote (s:String) : String = str "\"" <.> s <.> str "\""
 def strSpaceCatUncurried ((s1,s2):(String & String)) : String =
   s1 <.> str " " <.> s2
 
-def (<+>) (s1:String) (s2:String) : String =
-  strSpaceCatUncurried (s1, s2)
+def (<+>) (_:Show a) ?=> (_:Show b) ?=> (s1:a) (s2:b) : String =
+  strSpaceCatUncurried ((show s1), (show s2))
 
 def selfClosingBrackets (s:String) : String = str "<" <.> s <.> str "/>"
 
@@ -127,8 +127,8 @@ def tagBracketsAttrUncurried ((tag, attr, s):(String & String & String)) : Strin
 def tagBracketsAttr (tag:String) (attr:String) (s:String) : String =
   tagBracketsAttrUncurried (tag, attr, s)
 
-def makeAttr (attr:String) (val:String) : String =
-  attr <.> str "=" <.> quote val
+def (<=>) (_:Show b) ?=> (attr:String) (val:b) : String =
+  attr <.> str "=" <.> quote (show val)
 
 def htmlColorStr (cs:HtmlColor) : String =
   (r, g, b) = cs
@@ -141,32 +141,33 @@ def optionalHtmlColorStr (c: Maybe HtmlColor) : String =
 
 @noinline
 def attrString (attr:GeomStyle) : String =
-  (  --  makeAttr (str "stroke")       (optionalHtmlColorStr $ getAt #strokeColor attr)
-      makeAttr (str "fill")         (optionalHtmlColorStr $ getAt #fillColor   attr)
-  <+> makeAttr (str "stroke-width") (show                 $ getAt #strokeWidth attr))
+  (  -- (str "stroke") <=> (optionalHtmlColorStr $ getAt #strokeColor attr)
+      (str "fill") <=> (optionalHtmlColorStr $ getAt #fillColor   attr)
+  <+> (str "stroke-width") <=> (getAt #strokeWidth attr))
 
 def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
+  groupEle = \attr. tagBracketsAttr (str "g") (attrString attr)
   case geom of
     PointGeom ->
-     pointAttr = setAt #fillColor (getAt #strokeColor attr) attr
-     tagBracketsAttr (str "g") (attrString pointAttr) $ selfClosingBrackets $
-       (str "circle" <+>
-        str "cx=" <.> quote (show x) <.>
-        str "cy=" <.> quote (show y) <.>
-        str "r=\"1\"")
+      pointAttr = setAt #fillColor (getAt #strokeColor attr) attr
+      groupEle pointAttr $ selfClosingBrackets $
+        (str "circle" <+>
+         str "cx" <=> x <.>
+         str "cy" <=> y <.>
+         str "r=\"1\"")
     Circle r ->
-     tagBracketsAttr (str "g") (attrString attr) $ selfClosingBrackets $
-       (str "circle" <+>
-        str "cx=" <.> quote (show x) <.>
-        str "cy=" <.> quote (show y) <.>
-        str "r="  <.> quote (show r))
+      groupEle attr $ selfClosingBrackets $
+        (str "circle" <+>
+         str "cx" <=> x <.>
+         str "cy" <=> y <.>
+         str "r"  <=> r)
     Rectangle w h ->
-     tagBracketsAttr (str "g") (attrString attr) $ selfClosingBrackets $
-       (str "rect" <+>
-        str "width="  <.> quote (show w) <.>
-        str "height=" <.> quote (show h) <.>
-        str "x="      <.> quote (show (x - (w/2.0))) <.>
-        str "y="      <.> quote (show (y - (h/2.0))))
+      groupEle attr $ selfClosingBrackets $
+        (str "rect" <+>
+         str "width"  <=> w <.>
+         str "height" <=> h <.>
+         str "x"      <=> (x - (w/2.0)) <.>
+         str "y"      <=> (y - (h/2.0)))
 
 BoundingBox : Type = (Point & Point)
 
@@ -175,13 +176,12 @@ def renderSVG (d:Diagram) (bounds:BoundingBox) : String =
   imgWidth = 400.0
   scaleFactor = imgWidth / (xmax - xmin)
   imgHeight = (ymax - ymin) * scaleFactor
+  imgXMin   =  xmin * scaleFactor
+  imgYMin   = -ymax * scaleFactor
   (MkDiagram (AsList _ objs)) = d |> flipY |> scale scaleFactor
-  viewBoxStr = makeAttr (str "viewBox") $
-     (show (xmin * scaleFactor) <+> show (-(ymax * scaleFactor)) <+>
-      show imgWidth <+> show imgHeight)
-  svgAttrStr = (    makeAttr (str "width" ) (show imgWidth)
-                <+> makeAttr (str "height") (show imgHeight)
-                <+> viewBoxStr)
+  svgAttrStr = (    str "width"   <=> imgWidth
+                <+> str "height"  <=> imgHeight
+                <+> str "viewBox" <=> (imgXMin <+> imgYMin <+> imgWidth <+> imgHeight))
   tagBracketsAttr (str "svg") svgAttrStr $
     concat for i.
       (attr, pos, geom) = objs.i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -869,6 +869,9 @@ def codepoint (c:Char) : Int = W8ToI c
 interface Show a:Type where
   show : a -> String
 
+instance showString : Show String where
+  show = id
+
 instance showInt32 : Show Int32 where
   show = \x: Int32.
     (n, ptr) = %ffi showInt32 (Int32 & CharPtr) x

--- a/tests/show-tests.dx
+++ b/tests/show-tests.dx
@@ -1,4 +1,8 @@
 '# `Show` instances
+-- String
+
+:p show (AsList _ "abc")
+> (AsList 3 "abc")
 
 -- Int32
 


### PR DESCRIPTION
This PR has no functional changes to the user facing API of diagram.dx.
Just seeing if i can make the code neater.
I think this code is neater but I am not super commited to it

A big part of this PR is being a bit chillaxed about if things are strings or merely `show`able.
`<+>` and `<=>` now basically form bit of DSL for string building.
(Possibly for consistancy `<.>` should too but it doesn't come up)

What this PR does:

 - Defines `show` on `String` to just return the `String` as is. (identity operation)
 - changes `<+>` to work on anything `show`able, rather than on `String`s,
    - Thus removing a bunch of calls to `show` in the code
 - Rename `makeAttr` to `<=>` as a visual que that we are putting `=` signs in the output
 - Make `<=>` (`makeAttr`) accept anything `show`able as its second argument
    - thus removing a bunch of calls to show
    - and making it so it can be used all through `renderGeo`
 - moved the common code for making groups in `renderGeo` into a helper function (this is also in #376 )
 - Tinkers with how the `svgAttr`/`viewBoxStr` code is broken up   
    
    
It will conflict with #376 but I will rebase which ever is merged last.