### PR TITLE
Improve HTML doc generation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,14 +12,14 @@ To learn more, check out our
 or these example programs:
 
   * [Dex prelude](https://google-research.github.io/dex-lang/prelude.html)
-  * [Mandelbrot set](https://google-research.github.io/dex-lang/mandelbrot.html)
-  * [Ray tracer](https://google-research.github.io/dex-lang/raytrace.html)
-  * [Estimating pi](https://google-research.github.io/dex-lang/pi.html)
-  * [Hamiltonian Monte Carlo](https://google-research.github.io/dex-lang/mcmc.html)
-  * [ODE integrator](https://google-research.github.io/dex-lang/ode-integrator.html)
-  * [Sierpinski triangle](https://google-research.github.io/dex-lang/sierpinski.html)
-  * [Basis function regression](https://google-research.github.io/dex-lang/regression.html)
-  * [Brownian bridge](https://google-research.github.io/dex-lang/brownian_motion.html)
+  * [Mandelbrot set](https://google-research.github.io/dex-lang/examples/mandelbrot.html)
+  * [Ray tracer](https://google-research.github.io/dex-lang/examples/raytrace.html)
+  * [Estimating pi](https://google-research.github.io/dex-lang/examples/pi.html)
+  * [Hamiltonian Monte Carlo](https://google-research.github.io/dex-lang/examples/mcmc.html)
+  * [ODE integrator](https://google-research.github.io/dex-lang/oexamples/de-integrator.html)
+  * [Sierpinski triangle](https://google-research.github.io/dex-lang/examples/sierpinski.html)
+  * [Basis function regression](https://google-research.github.io/dex-lang/examples/regression.html)
+  * [Brownian bridge](https://google-research.github.io/dex-lang/examples/brownian_motion.html)
 
 ⚠️ Dex is an experimental research project at an early stage of
 development. Expect monstrous bugs and razor-sharp edges. Contributions welcome! ⚠️

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1,9 +1,8 @@
-
-'## Dex prelude
+'# Dex prelude
 
 'Runs before every Dex program unless an alternative is provided with `--prelude`.
 
-'Wrappers around primitives
+'## Wrappers around primitives
 
 Unit = %UnitType
 Type = %TyKind
@@ -137,7 +136,7 @@ instance float64Fractional : Fractional Float64 where
 instance float32Fractional : Fractional Float32 where
   divide = \x:Float32 y:Float32. %fdiv x y
 
-'Basic polymorphic functions and types
+'## Basic polymorphic functions and types
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
 def (,) (x:a) (y:b) : (a & b) = %pair x y
@@ -152,7 +151,7 @@ flip : (a -> b -> c) -> (b -> a -> c) = \f x y. f y x
 uncurry : (a -> b -> c) -> (a & b) -> c = \f (x,y). f x y
 const : a -> b -> a = \x _. x
 
-'Vector spaces
+'## Vector spaces
 
 data VSpace a:Type = MkVSpace (Add a) (Float -> a -> a)
 
@@ -168,7 +167,7 @@ def neg (_:VSpace a) ?=> (v:a) : a = (-1.0) .* v
 @instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i
 @instance unitVS : VSpace Unit = MkVSpace unitAdd \s u. ()
 
-'Bool type
+'## Boolean type
 
 data Bool =
   False
@@ -192,7 +191,7 @@ def not  (x:Bool) : Bool =
   x' = BToW8 x
   W8ToB $ %not x'
 
-'Sum types
+'## Sum types
 
 data Maybe a:Type =
   Nothing
@@ -213,7 +212,7 @@ def select (p:Bool) (x:a) (y:a) : a = case p of
 def BToI (x:Bool) : Int  = W8ToI $ BToW8 x
 def BToF (x:Bool) : Float = IToF (BToI x)
 
-'Effects
+'## Effects
 
 def Ref (r:Type) (a:Type) : Type = %Ref r a
 def get  (ref:Ref h s)       : {State h} s    = %get  ref
@@ -252,7 +251,7 @@ def unsafeIO (f: Unit -> {State World|eff} a) : {|eff} a =
 def unreachable (():Unit) : a = unsafeIO do
   %throwError a
 
-'Type classes
+'## Type classes
 
 data Eq  a:Type = MkEq  (a -> a -> Bool)
 data Ord a:Type = MkOrd (Eq a) (a -> a -> Bool) (a -> a -> Bool)  -- eq, gt, lt
@@ -308,7 +307,7 @@ def tabEq (n:Type) ?-> (eqA: Eq a) ?=> : Eq (n=>a) = MkEq $
         ref += (IToF (BToI (xs.i /= ys.i)))
     numDifferent == 0.0
 
-'Transcencendental functions
+'## Transcencendental functions
 
 interface Floating a:Type where
   exp    : a -> a
@@ -384,7 +383,7 @@ instance float32Floating : Floating Float32 where
   pow    = \x:Float32 y:Float32. %fpow x y
   lgamma = \x:Float32. %lgamma x
 
-'Working with index sets
+'## Index set utilities
 
 def Range (low:Int) (high:Int) : Type = %IntRange low high
 def Fin (n:Int) : Type = Range 0 n
@@ -518,7 +517,7 @@ def withTabPtr (_:Storable a) ?=>
 def tabFromPtr (_:Storable a) ?=> (n:Type) -> (ptr:Ptr a) : {State World} n=>a =
   for i. load $ ptr +>> ordinal i
 
-'Misc
+'## Miscellaneous common utilities
 
 pi : Float = 3.141592653589793
 
@@ -559,7 +558,6 @@ def std (xs:n=>Float) : Float = sqrt $ mean (map sq xs) - sq (mean xs)
 def any (xs:n=>Bool) : Bool = reduce False (||) xs
 def all (xs:n=>Bool) : Bool = reduce True  (&&) xs
 
-
 def applyN (n:Int) (x:a) (f:a -> a) : a =
   snd $ withState x \ref. for _:(Fin n).
     ref := f (get ref)
@@ -583,7 +581,7 @@ def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 def inner (x:n=>Float) (mat:n=>m=>Float) (y:m=>Float) : Float =
   fsum \(i,j). x.i * mat.i.j * y.j
 
-'Functions for working with the pseudorandom number generator
+'## Pseudorandom number generator utilities
 
 -- TODO: newtype
 Key = Int64
@@ -624,7 +622,7 @@ def cumSum (xs: n=>Float) : n=>Float =
       total := newTotal
       newTotal
 
-'Automatic differentiation
+'## Automatic differentiation
 
 -- TODO: add vector space constraints
 def linearize (f:a->b) (x:a) : (b & a --o b) = %linearize f x
@@ -682,7 +680,7 @@ def checkDerivBase (f:Float->Float) (x:Float) : Bool =
 def checkDeriv (f:Float->Float) (x:Float) : Bool =
   checkDerivBase f x && checkDerivBase (deriv f) x
 
-'Vector support
+'## Vector support
 
 -- TODO: Reenable vector suport once fixed-width types are supported.
 -- def UNSAFEFromOrdinal (n : Type) (i : Int) : n = %unsafeAsIndex n i
@@ -718,7 +716,7 @@ def checkDeriv (f:Float->Float) (x:Float) : Bool =
 -- @instance vectorFloatVSpace : VSpace VectorFloat =
 --   MkVSpace vectorFloatAdd \x v. broadcastVector x * v
 
-'Tiling
+'## Tiling functions
 
 def Tile (n : Type) (m : Type) : Type = %IndexSlice n m
 
@@ -746,7 +744,7 @@ def tile1 (n : Type) ?-> (l : Type) ?-> (m : Type) ?->
 --              arr.(t +> UNSAFEFromOrdinal idx 2)
 --              arr.(t +> UNSAFEFromOrdinal idx 3))
 
-'Monoid
+'## Monoid typeclass
 
 interface Monoid a:Type where
   mempty : a
@@ -754,7 +752,7 @@ interface Monoid a:Type where
 
 (<>) : Monoid a ?=> a -> a -> a = mcombine
 
-'Length-erased lists
+'## Length-erased lists
 
 data List a:Type =
   AsList n:Int foo:(Fin n => a)
@@ -778,7 +776,7 @@ instance monoidList : Monoid (List a) where
         True  -> xs.(unsafeFromOrdinal _ i')
         False -> ys.(unsafeFromOrdinal _ (i' - nx))
 
-'Isomorphisms
+'## Isomorphisms
 
 data Iso a:Type b:Type = MkIso { fwd: a -> b & bwd: b -> a }
 
@@ -945,7 +943,7 @@ instance showFloat64 : Show Float64 where
 -- pipe-like reverse function application
 def (|>) (x:a) (f: a -> b) : b = f x
 
-'## Floating point helper functions
+'## Floating-point helper functions
 
 def sign (x:Float) : Float =
   case x > 0.0 of
@@ -1213,7 +1211,7 @@ def argmin (_:Ord o) ?=> (xs:n=>o) : n =
 def clip (_:Ord a) ?=> ((low,high):(a&a)) (x:a) : a =
   min high $ max low x
 
-'## Trigonometric functions.
+'## Trigonometric functions
 
 def atan_inner (x:Float) : Float =
   -- From "Computing accurate Horner form approximations to
@@ -1254,7 +1252,6 @@ def atan2 (y:Float) (x:Float) : Float =
   select (either_is_nan x y) nan a  -- Propagate NaNs.
 
 def atan (x:Float) : Float = atan2 x 1.0
-
 
 '## Complex numbers
 
@@ -1381,7 +1378,7 @@ def (>>) (x:Byte) (y:Int) : Byte = %shr x (IToW8 y)
 def (.|.) (x:Byte) (y:Byte) : Byte = %or x y
 def (.&.) (x:Byte) (y:Byte) : Byte = %and x y
 
-'## Misc
+'## Miscellaneous utilities
 
 def reverse (x:n=>a) : n=>a =
   s = size n
@@ -1439,6 +1436,7 @@ def cumSumLow (xs: n=>Float) : n=>Float =
       oldTotal = get total
       total := oldTotal + xs.i
       oldTotal
+
 -- cdf should include 0.0 but not 1.0
 def categoricalFromCDF (cdf: n=>Float) (key: Key) : n =
   r = rand key

--- a/makefile
+++ b/makefile
@@ -91,6 +91,8 @@ test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              record-variant-tests simple-include-test \
              typeclass-tests complex-tests trig-tests
 
+lib-names = diagram plot png
+
 all-names = $(test-names:%=tests/%) $(example-names:%=examples/%)
 
 quine-test-targets = $(all-names:%=run-%)
@@ -98,7 +100,9 @@ quine-test-targets = $(all-names:%=run-%)
 update-test-targets    = $(test-names:%=update-tests-%)
 update-example-targets = $(example-names:%=update-examples-%)
 
-doc-names = $(example-names:%=doc/%.html)
+doc-example-names = $(example-names:%=doc/examples/%.html)
+
+doc-lib-names = $(lib-names:%=doc/lib/%.html)
 
 tests: quine-tests repl-test export-tests
 
@@ -172,16 +176,21 @@ bench-summary:
 
 # --- building docs ---
 
-slow-docs = doc/mnist-nearest-neighbors.html
+slow-docs = doc/examples/mnist-nearest-neighbors.html
 
-docs: doc/style.css $(doc-names) $(slow-docs)
-	$(dex) --prelude /dev/null script prelude.dx --html > doc/prelude.html
+docs: doc-prelude $(doc-example-names) $(doc-lib-names) $(slow-docs)
 
-doc/%.html: examples/%.dx
+doc-prelude: lib/prelude.dx
+	mkdir -p doc
+	$(dex) --prelude /dev/null script lib/prelude.dx --outfmt HTML > doc/prelude.html
+
+doc/examples/%.html: examples/%.dx
+	mkdir -p doc/examples
 	$(dex) script $^ --outfmt HTML > $@
 
-doc/%.css: static/%.css
-	cp $^ $@
+doc/lib/%.html: lib/%.dx
+	mkdir -p doc/lib
+	$(dex) script $^ --outfmt HTML > $@
 
 clean:
 	$(STACK) clean

--- a/src/lib/RenderHtml.hs
+++ b/src/lib/RenderHtml.hs
@@ -12,6 +12,7 @@ module RenderHtml (pprintHtml, progHtml, ToMarkup) where
 import Text.Blaze.Html5 as H  hiding (map)
 import Text.Blaze.Html5.Attributes as At
 import Text.Blaze.Html.Renderer.String
+import Data.Char (isSpace)
 import Data.Text (pack)
 import CMark (commonmarkToHtml)
 
@@ -19,10 +20,11 @@ import Control.Monad
 import Text.Megaparsec hiding (chunk)
 import Text.Megaparsec.Char as C
 
+import Resources (cssSource)
 import Syntax
 import PPrint
 import Parser
-import Serialize()
+import Serialize ()
 
 pprintHtml :: ToMarkup a => a -> String
 pprintHtml x = renderHtml $ toMarkup x
@@ -31,10 +33,15 @@ progHtml :: LitProg -> String
 progHtml blocks = renderHtml $ wrapBody $ map toHtmlBlock blocks
   where toHtmlBlock (block,result) = toMarkup block <> toMarkup result
 
+-- Minifies the given CSS snippet.
+-- Currently, this simply removes all whitespace.
+minifyCSS :: String -> String
+minifyCSS = filter (not . isSpace)
+
 wrapBody :: [Html] -> Html
 wrapBody blocks = docTypeHtml $ do
   H.head $ do
-    H.link ! rel "stylesheet" ! href "style.css" ! type_ "text/css"
+    H.style ! type_ "text/css" $ toHtml $ minifyCSS cssSource
     H.meta ! charset "UTF-8"
   H.body $ H.div inner ! At.id "main-output"
   where inner = foldMap (cdiv "cell") blocks

--- a/src/resources/Resources.hs
+++ b/src/resources/Resources.hs
@@ -1,6 +1,6 @@
 {-# LANGUAGE TemplateHaskell #-}
 
-module Resources (dexrtBC, preludeSource, curResourceVersion) where
+module Resources (dexrtBC, preludeSource, cssSource, curResourceVersion) where
 
 import qualified Data.ByteString.Char8 as B
 import Data.FileEmbed
@@ -11,5 +11,10 @@ curResourceVersion = __TIME__
 dexrtBC :: B.ByteString
 dexrtBC = $(embedFile "src/lib/dexrt.bc")
 
+-- The Dex prelude source code.
 preludeSource :: String
-preludeSource = B.unpack $ $(embedFile "lib/prelude.dx")
+preludeSource = B.unpack $(embedFile "lib/prelude.dx")
+
+-- The source code of the CSS used for rendering Dex programs as HTML.
+cssSource :: String
+cssSource = B.unpack $(embedFile "static/style.css")


### PR DESCRIPTION
## Genotypical changes

Improve makefile:
- Add support for building docs for files in lib/.
- Add `mkdir -p doc` to commands so they do not fail if doc/ does not exist.
- Add standalone `doc-prelude` target so that `make docs` is fully incremental.

Improve prelude formatting:
- Use consistent formatting (h2, ##) for section headers.

## Phenotypical consequences

`make docs` always works now.

Prelude headings look a bit more uniform.

<img width="835" alt="Screen Shot 2020-12-26 at 9 37 18 AM" src="https://user-images.githubusercontent.com/5590046/103153351-f6053880-475d-11eb-8e7b-1016139c2e8b.png">