### PR TITLE
Add completions to REPL

### DIFF
--- a/src/dex.hs
+++ b/src/dex.hs
@@ -17,7 +17,6 @@ import System.Exit
 import System.Directory
 import Data.List
 import Data.Text.Prettyprint.Doc
-import Debug.Trace
 
 import Syntax
 import PPrint

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -39,7 +39,7 @@ data EvalMode = ReplMode String
 data CmdOpts = CmdOpts EvalMode (Maybe FilePath) EvalConfig
 
 
-keywordList = ["def", "for", "rof", "case", "data", "where", "of", "if", "then", "else", "interface", "instance", "do", "view"]
+keywordList = ["def", "for", "rof", "case", "data", "where", "of", "if", "then", "else", "interface", "instance", "do", "view", "%bench \"", ":p", ":t", ":html", ":export"]
 filterKeywords :: String -> [Completion]
 filterKeywords str = map simpleCompletion $ filter (str `isPrefixOf`) keywordList
 

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -91,10 +91,11 @@ dexCompletions (line, _) = do
   let varNames = map pprint $ envNames env
   -- note: line and thus word and rest have character order reversed
   let (word, rest) = break (== ' ') line
-  let anywhereKeywords = ["def", "for", "rof", "case", "data", "where", "of", "if", "then", "else", "interface", "instance", "do", "view"]
+  let anywhereKeywords = ["def", "for", "rof", "case", "data", "where", "of", "if",
+                          "then", "else", "interface", "instance", "do", "view"]
   let startoflineKeywords = ["%bench \"", ":p", ":t", ":html", ":export"]
-  let candidates = varNames ++ anywhereKeywords ++
-                   if null rest then startoflineKeywords else []
+  let candidates = (if null rest then startoflineKeywords else []) ++
+                   anywhereKeywords ++ varNames
   let completions = map simpleCompletion $ filter ((reverse word) `isPrefixOf`) candidates
   return (rest, completions)
 


### PR DESCRIPTION
This adds completions to the REPL, both of language keywords and of currently defined top level names;
as well as restricting filename completions to only happen within a quoted string.

Shown is me pressing tab at the end of each line.

<img width="854" alt="image" src="https://user-images.githubusercontent.com/5127634/103482846-19258d00-4ddb-11eb-8073-74f4479b73d3.png">


<s>
A follow up PR would add globally inscope variables to this.
I think it would not be too hard, though I don't think I will work out out anytime soon.
There is discussion in [this Reddit thread](https://www.reddit.com/r/haskell/comments/1os0yq/haskeline_woes/) about how to dynamically update the list of completions for Haskline

It also would be good to add other things like `:p` and `:html` filtered to only be allowed occur at line start
</s>