### PR TITLE
Add shell.nix.

### DIFF
--- a/shell.nix
+++ b/shell.nix
@@ -1,0 +1,15 @@
+{ nixpkgs ? import <nixpkgs> {} }:
+with nixpkgs;
+stdenv.mkDerivation {
+  name = "dex";
+  buildInputs = [
+    cabal-install
+    haskell.compiler.ghc884
+    llvm_9
+    clang_9
+    pkg-config
+    libpng
+    git
+    cacert
+  ];
+}


### PR DESCRIPTION
This makes it much more convenient to compile Dex for the lucky few who use Nix or NixOS.