### PR TITLE
Extend rejection sampling example

### DIFF
--- a/examples/rejection-sampler.dx
+++ b/examples/rejection-sampler.dx
@@ -1,34 +1,86 @@
+'# Rejection sampler of a Binomial distribution
+
+'We implement rejection sampling from a Binomial distribution using a uniform proposal.
 
 def rejectionSample (try: Key -> Maybe a) (k:Key) : a =
-  ans = fst $ withState 0 \i.
+  fromJust $ fst $ withState 0 \i.
     snd $ withState Nothing \sample.
       while (\(). isNothing (get sample)) \().
         i := get i + 1
         sample := try $ hash k (get i)
-  case ans of Just sample -> sample
 
 Prob    = Float
 LogProb = Float
 
-def binomialSample (n:Int) (p:Prob) (k:Key) : Int = todo
-
+-- log probability density of a Binomial distribution
 def logBinomialProb (n:Int) (p:Prob) (counts:Int) : LogProb =
   pSuccess = log p * IToF counts
   pFailure = log1p (-p) * IToF (n - counts)
   normConst = (lbeta (1. + IToF counts) (1. + IToF n - IToF counts) +
-               log (1. + IToF n))
+               log1p (IToF n))
   pSuccess + pFailure - normConst
 
-def binomialProb (n:Int) (p:Prob) (count:Int) : Prob =
-  exp $ logBinomialProb n p count
-
 def trySampleBinomial (n:Int) (p:Prob) (k:Key) : Maybe Int =
-  (k1, k2) = splitKey k
+  [k1, k2] = splitKey k
   proposal = FToI $ floor $ rand k1 * IToF (n + 1)
-  acceptance = rand k2 < binomialProb n p proposal
-  case proposal < (n + 1) && acceptance of
-    True -> Just proposal
-    False -> Nothing
+  if proposal > n
+    then Nothing
+    else
+      acceptance = log (rand k2) < logBinomialProb n p proposal
+      if acceptance
+        then Just proposal
+        else Nothing
 
-:p randVec 10 (rejectionSample (trySampleBinomial 10 0.5)) (newKey 0)
-> [4, 2, 5, 4, 6, 7, 3, 6, 6, 3]
+'## Example
+
+'We test the implementation by sampling from a Binomial distribution with 10 trials and success probability 0.4.
+
+-- parameters
+n = 10
+p = 0.4
+numSamples = 5000
+k0 = newKey 0
+
+rejectionSamples = randVec numSamples (rejectionSample $ trySampleBinomial n p) k0
+
+:p slice rejectionSamples 0 $ Fin 10
+> [4, 2, 5, 4, 6, 7, 3, 6, 4, 3]
+
+'The Binomial distribution has mean 4 and variance 2.4.
+
+def meanAndVariance (xs:n=>Float) : (Float&Float) = (mean xs, sq $ std xs)
+
+:p meanAndVariance $ map IToF rejectionSamples
+> (3.9933999, 2.3585567)
+
+'## Alternative: Inversion sampling
+
+'Alternatively, we can use inversion sampling.
+
+def binomialSample (n:Int) (p:Prob) (k:Key) : Int =
+  m = n + 1
+  logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
+  ordinal $ categorical logprobs k
+
+inversionSamples = randVec numSamples (binomialSample n p) k0
+
+:p slice inversionSamples 0 $ Fin 10
+> [6, 7, 6, 5, 3, 2, 4, 4, 3, 4]
+
+:p meanAndVariance $ map IToF inversionSamples
+> (3.9977999, 2.4097958)
+
+'The following variant is guaranteed to evaluate the CDF only once.
+
+def binomialBatch (n:Int) (p:Prob) (k:Key) : a => Int =
+  m = n + 1
+  logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
+  map ordinal $ categoricalBatch logprobs k
+
+inversionBatchSamples = (binomialBatch n p k0) : Fin numSamples => Int
+
+:p slice inversionBatchSamples 0 $ Fin 10
+> [6, 7, 6, 5, 3, 2, 4, 4, 3, 4]
+
+:p meanAndVariance $ map IToF inversionBatchSamples
+> (3.9977999, 2.4097958)


### PR DESCRIPTION
This PR extends the rejection sampling example.
- It adds some additional explanations
- It replaces one occurrence of `log(1 + ...)` in the log density of the Binomial distribution with `log1p(...)`
- It performs all calculations in log space and therefore removes `binomialProb`
- It adds evaluations of the mean and the variance of a larger number of samples
- It adds implementations of inversion sampling as a comparison