### PR TITLE
Fix `stack build` on macOS again.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -99,7 +99,7 @@ foreign-library Dex
   hs-source-dirs:      src/
   c-sources:           src/Dex/Foreign/rts.c
   cc-options:          -std=c11 -fPIC
-  ghc-options:         -Wall -fPIC
+  ghc-options:         -Wall -fPIC -optP-Wno-nonportable-include-path
   default-language:    Haskell2010
   default-extensions:  TypeApplications, ScopedTypeVariables, LambdaCase
   if flag(optimized)


### PR DESCRIPTION
Disable `-Wnonportable-include-path`. Follow-up to a similar previous fix #378.

I am not yet sure what earlier change surfaced this macOS build error or why macOS CI does not encounter it.

---

Reproducer:
```
$ make
...
Preprocessing foreign library 'Dex' for dex-0.1.0.0..
Building foreign library 'Dex' for dex-0.1.0.0..
[2 of 5] Compiling Dex.Foreign.Context [PPrint changed]
[3 of 5] Compiling Dex.Foreign.Serialize [Serialize changed]
[4 of 5] Compiling Dex.Foreign.JIT [Export changed]
[5 of 5] Compiling Dex.Foreign.API [Export changed]

/Users/danielzheng/dex-lang/<built-in>:2:10: error:
     warning: non-portable path to file '".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/dex/autogen/cabal_macros.h"'; specified path differs in case from file name on disk [-Wnonportable-include-path]
#include ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/Dex/autogen/cabal_macros.h"
         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
         ".stack-work/dist/x86_64-osx/Cabal-3.0.1.0/build/dex/autogen/cabal_macros.h"
1 warning generated.
```