### PR TITLE
Flag to check if we're running in "test mode"

### DIFF
--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -88,14 +88,16 @@ def myLogProb (x:(Fin 2)=>Float) : LogProb =
   x' = x - [1.5, 2.5]
   neg $ 0.5 * inner x' [[1.,0.],[0.,20.]] x'
 
-numSamples = 10000
+numSamples = if dex_test_mode ()
+               then 1000
+               else 10000
 k0 = newKey 1
 
 mhParams = 0.1
 mhSamples  = runChain randnVec (mhStep  mhParams  myLogProb) numSamples k0
 
 :p meanAndCovariance mhSamples
-> ([1.51656, 2.493105], [[1.037397, 0.011821], [0.011821, 0.053776]])
+> ([0.369159, 2.453517], [[0.575722, 0.08787], [0.08787, 0.125873]])
 
 :html showPlot $ yPlot $
   slice (map head mhSamples) 0 (Fin 1000)
@@ -105,7 +107,7 @@ hmcParams = (10, 0.1)
 hmcSamples = runChain randnVec (hmcStep hmcParams myLogProb) numSamples k0
 
 :p meanAndCovariance hmcSamples
-> ([1.50457, 2.500021], [[0.973867, 0.003423], [0.003423, 0.050586]])
+> ([1.431633, 2.503093], [[0.964188, 0.005688], [0.005688, 0.049492]])
 
 :html showPlot $ yPlot $
   slice (map head hmcSamples) 0 (Fin 1000)

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -308,8 +308,10 @@ defaultCamera = { numPix     = 250
                 , sensorDist = 1.0 }
 
 -- We change to a small num pix here to reduce the compute needed for tests
-camera = defaultCamera |> setAt #numPix 10
 params = defaultParams
+camera = if dex_test_mode ()
+           then defaultCamera |> setAt #numPix 10
+           else defaultCamera
 
 -- %time
 (MkImage _ _ image) = takePicture params theScene camera

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -18,6 +18,8 @@ Word8 = %Word8
 Byte = Word8
 Char = Byte
 
+RawPtr : Type = %Word8Ptr
+
 Int = Int32
 Float = Float32
 
@@ -35,6 +37,8 @@ def IToI32 (x : Int)     : Int32   = internalCast _ x
 def IToW8  (x : Int)     : Word8   = internalCast _ x
 def IToF (x:Int) : Float = internalCast _ x
 def FToI (x:Float) : Int = internalCast _ x
+def I64ToRawPtr (x:Int64 ) : RawPtr = internalCast _ x
+def RawPtrToI64 (x:RawPtr) : Int64  = internalCast _ x
 
 interface Add a:Type where
   add : a -> a -> a
@@ -274,6 +278,7 @@ def (>=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x>y || x==y
 @instance word8Eq   : Eq Word8   = MkEq \x:Word8   y:Word8.   W8ToB $ %ieq x y
 @instance boolEq    : Eq Bool    = MkEq \x y. BToW8 x == BToW8 y
 @instance unitEq    : Eq Unit    = MkEq \x y. True
+@instance rawPtrEq  : Eq RawPtr  = MkEq \x y. RawPtrToI64 x == RawPtrToI64 y
 
 @instance float64Ord : Ord Float64 = (MkOrd float64Eq (\x y. W8ToB $ %fgt x y)
                                                       (\x y. W8ToB $ %flt x y))
@@ -401,8 +406,6 @@ def finOrd (n:Int) ?-> : Ord (Fin n) =
   MkOrd finEq (\x y. ordinal x > ordinal y) (\x y. ordinal x < ordinal y)
 
 '## Raw pointer operations
-
-RawPtr : Type = %Word8Ptr
 
 data Ptr a:Type = MkPtr RawPtr
 
@@ -903,6 +906,9 @@ def loadDynBuffer (_:Storable a) ?=>
   (size, _, bufPtr) = load dbPtr
   AsList size $ tabFromPtr _ bufPtr
 
+def pushDynBuffer (_:Storable a) ?=>
+      (buf: DynBuffer a) (x:a) : {State World} Unit =
+  extendDynBuffer buf $ AsList _ [x]
 
 '## Strings and Characters
 
@@ -975,6 +981,17 @@ def either_is_nan (x:Float) (y:Float) : Bool = (isnan x) || (isnan y)
 FilePath : Type = String
 data CString = MkCString RawPtr
 
+def nullRawPtr : RawPtr = I64ToRawPtr $ IToI64 0
+
+def fromNullableRawPtr (ptr:RawPtr) : Maybe (Ptr a) =
+  if ptr == nullRawPtr
+    then Nothing
+    else Just $ MkPtr ptr
+
+def cStringPtr (s:CString) : Maybe (Ptr Char) =
+  (MkCString ptr) = s
+  fromNullableRawPtr ptr
+
 data StreamMode =
   ReadMode
   WriteMode
@@ -1045,6 +1062,22 @@ def boundedIter (maxIters:Int) (fallback:a)
     if i >= maxIters
       then Done fallback
       else body i
+
+def fromCString (s:CString) : {State World} (Maybe String) =
+  case cStringPtr s of
+    Nothing -> Nothing
+    Just ptr ->
+      Just $ withDynamicBuffer \buf. iter \i.
+        c = load $ ptr +>> i
+        if c == '\NUL'
+          then Done $ loadDynBuffer buf
+          else
+            pushDynBuffer buf c
+            Continue
+
+def getEnv (name:String) : {State World} Maybe String =
+  withCString name \(MkCString ptr).
+    fromCString $ MkCString $ %ffi getenv RawPtr ptr
 
 def fread (stream:Stream ReadMode) : {State World} String =
   (MkStream stream') = stream

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -205,6 +205,8 @@ def isNothing (x:Maybe a) : Bool = case x of
   Nothing -> True
   Just _ -> False
 
+def isJust (x:Maybe a) : Bool = not $ isNothing x
+
 data (|) a:Type b:Type =
   Left  a
   Right b
@@ -1079,6 +1081,13 @@ def getEnv (name:String) : {State World} Maybe String =
   withCString name \(MkCString ptr).
     fromCString $ MkCString $ %ffi getenv RawPtr ptr
 
+def checkEnv (name:String) : {State World} Bool =
+  -- This should be just `isJust $ getEnv name` but that sefaults (only if the
+  -- env var *is* defined), possibly related to bug #348.
+  withCString name \(MkCString ptr).
+    resultPtr = %ffi getenv RawPtr ptr
+    not $ resultPtr == nullRawPtr
+
 def fread (stream:Stream ReadMode) : {State World} String =
   (MkStream stream') = stream
   -- TODO: allow reading longer files!
@@ -1510,3 +1519,5 @@ def softmax (x: n=>Float) : n=>Float =
 def evalpoly (_:VSpace v) ?=> (coefficients:n=>v) (x:Float) : v =
   -- Evaluate a polynomial at x.  Same as Numpy's polyval.
   fold zero \i c. coefficients.i + x .* c
+
+def dex_test_mode (():Unit) : Bool = unsafeIO do checkEnv "DEX_TEST_MODE"

--- a/makefile
+++ b/makefile
@@ -111,6 +111,8 @@ quine-tests: $(quine-test-targets)
 quine-tests-interp: runinterp-eval-tests runinterp-ad-tests-interp runinterp-interp-tests
 
 run-%: export DEX_ALLOW_CONTRACTIONS=0
+run-%: export DEX_TEST_MODE=t
+
 run-tests/%: tests/%.dx build
 	misc/check-quine $< $(dex) script --allow-errors
 run-examples/%: examples/%.dx build

--- a/makefile
+++ b/makefile
@@ -123,6 +123,7 @@ prop-tests: cbits/libdex.so
 	$(STACK) test $(PROF)
 
 update-%: export DEX_ALLOW_CONTRACTIONS=0
+update-%: export DEX_TEST_MODE=t
 
 update-all: $(update-test-targets) $(update-example-targets)
 

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1217,6 +1217,8 @@ instrTypeChecked instr = case instr of
     case (dt, st) of
       (PtrType _, PtrType _) -> return ()
       (Scalar  _, Scalar  _) -> return ()
+      (Scalar Int64Type, PtrType  _) -> return ()
+      (PtrType _,  Scalar Int64Type) -> return ()
       _ -> throw CompilerErr $
             "Can't cast " ++ pprint st ++ " to " ++ pprint dt
     return dt

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -304,6 +304,9 @@ compileInstr instr = case instr of
       (L.FloatingPointType _, L.IntegerType _) -> emitInstr dt $ L.FPToSI x dt []
       (L.IntegerType _, L.FloatingPointType _) -> emitInstr dt $ L.SIToFP x dt []
       (L.PointerType _ _, L.PointerType eltTy _) -> castLPtr eltTy x
+      (L.IntegerType 64 , ptrTy@(L.PointerType _ _)) ->
+        emitInstr ptrTy $ L.IntToPtr x ptrTy []
+      (L.PointerType _ _, L.IntegerType 64) -> emitInstr i64 $ L.PtrToInt x i64 []
       _ -> error $ "Unsupported cast"
   ICall f@(fname:> IFunType cc argTys resultTys) args -> do
     -- TODO: consider having a separate calling convention specification rather

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -648,6 +648,8 @@ checkFloatBaseType allowVector t = case t of
 
 checkValidCast :: Type -> Type -> TypeM ()
 checkValidCast (BaseTy (PtrType _)) (BaseTy (PtrType _)) = return ()
+checkValidCast (BaseTy (PtrType _)) (BaseTy (Scalar Int64Type)) = return ()
+checkValidCast (BaseTy (Scalar Int64Type)) (BaseTy (PtrType _)) = return ()
 checkValidCast sourceTy destTy =
   checkScalarType sourceTy >> checkScalarType destTy
   where

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -69,3 +69,9 @@ unsafeIO \().
     (AsList _ s') = readFile fname
     sum (for i. W8ToI s.i) == sum (for i. W8ToI s'.i)
 > True
+
+:p unsafeIO do getEnv "NOT_AN_ENV_VAR"
+> Nothing
+
+:p unafeIO do getEnv "DEX_TEST_MODE"
+> (Just (AsList 1 "t"))

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -73,5 +73,8 @@ unsafeIO \().
 :p unsafeIO do getEnv "NOT_AN_ENV_VAR"
 > Nothing
 
-:p unafeIO do getEnv "DEX_TEST_MODE"
+:p unsafeIO do getEnv "DEX_TEST_MODE"
 > (Just (AsList 1 "t"))
+
+:p dex_test_mode ()
+> True


### PR DESCRIPTION
We want to include all our example programs in our tests, at least as smoke tests. But we want the tests to be fast, whereas some of the examples take 10 mins or so to run. This PR adds FFI wrappers for querying OS env vars, and a `DEX_TEST_MODE` flag that lets us run with different parameters (e.g. fewer samples) when we're just testing.

