### PR TITLE
Add cabal.project.

### DIFF
--- a/cabal.project
+++ b/cabal.project
@@ -1,0 +1,13 @@
+packages:        dex.cabal
+
+source-repository-package
+    type:       git
+    location:   https://github.com/apaszke/llvm-hs
+    tag:        a9a74be1a7c15f3d21b2fffd35a425002ae7736f
+    subdir:     llvm-hs
+
+source-repository-package
+    type:       git
+    location:   https://github.com/apaszke/llvm-hs
+    tag:        a9a74be1a7c15f3d21b2fffd35a425002ae7736f
+    subdir:     llvm-hs-pure


### PR DESCRIPTION
This is necessary for cabal to find dependencies stored in Git repositories.

This is not by itself sufficient for `cabal` to work, since the `install` rule in the `makefile` contains stuff that only works for `stack`, but it does make `make` and `cabal run dex` work.