### PR TITLE
RFC: make print polymorphic and fluent

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1146,8 +1146,9 @@ def withTempFiles (action: (n=>FilePath) -> {State World} a) : {State World} a =
 def getOutputStream (_:Unit) : {State World} Stream WriteMode =
   MkStream $ %ptrLoad OUT_STREAM_PTR
 
-def print (s:String) : {State World} Unit =
-  fwrite (getOutputStream ()) (s <> "\n")
+def print (_:Show a) ?=> (s:a) : {State World} a =
+  fwrite (getOutputStream ()) ((show s) <> "\n")
+  s
 
 def shellOut (command:String) : {State World} String =
   modeStr = "r"


### PR DESCRIPTION
Putting this out there for comments as to if it is a good idea.
If it is then this PR still needs tests added.

 - Making it call `show` on its input just seems more convient
 - Making it return its input means you can (for debugging purposes) slip it inside some compouind expression
     -  e.g. `x |> f |>g` can become `x |> f |> print |> g`

idk how useful this really is.
