### PR TITLE
Parser combinators

### DIFF
--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -112,15 +112,15 @@ def odeint (func: d=>Float -> Time -> d=>Float)
   atol = 1.4e-8 -- absolute local error tolerance for solver.
   max_iters = 10000
 
-  integrate_to_next_time = \iter init_carry.
-    target_t = times.iter
+  integrate_to_next_time = \i init_carry.
+    target_t = times.i
 
-    stopping_condition = \(_, _, t, dt, _, _).
+    continue_condition = \(_, _, t, dt, _, _).
       -- State of solver: (next state, next f, next time, dt, t, interp coeffs)
       -- def State (v:Type) : Type = (v & v & Time & Time & Time & (Fin 5)=>v)
       -- This ended up being unnecessary to spell anywhere, but was
       -- useful for debugging.
-      (t < target_t) && (dt > 0.0) && (ordinal iter < max_iters)
+      (t < target_t) && (dt > 0.0) && (ordinal i < max_iters)
 
     possible_step = \(z, f, t, dt, last_t, interp_coeff).
       (next_z, next_f, next_z_error, k) = runge_kutta_step func z f t dt
@@ -134,9 +134,14 @@ def odeint (func: d=>Float -> Time -> d=>Float)
       select (ratio <= 1.0) move_state stay_state
 
     -- Take steps until we pass target_t
-    new_state = snd $ withState init_carry \state.
-      while (do stopping_condition (get state)) do
-        state := possible_step (get state)
+    new_state = snd $ withState init_carry \stateRef.
+      iter \_.
+        state = get stateRef
+        if continue_condition state
+          then
+            stateRef := possible_step state
+            Continue
+          else Done ()
     (_, _, t, _, last_t, interp_coeff) = new_state
 
     -- Interpolate to the target time.

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -21,57 +21,68 @@ def indexList (l:List a) (i:Int) : {Except} a =
 
 def ParserHandle (h:Type) : Type = (String & Ref h Int)
 
-def Parser (a:Type) : Type = h:Type ?-> ParserHandle h -> {Except, State h} a
+data Parser a:Type =
+  MkParser (h:Type ?-> ParserHandle h -> {Except, State h} a)
 
-def runParser (s:String) (parser:Parser a) : Maybe a =
+def parse (handle:ParserHandle h) (parser:Parser a) : {Except, State h} a =
+  (MkParser f) = parser
+  f handle
+
+def runParserPartial (s:String) (parser:Parser a) : Maybe a =
+  (MkParser f) = parser
   fst $ withState 0 \pos.
     catch $ do
-      parser (s, pos)
+      f (s, pos)
 
 'Primitive combinators
 
-def pChar (c:Char) : Parser Unit = \(s, posRef).
+def pChar (c:Char) : Parser Unit = MkParser \(s, posRef).
   i = get posRef
   c' = indexList s i
   assert (c == c')
   posRef := i + 1
 
-def pEOF : Parser Unit = \(s, posRef).
+def pEOF : Parser Unit = MkParser \(s, posRef).
   assert $ get posRef >= listLength s
 
-def (<|>) (p1:Parser a) (p2:Parser a) : Parser a = \h.
+def (<|>) (p1:Parser a) (p2:Parser a) : Parser a = MkParser \h.
   (s, posRef) = h
   curPos = get posRef
-  case catch do p1 h of
+  case catch do parse h p1 of
     Nothing ->
       assert $ curPos == get posRef
-      p2 h
+      parse h p2
     Just ans -> ans
 
-def return (x:a) : Parser a = \_. x
+def return (x:a) : Parser a = MkParser \_. x
+
+def runParser (s:String) (parser:Parser a) : Maybe a =
+  runParserPartial s $ MkParser \h.
+    ans = parse h parser
+    _   = parse h pEOF
+    ans
 
 'Derived combinators
 
-def optional (parser:Parser a) : Parser (Maybe a) =
-  (\h. Just (parser h)) <|> return Nothing
+def optional (p:Parser a) : Parser (Maybe a) =
+  (MkParser \h. Just (parse h p)) <|> return Nothing
 
-def parseMany (parser:Parser a) : Parser (List a) = \h.
+def parseMany (parser:Parser a) : Parser (List a) = MkParser \h.
   snd $ withState (AsList _ []) \results.
     iter \_.
-      maybeVal = optional parser h
+      maybeVal = parse h $ optional parser
       case maybeVal of
         Nothing -> Done ()
         Just x ->
           push results x
           Continue
 
-def bracketed (l:Parser Unit) (r:Parser Unit) (body:Parser a) : Parser a = \h.
-  l          h
-  ans = body h
-  r          h
-  ans
+def bracketed (l:Parser Unit) (r:Parser Unit) (body:Parser a) : Parser a =
+  MkParser \h.
+    _   = parse h l
+    ans = parse h body
+    _   = parse h r
+    ans
 
--- This fails. Type inference is unable to unify two region variables. I think
--- it's to do with implicit type application.
--- def parens (parser:Parser Unit) : Parser a =
---   bracketed (pChar '(') (pChar ')') parser
+def parens (parser:Parser a) : Parser a =
+  bracketed (pChar '(') (pChar ')') parser

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -1,0 +1,27 @@
+
+def ParserHandle (h:Type) : Type = (String & Ref h Int)
+
+def Parser (a:Type) : Type = h:Type ?-> ParserHandle h -> {Except, State h} a
+
+def fromOrdinalExc (n:Type) (i:Int) : {Except} n =
+  if (0 <= i) && (i < size n)
+    then unsafeFromOrdinal _ i
+    else throw ()
+
+def indexList (l:List a) (i:Int) : {Except} a =
+  (AsList n xs) = l
+  xs.(fromOrdinalExc _ i)
+
+def pChar (c:Char) : Parser Unit = \(s, posRef).
+  i = get posRef
+  c' = indexList s i
+  assert (c == c')
+  posRef := i + 1
+
+def pEOF : Parser Unit = \(s, posRef).
+  assert $ get posRef >= listLength s
+
+def runParser (s:String) (parser:Parser a) : Maybe a =
+  fst $ withState 0 \pos.
+    catch $ do
+      parser (s, pos)

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -62,7 +62,30 @@ def runParser (s:String) (parser:Parser a) : Maybe a =
     _   = parse h pEOF
     ans
 
+def parseAny : Parser Char = MkParser \h.
+  (s, posRef) = h
+  i = get posRef
+  c' = indexList s i
+  posRef := i + 1
+  c'
+
+def try (parser:Parser a) : Parser a = MkParser \h.
+  (s, posRef) = h
+  savedPos = get posRef
+  ans = catch do parse h parser
+  case ans of
+    Nothing ->
+      posRef := savedPos
+      throw ()
+    Just x -> x
+
 'Derived combinators
+
+def parseDigit : Parser Int = try $ MkParser \h.
+  c = parse h $ parseAny
+  i = W8ToI c - 48
+  assert $ 0 <= i && i < 10
+  i
 
 def optional (p:Parser a) : Parser (Maybe a) =
   (MkParser \h. Just (parse h p)) <|> return Nothing
@@ -76,6 +99,19 @@ def parseMany (parser:Parser a) : Parser (List a) = MkParser \h.
         Just x ->
           push results x
           Continue
+
+def parseUnsignedInt : Parser Int = MkParser \h.
+  (AsList _ digits) = parse h $ parseMany parseDigit
+  snd $ withState 0 \ref.
+    for i.
+      ref := 10 * get ref + digits.i
+
+def parseInt : Parser Int = MkParser \h.
+  negSign = parse h $ optional $ pChar '-'
+  x       = parse h $ parseUnsignedInt
+  case negSign of
+    Nothing -> x
+    Just () -> (-1) * x
 
 def bracketed (l:Parser Unit) (r:Parser Unit) (body:Parser a) : Parser a =
   MkParser \h.

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -1,16 +1,34 @@
 
-def ParserHandle (h:Type) : Type = (String & Ref h Int)
 
-def Parser (a:Type) : Type = h:Type ?-> ParserHandle h -> {Except, State h} a
+'Utilities unrelated to parsing
 
 def fromOrdinalExc (n:Type) (i:Int) : {Except} n =
   if (0 <= i) && (i < size n)
     then unsafeFromOrdinal _ i
     else throw ()
 
+-- TODO: allow this to happen in-place
+-- TODO: if it takes too long to make that possible, start with a bounded version
+def push (ref:Ref h (List a)) (x:a) : {State h} Unit =
+  l = get ref
+  ref := l <> AsList _ [x]
+
 def indexList (l:List a) (i:Int) : {Except} a =
   (AsList n xs) = l
   xs.(fromOrdinalExc _ i)
+
+'The Parser type
+
+def ParserHandle (h:Type) : Type = (String & Ref h Int)
+
+def Parser (a:Type) : Type = h:Type ?-> ParserHandle h -> {Except, State h} a
+
+def runParser (s:String) (parser:Parser a) : Maybe a =
+  fst $ withState 0 \pos.
+    catch $ do
+      parser (s, pos)
+
+'Primitive combinators
 
 def pChar (c:Char) : Parser Unit = \(s, posRef).
   i = get posRef
@@ -21,7 +39,39 @@ def pChar (c:Char) : Parser Unit = \(s, posRef).
 def pEOF : Parser Unit = \(s, posRef).
   assert $ get posRef >= listLength s
 
-def runParser (s:String) (parser:Parser a) : Maybe a =
-  fst $ withState 0 \pos.
-    catch $ do
-      parser (s, pos)
+def (<|>) (p1:Parser a) (p2:Parser a) : Parser a = \h.
+  (s, posRef) = h
+  curPos = get posRef
+  case catch do p1 h of
+    Nothing ->
+      assert $ curPos == get posRef
+      p2 h
+    Just ans -> ans
+
+def return (x:a) : Parser a = \_. x
+
+'Derived combinators
+
+def optional (parser:Parser a) : Parser (Maybe a) =
+  (\h. Just (parser h)) <|> return Nothing
+
+def parseMany (parser:Parser a) : Parser (List a) = \h.
+  snd $ withState (AsList _ []) \results.
+    iter \_.
+      maybeVal = optional parser h
+      case maybeVal of
+        Nothing -> Done ()
+        Just x ->
+          push results x
+          Continue
+
+def bracketed (l:Parser Unit) (r:Parser Unit) (body:Parser a) : Parser a = \h.
+  l          h
+  ans = body h
+  r          h
+  ans
+
+-- This fails. Type inference is unable to unify two region variables. I think
+-- it's to do with implicit type application.
+-- def parens (parser:Parser Unit) : Parser a =
+--   bracketed (pChar '(') (pChar ')') parser

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1030,11 +1030,10 @@ def fwrite (stream:Stream WriteMode) (s:String) : {State World} Unit =
 
 def while
     (eff:Effects) ?->
-    (cond: Unit -> {|eff} Bool)
-    (body: Unit -> {|eff} Unit)
+    (body: Unit -> {|eff} Bool)
     : {|eff} Unit =
-  cond' : Unit -> {|eff} Word8 = \_. BToW8 $ cond ()
-  %while cond' body
+  body' : Unit -> {|eff} Word8 = \_. BToW8 $ body ()
+  %while body'
 
 data IterResult a:Type =
   Continue
@@ -1052,10 +1051,15 @@ def liftState (ref: Ref h c) (f:a -> {|eff} b) (x:a) : {State h|eff} b =
 -- A little iteration combinator
 def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
   result = snd $ withState Nothing \resultRef. withState 0 \i.
-    while (do isNothing $ get resultRef) do
-      case liftState resultRef (liftState i body) (get i) of
-        Continue -> i := get i + 1
-        Done result -> resultRef := Just result
+    while do
+      continue = isNothing $ get resultRef
+      if continue
+        then case liftState resultRef (liftState i body) (get i) of
+          Continue -> i := get i + 1
+          Done result -> resultRef := Just result
+        else ()
+      continue
+
   case result of
     Just ans -> ans
     Nothing -> unreachable ()
@@ -1465,9 +1469,14 @@ def concat (lists:n=>(List a)) : List a =
   AsList _ $ fst $ withState 0 \listIdx.
     fst $ withState 0 \eltIdx.
       for i:(Fin totalSize).
-        while (do get eltIdx >= listLength (lists.((get listIdx)@_))) do
-          eltIdx := 0
-          listIdx := get listIdx + 1
+        while do
+          continue = get eltIdx >= listLength (lists.((get listIdx)@_))
+          if continue
+            then
+              eltIdx := 0
+              listIdx := get listIdx + 1
+            else ()
+          continue
         (AsList _ xs) = lists.((get listIdx)@_)
         eltIdxVal = get eltIdx
         eltIdx := eltIdxVal + 1

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1028,10 +1028,7 @@ def fwrite (stream:Stream WriteMode) (s:String) : {State World} Unit =
   %ffi fflush Int64 stream'
   ()
 
-def while
-    (eff:Effects) ?->
-    (body: Unit -> {|eff} Bool)
-    : {|eff} Unit =
+def while (eff:Effects) ?-> (body: Unit -> {|eff} Bool) : {|eff} Unit =
   body' : Unit -> {|eff} Word8 = \_. BToW8 $ body ()
   %while body'
 
@@ -1063,6 +1060,20 @@ def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
   case result of
     Just ans -> ans
     Nothing -> unreachable ()
+
+-- XXX: used internally by compiler for exceptional while
+def whileMaybe (eff:Effects) -> (body: Unit -> {|eff} (Maybe Word8)) : {|eff} Maybe Unit =
+  hadError = snd $ withState False \ref.
+    while do
+      ans = liftState ref body ()
+      case ans of
+        Nothing ->
+          ref := True
+          False
+        Just cond -> W8ToB cond
+  if hadError
+    then Nothing
+    else Just ()
 
 def boundedIter (maxIters:Int) (fallback:a)
   (body: Int -> {|eff} IterResult a) : {|eff} a  =

--- a/makefile
+++ b/makefile
@@ -87,7 +87,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              shadow-tests monad-tests io-tests exception-tests \
-             ad-tests parser-tests serialize-tests \
+             ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests
 
 lib-names = diagram plot png

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -274,7 +274,7 @@ linearizeHof env hof = case hof of
   -- TODO: Consider providing an upper bound for the number of while iterations as a hint.
   --       In the current form the best we can do is try to use some dynamically growing lists,
   --       but that won't work on the GPU.
-  While _ _   -> notImplemented
+  While _     -> notImplemented
   Linearize _ -> error "Unexpected linearization"
   Transpose _ -> error "Unexpected transposition"
   PTileReduce _ _ -> error "Unexpected PTileReduce"
@@ -698,7 +698,7 @@ transposeHof hof ct = case hof of
     transposeAtom s cts
   RunIO _ -> error "Not implemented"
   Tile      _ _ _ -> notImplemented
-  While       _ _ -> notImplemented
+  While         _ -> notImplemented
   Linearize     _ -> error "Unexpected linearization"
   Transpose     _ -> error "Unexpected transposition"
   PTileReduce _ _ -> error "Unexpected PTileReduce"

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -363,20 +363,20 @@ toImpHof env (maybeDest, hof) = do
                 let idx = Con $ ParIndexCon idxTy $ toScalarAtom i
                 ithDest <- destGet dest idx
                 void $ translateBlock (env <> b @> idx) (Just ithDest, body)
-            -- GPU -> do -- Grid stride loop
-            --   iPtr <- alloc IdxRepTy
-            --   copyAtom iPtr gtid
-            --   cond <- liftM snd $ scopedBlock $ do
-            --     i <- destToAtom iPtr
-            --     inRange <- (fromScalarAtom i) `iltI` n
-            --     return ((), [inRange])
-            --   wbody <- scopedErrBlock $ do
-            --     i <- destToAtom iPtr
-            --     let idx = Con $ ParIndexCon idxTy i
-            --     ithDest <- destGet dest idx
-            --     void $ translateBlock (env <> b @> idx) (Just ithDest, body)
-            --     copyAtom iPtr . toScalarAtom =<< iaddI (fromScalarAtom i) (fromScalarAtom numThreads)
-            --   emitStatement $ IWhile cond wbody
+            GPU -> do -- Grid stride loop
+              iPtr <- alloc IdxRepTy
+              copyAtom iPtr gtid
+              cond <- liftM snd $ scopedBlock $ do
+                i <- destToAtom iPtr
+                inRange <- (fromScalarAtom i) `iltI` n
+                emitWhen inRange $ do
+                  let idx = Con $ ParIndexCon idxTy i
+                  ithDest <- destGet dest idx
+                  void $ translateBlock (env <> b @> idx) (Just ithDest, body)
+                  copyAtom iPtr . toScalarAtom =<< iaddI (fromScalarAtom i)
+                                                     (fromScalarAtom numThreads)
+                return ((), [inRange])
+              emitStatement $ IWhile cond
           destToAtom dest
         _ -> do
           n <- indexSetSize idxTy
@@ -418,80 +418,80 @@ toImpHof env (maybeDest, hof) = do
         sDest <- fromEmbed $ indexDestDim d dest idx
         void $ translateBlock (env <> sb @> idx) (Just sDest, sBody)
       destToAtom dest
-    -- PTileReduce idxTy' ~(BinaryFunVal gtidB nthrB _ body) -> do
-    --   idxTy <- impSubst env idxTy'
-    --   (mappingDest, finalAccDest) <- destPairUnpack <$> allocDest maybeDest resultTy
-    --   let PairTy _ accType = resultTy
-    --   (numTileWorkgroups, wgResArr, widIdxTy) <- buildKernel idxTy $ \LaunchInfo{..} buildBody -> do
-    --     let widIdxTy = Fin $ toScalarAtom numWorkgroups
-    --     let tidIdxTy = Fin $ toScalarAtom workgroupSize
-    --     wgResArr  <- alloc $ TabTy (Ignore widIdxTy) accType
-    --     thrAccArr <- alloc $ TabTy (Ignore widIdxTy) $ TabTy (Ignore tidIdxTy) accType
-    --     mappingKernelBody <- buildBody $ \ThreadInfo{..} -> do
-    --       let TC (ParIndexRange _ gtid nthr) = threadRange
-    --       let scope = freeVars mappingDest
-    --       let tileDest = Con $ TabRef $ fst $ flip runSubstEmbed scope $ do
-    --             buildLam (Bind $ "hwidx":>threadRange) TabArrow $ \hwidx -> do
-    --               indexDest mappingDest =<< (emitOp $ Inject hwidx)
-    --       wgAccs <- destGet thrAccArr =<< intToIndex widIdxTy wid
-    --       thrAcc <- destGet wgAccs    =<< intToIndex tidIdxTy tid
-    --       let threadDest = Con $ ConRef $ PairCon tileDest thrAcc
-    --       void $ translateBlock (env <> gtidB @> gtid <> nthrB @> nthr) (Just threadDest, body)
-    --       wgRes <- destGet wgResArr =<< intToIndex widIdxTy wid
-    --       workgroupReduce tid wgRes wgAccs workgroupSize
-    --     return (mappingKernelBody, (numWorkgroups, wgResArr, widIdxTy))
-    --   -- TODO: Skip the reduction kernel if unnecessary?
-    --   -- TODO: Reduce sequentially in the CPU backend?
-    --   -- TODO: Actually we only need the previous-power-of-2 many threads
-    --   buildKernel widIdxTy $ \LaunchInfo{..} buildBody -> do
-    --     -- We only do a one-level reduciton in the workgroup, so it is correct
-    --     -- only if the end up scheduling a single workgroup.
-    --     moreThanOneGroup <- (IIdxRepVal 1) `iltI` numWorkgroups
-    --     guardBlock moreThanOneGroup $ emitStatement IThrowError
-    --     redKernelBody <- buildBody $ \ThreadInfo{..} ->
-    --       workgroupReduce tid finalAccDest wgResArr numTileWorkgroups
-    --     return (redKernelBody, ())
-    --   PairVal <$> destToAtom mappingDest <*> destToAtom finalAccDest
-    --   where
-    --     guardBlock cond m = do
-    --       block <- scopedErrBlock m
-    --       emitStatement $ ICond cond block (ImpBlock mempty mempty)
-    --     workgroupReduce tid resDest arrDest elemCount = do
-    --       elemCountDown2 <- prevPowerOf2 elemCount
-    --       let RawRefTy (TabTy arrIdxB _) = getType arrDest
-    --       let arrIdxTy = binderType arrIdxB
-    --       offPtr <- alloc IdxRepTy
-    --       copyAtom offPtr $ toScalarAtom elemCountDown2
-    --       cond <- liftM snd $ scopedBlock $ do
-    --         off  <- fromScalarAtom <$> destToAtom offPtr
-    --         cond <- emitInstr $ IPrimOp $ ScalarBinOp (ICmp Greater) off (IIdxRepVal 0)
-    --         return ((), [cond])
-    --       wbody <- scopedErrBlock $ do
-    --         off       <- fromScalarAtom <$> destToAtom offPtr
-    --         loadIdx   <- iaddI tid off
-    --         shouldAdd <- bindM2 bandI (tid `iltI` off) (loadIdx `iltI` elemCount)
-    --         guardBlock shouldAdd $ do
-    --           threadDest <- destGet arrDest =<< intToIndex arrIdxTy tid
-    --           addToAtom threadDest =<< destToAtom =<< destGet arrDest =<< intToIndex arrIdxTy loadIdx
-    --         emitStatement ISyncWorkgroup
-    --         copyAtom offPtr . toScalarAtom =<< off `idivI` (IIdxRepVal 2)
-    --       emitStatement $ IWhile cond wbody
-    --       firstThread <- tid `iltI` (IIdxRepVal 1)
-    --       guardBlock firstThread $
-    --         copyAtom resDest =<< destToAtom =<< destGet arrDest =<< intToIndex arrIdxTy tid
-    --     -- TODO: Do some popcount tricks?
-    --     prevPowerOf2 :: IExpr -> ImpM IExpr
-    --     prevPowerOf2 x = do
-    --       rPtr <- alloc IdxRepTy
-    --       copyAtom rPtr (IdxRepVal 1)
-    --       let getNext = imulI (IIdxRepVal 2) . fromScalarAtom =<< destToAtom rPtr
-    --       cond <- liftM snd $ scopedBlock $ do
-    --         canGrow <- getNext >>= (`iltI` x)
-    --         return ((), [canGrow])
-    --       wbody <- scopedErrBlock $ do
-    --         copyAtom rPtr . toScalarAtom =<< getNext
-    --       emitStatement $ IWhile cond wbody
-    --       fromScalarAtom <$> destToAtom rPtr
+    PTileReduce idxTy' ~(BinaryFunVal gtidB nthrB _ body) -> do
+      idxTy <- impSubst env idxTy'
+      (mappingDest, finalAccDest) <- destPairUnpack <$> allocDest maybeDest resultTy
+      let PairTy _ accType = resultTy
+      (numTileWorkgroups, wgResArr, widIdxTy) <- buildKernel idxTy $ \LaunchInfo{..} buildBody -> do
+        let widIdxTy = Fin $ toScalarAtom numWorkgroups
+        let tidIdxTy = Fin $ toScalarAtom workgroupSize
+        wgResArr  <- alloc $ TabTy (Ignore widIdxTy) accType
+        thrAccArr <- alloc $ TabTy (Ignore widIdxTy) $ TabTy (Ignore tidIdxTy) accType
+        mappingKernelBody <- buildBody $ \ThreadInfo{..} -> do
+          let TC (ParIndexRange _ gtid nthr) = threadRange
+          let scope = freeVars mappingDest
+          let tileDest = Con $ TabRef $ fst $ flip runSubstEmbed scope $ do
+                buildLam (Bind $ "hwidx":>threadRange) TabArrow $ \hwidx -> do
+                  indexDest mappingDest =<< (emitOp $ Inject hwidx)
+          wgAccs <- destGet thrAccArr =<< intToIndex widIdxTy wid
+          thrAcc <- destGet wgAccs    =<< intToIndex tidIdxTy tid
+          let threadDest = Con $ ConRef $ PairCon tileDest thrAcc
+          void $ translateBlock (env <> gtidB @> gtid <> nthrB @> nthr) (Just threadDest, body)
+          wgRes <- destGet wgResArr =<< intToIndex widIdxTy wid
+          workgroupReduce tid wgRes wgAccs workgroupSize
+        return (mappingKernelBody, (numWorkgroups, wgResArr, widIdxTy))
+      -- TODO: Skip the reduction kernel if unnecessary?
+      -- TODO: Reduce sequentially in the CPU backend?
+      -- TODO: Actually we only need the previous-power-of-2 many threads
+      buildKernel widIdxTy $ \LaunchInfo{..} buildBody -> do
+        -- We only do a one-level reduciton in the workgroup, so it is correct
+        -- only if the end up scheduling a single workgroup.
+        moreThanOneGroup <- (IIdxRepVal 1) `iltI` numWorkgroups
+        guardBlock moreThanOneGroup $ emitStatement IThrowError
+        redKernelBody <- buildBody $ \ThreadInfo{..} ->
+          workgroupReduce tid finalAccDest wgResArr numTileWorkgroups
+        return (redKernelBody, ())
+      PairVal <$> destToAtom mappingDest <*> destToAtom finalAccDest
+      where
+        guardBlock cond m = do
+          block <- scopedErrBlock m
+          emitStatement $ ICond cond block (ImpBlock mempty mempty)
+        workgroupReduce tid resDest arrDest elemCount = do
+          elemCountDown2 <- prevPowerOf2 elemCount
+          let RawRefTy (TabTy arrIdxB _) = getType arrDest
+          let arrIdxTy = binderType arrIdxB
+          offPtr <- alloc IdxRepTy
+          copyAtom offPtr $ toScalarAtom elemCountDown2
+          let wbody = do
+                off       <- fromScalarAtom <$> destToAtom offPtr
+                loadIdx   <- iaddI tid off
+                shouldAdd <- bindM2 bandI (tid `iltI` off) (loadIdx `iltI` elemCount)
+                guardBlock shouldAdd $ do
+                  threadDest <- destGet arrDest =<< intToIndex arrIdxTy tid
+                  addToAtom threadDest =<< destToAtom =<< destGet arrDest =<< intToIndex arrIdxTy loadIdx
+                emitStatement ISyncWorkgroup
+                copyAtom offPtr . toScalarAtom =<< off `idivI` (IIdxRepVal 2)
+          cond <- liftM snd $ scopedBlock $ do
+            off  <- fromScalarAtom <$> destToAtom offPtr
+            cond <- emitInstr $ IPrimOp $ ScalarBinOp (ICmp Greater) off (IIdxRepVal 0)
+            emitWhen cond wbody
+            return ((), [cond])
+          emitStatement $ IWhile cond
+          firstThread <- tid `iltI` (IIdxRepVal 1)
+          guardBlock firstThread $
+            copyAtom resDest =<< destToAtom =<< destGet arrDest =<< intToIndex arrIdxTy tid
+        -- TODO: Do some popcount tricks?
+        prevPowerOf2 :: IExpr -> ImpM IExpr
+        prevPowerOf2 x = do
+          rPtr <- alloc IdxRepTy
+          copyAtom rPtr (IdxRepVal 1)
+          let getNext = imulI (IIdxRepVal 2) . fromScalarAtom =<< destToAtom rPtr
+          cond <- liftM snd $ scopedBlock $ do
+            canGrow <- getNext >>= (`iltI` x)
+            emitWhen canGrow $ copyAtom rPtr . toScalarAtom =<< getNext
+            return ((), [canGrow])
+          emitStatement $ IWhile cond
+          fromScalarAtom <$> destToAtom rPtr
     While ~(Lam (Abs _ (_, body))) -> do
       body' <- liftM snd $ scopedBlock $ do
                  ans <- translateBlock env (Nothing, body)
@@ -1045,6 +1045,9 @@ alloc ty = makeAllocDest Managed ty
 
 handleErrors :: ImpM () -> ImpM ()
 handleErrors m = m `catchError` (const $ emitStatement IThrowError)
+
+emitWhen :: IExpr -> ImpM () -> ImpM ()
+emitWhen cond doIfTrue = emitSwitch cond [return (), doIfTrue]
 
 -- TODO: Consider targeting LLVM's `switch` instead of chained conditionals.
 emitSwitch :: IExpr -> [ImpM ()] -> ImpM ()

--- a/src/lib/Imp/Embed.hs
+++ b/src/lib/Imp/Embed.hs
@@ -147,8 +147,7 @@ traverseImpInstr def instr = case instr of
     b' <- freshIVar b
     IFor dir (Bind b') <$> traverseIExpr size
                        <*> (extendValSubst (b @> IVar b') $ traverseImpBlock def body)
-  IWhile cond body ->
-    IWhile <$> traverseImpBlock def cond <*> traverseImpBlock def body
+  IWhile body -> IWhile <$> traverseImpBlock def body
   ICond cond tb fb -> ICond <$> traverseIExpr cond
                             <*> traverseImpBlock def tb
                             <*> traverseImpBlock def fb

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -478,9 +478,7 @@ instance Pretty ImpFunction where
 instance Pretty ImpInstr where
   pretty (IFor a i n block) = forStr (RegularFor a) <+> p i <+> "<" <+> p n <>
                                 nest 4 (hardline <> p block)
-  pretty (IWhile cond body) = "while" <+>
-                                  nest 2 (p cond) <+> "do" <>
-                                  nest 4 (hardline <> p body)
+  pretty (IWhile body) = "while" <+> nest 2 (p body)
   pretty (ICond predicate cons alt) =
     "if" <+> p predicate <+> "then" <> nest 2 (hardline <> p cons) <>
     hardline <> "else" <> nest 2 (hardline <> p alt)

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -447,10 +447,9 @@ simplifyHof hof = case hof of
     ~(fS', Nothing) <- simplifyLam fS
     emit $ Hof $ Tile d fT' fS'
   PTileReduce _ _ -> error "Unexpected PTileReduce"
-  While cond body -> do
-    ~(cond', Nothing) <- simplifyLam cond
+  While body -> do
     ~(body', Nothing) <- simplifyLam body
-    emit $ Hof $ While cond' body'
+    emit $ Hof $ While body'
   Linearize lam -> do
     ~(lam', Nothing) <- simplifyLam lam
     scope <- getScope

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -365,7 +365,7 @@ data PrimOp e =
 data PrimHof e =
         For ForAnn e
       | Tile Int e e          -- dimension number, tiled body, scalar body
-      | While e e
+      | While e
       | RunReader e e
       | RunWriter e
       | RunState  e e
@@ -529,7 +529,7 @@ data ImpFunction = ImpFunction IFunVar [IBinder] ImpBlock
 data ImpBlock    = ImpBlock (Nest ImpDecl) [IExpr]    deriving (Show)
 data ImpDecl     = ImpLet [IBinder] ImpInstr deriving (Show)
 data ImpInstr = IFor Direction IBinder Size ImpBlock
-              | IWhile ImpBlock ImpBlock  -- cond block, body block
+              | IWhile ImpBlock
               | ICond IExpr ImpBlock ImpBlock
               | IQueryParallelism IFunVar IExpr -- returns the number of available concurrent threads
               | ISyncWorkgroup
@@ -1264,7 +1264,7 @@ instance HasIVars ImpBlock where
 instance HasIVars ImpInstr where
   freeIVars i = case i of
     IFor _ b n p      -> freeIVars n <> (freeIVars p `envDiff` (b @> ()))
-    IWhile c p        -> freeIVars c <> freeIVars p
+    IWhile p          -> freeIVars p
     ICond  c t f      -> freeIVars c <> freeIVars t <> freeIVars f
     IQueryParallelism _ s -> freeIVars s
     ISyncWorkgroup      -> mempty
@@ -1548,7 +1548,7 @@ builtinNames = M.fromList
   , ("indexRef"   , OpExpr $ IndexRef () ())
   , ("inject"     , OpExpr $ Inject ())
   , ("select"     , OpExpr $ Select () () ())
-  , ("while"           , HofExpr $ While () ())
+  , ("while"           , HofExpr $ While ())
   , ("linearize"       , HofExpr $ Linearize ())
   , ("linearTranspose" , HofExpr $ Transpose ())
   , ("runReader"       , HofExpr $ RunReader () ())

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -647,8 +647,12 @@ def newtonIter (f: Float -> Float) (x:Float) : Float =
 
 def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
   snd $ withState x0 \x.
-    while (\(). abs (f $ get x) > tol) \().
-      x := newtonIter f $ get x
+    iter \i.
+      if abs (f $ get x) <= tol
+        then Done ()
+        else
+          x := newtonIter f $ get x
+          Continue
 
 :p newtonSolve 0.001 (\x. sq x - 2.0) 1.0
 > 1.414216

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -51,10 +51,9 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
          ref!i := 1
 > [0, 1, 0, 1, 0, 1]
 
--- Doesn't work yet
--- :p catch do
---      withState 0 \ref.
---        ref := 1
---        assert False
---        ref := 2
-
+:p catch do
+     withState 0 \ref.
+       ref := 1
+       assert False
+       ref := 2
+> Nothing

--- a/tests/parser-combinator-tests.dx
+++ b/tests/parser-combinator-tests.dx
@@ -40,3 +40,15 @@ def parserTFTriple : Parser (Fin 3=>Bool) = MkParser \h.
 
 :p runParser "TTFFTT" $ parseMany parseTF
 > (Just (AsList 6 [True, True, False, False, True, True]))
+
+:p runParser "1021389" $ parseMany parseDigit
+> (Just (AsList 7 [1, 0, 2, 1, 3, 8, 9]))
+
+:p runParser "1389" $ parseInt
+> (Just 1389)
+
+:p runParser "01389" $ parseInt
+> (Just 1389)
+
+:p runParser "-1389" $ parseInt
+> (Just -1389)

--- a/tests/parser-combinator-tests.dx
+++ b/tests/parser-combinator-tests.dx
@@ -1,11 +1,10 @@
 
 include "parser.dx"
 
-parseABC : Parser Unit = \h.
-  pChar 'A' h
-  pChar 'B' h
-  pChar 'C' h
-  pEOF      h
+parseABC : Parser Unit = MkParser \h.
+  parse h $ pChar 'A'
+  parse h $ pChar 'B'
+  parse h $ pChar 'C'
 
 :p runParser "AAA" parseABC
 > Nothing
@@ -19,18 +18,19 @@ parseABC : Parser Unit = \h.
 :p runParser "ABC" parseABC
 > (Just ())
 
-def parseTF : Parser Bool =
-  (\h.
-    pChar 'T' h
-    True) <|> (\h.
-      pChar 'F' h
-      False)
+def parseT : Parser Bool = MkParser \h.
+  parse h $ pChar 'T'
+  True
 
-def parserTFTriple : Parser (Fin 3=>Bool) =
-  \h.
-    ans = for i. parseTF h
-    pEOF h
-    ans
+def parseF : Parser Bool = MkParser \h.
+  parse h $ pChar 'F'
+  False
+
+def parseTF : Parser Bool =
+  parseT <|> parseF
+
+def parserTFTriple : Parser (Fin 3=>Bool) = MkParser \h.
+  for i. parse h parseTF
 
 :p runParser "TTF" parserTFTriple
 > (Just [True, True, False])
@@ -38,3 +38,5 @@ def parserTFTriple : Parser (Fin 3=>Bool) =
 :p runParser "TTFX" parserTFTriple
 > Nothing
 
+:p runParser "TTFFTT" $ parseMany parseTF
+> (Just (AsList 6 [True, True, False, False, True, True]))

--- a/tests/parser-combinator-tests.dx
+++ b/tests/parser-combinator-tests.dx
@@ -18,3 +18,23 @@ parseABC : Parser Unit = \h.
 
 :p runParser "ABC" parseABC
 > (Just ())
+
+def parseTF : Parser Bool =
+  (\h.
+    pChar 'T' h
+    True) <|> (\h.
+      pChar 'F' h
+      False)
+
+def parserTFTriple : Parser (Fin 3=>Bool) =
+  \h.
+    ans = for i. parseTF h
+    pEOF h
+    ans
+
+:p runParser "TTF" parserTFTriple
+> (Just [True, True, False])
+
+:p runParser "TTFX" parserTFTriple
+> Nothing
+

--- a/tests/parser-combinator-tests.dx
+++ b/tests/parser-combinator-tests.dx
@@ -1,0 +1,20 @@
+
+include "parser.dx"
+
+parseABC : Parser Unit = \h.
+  pChar 'A' h
+  pChar 'B' h
+  pChar 'C' h
+  pEOF      h
+
+:p runParser "AAA" parseABC
+> Nothing
+
+:p runParser "ABCABC" parseABC
+> Nothing
+
+:p runParser "AB" parseABC
+> Nothing
+
+:p runParser "ABC" parseABC
+> (Just ())


### PR DESCRIPTION
First steps towards a parser combinator library. The next step will be to see if we can parse real data formats.

Parser combinators like `<|>` operate directly on monadic values, which is a bit of a challenge for Dex. Our effects occur at function applications, following Koka. That's quite convenient for ordinary effects like reading and writing. But it means we have to simulate moandic values with nullary functions if we want to pass them around. Worse, to use the state effect we need to pass around references too, which is even more boilerplate.

Our parser is based on a combination of the state effect, for tracking the current position in the input stream, and the exception effect, for handling errors:

```
def ParserHandle (h:Type) : Type = (String & Ref h Int)

data Parser a:Type =
  MkParser (h:Type ?-> ParserHandle h -> {Except, State h} a)
```

To sequence parsers using the effect system, we have to pass around the `ParserHandle`. For example, here's the combinator for parsing bracketed terms:

```
def bracketed (left:Parser Unit) (right:Parser Unit) (body:Parser a) : Parser a =
  MkParser \h.
    _   = parse h left
    ans = parse h body
    _   = parse h right
    ans
```
In Haskell, it would just be this:

```
bracketed :: Parser () -> Parser () -> Parser a -> Parser a
bracketed left right body = do
  _   <- left
  ans <- body
  _   <- right
  return ans
```

It's probably an acceptable limitation. Parsing and other moandic trickery was never meant to be Dex's strength. At least it looks like we can do it at all!

A more serious limitation is that we need to be able to do in-place writes and copy-free reads of lists in order to have any hope of this being fast. But I'll leave that for another PR.

