### PR TITLE
Add HTML redirection pages.

### DIFF
--- a/brownian_motion.html
+++ b/brownian_motion.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/brownian_motion.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/brownian_motion.html">the new page</a>.</h2>
+</body>
+</html>

--- a/ctc.html
+++ b/ctc.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/ctc.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/ctc.html">the new page</a>.</h2>
+</body>
+</html>

--- a/diagram.html
+++ b/diagram.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/lib/diagram.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/lib/diagram.html">the new page</a>.</h2>
+</body>
+</html>

--- a/fluidsim.html
+++ b/fluidsim.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/fluidsim.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/fluidsim.html">the new page</a>.</h2>
+</body>
+</html>

--- a/isomorphisms.html
+++ b/isomorphisms.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/isomorphisms.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/isomorphisms.html">the new page</a>.</h2>
+</body>
+</html>

--- a/linear_algebra.html
+++ b/linear_algebra.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/linear_algebra.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/linear_algebra.html">the new page</a>.</h2>
+</body>
+</html>

--- a/mandelbrot.html
+++ b/mandelbrot.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/mandelbrot.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/mandelbrot.html">the new page</a>.</h2>
+</body>
+</html>

--- a/mcmc.html
+++ b/mcmc.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/mcmc.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/mcmc.html">the new page</a>.</h2>
+</body>
+</html>

--- a/mnist-nearest-neighbors.html
+++ b/mnist-nearest-neighbors.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/mnist-nearest-neighbors.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/mnist-nearest-neighbors.html">the new page</a>.</h2>
+</body>
+</html>

--- a/ode-integrator.html
+++ b/ode-integrator.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/ode-integrator.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/ode-integrator.html">the new page</a>.</h2>
+</body>
+</html>

--- a/particle-filter.html
+++ b/particle-filter.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/particle-filter.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/particle-filter.html">the new page</a>.</h2>
+</body>
+</html>

--- a/particle-swarm-optimizer.html
+++ b/particle-swarm-optimizer.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/particle-swarm-optimizer.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/particle-swarm-optimizer.html">the new page</a>.</h2>
+</body>
+</html>

--- a/pi.html
+++ b/pi.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/pi.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/pi.html">the new page</a>.</h2>
+</body>
+</html>

--- a/plot.html
+++ b/plot.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/lib/plot.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/lib/plot.html">the new page</a>.</h2>
+</body>
+</html>

--- a/png.html
+++ b/png.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/lib/png.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/lib/png.html">the new page</a>.</h2>
+</body>
+</html>

--- a/raytrace.html
+++ b/raytrace.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/raytrace.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/raytrace.html">the new page</a>.</h2>
+</body>
+</html>

--- a/regression.html
+++ b/regression.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/regression.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/regression.html">the new page</a>.</h2>
+</body>
+</html>

--- a/rejection-sampler.html
+++ b/rejection-sampler.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/rejection-sampler.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/rejection-sampler.html">the new page</a>.</h2>
+</body>
+</html>

--- a/sierpinski.html
+++ b/sierpinski.html
@@ -1,0 +1,20 @@
+<!DOCTYPE HTML>
+<html>
+<head>
+<style type="text/css">
+body {
+  margin: 1em auto 1em auto;
+  padding: 1em 1em 1em 1em;
+  max-width: 50em;
+  font-family: Helvetica, sans-serif;
+  font-size: 100%;
+  color: #333;
+  padding-bottom: 500px;
+}
+</style>
+<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/examples/sierpinski.html'"/>
+</head>
+<body>
+<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/examples/sierpinski.html">the new page</a>.</h2>
+</body>
+</html>


### PR DESCRIPTION
Add HTML redirection pages. For example, `mcmc.html` redirects to `https://google-research.github.io/dex-lang/examples/mcmc.html`.

Redirection pages generated via this Python script (run inside `gh-pages` branch):

<details>
<p>

```python3
#!/usr/bin/env python3

import os

REDIRECT_HTML_TEMPLATE="""
<!DOCTYPE HTML>
<html>
<head>
<style type="text/css">
body {{
  margin: 1em auto 1em auto;
  padding: 1em 1em 1em 1em;
  max-width: 50em;
  font-family: Helvetica, sans-serif;
  font-size: 100%;
  color: #333;
  padding-bottom: 500px;
}}
</style>
<meta http-equiv="refresh" content="0; URL='https://google-research.github.io/dex-lang/{path}'"/>
</head>
<body>
<h2>This page has moved; redirecting to <a href="https://google-research.github.io/dex-lang/{path}">the new page</a>.</h2>
</body>
</html>
""".strip()

def generate_redirect_html(directory):
  files = os.listdir(directory)
  for filename in files:
    path = os.path.join(directory, filename)
    html = REDIRECT_HTML_TEMPLATE.format(path=path)
    # Write to redirect HTML page.
    with open(filename, "w") as f:
      f.write(html)

generate_redirect_html("examples")
generate_redirect_html("lib")
```

</p>
</details>