### PR TITLE
Add an exception effect

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1524,3 +1524,16 @@ def evalpoly (_:VSpace v) ?=> (coefficients:n=>v) (x:Float) : v =
   fold zero \i c. coefficients.i + x .* c
 
 def dex_test_mode (():Unit) : Bool = unsafeIO do checkEnv "DEX_TEST_MODE"
+
+'## Exception effect
+
+def catch (f:Unit -> {Except|eff} a) : {|eff} Maybe a =
+  %catchException f
+
+def throw (_:Unit) : {Except} a =
+  %throwException a
+
+def assert (b:Bool) : {Except} Unit =
+  if b
+   then ()
+   else throw ()

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1443,9 +1443,8 @@ def fromJust (x:Maybe a) : a = case x of Just x' -> x'
 
 def anySat (f:a -> Bool) (xs:n=>a) : Bool = any (map f xs)
 
--- In Haskell this would just be `mapM`. The equivalent for us would be having
--- an exception effect.
-def seqMaybes (xs : n=>Maybe a) : Maybe (n => a) =
+-- XXX: we use this internally so it's important to make the type args explicit
+def seqMaybes (n:Type) ?-> (a:Type) ?-> (xs : n=>Maybe a) : Maybe (n => a) =
   -- is it possible to implement this safely? (i.e. without using partial
   -- functions)
   case anySat isNothing xs of

--- a/makefile
+++ b/makefile
@@ -86,7 +86,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 sgd chol
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
-             shadow-tests monad-tests io-tests \
+             shadow-tests monad-tests io-tests exception-tests \
              ad-tests parser-tests serialize-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests
 

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -357,11 +357,11 @@ emitRunState :: MonadEmbed m => Name -> Atom -> (Atom -> m Atom) -> m Atom
 emitRunState v x0 body = do
   emit . Hof . RunState x0 =<< mkBinaryEffFun State v (getType x0) body
 
-mkBinaryEffFun :: MonadEmbed m => EffectName -> Name -> Type -> (Atom -> m Atom) -> m Atom
-mkBinaryEffFun newEff v ty body = do
+mkBinaryEffFun :: MonadEmbed m => RWS -> Name -> Type -> (Atom -> m Atom) -> m Atom
+mkBinaryEffFun rws v ty body = do
   eff <- getAllowedEffects
   buildLam (Bind ("h":>TyKind)) PureArrow $ \r@(Var (rName:>_)) -> do
-    let arr = PlainArrow $ extendEffect (newEff, rName) eff
+    let arr = PlainArrow $ extendEffect (RWSEffect rws rName) eff
     buildLam (Bind (v:> RefTy r ty)) arr body
 
 buildForAnnAux :: MonadEmbed m => ForAnn -> Binder -> (Atom -> m (Atom, a)) -> m (Atom, a)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -665,14 +665,18 @@ spaced xs = hsep $ map p $ toList xs
 instance Pretty EffectRow where
   pretty Pure = mempty
   pretty (EffectRow effs tailVar) =
-    braces $ hsep (punctuate "," (fmap prettyEff (toList effs))) <> tailStr
+    braces $ hsep (punctuate "," (map p (toList effs))) <> tailStr
     where
-      prettyEff (effName, region) = p effName <+> p region
       tailStr = case tailVar of
         Nothing -> mempty
         Just v  -> "|" <> p v
 
-instance Pretty EffectName where
+instance Pretty Effect where
+  pretty eff = case eff of
+    RWSEffect rws h -> p rws <+> p h
+    ExceptionEffect -> "Except"
+
+instance Pretty RWS where
   pretty eff = case eff of
     Reader -> "Read"
     Writer -> "Accum"

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -496,11 +496,8 @@ exceptToMaybeBlock (Block (Nest (Let _ b expr) decls) result) = do
     NothingAtom a -> return $ NothingAtom a
     _ -> do
       blockTy <- substEmbedR $ getType result
-      let nothingPath = Abs Empty $ Block Empty $ Atom $ NothingAtom blockTy
-      b' <- mapM substEmbedR b
-      justPath <- buildNAbs (Nest b' Empty) $ \[x] ->
-          extendR (b@>x) $ exceptToMaybeBlock $ Block decls result
-      emit $ Case maybeResult [nothingPath, justPath] (MaybeTy blockTy)
+      emitMaybeCase maybeResult (return $ NothingAtom blockTy) $ \x -> do
+        extendR (b@>x) $ exceptToMaybeBlock $ Block decls result
 
 exceptToMaybeExpr :: Expr -> SubstEmbed Atom
 exceptToMaybeExpr expr = do

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -271,10 +271,10 @@ exprEffs expr = case expr of
   App f _ -> functionEffs f
   Op op   -> case op of
     PrimEffect ref m -> case m of
-      MGet    -> oneEffect (State,  h)
-      MPut  _ -> oneEffect (State,  h)
-      MAsk    -> oneEffect (Reader, h)
-      MTell _ -> oneEffect (Writer, h)
+      MGet    -> oneEffect (RWSEffect State  h)
+      MPut  _ -> oneEffect (RWSEffect State  h)
+      MAsk    -> oneEffect (RWSEffect Reader h)
+      MTell _ -> oneEffect (RWSEffect Writer h)
       where RefTy (Var (h:>_)) _ = getType ref
     IOAlloc  _ _  -> oneEffect ioEffect
     IOFree   _    -> oneEffect ioEffect
@@ -288,16 +288,16 @@ exprEffs expr = case expr of
     While cond body -> functionEffs cond <> functionEffs body
     Linearize _     -> mempty  -- Body has to be a pure function
     Transpose _     -> mempty  -- Body has to be a pure function
-    RunReader _ f   -> handleRunner Reader f
-    RunWriter   f   -> handleRunner Writer f
-    RunState  _ f   -> handleRunner State  f
+    RunReader _ f   -> handleRWSRunner Reader f
+    RunWriter   f   -> handleRWSRunner Writer f
+    RunState  _ f   -> handleRWSRunner State  f
     PTileReduce _ _ -> mempty
     RunIO ~(Lam (Abs _ (PlainArrow (EffectRow effs t), _))) ->
       EffectRow (S.delete ioEffect effs) t
   Case _ alts _ -> foldMap (\(Abs _ block) -> blockEffs block) alts
   where
-    handleRunner effName ~(BinaryFunVal (Bind (h:>_)) _ (EffectRow effs t) _) =
-      EffectRow (S.delete (effName, h) effs) t
+    handleRWSRunner rws ~(BinaryFunVal (Bind (h:>_)) _ (EffectRow effs t) _) =
+      EffectRow (S.delete (RWSEffect rws h) effs) t
 
 functionEffs :: Atom -> EffectRow
 functionEffs f = case getType f of
@@ -474,7 +474,9 @@ addExpr x m = modifyErr m $ \e -> case e of
 
 checkEffRow :: EffectRow -> TypeM ()
 checkEffRow (EffectRow effs effTail) = do
-  forM_ effs $ \(_, v) -> Var (v:>TyKind) |: TyKind
+  forM_ effs $ \eff -> case eff of
+    RWSEffect _ v -> Var (v:>TyKind) |: TyKind
+    ExceptionEffect -> return ()
   forM_ effTail $ \v -> do
     checkWithEnv $ \(env, _) -> case envLookup env (v:>()) of
       Nothing -> throw CompilerErr $ "Lookup failed: " ++ pprint v
@@ -504,7 +506,7 @@ oneEffect :: Effect -> EffectRow
 oneEffect eff = EffectRow (S.singleton eff) Nothing
 
 ioEffect :: Effect
-ioEffect = (State, theWorld)
+ioEffect = RWSEffect State theWorld
 
 -- === labeled row types ===
 
@@ -698,10 +700,10 @@ typeCheckOp op = case op of
   PrimEffect ref m -> do
     TC (RefType ~(Just (Var (h':>TyKind))) s) <- typeCheck ref
     case m of
-      MGet    ->         declareEff (State , h') $> s
-      MPut  x -> x|:s >> declareEff (State , h') $> UnitTy
-      MAsk    ->         declareEff (Reader, h') $> s
-      MTell x -> x|:s >> declareEff (Writer, h') $> UnitTy
+      MGet    ->         declareEff (RWSEffect State  h') $> s
+      MPut  x -> x|:s >> declareEff (RWSEffect State  h') $> UnitTy
+      MAsk    ->         declareEff (RWSEffect Reader h') $> s
+      MTell x -> x|:s >> declareEff (RWSEffect Writer h') $> UnitTy
   IndexRef ref i -> do
     RefTy h (TabTyAbs a) <- typeCheck ref
     i |: absArgType a
@@ -871,12 +873,12 @@ typeCheckHof hof = case hof of
     Pi (Abs (Ignore a) (LinArrow, b)) <- typeCheck f
     return $ b --@ a
   RunReader r f -> do
-    (resultTy, readTy) <- checkAction Reader f
+    (resultTy, readTy) <- checkRWSAction Reader f
     r |: readTy
     return resultTy
-  RunWriter f -> uncurry PairTy <$> checkAction Writer f
+  RunWriter f -> uncurry PairTy <$> checkRWSAction Writer f
   RunState s f -> do
-    (resultTy, stateTy) <- checkAction State f
+    (resultTy, stateTy) <- checkRWSAction State f
     s |: stateTy
     return $ PairTy resultTy stateTy
   RunIO f -> do
@@ -884,12 +886,12 @@ typeCheckHof hof = case hof of
     extendAllowedEffect ioEffect $ declareEffs eff
     return resultTy
 
-checkAction :: EffectName -> Atom -> TypeM (Type, Type)
-checkAction effName f = do
+checkRWSAction :: RWS -> Atom -> TypeM (Type, Type)
+checkRWSAction rws f = do
   BinaryFunTy (Bind regionBinder) refBinder eff resultTy <- typeCheck f
   regionName:>_ <- return regionBinder
   let region = Var regionBinder
-  extendAllowedEffect (effName, regionName) $ declareEffs eff
+  extendAllowedEffect (RWSEffect rws regionName) $ declareEffs eff
   checkEq (varAnn regionBinder) TyKind
   RefTy region' referentTy <- return $ binderAnn refBinder
   checkEq region' region

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -27,9 +27,34 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
        ref := 2
 > 1
 
+:p catch do
+  for i:(Fin 5).
+    if ordinal i > 3
+      then throw ()
+      else 23
+> Nothing
+
+:p catch do
+  for i:(Fin 3).
+    if ordinal i > 3
+      then throw ()
+      else 23
+> (Just [23, 23, 23])
+
+-- Is this the result we want?
+:p snd $ withState zero \ref.
+     catch do
+       for i:(Fin 6).
+         if (ordinal i `rem` 2) == 0
+           then throw ()
+           else ()
+         ref!i := 1
+> [0, 1, 0, 1, 0, 1]
+
 -- Doesn't work yet
 -- :p catch do
 --      withState 0 \ref.
 --        ref := 1
 --        assert False
 --        ref := 2
+

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -1,0 +1,35 @@
+
+
+def checkFloatInUnitInterval (x:Float) : {Except} Float =
+  assert $ x >= 0.0
+  assert $ x <= 1.0
+  x
+
+:p catch do assert False
+> Nothing
+
+:p catch do assert True
+> (Just ())
+
+:p catch do checkFloatInUnitInterval 1.2
+> Nothing
+
+:p catch do checkFloatInUnitInterval (-1.2)
+> Nothing
+
+:p catch do checkFloatInUnitInterval 0.2
+> (Just 0.2)
+
+:p snd $ withState 0 \ref.
+     catch do
+       ref := 1
+       assert False
+       ref := 2
+> 1
+
+-- Doesn't work yet
+-- :p catch do
+--      withState 0 \ref.
+--        ref := 1
+--        assert False
+--        ref := 2


### PR DESCRIPTION
This adds an exception effect, `{Except}`, along with primitives for throwing and catching exceptions:

    throw : Unit -> {Except} a
    catch : (Unit -> {Except|eff} a) -> {|eff} Maybe a

We lower away the exceptions to case expressions and Maybes in the simplification pass, similar to the we lower away AD transformations. So this doesn't add any fundamentally new capabilities. It's just for plumbing convenience.

A function like this:


```
def maxOfLogs (xs:n=>Float) : {Except} Float =
  assert $ size n > 0
  maximum $ for i.
    assert $ xs.i > 0.
    log xs.i
```

Becomes something like this:

```
def maxOfLogs2 (xs:n=>Float) : Maybe Float =
  if size n > 0
    then
      maybes = for i.
        if xs.i > 0.
          then Just $ log xs.i
          else Nothing
      case seqMaybes maybes of
        Just xs -> Just $ maximum xs
        Nothing -> Nothing
    else
      Nothing
```

With assert defined as just:

```
def assert (b:Bool) : {Except} Unit = if b then () else throw ()
```

Notice that the `for` can still happen in parallel. Adding exceptions to a loop doesn't force it to be sequential in the way that adding state does.

**No exception payload.** It's traditional to represent exceptions with a type like `Either e a`, where the `e`, perhaps a `String`, carries information about the error. The exception in this PR doesn't have such a payload: it's just `Maybe a`. The main reason is that it's easier to implement. But I actually think it might be a good design too. The problem with `Either e a`, is that it doesn't give you a way to combine the different errors you get if you run an exception-producing function in parallel over many indices. You're losing a lot of information if you just keep the first one. It would natural to ask for a monoid instance for `e` so you can combine the error messages. But then it's very close to a `(Maybe a, e)`, and we may as well use our ordinary `Accum` writer effect for the error messages `e`, since we already have technology handling parallelization.

**Interactions with other effect**. Designing a system for combining effects requires thinking very carefully about the semantics of composition. I haven't done that even a little bit. Things will break in arbitrary ways if we nest exceptions, and the interaction between exceptions and state is unclear.

One surprising consequence of the way we allow parallelism in exceptional `for` expressions is that a *stateful* loop still continues to the next iteraion even after an exception. For example, the following throws an exception at every even index, but the loop carries on regardless? Is that what we want? I have no idea.

```
-- Is this the result we want?
:p snd $ withState zero \ref.
     catch do
       for i:(Fin 6).
         if (ordinal i `rem` 2) == 0
           then throw ()
           else ()
         ref!i := 1
> [0, 1, 0, 1, 0, 1]
```

