### PR TITLE
Make the `else` clause of `if..then..else` optional.

### DIFF
--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -218,7 +218,7 @@ def sampleLightRadiance
       Light lightPos hw _ ->
         (dirToLight, distToLight) = directionAndLength $
                                       lightPos + sampleSquare hw k - rayPos
-        when (positiveProjection dirToLight surfNor) do
+        if positiveProjection dirToLight surfNor then
           -- light on this far side of current surface
           fracSolidAngle = (relu $ dot dirToLight yHat) * sq hw / (pi * sq distToLight)
           outRay = (rayPos, dirToLight)
@@ -234,7 +234,7 @@ def trace (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
         case raymarch scene $ get ray of
           HitNothing -> Done ()
           HitLight intensity ->
-            when (i == 0) do radiance += intensity   -- TODO: scale etc
+            if i == 0 then radiance += intensity   -- TODO: scale etc
             Done ()
           HitObj incidentRay osurf ->
             [k1, k2] = splitKey $ hash k i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -911,14 +911,12 @@ def maybeIncreaseBufferSize (_:Storable a) ?=>
   (MkDynBuffer dbPtr) = buf
   (size, maxSize, bufPtr) = load dbPtr
   newSize = sizeDelta + size
-  if newSize > maxSize
-    then
-      -- TODO: maybe this should use integer arithmetic?
-      newMaxSize = FToI $ pow 2.0 (ceil $ log2 $ IToF newSize)
-      newBufPtr = malloc newMaxSize
-      memcpy newBufPtr bufPtr size
-      store dbPtr (size, newMaxSize, newBufPtr)
-    else ()
+  if newSize > maxSize then
+    -- TODO: maybe this should use integer arithmetic?
+    newMaxSize = FToI $ pow 2.0 (ceil $ log2 $ IToF newSize)
+    newBufPtr = malloc newMaxSize
+    memcpy newBufPtr bufPtr size
+    store dbPtr (size, newMaxSize, newBufPtr)
 
 def extendDynBuffer (_:Storable a) ?=>
     (buf: DynBuffer a) (new:List a) : {State World} Unit =
@@ -1062,11 +1060,6 @@ data IterResult a:Type =
   Continue
   Done a
 
-def when (cond:Bool) (f:Unit -> {|eff} Unit) : {|eff} Unit =
-  if cond
-    then f ()
-    else ()
-
 -- TODO: can we improve effect inference so we don't need this?
 def liftState (ref: Ref h c) (f:a -> {|eff} b) (x:a) : {State h|eff} b =
   f x
@@ -1076,11 +1069,10 @@ def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
   result = yieldState Nothing \resultRef. withState 0 \i.
     while do
       continue = isNothing $ get resultRef
-      if continue
-        then case liftState resultRef (liftState i body) (get i) of
+      if continue then
+        case liftState resultRef (liftState i body) (get i) of
           Continue -> i := get i + 1
           Done result -> resultRef := Just result
-        else ()
       continue
 
   case result of
@@ -1578,6 +1570,4 @@ def throw (_:Unit) : {Except} a =
   %throwException a
 
 def assert (b:Bool) : {Except} Unit =
-  if b
-   then ()
-   else throw ()
+  if not b then throw ()

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -111,3 +111,20 @@ def myInt : {State h} Int = 1
 > 107 | def myInt : {State h} Int = 1
 >     |                           ^
 > Nullary def can't have effects
+
+:p
+  yieldAccum \ref.
+    x = if True then 1. else 3.
+    if True then ref += x
+
+    if True then
+      ref += 1.
+      ref += 2.
+
+    if False then ref += 100. else
+      ref += 1.
+      ref += 2.
+
+    if True
+      then ref += 2.
+> 9.


### PR DESCRIPTION
If the `else` clause is absent it parses as a trivial `else` clause, `()`.
This is convenient for conditionally executing an effect.

Also allow `if..then..else` on a single line.