### PR TITLE
Expose `view`, a "lazy" variant of `for`

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -397,7 +397,7 @@ def Fin (n:Int) : Type = Range 0 n
 def ordinal (i:a) : Int = %toOrdinal i
 def size (n:Type) : Int = %idxSetSize n
 def unsafeFromOrdinal (n : Type) (i : Int) : n = %unsafeFromOrdinal n i
-def iota (n:Type) : n=>Int = for i. ordinal i
+def iota (n:Type) : n=>Int = view i. ordinal i
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`
 @instance
@@ -529,9 +529,9 @@ pi : Float = 3.141592653589793
 def id (x:a) : a = x
 def dup (x:a) : (a & a) = (x, x)
 def map (f:a->{|eff} b) (xs: n=>a) : {|eff} (n=>b) = for i. f xs.i
-def zip (xs:n=>a) (ys:n=>b) : (n=>(a&b)) = for i. (xs.i, ys.i)
+def zip (xs:n=>a) (ys:n=>b) : (n=>(a&b)) = view i. (xs.i, ys.i)
 def unzip (xys:n=>(a&b)) : (n=>a & n=>b) = (map fst xys, map snd xys)
-def fanout (n:Type) (x:a) : n=>a = for i. x
+def fanout (n:Type) (x:a) : n=>a = view i. x
 def sq (d:Mul a) ?=> (x:a) : a = x * x
 def abs (_:Add a) ?=> (_:Ord a) ?=> (x:a) : a = select (x > zero) x (zero - x)
 def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
@@ -555,7 +555,7 @@ def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
-def fsum (xs:n->Float) : Float = snd $ withAccum \ref. for i. ref += xs i
+def fsum (xs:n=>Float) : Float = snd $ withAccum \ref. for i. ref += xs i
 def sum  (_: Add v) ?=> (xs:n=>v) : v = reduce zero (+) xs
 def prod (_: Mul v) ?=> (xs:n=>v) : v = reduce one  (*) xs
 def mean (n:Type) ?-> (xs:n=>Float) : Float = sum xs / IToF (size n)
@@ -571,20 +571,19 @@ def linspace (n:Type) (low:Float) (high:Float) : n=>Float =
   dx = (high - low) / IToF (size n)
   for i:n. low + IToF (ordinal i) * dx
 
-def transpose (x:n=>m=>a) : m=>n=>a = for i j. x.j.i
-def vdot (x:n=>Float) (y:n=>Float) : Float = fsum \i. x.i * y.i
+def transpose (x:n=>m=>a) : m=>n=>a = view i j. x.j.i
+def vdot (x:n=>Float) (y:n=>Float) : Float = fsum view i. x.i * y.i
 def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
 (**) : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
-  y' = transpose y
-  for i k. fsum \j. x.i.j * y'.k.j
+  for i k. fsum view j. x.i.j * y.j.k
 
 (**.) : (n=>m=>Float) -> (m=>Float) -> (n=>Float) = \mat v. for i. vdot mat.i v
 (.**) : (m=>Float) -> (n=>m=>Float) -> (n=>Float) = flip (**.)
 
 def inner (x:n=>Float) (mat:n=>m=>Float) (y:m=>Float) : Float =
-  fsum \(i,j). x.i * mat.i.j * y.j
+  fsum view (i,j). x.i * mat.i.j * y.j
 
 def eye (_:Eq n) ?=> : n=>n=>Float =
   for i j. select (i == j) 1.0 0.0

--- a/misc/dex.el
+++ b/misc/dex.el
@@ -10,7 +10,7 @@
     ("^'\\(.\\|\n.\\)*\n\n"  . font-lock-comment-face)
     ("\\w+:"                 . font-lock-comment-face)
     ("^:\\w*"                . font-lock-preprocessor-face)
-    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bdo\\b" .
+    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bdo\\b\\|\\bview\\b" .
            font-lock-keyword-face)
     ("--o"                               . font-lock-variable-name-face)
     ("[-.,!$^&*:~+/=<>|?\\\\]"           . font-lock-variable-name-face)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -404,12 +404,12 @@ litArr = [10, 5, 3]
 -- Not sure why the ordinary `sum/for` version doesn't work anymore
 :p
     n = 3 + 7
-    fsum \i:(Fin n). 1.0
+    fsum view i:(Fin n). 1.0
 > 10.
 
 :p
     n = 4
-    fsum \i:(Fin n). 1.0
+    fsum view i:(Fin n). 1.0
 > 4.
 
 :p


### PR DESCRIPTION
Dex tables are already represented internally as lambda expression that describe how to obtain each index. This is the bridge between the physical representation (buffers of flat arrays) and the logical representation (index-to-value mappings). Different lambdas can represent different views of the same underlying data. It's similar to strided arrays but more general.

This PR exposes that representation to the surface language. This lets us write reindexing functions like `transpose` and ensure they don't materialize new data, without relying on a compiler optimization. For example, we can use `view` to define `transpose`, and guarantee that it will have `O(1)` cost instead of potentially `O(N^2)` cost.

      def transpose (x:n=>m=>a) : m=>n=>a = view i j. x.j.i

One objection to exposing `view` is that it should be the compiler's job to figure out when to materialize tables and when to keep them as views. That might still be the right way to do things eventually, but in the meantime I want to see what happens if we give some of this power to users.  One clear benefit is that it makes it possible to reason about asymptotic performance based on a simple baseline operational semantics without having to reason about compiler optimizations. (Of course, the compiler is always free to *improve* performance over this baseline.)

For example, with the old `for` definition of `transpose`, this function may run in `O(N^3)` time if the inlining optimization doesn't fire. With the new `view` version, it's guaranteed to be `O(N^2)`.

      def diagOfXTimesXT (mat:n=>n=>Float) : n=>Float =
        for i. vdot mat.i (transpose mat).i

Similarly, we can write matmul using `view`, and be sure that the argument to `sum` won't be fully materialized.

     matmul : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
       for i k. sum view j. x.i.j * y.j.k

Note that these are not *mutable* views. However, we can achieve something very similar to mutable views using views of tables of references.

