### PR TITLE
*Breaking change:* new run/with/yield naming convention for effect runners.

### DIFF
--- a/examples/chol.dx
+++ b/examples/chol.dx
@@ -4,7 +4,7 @@ https://en.wikipedia.org/wiki/Cholesky_decomposition
 ' ## Cholesky Algorithm
 
 def chol (_:Eq n) ?=> (x:n=>n=>Float) : (n=>n=>Float) =
-  snd $ withState zero \buf.
+  yieldState zero \buf.
     for_ i. for j':(..i).
       j = %inject(j')
       row  = for k:(..<j). get buf!i!(%inject k)
@@ -20,13 +20,13 @@ def chol (_:Eq n) ?=> (x:n=>n=>Float) : (n=>n=>Float) =
 ' ## PSD solver based on Cholesky decomposition
 
 def trisolveL (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
-  snd $ withState zero \buf. for i.
+  yieldState zero \buf. for i.
     row   = for j:(..<i). mat.i.(%inject j)
     xPrev = for j:(..<i). get (buf!%inject j)
     buf!i := (b.i - vdot row xPrev) / mat.i.i
 
 def trisolveU (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
-  snd $ withState zero \buf. rof i.
+  yieldState zero \buf. rof i.
     row   = for j:(i..). mat.i.%inject(j)
     xPrev = for j:(i..). get (buf!%inject j)
     buf!i := (b.i - vdot row xPrev) / mat.i.i

--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -51,7 +51,7 @@ def project (_:VSpace a) ?=> (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
 
   div = -0.5 .* h .* (divergence vx vy)
 
-  p = snd $ withState zero \state.
+  p = yieldState zero \state.
     for i:(Fin 10).
       state := (1.0 / 4.0) .* (div + add_neighbours_2d (get state))
 
@@ -97,7 +97,7 @@ def advect (_:VSpace a) ?=> (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
 
 def fluidsim (_: VSpace a) ?=> (num_steps: Int) (color_init: n=>m=>a)
   (v: n=>m=>(Fin 2)=>Float) : (Fin num_steps)=>n=>m=>a =
-  fst $ withState (color_init, v) \state.
+  withState (color_init, v) \state.
     for i:(Fin num_steps).
       (color, v) = get state
       v = advect v v          -- Move velocities

--- a/examples/linear_algebra.dx
+++ b/examples/linear_algebra.dx
@@ -13,7 +13,7 @@ def lowerTriDiag (l:LowerTriMat n v) : n=>v = for i. l.i.((ordinal i)@_)
 
 def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n Float) (b:n=>v) : n=>v =
   -- Solves lower triangular linear system (inverse a) **. b
-  snd $ withState zero \sRef.
+  yieldState zero \sRef.
     for i:n.
       s = sum for k:(..<i).  -- dot product
         a.i.((ordinal k)@_) .* get sRef!(%inject k)
@@ -21,7 +21,7 @@ def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n Float) (b:n=>v) : n=>v 
 
 def backward_substitute (_:VSpace v) ?=> (a:UpperTriMat n Float) (b:n=>v) : n=>v =
   -- Solves upper triangular linear system (inverse a) **. b
-  snd $ withState zero \sRef.
+  yieldState zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
         a.i.((ordinal k)@_) .* get sRef!(%inject k)
@@ -63,7 +63,7 @@ def permSign   ((_, sign):Permutation n) : PermutationSign = sign
 
 def pivotize (_:Eq n) ?=> (a:n=>n=>Float) : Permutation n =
   -- Gives a row permutation that makes Gaussian elimination more stable.
-  snd $ withState identity_permutation \permRef.
+  yieldState identity_permutation \permRef.
     for j:n.
       row_with_largest' = argmin for i:(j..). (-(abs a.(%inject i).j))
       row_with_largest = %inject row_with_largest'
@@ -82,7 +82,7 @@ def lu (_:Eq n) ?=> (a: n=>n=>Float) :
     select (i == (%inject j')) 1.0 0.0
   init_upper = for i:n. for j'':(i..). 0.0
 
-  (lower, upper) = snd $ withState (init_lower, init_upper) \stateRef.
+  (lower, upper) = yieldState (init_lower, init_upper) \stateRef.
     lRef = fstRef stateRef
     uRef = sndRef stateRef
 

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -13,7 +13,7 @@ def runChain
       (k:Key)
       : Fin numSamples => a =
   [k1, k2] = splitKey k
-  fst $ withState (initialize k1) \s.
+  withState (initialize k1) \s.
     for i:(Fin numSamples).
       x = step (ixkey k2 i) (get s)
       s := x

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -67,10 +67,10 @@ c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
 def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
     (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
 
-  evals_init = snd $ withState zero \r.
+  evals_init = yieldState zero \r.
     r!(0@_) := f0
 
-  evals_filled = snd $ withState evals_init \func_evals. for i:(Fin 6).
+  evals_filled = yieldState evals_init \func_evals. for i:(Fin 6).
     cur_evals = for j:(..i). get func_evals!((ordinal j)@_)
     ti = t0 + dt .* alpha.i
     zi = z0 + dt .* dot beta.i cur_evals
@@ -134,7 +134,7 @@ def odeint (func: d=>Float -> Time -> d=>Float)
       select (ratio <= 1.0) move_state stay_state
 
     -- Take steps until we pass target_t
-    new_state = snd $ withState init_carry \stateRef.
+    new_state = yieldState init_carry \stateRef.
       iter \_.
         state = get stateRef
         if continue_condition state

--- a/examples/particle-filter.dx
+++ b/examples/particle-filter.dx
@@ -15,7 +15,7 @@ def simulate (model: Model s v) (t: Int) (key: Key) : Fin t=>(s & v) =
   (init, dynamics, observe) = model
   [key, subkey] = splitKey key
   s0 = sample init subkey
-  fst $ withState s0 \s_ref .
+  withState s0 \s_ref .
     for i.
       [k1, k2] = splitKey (ixkey key i)
       s = get s_ref
@@ -34,7 +34,7 @@ def filter
   (init, dynamics, observe) = model
   [key, init_key] = splitKey key
   init_particles = for i: (Fin num_particles). sample init (ixkey init_key i)
-  fst $ withState init_particles \p_ref .
+  withState init_particles \p_ref .
     for t: (Fin num_timesteps).
       p_prev = get p_ref
       logLikelihoods = for i. snd (observe p_prev.i) obs.t

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -25,7 +25,7 @@ def randuniform (lower:Float) (upper:Float) (k:Key) : Float =
   lower + (rand k) * (upper - lower)
 
 def sampleAveraged (_:VSpace a) ?=> (sample:Key -> a) (n:Int) (k:Key) : a =
-  snd $ withState zero \total.
+  yieldState zero \total.
     for i:(Fin n).
       total := get total + sample (ixkey k i) / IToF n
 
@@ -174,7 +174,7 @@ def raymarch (scene:Scene n) (ray:Ray) : RayMarchResult =
   tol = 0.01
   startLength = 10.0 * tol  -- trying to escape the current surface
   (rayOrigin, rayDir) = ray
-  fst $ withState (10.0 * tol) \rayLength.
+  withState (10.0 * tol) \rayLength.
     boundedIter maxIters HitNothing \_.
       rayPos = rayOrigin + get rayLength .* rayDir
       (obj, d) = sdScene scene $ rayPos
@@ -212,7 +212,7 @@ def sampleLightRadiance
   (surfNor, surf) = osurf
   (rayPos, _) = inRay
   (MkScene objs) = scene
-  snd $ withAccum \radiance.
+  yieldAccum \radiance.
     for i. case objs.i of
       PassiveObject _ _ -> ()
       Light lightPos hw _ ->
@@ -227,9 +227,9 @@ def sampleLightRadiance
 
 def trace (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
   noFilter = [1.0, 1.0, 1.0]
-  snd $ withAccum \radiance.
-    withState  noFilter \filter.
-     withState initRay  \ray.
+  yieldAccum \radiance.
+    runState  noFilter \filter.
+     runState initRay  \ray.
       boundedIter (getAt #maxBounces params) () \i.
         case raymarch scene $ get ray of
           HitNothing -> Done ()

--- a/examples/sgd.dx
+++ b/examples/sgd.dx
@@ -10,7 +10,7 @@ def sgd_step (dict: VSpace a) ?=> (step_size: Float) (decay: Float) (gradfunc: a
 -- In-place optimization loop.
 def sgd (dict: VSpace a) ?=> (step_size:Float) (decay:Float) (num_steps:Int) (gradient: a -> Int -> a) (x0: a) : a =
   m0 = zero
-  (x_final, m_final) = snd $ withState (x0, m0) \state.
+  (x_final, m_final) = yieldState (x0, m0) \state.
     for i:(Fin num_steps).
       (x, m) = get state
       state := sgd_step step_size decay gradient x m (ordinal i)

--- a/examples/tiled-matmul.dx
+++ b/examples/tiled-matmul.dx
@@ -16,7 +16,7 @@ def matmul (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
   vectorTile = Fin VectorWidth
   colTile = (colVectors & vectorTile)
   (tile2d (\nt:(Tile n rowTile). \mt:(Tile m colTile).
-             ct = snd $ withAccum \acc.
+             ct = yieldAccum \acc.
                for l:k.
                  for i:rowTile.
                    ail = broadcastVector a.(nt +> i).l

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -30,7 +30,7 @@ def parse (handle:ParserHandle h) (parser:Parser a) : {Except, State h} a =
 
 def runParserPartial (s:String) (parser:Parser a) : Maybe a =
   (MkParser f) = parser
-  fst $ withState 0 \pos.
+  withState 0 \pos.
     catch $ do
       f (s, pos)
 
@@ -91,7 +91,7 @@ def optional (p:Parser a) : Parser (Maybe a) =
   (MkParser \h. Just (parse h p)) <|> return Nothing
 
 def parseMany (parser:Parser a) : Parser (List a) = MkParser \h.
-  snd $ withState (AsList _ []) \results.
+  yieldState (AsList _ []) \results.
     iter \_.
       maybeVal = parse h $ optional parser
       case maybeVal of
@@ -102,9 +102,8 @@ def parseMany (parser:Parser a) : Parser (List a) = MkParser \h.
 
 def parseUnsignedInt : Parser Int = MkParser \h.
   (AsList _ digits) = parse h $ parseMany parseDigit
-  snd $ withState 0 \ref.
-    for i.
-      ref := 10 * get ref + digits.i
+  yieldState 0 \ref.
+    for i. ref := 10 * get ref + digits.i
 
 def parseInt : Parser Int = MkParser \h.
   negSign = parse h $ optional $ pChar '-'

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -229,27 +229,53 @@ def (!)  (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
 def fstRef (ref: Ref h (a & b)) : Ref h a = %fstRef ref
 def sndRef (ref: Ref h (a & b)) : Ref h b = %sndRef ref
 
-def withReader
-      (eff:Effects) ?-> (a:Type) ?-> (r:Type) ?->
-      (init:r) (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
+def runReader
+      (eff:Effects) ?->
+      (init:r)
+      (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
     def explicitAction (h':Type) (ref:Ref h' r) : {Read h'|eff} a = action ref
     %runReader init explicitAction
 
-def withAccum
-      (eff:Effects) ?-> (a:Type) ?-> (w:Type) ?->
+def withReader
+      (eff:Effects) ?->
+      (init:r)
+      (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
+      : {|eff} a =
+    runReader init action
+
+def runAccum
+      (eff:Effects) ?->
       (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
       : {|eff} (a & w) =
     def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a = action ref
     %runWriter explicitAction
 
-def withState
-      (eff:Effects) ?-> (a:Type) ?-> (s:Type) ?->
+def yieldAccum
+      (eff:Effects) ?->
+      (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
+      : {|eff} w =
+  snd $ runAccum action
+
+def runState
+      (eff:Effects) ?->
       (init:s)
-      (action: (h:Type ?-> Ref h s -> {State h |eff} a))
+      (action: h:Type ?-> Ref h s -> {State h |eff} a)
       : {|eff} (a & s) =
-    def explicitAction (h':Type) (ref:Ref h' s) : {State h'|eff} a = action ref
-    %runState init explicitAction
+  def explicitAction (h':Type) (ref:Ref h' s) : {State h'|eff} a = action ref
+  %runState init explicitAction
+
+def withState
+      (eff:Effects) ?->
+      (init:s)
+      (action: h:Type ?-> Ref h s -> {State h |eff} a)
+      : {|eff} a = fst $ runState init action
+
+def yieldState
+      (eff:Effects) ?->
+      (init:s)
+      (action: h:Type ?-> Ref h s -> {State h |eff} a)
+      : {|eff} s = snd $ runState init action
 
 def unsafeIO (f: Unit -> {State World|eff} a) : {|eff} a =
   %runIO f
@@ -310,7 +336,7 @@ def pairOrd (ordA: Ord a)?=> (ordB: Ord b)?=> : Ord (a & b) =
 def tabEq (n:Type) ?-> (eqA: Eq a) ?=> : Eq (n=>a) = MkEq $
   \xs ys.
     numDifferent : Float =
-      snd $ withAccum \ref. for i.
+      yieldAccum \ref. for i.
         ref += (IToF (BToI (xs.i /= ys.i)))
     numDifferent == 0.0
 
@@ -539,7 +565,7 @@ def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
 def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
 def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
-  swap $ withState init \s. for i.
+  swap $ runState init \s. for i.
     c = get s
     (c', y) = body i c
     s := c'
@@ -555,7 +581,7 @@ def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
-def fsum (xs:n=>Float) : Float = snd $ withAccum \ref. for i. ref += xs i
+def fsum (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs i
 def sum  (_: Add v) ?=> (xs:n=>v) : v = reduce zero (+) xs
 def prod (_: Mul v) ?=> (xs:n=>v) : v = reduce one  (*) xs
 def mean (n:Type) ?-> (xs:n=>Float) : Float = sum xs / IToF (size n)
@@ -564,7 +590,7 @@ def any (xs:n=>Bool) : Bool = reduce False (||) xs
 def all (xs:n=>Bool) : Bool = reduce True  (&&) xs
 
 def applyN (n:Int) (x:a) (f:a -> a) : a =
-  snd $ withState x \ref. for _:(Fin n).
+  yieldState x \ref. for _:(Fin n).
     ref := f (get ref)
 
 def linspace (n:Type) (low:Float) (high:Float) : n=>Float =
@@ -623,7 +649,7 @@ def randnVec (n:Type) ?-> (k:Key) : n=>Float =
   for i. randn (ixkey k i)
 
 def cumSum (xs: n=>Float) : n=>Float =
-  fst $ withState 0.0 \total.
+  withState 0.0 \total.
     for i.
       newTotal = get total + xs.i
       total := newTotal
@@ -1047,7 +1073,7 @@ def liftState (ref: Ref h c) (f:a -> {|eff} b) (x:a) : {State h|eff} b =
 
 -- A little iteration combinator
 def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
-  result = snd $ withState Nothing \resultRef. withState 0 \i.
+  result = yieldState Nothing \resultRef. withState 0 \i.
     while do
       continue = isNothing $ get resultRef
       if continue
@@ -1063,7 +1089,7 @@ def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
 
 -- XXX: used internally by compiler for exceptional while
 def whileMaybe (eff:Effects) -> (body: Unit -> {|eff} (Maybe Word8)) : {|eff} Maybe Unit =
-  hadError = snd $ withState False \ref.
+  hadError = yieldState False \ref.
     while do
       ans = liftState ref body ()
       case ans of
@@ -1233,7 +1259,7 @@ def searchSorted (_:Ord a) ?=> (xs:n=>a) (x:a) : Maybe n =
     then Nothing
     else if x < xs.(fromOrdinal _ 0)
       then Nothing
-      else fst $ withState 0 \low. fst $ withState (size n) \high. iter \_.
+      else withState 0 \low. withState (size n) \high. iter \_.
         numLeft = get high - get low
         if numLeft == 1
           then Done $ Just $ fromOrdinal _ $ get low
@@ -1466,7 +1492,7 @@ def seqMaybes (n:Type) ?-> (a:Type) ?-> (xs : n=>Maybe a) : Maybe (n => a) =
     False -> Just $ map fromJust xs
 
 def linearSearch (_:Eq a) ?=> (xs:n=>a) (query:a) : Maybe n =
-  snd $ withState Nothing \ref. for i.
+  yieldState Nothing \ref. for i.
     case xs.i == query of
       True  -> ref := Just i
       False -> ()
@@ -1477,8 +1503,8 @@ def listLength ((AsList n _):List a) : Int = n
 -- TODO: we want this for any monoid but this implementation won't work.
 def concat (lists:n=>(List a)) : List a =
   totalSize = sum for i. listLength lists.i
-  AsList _ $ fst $ withState 0 \listIdx.
-    fst $ withState 0 \eltIdx.
+  AsList _ $ withState 0 \listIdx.
+    withState 0 \eltIdx.
       for i:(Fin totalSize).
         while do
           continue = get eltIdx >= listLength (lists.((get listIdx)@_))
@@ -1494,7 +1520,7 @@ def concat (lists:n=>(List a)) : List a =
         xs.(eltIdxVal@_)
 
 def cumSumLow (xs: n=>Float) : n=>Float =
-  fst $ withState 0.0 \total.
+  withState 0.0 \total.
     for i.
       oldTotal = get total
       total := oldTotal + xs.i

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -1,6 +1,6 @@
 
 -- TODO: use prelude sum instead once we can differentiate state effect
-def sum'  (xs:n=>Float) : Float = snd $ withAccum \ref. for i. ref += xs.i
+def sum'  (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs.i
 
 :p
    f : Float -> Float = \x. x
@@ -69,7 +69,7 @@ def sum'  (xs:n=>Float) : Float = snd $ withAccum \ref. for i. ref += xs.i
 :p jvp sum' [1., 2.] [10.0, 20.0]
 > 30.
 
-f : Float -> Float = \x. snd $ withAccum \ref. ref += x
+f : Float -> Float = \x. yieldAccum \ref. ref += x
 :p jvp f 1.0 1.0
 > 1.
 
@@ -167,7 +167,7 @@ tripleit : Float --o Float = \x. x + x + x
 > [2., 4.]
 
 myOtherSquare : Float -> Float =
-  \x. snd $ withAccum \w. w += x * x
+  \x. yieldAccum \w. w += x * x
 
 :p checkDeriv myOtherSquare 3.0
 > True
@@ -225,7 +225,7 @@ vec = [1.]
 :p
   f : Float -> Float = \x.
     y = x * 2.0
-    snd $ withAccum \a.
+    yieldAccum \a.
       a += x * 2.0
       a += y
   grad f 1.0
@@ -242,7 +242,7 @@ vec = [1.]
 
 :p
   f : Float -> Float = \x.
-    snd $ withState x \xr.
+    yieldState x \xr.
       for i:(Fin 2).
         xr := get xr * get xr
   checkDeriv f 2.0
@@ -297,7 +297,7 @@ vec = [1.]
 :p
   f = \c.
     v = for i:(Fin 2). 2.0
-    (c, v) = snd $ withState (c, v) \r. for i:(Fin 2).
+    (c, v) = yieldState (c, v) \r. for i:(Fin 2).
       (c, v) = get r
       r := (c + sum v, v)
     c

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -102,7 +102,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 > Runtime error
 
 :p
-  snd $ withAccum \ref.
+  yieldAccum \ref.
     for i. case myTab.i of
       MyLeft tmp -> ()
       MyRight val -> ref += 1.0 + val
@@ -110,7 +110,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 
 :p
   -- check that the order of the case alternatives doesn't matter
-  snd $ withAccum \ref.
+  yieldAccum \ref.
     for i. case myTab.i of
       MyRight val -> ref += 1.0 + val
       MyLeft tmp -> ()
@@ -128,7 +128,7 @@ threeCaseTab : (Fin 4)=>ThreeCases =
 > [(TheIntCase 3), TheEmptyCase, (ThePairCase 2 0.1), TheEmptyCase]
 
 :p
-  snd $ withAccum \ref.
+  yieldAccum \ref.
     for i. case threeCaseTab.i of
       TheEmptyCase    -> ref += 1000.0
       ThePairCase x y -> ref +=  100.0 + y + IToF x
@@ -250,7 +250,7 @@ data Graph a:Type =
 
 def graphToAdjacencyMatrix ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
   init = for i j. False
-  snd $ withState init \mRef.
+  yieldState init \mRef.
     for i:m.
       (from, to) = edges.i
       mRef!from!to := True

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -502,14 +502,14 @@ litArr = [10, 5, 3]
 -- > [2.0, 2.0, 2.0]
 
 :p
-  withState 0.0 \ref. for i:(Fin 4).
+  runState 0.0 \ref. for i:(Fin 4).
       c = get ref
       ref := c + 1.0
       c
 > ([0., 1., 2., 3.], 4.)
 
 :p
-  withState 0.0 \ref. rof i:(Fin 4).
+  runState 0.0 \ref. rof i:(Fin 4).
       c = get ref
       ref := c + 1.0
       c
@@ -646,7 +646,7 @@ def newtonIter (f: Float -> Float) (x:Float) : Float =
   x - (f x / deriv f x)
 
 def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
-  snd $ withState x0 \x.
+  yieldState x0 \x.
     iter \i.
       if abs (f $ get x) <= tol
         then Done ()
@@ -661,7 +661,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 --   x = for i:(Fin 3). for j:(Fin 200). 1.0
 --   -- Last dimension split to allow for vector loads
 --   y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). IToF $ (iota _).(i,j,h)
---   z = snd $ withAccum \acc.
+--   z = yieldAccum \acc.
 --         for l.
 --           for i.
 --             xil = (broadcastVector x.i.l)
@@ -689,7 +689,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 > [0, 2, 4, 6]
 
 :p
-  f = fst $ withState 1 \ref.
+  f = withState 1 \ref.
     x = get ref
     ref := 3 + x
     y = get ref
@@ -698,7 +698,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 > 415
 
 :p
-  (f, w) = withAccum \ref.
+  (f, w) = runAccum \ref.
     ref += 2.0
     w = 2
     \z. z + w
@@ -717,7 +717,7 @@ arr2d.(1@_)
 > [2, 3]
 
 :p
-  withState (1,2) \ref.
+  runState (1,2) \ref.
     r1 = fstRef ref
     r2 = sndRef ref
     x = get r1

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -20,7 +20,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 :p catch do checkFloatInUnitInterval 0.2
 > (Just 0.2)
 
-:p snd $ withState 0 \ref.
+:p yieldState 0 \ref.
      catch do
        ref := 1
        assert False
@@ -42,7 +42,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 > (Just [23, 23, 23])
 
 -- Is this the result we want?
-:p snd $ withState zero \ref.
+:p yieldState zero \ref.
      catch do
        for i:(Fin 6).
          if (ordinal i `rem` 2) == 0
@@ -52,7 +52,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 > [0, 1, 0, 1, 0, 1]
 
 :p catch do
-     withState 0 \ref.
+     runState 0 \ref.
        ref := 1
        assert False
        ref := 2

--- a/tests/gpu-tests.dx
+++ b/tests/gpu-tests.dx
@@ -27,7 +27,7 @@ testNestedLoops.(4@_).(5@_)
 -- single GPU thread. It should get lifted to a top-level allocation instead.
 allocationLiftingTest =
   for i:(Fin 100).
-    snd $ withState (for j:(Fin 1000). ordinal i) $ \s.
+    yieldState (for j:(Fin 1000). ordinal i) $ \s.
       s!(0@_) := get s!(0@_) + 1
 (allocationLiftingTest.(4@_).(0@_), allocationLiftingTest.(4@_).(1@_))
 > (5, 4)

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -1,12 +1,12 @@
 
 :p
    def m (h:Type) ?-> (ref:Ref h Int) : {State h} Int = get ref
-   withState 2 m
+   runState 2 m
 > (2, 2)
 
 :p
    def m (h:Type) ?-> (ref:Ref h Int) : {State h} Unit = ref := 3
-   withState 0 m
+   runState 0 m
 > ((), 3)
 
 :p
@@ -21,7 +21,7 @@
      z = get ref
      ref := (z * 3.0)
 
-  withState 1.0 stateAction
+  runState 1.0 stateAction
 > ((), 9.)
 
 :p
@@ -37,8 +37,8 @@
     r + 2
 
   withReader 2 \r.
-    withState True \s.
-      withAccum \w.
+    runState True \s.
+      runAccum \w.
         rwsAction r w s
 > ((4, 6.), False)
 
@@ -48,7 +48,7 @@
      s!(fromOrdinal _ 2) := 20
      x = get (s!(fromOrdinal _ 0))
      s!(fromOrdinal _ 1) := x
-   withState [0,0,0] m
+   runState [0,0,0] m
 > ((), [10, 10, 20])
 
 :p withReader [1,2,3] \r . ask r!(fromOrdinal _ 1)
@@ -60,7 +60,7 @@
         : {Accum wh, State sh} Unit =
     x = get s
     w += x
-  withState 1.0 \s. withAccum \w . m w s
+  runState 1.0 \s. runAccum \w . m w s
 > (((), 1.), 1.)
 
 def myAction  (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
@@ -68,7 +68,7 @@ def myAction  (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
   w += x
   w += 2.0
 
-:p withReader 1.5 \r. withAccum \w. myAction w r
+:p withReader 1.5 \r. runAccum \w. myAction w r
 > ((), 3.5)
 
 :p
@@ -78,14 +78,14 @@ def myAction  (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
     w1 += 1.0
     w2 += 3.0
     w1 += 1.0
-  withAccum \w1. withAccum \w2. m w1 w2
+  runAccum \w1. runAccum \w2. m w1 w2
 > (((), 3.), 2.)
 
 def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
   s!(fromOrdinal _ 0) := 1
   s!(fromOrdinal _ 2) := 2
 
-:p withState [0,0,0] foom
+:p runState [0,0,0] foom
 > ((), [1, 0, 2])
 
 -- TODO: handle effects returning functions
@@ -102,7 +102,7 @@ def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 -- :p
 --   foo : Float -> (Float, Float)
 --   foo x =
---      (f, ans) = withState x \s.
+--      (f, ans) = runState x \s.
 --          y = get s
 --          \z. 100.0 * x + 10.0 * y + z
 --      (f 1.0, ans)
@@ -113,7 +113,7 @@ def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 -- :p
 --   foo : Float -> (Float, Float)
 --   foo x =
---      (f, ans) = withAccumulator \s.
+--      (f, ans) = runAccumulator \s.
 --         s += x
 --         \y. 10.0 * x + y
 --      (f 1.0, ans)
@@ -121,13 +121,13 @@ def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 --   foo 3.0
 -- > (31.0, 3.0)
 
--- TODO: some way to explicitly give type to `withAccum`
+-- TODO: some way to explicitly give type to `runAccum`
 --       (maybe just explicit implicit args)
 :p
   withReader 2.0 \r.
-    withAccum \w.
-      withAccum \w'.
-        withState 3 \s.
+    runAccum \w.
+      runAccum \w'.
+        runState 3 \s.
           x = ask r
           y = get s
           w += x
@@ -137,7 +137,7 @@ def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 > ((((2., 3), 4), 4.), 2.)
 
 def symmetrizeInPlace (mat:n=>n=>Float) : n=>n=>Float =
-  snd $ withState mat \ref.
+  yieldState mat \ref.
     for i j.
        x = get ref!i!j
        y = get ref!j!i
@@ -151,19 +151,19 @@ symmetrizeInPlace [[1.,2.],[3.,4.]]
 :p withReader 5 \r. ()
 > ()
 
-:p snd $ withAccum \w.
+:p yieldAccum \w.
   for i:(Fin 2).
     w += 1.0
     w += 1.0
 > 4.
 
-:p snd $ withAccum \w.
+:p yieldAccum \w.
   for i:(Fin 2).
     w += 1.0
   w += 1.0
 > 3.
 
-:p snd $ withAccum \ref.
+:p yieldAccum \ref.
      ref += [1.,2.,3.]
      ref += [2.,4.,5.]
 > [3., 6., 8.]
@@ -172,5 +172,5 @@ def effectsAtZero (eff:Effects)?-> (f: Int ->{|eff} Unit) : {|eff} Unit =
   f 0
   ()
 
-:p withState 0 \ref. effectsAtZero \_. ref := 1
+:p runState 0 \ref. effectsAtZero \_. ref := 1
 > ((), 1)

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -94,7 +94,7 @@ lam4 = \n m ?-> (0@n, 0@m)
 > [1, 0, 0]
 
 :p
-  withState 5 \ref.
+  runState 5 \ref.
     n = get ref
     for_ i:(Fin n).
       ref := get ref + 1

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -100,13 +100,13 @@ myPair = (1, 2.3)
 > 1
 
 :p
-   snd $ withState 2 \s.
+   yieldState 2 \s.
      x = get s
      s := x + 3
 > 5
 
 :p
-   snd $ withState 1 \s.
+   yieldState 1 \s.
      for i:(Fin 10).
        x = get s
        s := x + x
@@ -178,7 +178,7 @@ myPair = (1, 2.3)
 >    ^^^
 
 :p
-  snd $ withState [1,2,3] \xsRef.
+  yieldState [1,2,3] \xsRef.
     for i:(Fin 3).
       xsRef!i := ordinal i
 > [0, 1, 2]
@@ -186,13 +186,13 @@ myPair = (1, 2.3)
 def passthrough (eff:Effects) ?-> (f:(a -> {|eff} b)) (x:a) : {|eff} b = f x
 
 :p
-  snd $ withState 1 \ref.
+  yieldState 1 \ref.
     passthrough (\(). ref := 10) ()
 > 10
 
 :p
-  withState 0 \r1.
-    withState 0 \r2.
+  runState 0 \r1.
+    runState 0 \r2.
       r1 := 1
       r2 := 2
 > (((), 2), 1)


### PR DESCRIPTION
I still find it hard to remember whether to write `snd $ withState ...` or
`fst $ withState` when I'm interested in the final state instead of the result
of the body. Haskell's MTL convention is `run`/`eval`/`exec` for returning
everything/result/state but I've never found that easy to remember. This change
implements the following convention.

  * `run*`    runs the effect in the most general way". For `State`, that means
          that you get back both the result of the body and the final state

  * `with*`  only returns the result of the body. This convention can go beyond
          effects, and include things like `withFile`. If you use something
          whose name starts with `with`, you can be sure that the result of the
          whole `with*` expression is the same as the result of the body.

  * `yield*`  only gives the final state or accumulation.