### PR TITLE
Fix `stack build` on macOS.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -57,7 +57,7 @@ library
     build-depends:     dex-resources
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
-  ghc-options:         -Wall -fPIC
+  ghc-options:         -Wall -fPIC -optP-Wno-nonportable-include-path
   cxx-sources:         src/lib/dexrt.cpp
   cxx-options:         -std=c++11 -fPIC
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,


### PR DESCRIPTION
Disable `-Wnonportable-include-path` [(workaround suggested by Stack Overflow)](https://github.com/haskell/cabal/issues/4739#issuecomment-359209133):
```
$ make
stack --stack-yaml=stack-macos.yaml build
...
Preprocessing foreign library 'Dex' for dex-0.1.0.0..
Building foreign library 'Dex' for dex-0.1.0.0..
[1 of 5] Compiling Dex.Foreign.Util
[2 of 5] Compiling Dex.Foreign.Context
[3 of 5] Compiling Dex.Foreign.Serialize
[4 of 5] Compiling Dex.Foreign.JIT
[5 of 5] Compiling Dex.Foreign.API

/Users/danielzheng/dex-lang/<built-in>:2:10: error:
     warning: non-portable path to file '".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/dex/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Dex/autogen/cabal_macros.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/dex/autogen/cabal_macros.h"
1 warning generated.
```
I am not sure what earlier change surfaced this macOS build error.