### PR TITLE
Improve type class syntax

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -61,7 +61,8 @@ library
   cxx-sources:         src/lib/dexrt.cpp
   cxx-options:         -std=c++11 -fPIC
   default-extensions:  CPP, DeriveTraversable, TypeApplications, OverloadedStrings,
-                       TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms
+                       TupleSections, ScopedTypeVariables, LambdaCase, PatternSynonyms,
+                       BlockArguments
   pkgconfig-depends:   libpng
   if flag(cuda)
     include-dirs:      /usr/local/cuda/include
@@ -82,7 +83,7 @@ executable dex
     build-depends:     dex-resources
   default-language:    Haskell2010
   hs-source-dirs:      src
-  default-extensions:  CPP, LambdaCase
+  default-extensions:  CPP, LambdaCase, BlockArguments
   ghc-options:         -threaded
   if flag(optimized)
     ghc-options:       -O3
@@ -101,7 +102,8 @@ foreign-library Dex
   cc-options:          -std=c11 -fPIC
   ghc-options:         -Wall -fPIC -optP-Wno-nonportable-include-path
   default-language:    Haskell2010
-  default-extensions:  TypeApplications, ScopedTypeVariables, LambdaCase
+  default-extensions:  TypeApplications, ScopedTypeVariables, LambdaCase,
+                       BlockArguments
   if flag(optimized)
     ghc-options:       -O3
   else

--- a/examples/chol.dx
+++ b/examples/chol.dx
@@ -3,7 +3,7 @@ https://en.wikipedia.org/wiki/Cholesky_decomposition
 
 ' ## Cholesky Algorithm
 
-def chol (_:Eq n) ?=> (x:n=>n=>Float) : (n=>n=>Float) =
+def chol [Eq n] (x:n=>n=>Float) : (n=>n=>Float) =
   yieldState zero \buf.
     for_ i. for j':(..i).
       j = %inject(j')
@@ -31,7 +31,7 @@ def trisolveU (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
     xPrev = for j:(i..). get (buf!%inject j)
     buf!i := (b.i - vdot row xPrev) / mat.i.i
 
-def psdsolve (_:Eq n) ?=> (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
+def psdsolve [Eq n] (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
   l = chol mat
   trisolveU (transpose l) $  trisolveL l b
 

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -48,8 +48,11 @@ def logaddexp (x:Float) (y:Float) : Float =
   m = max x y
   m + ( log ( (exp (x - m) + exp (y - m))))
 
-def ctc (dict: Eq vocab) ?=> (dict2: Eq position) ?=> (dict3: Eq time) ?=> (blank: vocab)
-        (logits: time=>vocab=>Float) (labels: position=>vocab) : Float =
+def ctc [Eq vocab, Eq position, Eq time]
+        (blank:  vocab)
+        (logits: time=>vocab=>Float)
+        (labels: position=>vocab)
+        : Float =
   -- Computes log p(labels | logits), marginalizing over possible alignments.
   -- Todo: remove unnecessary implicit type annotations once
   -- Dex starts putting implicit types in scope.

--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -14,10 +14,10 @@ def incwrap (i:n) : n =  -- Increment index, wrapping around at ends.
 def decwrap (i:n) : n =  -- Decrement index, wrapping around at ends.
   asidx $ mod ((ordinal i) - 1) $ size n
 
-def finite_difference_neighbours (_:Add a) ?=> (x:n=>a) : n=>a =
+def finite_difference_neighbours [Add a] (x:n=>a) : n=>a =
   for i. x.(incwrap i) - x.(decwrap i)
 
-def add_neighbours (_:Add a) ?=> (x:n=>a) : n=>a =
+def add_neighbours [Add a] (x:n=>a) : n=>a =
   for i. x.(incwrap i) + x.(decwrap i)
 
 def apply_along_axis1 (f:b=>a -> b=>a) (x:b=>c=>a) : b=>c=>a =
@@ -26,21 +26,21 @@ def apply_along_axis1 (f:b=>a -> b=>a) (x:b=>c=>a) : b=>c=>a =
 def apply_along_axis2 (f:c=>a -> c=>a) (x:b=>c=>a) : b=>c=>a =
   for i. f x.i
 
-def fdx (_:Add a) ?=> (x:n=>m=>a) : (n=>m=>a) =
+def fdx [Add a] (x:n=>m=>a) : (n=>m=>a) =
   apply_along_axis1 finite_difference_neighbours x
 
-def fdy (_:Add a) ?=> (x:n=>m=>a) : (n=>m=>a) =
+def fdy [Add a] (x:n=>m=>a) : (n=>m=>a) =
   apply_along_axis2 finite_difference_neighbours x
 
-def divergence (_:Add a) ?=> (vx:n=>m=>a) (vy:n=>m=>a) : (n=>m=>a) =
+def divergence [Add a] (vx:n=>m=>a) (vy:n=>m=>a) : (n=>m=>a) =
   fdx vx + fdy vy
 
-def add_neighbours_2d (_:Add a) ?=> (x:n=>m=>a) : (n=>m=>a) =
+def add_neighbours_2d [Add a] (x:n=>m=>a) : (n=>m=>a) =
   ax1 = apply_along_axis1 add_neighbours x
   ax2 = apply_along_axis2 add_neighbours x
   ax1 + ax2
 
-def project (_:VSpace a) ?=> (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
+def project [VSpace a] (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
   -- Project the velocity field to be approximately mass-conserving,
   -- using a few iterations of Gauss-Seidel.
   h = 1.0 / IToF (size n)
@@ -60,13 +60,13 @@ def project (_:VSpace a) ?=> (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
 
   for i j. [vx.i.j, vy.i.j]  -- pack back into a table.
 
-def bilinear_interp (_:VSpace a) ?=> (right_weight:Float) (bottom_weight:Float)
+def bilinear_interp [VSpace a] (right_weight:Float) (bottom_weight:Float)
   (topleft: a) (bottomleft: a) (topright: a) (bottomright: a) : a =
   left  = (1.0 - right_weight) .* ((1.0 - bottom_weight) .* topleft  + bottom_weight .* bottomleft)
   right =        right_weight  .* ((1.0 - bottom_weight) .* topright + bottom_weight .* bottomright)
   left + right
 
-def advect (_:VSpace a) ?=> (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
+def advect [VSpace a] (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
   -- Move field f according to x and y velocities (u and v)
   -- using an implicit Euler integrator.
 
@@ -95,7 +95,7 @@ def advect (_:VSpace a) ?=> (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
     -- A convex weighting of the 4 surrounding cells.
     bilinear_interp right_weight bottom_weight f.l.t f.l.b f.r.t f.r.b
 
-def fluidsim (_: VSpace a) ?=> (num_steps: Int) (color_init: n=>m=>a)
+def fluidsim [ VSpace a] (num_steps: Int) (color_init: n=>m=>a)
   (v: n=>m=>(Fin 2)=>Float) : (Fin num_steps)=>n=>m=>a =
   withState (color_init, v) \state.
     for i:(Fin num_steps).

--- a/examples/linear_algebra.dx
+++ b/examples/linear_algebra.dx
@@ -1,6 +1,6 @@
 '## LU Decomposition and Matrix Inversion
 
-def identity_matrix (_:Eq n) ?=> (_:Add a) ?=> (_:Mul a) ?=> : n=>n=>a =
+def identity_matrix [Eq n, Add a, Mul a] : n=>n=>a =
   for i j. select (i == j) one zero
 
 '### Triangular matrices
@@ -11,7 +11,7 @@ def UpperTriMat (n:Type) (v:Type) : Type = i:n=>(i..)=>v
 def upperTriDiag (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
 def lowerTriDiag (l:LowerTriMat n v) : n=>v = for i. l.i.((ordinal i)@_)
 
-def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n Float) (b:n=>v) : n=>v =
+def forward_substitute [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v =
   -- Solves lower triangular linear system (inverse a) **. b
   yieldState zero \sRef.
     for i:n.
@@ -19,7 +19,7 @@ def forward_substitute (_:VSpace v) ?=> (a:LowerTriMat n Float) (b:n=>v) : n=>v 
         a.i.((ordinal k)@_) .* get sRef!(%inject k)
       sRef!i := (b.i - s) / a.i.((ordinal i)@_)
 
-def backward_substitute (_:VSpace v) ?=> (a:UpperTriMat n Float) (b:n=>v) : n=>v =
+def backward_substitute [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =
   -- Solves upper triangular linear system (inverse a) **. b
   yieldState zero \sRef.
     rof i:n.
@@ -61,7 +61,7 @@ def permSign   ((_, sign):Permutation n) : PermutationSign = sign
 
 '### LU decomposition functions
 
-def pivotize (_:Eq n) ?=> (a:n=>n=>Float) : Permutation n =
+def pivotize [Eq n] (a:n=>n=>Float) : Permutation n =
   -- Gives a row permutation that makes Gaussian elimination more stable.
   yieldState identity_permutation \permRef.
     for j:n.
@@ -71,7 +71,7 @@ def pivotize (_:Eq n) ?=> (a:n=>n=>Float) : Permutation n =
         True -> ()
         False -> swapInPlace permRef j row_with_largest
 
-def lu (_:Eq n) ?=> (a: n=>n=>Float) :
+def lu [Eq n] (a: n=>n=>Float) :
        (LowerTriMat n Float & UpperTriMat n Float & Permutation n) =
   -- Computes lower, upper, and permuntation matrices from a square matrix,
   -- such that apply_permutation permutation a == lower ** upper.
@@ -113,10 +113,10 @@ def lu (_:Eq n) ?=> (a: n=>n=>Float) :
           ukj = get (upperTriIndex uRef k')!(((ordinal j) - (ordinal k))@_)
           lik = get (lowerTriIndex lRef i')!((ordinal k)@_)
           ukj * lik
-          
+
         uijRef = (upperTriIndex uRef i')!(((ordinal j) - (ordinal i))@_)
         uijRef := a.(%inject i).j - s
-      
+
       for i:(j<..).
         i' = %inject i
         s = sum for k:(..j).
@@ -125,7 +125,7 @@ def lu (_:Eq n) ?=> (a: n=>n=>Float) :
           ukj = get (upperTriIndex uRef k')!i''
           lik = get (lowerTriIndex lRef i')!((ordinal k)@_)
           ukj * lik
-        
+
         i'' = ((ordinal i) + (ordinal j) + 1)@_
         ujj = get (upperTriIndex uRef j)!(0@_)
         lijRef = (lowerTriIndex lRef i'')!((ordinal j)@_)
@@ -135,7 +135,7 @@ def lu (_:Eq n) ?=> (a: n=>n=>Float) :
 
 '### General linear algebra functions.
 
-def solve (_:Eq n) ?=> (_:VSpace v) ?=> (a:n=>n=>Float) (b:n=>v) : n=>v =
+def solve [Eq n, VSpace v] (a:n=>n=>Float) (b:n=>v) : n=>v =
   -- There's a small speedup possible by exploiting the fact
   -- that l always has ones on the diagonal.  It would just require a
   -- custom forward_substitute routine that doesn't divide
@@ -145,18 +145,18 @@ def solve (_:Eq n) ?=> (_:VSpace v) ?=> (a:n=>n=>Float) (b:n=>v) : n=>v =
   y = forward_substitute l b'
   backward_substitute u y
 
-def invert (_:Eq n) ?=> (a:n=>n=>Float) : n=>n=>Float =
+def invert [Eq n] (a:n=>n=>Float) : n=>n=>Float =
   solve a identity_matrix
 
-def determinant (_:Eq n) ?=> (a:n=>n=>Float) : Float =
+def determinant [Eq n] (a:n=>n=>Float) : Float =
   (l, u, perm) = lu a
   prod (for i. (upperTriDiag u).i * (lowerTriDiag l).i) * permSign perm
 
-def sign_and_log_determinant (_:Eq n) ?=> (a:n=>n=>Float) : (Float & Float) =
+def sign_and_log_determinant [Eq n] (a:n=>n=>Float) : (Float & Float) =
   (l, u, perm) = lu a
   diags = for i. (upperTriDiag u).i * (lowerTriDiag l).i
   sign = (permSign perm) * prod for i. sign diags.i
-  sum_of_log_abs = sum for i. log (abs diags.i) 
+  sum_of_log_abs = sum for i. log (abs diags.i)
   (sign, sum_of_log_abs)
 
 

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -55,7 +55,7 @@ def mhStep
 HMCParams : Type = (Int & Float)  -- leapfrog steps, step size
 
 def leapfrogIntegrate
-      (_:VSpace a) ?=>
+      [VSpace a]
       ((nsteps, dt): HMCParams)
       (logProb: a -> LogProb)
       ((x, p): (a & a))

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -28,8 +28,7 @@ def propose
   accept = logDensity proposal > (logDensity cur + log (rand k))
   select accept proposal cur
 
-def meanAndCovariance (n:Type) ?-> (d:Type) ?->
-      (xs:n=>d=>Float) : (d=>Float & d=>d=>Float) =
+def meanAndCovariance (xs:n=>d=>Float) : (d=>Float & d=>d=>Float) =
    xsMean :    d=>Float = (for i. sum for j. xs.j.i) / IToF (size n)
    xsCov  : d=>d=>Float = (for i i'. sum for j.
                            (xs.j.i' - xsMean.i') *

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -12,7 +12,7 @@ Time = Float
 def length (x: d=>Float) : Float = sqrt $ sum for i. sq x.i
 def (./) (x: d=>Float) (y: d=>Float) : d=>Float = for i. x.i / y.i
 
-def fit_4th_order_polynomial (_:VSpace v) ?=>
+def fit_4th_order_polynomial [VSpace v]
     (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
   -- dz0 and dz1 are gradient evaluations.
   a = -2. * dt .* dz0 + 2. * dt .* dz1 -  8. .* z0 -  8. .* z1 + 16. .* z_mid
@@ -26,7 +26,7 @@ dps_c_mid = [6025192743. /30085553152. /2., 0., 51252292925. /65400821598. /2.,
             -2691868925. /45128329728. /2., 187940372067. /1594534317056. /2.,
             -1776094331. /19743644256. /2., 11237099. /235043384. /2.]
 
-def interp_fit_dopri (_:VSpace v) ?=>
+def interp_fit_dopri [VSpace v]
     (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
   -- Fit a polynomial to the results of a Runge-Kutta step.
   z_mid = z0 + dt .* (dot dps_c_mid k)
@@ -64,7 +64,7 @@ c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
            125. / 192. - 451. / 720., -2187. / 6784. + 12231. / 42400.,
            11. / 84. - 649. / 6300., -1. / 60.]
 
-def runge_kutta_step (_:VSpace v) ?=> (func:v->Time->v)
+def runge_kutta_step [VSpace v] (func:v->Time->v)
     (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
 
   evals_init = yieldState zero \r.

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -57,7 +57,6 @@ We have **arguments**:
 ' **Returns**: the optimal point found with-in the bounds on the input domain of `f`.
 
 def optimize
-      (d:Type) ?->
       (np':Int)                                        -- number of particles
       (niter:Int)                                      -- number of iterations
       (key:Key)                                        -- random seed

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -24,7 +24,7 @@ def directionAndLength (x: d=>Float) : (d=>Float & Float) =
 def randuniform (lower:Float) (upper:Float) (k:Key) : Float =
   lower + (rand k) * (upper - lower)
 
-def sampleAveraged (_:VSpace a) ?=> (sample:Key -> a) (n:Int) (k:Key) : a =
+def sampleAveraged [VSpace a] (sample:Key -> a) (n:Int) (k:Key) : a =
   yieldState zero \total.
     for i:(Fin n).
       total := get total + sample (ixkey k i) / IToF n

--- a/examples/sgd.dx
+++ b/examples/sgd.dx
@@ -1,14 +1,14 @@
 
 '## Stochastic Gradient Descent with Momentum
 
-def sgd_step (dict: VSpace a) ?=> (step_size: Float) (decay: Float) (gradfunc: a -> Int -> a) (x: a) (m: a) (iter:Int) : (a & a) =
+def sgd_step [VSpace a] (step_size: Float) (decay: Float) (gradfunc: a -> Int -> a) (x: a) (m: a) (iter:Int) : (a & a) =
   g = gradfunc x iter
   new_m = decay .* m + g
   new_x = x - step_size .* new_m
   (new_x, new_m)
 
 -- In-place optimization loop.
-def sgd (dict: VSpace a) ?=> (step_size:Float) (decay:Float) (num_steps:Int) (gradient: a -> Int -> a) (x0: a) : a =
+def sgd [VSpace a] (step_size:Float) (decay:Float) (num_steps:Int) (gradient: a -> Int -> a) (x0: a) : a =
   m0 = zero
   (x_final, m_final) = yieldState (x0, m0) \state.
     for i:(Fin num_steps).

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -112,7 +112,7 @@ def quote (s:String) : String = "\"" <.> s <.> "\""
 def strSpaceCatUncurried ((s1,s2):(String & String)) : String =
   s1 <.> " " <.> s2
 
-def (<+>) (_:Show a) ?=> (_:Show b) ?=> (s1:a) (s2:b) : String =
+def (<+>) [Show a, Show b] (s1:a) (s2:b) : String =
   strSpaceCatUncurried ((show s1), (show s2))
 
 def selfClosingBrackets (s:String) : String = "<" <.> s <.> "/>"
@@ -127,7 +127,7 @@ def tagBracketsAttrUncurried ((tag, attr, s):(String & String & String)) : Strin
 def tagBracketsAttr (tag:String) (attr:String) (s:String) : String =
   tagBracketsAttrUncurried (tag, attr, s)
 
-def (<=>) (_:Show b) ?=> (attr:String) (val:b) : String =
+def (<=>) [Show b] (attr:String) (val:b) : String =
   attr <.> "=" <.> quote (show val)
 
 def htmlColor(cs:HtmlColor) : String =

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -36,7 +36,7 @@ defaultGeomStyle : GeomStyle =
 -- TODO: consider sharing attributes among a set of objects for efficiency
 data Diagram = MkDiagram (List (GeomStyle & Point & Geom))
 
-instance monoidDiagram : Monoid Diagram where
+instance Monoid Diagram
   mempty = MkDiagram mempty
   mcombine = \(MkDiagram d1) (MkDiagram d2). MkDiagram $ d1 <> d2
 

--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -49,7 +49,7 @@ def getScaled (sd:ScaledData n a) (i:n) : Maybe Float =
 lowColor  = [1.0, 0.5, 0.0]
 highColor = [0.0, 0.5, 1.0]
 
-def interpolate (_:VSpace a) ?=> (low:a) (high:a) (x:Float) : a =
+def interpolate [VSpace a] (low:a) (high:a) (x:Float) : a =
   x' = clip (0.0, 1.0) x
   (x' .* low) + ((1.0 - x') .* high)
 

--- a/lib/png.dx
+++ b/lib/png.dx
@@ -72,7 +72,7 @@ def decodeChunk (chunk : Fin 4 => Char) : Maybe (Fin 3 => Char) =
     Just base64s -> Just $ base64sToBytes base64s
 
 -- TODO: put this in prelude?
-def replace (_:Eq a) ?=> ((old,new):(a&a)) (x:a) : a =
+def replace [Eq a] ((old,new):(a&a)) (x:a) : a =
   case x == old of
     True  -> new
     False -> x

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -45,8 +45,8 @@ interface Add a:Type where
   sub : a -> a -> a
   zero : a
 
-def (+)  (d:Add a) ?=> : a -> a -> a = add
-def (-)  (d:Add a) ?=> : a -> a -> a = sub
+def (+) [Add a] : a -> a -> a = add
+def (-) [Add a] : a -> a -> a = sub
 
 instance float64Add : Add Float64 where
   add = \x:Float64 y:Float64. %fadd x y
@@ -87,7 +87,7 @@ interface Mul a:Type where
   mul : a -> a -> a
   one : a
 
-def (*) (d:Mul a) ?=> : a -> a -> a = mul
+def (*) [Mul a] : a -> a -> a = mul
 
 instance float64Mul : Mul Float64 where
   mul = \x:Float64 y:Float64. %fmul x y
@@ -162,10 +162,10 @@ data VSpace a:Type = MkVSpace (Add a) (Float -> a -> a)
 @superclass
 def addFromVSpace (d:VSpace a) : Add a = case d of MkVSpace addDict _ -> addDict
 
-def (.*)  (d:VSpace a) ?=> : Float -> a -> a = case d of MkVSpace _ scale -> scale
-(*.)  : VSpace a ?=> a -> Float -> a = flip (.*)
-def (/) (_:VSpace a) ?=> (v:a) (s:Float) : a = (divide 1.0 s) .* v
-def neg (_:VSpace a) ?=> (v:a) : a = (-1.0) .* v
+def (.*) (d:VSpace a) ?=> : Float -> a -> a = case d of MkVSpace _ scale -> scale
+def (*.) [VSpace a]       : a -> Float -> a = flip (.*)
+def (/)  [VSpace a] (v:a) (s:Float) : a = divide 1.0 s .* v
+def neg  [VSpace a] (v:a) : a = (-1.0) .* v
 
 @instance floatVS : VSpace Float = MkVSpace float32Add (*)
 @instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i
@@ -292,12 +292,12 @@ data Ord a:Type = MkOrd (Eq a) (a -> a -> Bool) (a -> a -> Bool)  -- eq, gt, lt
 def eqFromOrd (d:Ord a) : Eq a = case d of MkOrd eq _ _ -> eq
 
 def (==) (d:Eq a) ?=> (x:a) (y:a) : Bool = case d of MkEq eq -> eq x y
-def (/=) (d:Eq a) ?=> (x:a) (y:a) : Bool = not $ x == y
+def (/=) [Eq a] (x:a) (y:a) : Bool = not $ x == y
 
 def (>)  (d:Ord a) ?=> (x:a) (y:a) : Bool = case d of MkOrd _ gt _  -> gt x y
 def (<)  (d:Ord a) ?=> (x:a) (y:a) : Bool = case d of MkOrd _ _  lt -> lt x y
-def (<=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x<y || x==y
-def (>=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x>y || x==y
+def (<=) [Ord a] (x:a) (y:a) : Bool = x<y || x==y
+def (>=) [Ord a] (x:a) (y:a) : Bool = x>y || x==y
 
 @instance float64Eq : Eq Float64 = MkEq \x:Float64 y:Float64. W8ToB $ %feq x y
 @instance float32Eq : Eq Float32 = MkEq \x:Float32 y:Float32. W8ToB $ %feq x y
@@ -321,19 +321,18 @@ def (>=) (d:Ord a) ?=> (x:a) (y:a) : Bool = x>y || x==y
 @instance unitOrd    : Ord Unit    = (MkOrd unitEq (\x y. False) (\x y. False))
 
 @instance
-def pairEq (eqA: Eq a)?=> (eqB: Eq b)?=> : Eq (a & b) = MkEq $
+def pairEq [Eq a, Eq b] : Eq (a & b) = MkEq $
   \(x1,x2) (y1,y2). x1 == y1 && x2 == y2
 
 @instance
-def pairOrd (ordA: Ord a)?=> (ordB: Ord b)?=> : Ord (a & b) =
+def pairOrd [Ord a, Ord b] : Ord (a & b) =
   pairGt = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
   pairLt = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
   MkOrd pairEq pairGt pairLt
 
-
 -- TODO: accumulate using the True/&& monoid
 @instance
-def tabEq (n:Type) ?-> (eqA: Eq a) ?=> : Eq (n=>a) = MkEq $
+def tabEq [Eq a] : Eq (n=>a) = MkEq $
   \xs ys.
     numDifferent : Float =
       yieldAccum \ref. for i.
@@ -362,7 +361,7 @@ interface Floating a:Type where
   pow    : a -> a -> a
   lgamma : a -> a
 
-def lbeta (_ : Add a) ?=> (_ : Floating a) ?=> : a -> a -> a = \x y. lgamma x + lgamma y - lgamma (x + y)
+def lbeta [Add a, Floating a] : a -> a -> a = \x y. lgamma x + lgamma y - lgamma (x + y)
 
 -- Todo: better numerics for very large and small values.
 -- Using %exp here to avoid circular definition problems.
@@ -468,28 +467,28 @@ instance int32Storable : Storable Int32 where
   load  = int32Load
   storageSize = const 4
 
-def unpackPairPtr (_:Storable a) ?=> (_:Storable b) ?=>
+def unpackPairPtr [Storable a, Storable b]
       (pairPtr: Ptr (a & b)) : (Ptr a & Ptr b) =
   (MkPtr rawPtrX) = pairPtr
   rawPtrY = %ptrOffset rawPtrX (storageSize (typeVehicle a))
   (MkPtr rawPtrX, MkPtr rawPtrY)
 
-def pairStore (_:Storable a) ?=> (_:Storable b) ?=>
+def pairStore [Storable a, Storable b]
       (pairPtr:Ptr (a & b)) ((x, y):(a & b)) : {State World} Unit  =
   (xPtr, yPtr) = unpackPairPtr pairPtr
   store xPtr x
   store yPtr y
 
-def pairLoad (_:Storable a) ?=> (_:Storable b) ?=>
+def pairLoad [Storable a, Storable b]
       (pairPtr:Ptr (a & b)) : {State World} (a & b) =
   (xPtr, yPtr) = unpackPairPtr pairPtr
   (load xPtr, load yPtr)
 
-def pairStorageSize (_:Storable a) ?=> (_:Storable b) ?=>
+def pairStorageSize [Storable a, Storable b]
     (_:TypeVehicle (a & b)) : Int =
   storageSize (typeVehicle a) + storageSize (typeVehicle b)
 
-instance pairStorable : Storable a ?=> Storable b ?=> Storable (a & b) where
+instance pairStorable : (Storable a) ?=> (Storable b) ?=> Storable (a & b) where
   store = pairStore
   load  = pairLoad
   storageSize = pairStorageSize
@@ -508,7 +507,7 @@ instance ptrStorable : Storable (Ptr a) where
 
 -- TODO: Storable instances for other types
 
-def malloc (_:Storable a) ?=> (n:Int) : {State World} (Ptr a) =
+def malloc [Storable a] (n:Int) : {State World} (Ptr a) =
   numBytes = storageSize (typeVehicle a) * n
   MkPtr $ %alloc numBytes
 
@@ -516,7 +515,7 @@ def free (ptr:Ptr a) : {State World} Unit =
   (MkPtr ptr') = ptr
   %free ptr'
 
-def (+>>) (_:Storable a) ?=> (ptr:Ptr a) (i:Int) : Ptr a =
+def (+>>) [Storable a] (ptr:Ptr a) (i:Int) : Ptr a =
   (MkPtr ptr') = ptr
   i' = i * storageSize (typeVehicle a)
   MkPtr $ %ptrOffset ptr' i'
@@ -524,28 +523,28 @@ def (+>>) (_:Storable a) ?=> (ptr:Ptr a) (i:Int) : Ptr a =
 -- TODO: generalize these brackets to allow other effects
 
 -- TODO: consider making a Storable instance for tables instead
-def storeTab (_:Storable a) ?=> (ptr: Ptr a) (tab:n=>a) : {State World} Unit =
+def storeTab [Storable a] (ptr: Ptr a) (tab:n=>a) : {State World} Unit =
   for_ i. store (ptr +>> ordinal i) tab.i
 
-def memcpy (_:Storable a) ?=> (dest:Ptr a) (src:Ptr a) (n:Int) : {State World} Unit =
+def memcpy [Storable a] (dest:Ptr a) (src:Ptr a) (n:Int) : {State World} Unit =
   for_ i:(Fin n).
     i' = ordinal i
     store (dest +>> i') (load $ src +>> i')
 
-def withAlloc (_:Storable a) ?=>
+def withAlloc [Storable a]
       (n:Int) (action: Ptr a -> {State World} b) : {State World} b =
   ptr = malloc n
   result = action ptr
   free ptr
   result
 
-def withTabPtr (_:Storable a) ?=>
+def withTabPtr [Storable a]
       (xs:n=>a) (action : Ptr a -> {State World} b) : {State World} b =
   withAlloc (size n) \ptr.
     for i. store (ptr +>> ordinal i) xs.i
     action ptr
 
-def tabFromPtr (_:Storable a) ?=> (n:Type) -> (ptr:Ptr a) : {State World} n=>a =
+def tabFromPtr [Storable a] (n:Type) -> (ptr:Ptr a) : {State World} n=>a =
   for i. load $ ptr +>> ordinal i
 
 '## Miscellaneous common utilities
@@ -558,8 +557,8 @@ def map (f:a->{|eff} b) (xs: n=>a) : {|eff} (n=>b) = for i. f xs.i
 def zip (xs:n=>a) (ys:n=>b) : (n=>(a&b)) = view i. (xs.i, ys.i)
 def unzip (xys:n=>(a&b)) : (n=>a & n=>b) = (map fst xys, map snd xys)
 def fanout (n:Type) (x:a) : n=>a = view i. x
-def sq (d:Mul a) ?=> (x:a) : a = x * x
-def abs (_:Add a) ?=> (_:Ord a) ?=> (x:a) : a = select (x > zero) x (zero - x)
+def sq  [Mul a] (x:a) : a = x * x
+def abs [Add a, Ord a] (x:a) : a = select (x > zero) x (zero - x)
 def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
 
 def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
@@ -582,9 +581,9 @@ def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
 def fsum (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs i
-def sum  (_: Add v) ?=> (xs:n=>v) : v = reduce zero (+) xs
-def prod (_: Mul v) ?=> (xs:n=>v) : v = reduce one  (*) xs
-def mean (n:Type) ?-> (xs:n=>Float) : Float = sum xs / IToF (size n)
+def sum  [Add v] (xs:n=>v) : v = reduce zero (+) xs
+def prod [Mul v] (xs:n=>v) : v = reduce one  (*) xs
+def mean (xs:n=>Float) : Float = sum xs / IToF (size n)
 def std (xs:n=>Float) : Float = sqrt $ mean (map sq xs) - sq (mean xs)
 def any (xs:n=>Bool) : Bool = reduce False (||) xs
 def all (xs:n=>Bool) : Bool = reduce True  (&&) xs
@@ -599,7 +598,7 @@ def linspace (n:Type) (low:Float) (high:Float) : n=>Float =
 
 def transpose (x:n=>m=>a) : m=>n=>a = view i j. x.j.i
 def vdot (x:n=>Float) (y:n=>Float) : Float = fsum view i. x.i * y.i
-def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
+def dot [VSpace v] (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
 (**) : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
@@ -611,7 +610,7 @@ def dot (_:VSpace v) ?=> (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 def inner (x:n=>Float) (mat:n=>m=>Float) (y:m=>Float) : Float =
   fsum view (i,j). x.i * mat.i.j * y.j
 
-def eye (_:Eq n) ?=> : n=>n=>Float =
+def eye [Eq n] : n=>n=>Float =
   for i j. select (i == j) 1.0 0.0
 
 '## Pseudorandom number generator utilities
@@ -645,7 +644,7 @@ def randInt (k:Key) : Int = (I64ToI k) `mod` 2147483647
 
 def bern (p:Float) (k:Key) : Bool = rand k < p
 
-def randnVec (n:Type) ?-> (k:Key) : n=>Float =
+def randnVec (k:Key) : n=>Float =
   for i. randn (ixkey k i)
 
 def cumSum (xs: n=>Float) : n=>Float =
@@ -679,7 +678,7 @@ interface HasDefaultTolerance a:Type where
   atol : a
   rtol : a
 
-def (~~) (_:HasAllClose a) ?=> (d:HasDefaultTolerance a) ?=> : a -> a -> Bool = allclose atol rtol
+def (~~) [HasAllClose a, HasDefaultTolerance a] : a -> a -> Bool = allclose atol rtol
 
 instance allCloseF32 : HasAllClose Float32 where
   allclose = \atol rtol x y. abs (x - y) <= (atol + rtol * abs y)
@@ -758,14 +757,12 @@ def Tile (n : Type) (m : Type) : Type = %IndexSlice n m
 -- elements of n. In this view (+>) is just function application, while ++>
 -- is currying followed by function application. We cannot represent currying
 -- in isolation, because `Tile n (Tile u v)` does not make sense, unlike `Tile n (u & v)`.
-def (+>) (l : Type) ?-> (t:Tile n l) (i : l) : n = %sliceOffset t i
+def (+>)  (t:Tile n l) (i : l) : n = %sliceOffset t i
 def (++>) (t : Tile n (u & v)) (i : u) : Tile n v = %sliceCurry t i
 
-def tile  (l : Type) ?->
-          (fTile : (t:(Tile n l) -> {|eff} l=>a))
+def tile  (fTile : (t:(Tile n l) -> {|eff} l=>a))
           (fScalar : n -> {|eff} a) : {|eff} n=>a = %tiled fTile fScalar
-def tile1 (n : Type) ?-> (l : Type) ?-> (m : Type) ?->
-          (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
+def tile1 (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
           (fScalar : n -> {|eff} m=>a) : {|eff} m=>n=>a = %tiledd fTile fScalar
 
 -- TODO: This should become just `loadVector $ for i. arr.(t +> i)`
@@ -783,7 +780,7 @@ interface Monoid a:Type where
   mempty : a
   mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
 
-(<>) : Monoid a ?=> a -> a -> a = mcombine
+def (<>) [Monoid a] : a -> a -> a = mcombine
 
 '## Length-erased lists
 
@@ -793,7 +790,7 @@ data List a:Type =
 def unsafeCastTable (m:Type) (xs:n=>a) : m=>a =
   for i. xs.(unsafeFromOrdinal _ (ordinal i))
 
-def toList (n:Type) ?-> (xs:n=>a) : List a =
+def toList (xs:n=>a) : List a =
   n' = size n
   AsList _ $ unsafeCastTable (Fin n') xs
 
@@ -895,7 +892,7 @@ def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
 -- TODO: would be nice to be able to use records here
 data DynBuffer a:Type = MkDynBuffer (Ptr (Int & Int & Ptr a))  -- size, max size, buf ptr
 
-def withDynamicBuffer (_:Storable a) ?=>
+def withDynamicBuffer [Storable a]
       (action: DynBuffer a -> {State World} b) : {State World} b =
   initMaxSize = 256
   withAlloc 1 \dbPtr.
@@ -906,7 +903,7 @@ def withDynamicBuffer (_:Storable a) ?=>
     free bufPtr'
     result
 
-def maybeIncreaseBufferSize (_:Storable a) ?=>
+def maybeIncreaseBufferSize [Storable a]
     (buf: DynBuffer a) (sizeDelta:Int) : {State World} Unit =
   (MkDynBuffer dbPtr) = buf
   (size, maxSize, bufPtr) = load dbPtr
@@ -918,7 +915,7 @@ def maybeIncreaseBufferSize (_:Storable a) ?=>
     memcpy newBufPtr bufPtr size
     store dbPtr (size, newMaxSize, newBufPtr)
 
-def extendDynBuffer (_:Storable a) ?=>
+def extendDynBuffer [Storable a]
     (buf: DynBuffer a) (new:List a) : {State World} Unit =
   (AsList n xs) = new
   maybeIncreaseBufferSize buf n
@@ -928,13 +925,13 @@ def extendDynBuffer (_:Storable a) ?=>
   storeTab (bufPtr +>> size) xs
   store dbPtr (newSize, maxSize, bufPtr)
 
-def loadDynBuffer (_:Storable a) ?=>
+def loadDynBuffer [Storable a]
       (buf: DynBuffer a) : {State World} (List a) =
   (MkDynBuffer dbPtr) = buf
   (size, _, bufPtr) = load dbPtr
   AsList size $ tabFromPtr _ bufPtr
 
-def pushDynBuffer (_:Storable a) ?=>
+def pushDynBuffer [Storable a]
       (buf: DynBuffer a) (x:a) : {State World} Unit =
   extendDynBuffer buf $ AsList _ [x]
 
@@ -1194,7 +1191,7 @@ def error (s:String) : a = unsafeIO do
   print s
   %throwError a
 
-def todo (a:Type) ?-> : a = error "TODO: implement it!"
+def todo : a = error "TODO: implement it!"
 
 def fromOrdinal (n:Type) (i:Int) : n =
   case (0 <= i) && (i < size n) of
@@ -1210,7 +1207,7 @@ def castTable (m:Type) (xs:n=>a) : m=>a =
      False -> error $
        "Table size mismatch in cast: " <> show (size m) <> " vs " <> show (size n)
 
-def asidx (n:Type) ?-> (i:Int) : n = fromOrdinal n i
+def asidx (i:Int) : n = fromOrdinal n i
 def (@) (i:Int) (n:Type) : n = fromOrdinal n i
 
 def slice (xs:n=>a) (start:Int) (m:Type) : m=>a =
@@ -1218,11 +1215,11 @@ def slice (xs:n=>a) (start:Int) (m:Type) : m=>a =
 
 def head (xs:n=>a) : a = xs.(0@_)
 
-def tail (n:Type) ?-> (xs:n=>a) (start:Int) : List a =
+def tail (xs:n=>a) (start:Int) : List a =
   numElts = size n - start
   toList $ slice xs start (Fin numElts)
 
-def randIdx (n:Type) ?-> (k:Key) : n =
+def randIdx (k:Key) : n =
   unif = rand k
   fromOrdinal n $ FToI $ floor $ unif * IToF (size n)
 
@@ -1246,7 +1243,7 @@ instance finArb : n:Int ?-> Arbitrary (Fin n) where
 'Control flow
 
 -- returns the highest index `i` such that `xs.i <= x`
-def searchSorted (_:Ord a) ?=> (xs:n=>a) (x:a) : Maybe n =
+def searchSorted [Ord a] (xs:n=>a) (x:a) : Maybe n =
   if size n == 0
     then Nothing
     else if x < xs.(fromOrdinal _ 0)
@@ -1264,28 +1261,28 @@ def searchSorted (_:Ord a) ?=> (xs:n=>a) (x:a) : Maybe n =
 
 'min / max etc
 
-def minBy (_:Ord o) ?=> (f:a->o) (x:a) (y:a) : a = select (f x < f y) x y
-def maxBy (_:Ord o) ?=> (f:a->o) (x:a) (y:a) : a = select (f x > f y) x y
+def minBy [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x < f y) x y
+def maxBy [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x > f y) x y
 
-def min (_:Ord o) ?=> (x1: o) -> (x2: o) : o = minBy id x1 x2
-def max (_:Ord o) ?=> (x1: o) -> (x2: o) : o = maxBy id x1 x2
+def min [Ord o] (x1: o) -> (x2: o) : o = minBy id x1 x2
+def max [Ord o] (x1: o) -> (x2: o) : o = maxBy id x1 x2
 
-def minimumBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : a =
+def minimumBy [Ord o] (f:a->o) (xs:n=>a) : a =
   reduce xs.(0@_) (minBy f) xs
-def maximumBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : a =
+def maximumBy [Ord o] (f:a->o) (xs:n=>a) : a =
   reduce xs.(0@_) (maxBy f) xs
 
-def minimum (_:Ord o) ?=> (xs:n=>o) : o = minimumBy id xs
-def maximum (_:Ord o) ?=> (xs:n=>o) : o = maximumBy id xs
+def minimum [Ord o] (xs:n=>o) : o = minimumBy id xs
+def maximum [Ord o] (xs:n=>o) : o = maximumBy id xs
 
-def argmin (_:Ord o) ?=> (xs:n=>o) : n =
+def argmin [Ord o] (xs:n=>o) : n =
   zeroth = (0@_, xs.(0@_))
   compare = \(idx1, x1) (idx2, x2).
     select (x1 < x2) (idx1, x1) (idx2, x2)
   zipped = for i. (i, xs.i)
   fst $ reduce zeroth compare zipped
 
-def clip (_:Ord a) ?=> ((low,high):(a&a)) (x:a) : a =
+def clip [Ord a] ((low,high):(a&a)) (x:a) : a =
   min high $ max low x
 
 '## Trigonometric functions
@@ -1307,7 +1304,7 @@ def atan_inner (x:Float) : Float =
   r = r * s
   r * x + x
 
-def min_and_max (_: Ord a) ?=> (x:a) (y:a) : (a & a) =
+def min_and_max [Ord a] (x:a) (y:a) : (a & a) =
   select (x < y) (x, y) (y, x)  -- get both with one comparison.
 
 def atan2 (y:Float) (x:Float) : Float =
@@ -1461,7 +1458,7 @@ def reverse (x:n=>a) : n=>a =
   s = size n
   for i. x.((s - 1 - ordinal i)@_)
 
-def padTo (n:Type) ?-> (m:Type) (x:a) (xs:n=>a) : (m=>a) =
+def padTo (m:Type) (x:a) (xs:n=>a) : (m=>a) =
   n' = size n
   for i.
     i' = ordinal i
@@ -1483,7 +1480,7 @@ def seqMaybes (n:Type) ?-> (a:Type) ?-> (xs : n=>Maybe a) : Maybe (n => a) =
     True  -> Nothing
     False -> Just $ map fromJust xs
 
-def linearSearch (_:Eq a) ?=> (xs:n=>a) (query:a) : Maybe n =
+def linearSearch [Eq a] (xs:n=>a) (query:a) : Maybe n =
   yieldState Nothing \ref. for i.
     case xs.i == query of
       True  -> ref := Just i
@@ -1555,7 +1552,7 @@ def softmax (x: n=>Float) : n=>Float =
   s = sum e
   for i. e.i / s
 
-def evalpoly (_:VSpace v) ?=> (coefficients:n=>v) (x:Float) : v =
+def evalpoly [VSpace v] (coefficients:n=>v) (x:Float) : v =
   -- Evaluate a polynomial at x.  Same as Numpy's polyval.
   fold zero \i c. coefficients.i + x .* c
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -233,7 +233,6 @@ def fstRef (ref: Ref h (a & b)) : Ref h a = %fstRef ref
 def sndRef (ref: Ref h (a & b)) : Ref h b = %sndRef ref
 
 def runReader
-      (eff:Effects) ?->
       (init:r)
       (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
@@ -241,27 +240,23 @@ def runReader
     %runReader init explicitAction
 
 def withReader
-      (eff:Effects) ?->
       (init:r)
       (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
     runReader init action
 
 def runAccum
-      (eff:Effects) ?->
       (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
       : {|eff} (a & w) =
     def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a = action ref
     %runWriter explicitAction
 
 def yieldAccum
-      (eff:Effects) ?->
       (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
       : {|eff} w =
   snd $ runAccum action
 
 def runState
-      (eff:Effects) ?->
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
       : {|eff} (a & s) =
@@ -269,13 +264,11 @@ def runState
   %runState init explicitAction
 
 def withState
-      (eff:Effects) ?->
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
       : {|eff} a = fst $ runState init action
 
 def yieldState
-      (eff:Effects) ?->
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
       : {|eff} s = snd $ runState init action
@@ -449,10 +442,10 @@ def unsafeFromOrdinal (n : Type) (i : Int) : n = %unsafeFromOrdinal n i
 def iota (n:Type) : n=>Int = view i. ordinal i
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`
-instance (n:Int) ?-> Eq (Fin n)
+instance Eq (Fin n)
   (==) = \x y. ordinal x == ordinal y
 
-instance (n:Int) ?-> Ord (Fin n)
+instance Ord (Fin n)
   (>) = \x y. ordinal x > ordinal y
   (<) = \x y. ordinal x < ordinal y
 
@@ -625,7 +618,7 @@ def newKey (x:Int) : Key = hash (IToI64 0) x
 def many (f:Key->a) (k:Key) (i:n) : a = f (hash k (ordinal i))
 def ixkey (k:Key) (i:n) : Key = hash k (ordinal i)
 def ixkey2 (k:Key) (i:n) (j:m) : Key = hash (hash k (ordinal i)) (ordinal j)
-def splitKey (n:Int) ?-> (k:Key) : Fin n => Key = for i. ixkey k i
+def splitKey (k:Key) : Fin n => Key = for i. ixkey k i
 def rand (k:Key) : Float =  unsafeIO do F64ToF $ %ffi randunif Float64 k
 def randVec (n:Int) (f: Key -> a) (k: Key) : Fin n => a =
   for i:(Fin n). f (ixkey k i)
@@ -1036,7 +1029,7 @@ def fopen (path:String) (mode:StreamMode) : {State World} (Stream mode) =
     withCString modeStr \(MkCString modePtr).
       MkStream $ %ffi fopen RawPtr pathPtr modePtr
 
-def fclose (mode:StreamMode) ?-> (stream:Stream mode) : {State World} Unit =
+def fclose (stream:Stream mode) : {State World} Unit =
   (MkStream stream') = stream
   %ffi fclose Int64 stream'
   ()
@@ -1049,7 +1042,7 @@ def fwrite (stream:Stream WriteMode) (s:String) : {State World} Unit =
   %ffi fflush Int64 stream'
   ()
 
-def while (eff:Effects) ?-> (body: Unit -> {|eff} Bool) : {|eff} Unit =
+def while (body: Unit -> {|eff} Bool) : {|eff} Unit =
   body' : Unit -> {|eff} Word8 = \_. BToW8 $ body ()
   %while body'
 
@@ -1237,7 +1230,7 @@ instance Arbitrary Int32
 instance [Arbitrary a] Arbitrary (n=>a)
   arb = \key. for i. arb $ ixkey key i
 
-instance (n:Int) ?-> Arbitrary (Fin n)
+instance Arbitrary (Fin n)
   arb = randIdx
 
 'Control flow

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -40,7 +40,7 @@ def FToI (x:Float) : Int = internalCast _ x
 def I64ToRawPtr (x:Int64 ) : RawPtr = internalCast _ x
 def RawPtrToI64 (x:RawPtr) : Int64  = internalCast _ x
 
-interface Add a:Type where
+interface Add a
   add : a -> a -> a
   sub : a -> a -> a
   zero : a
@@ -48,97 +48,97 @@ interface Add a:Type where
 def (+) [Add a] : a -> a -> a = add
 def (-) [Add a] : a -> a -> a = sub
 
-instance float64Add : Add Float64 where
-  add = \x:Float64 y:Float64. %fadd x y
-  sub = \x:Float64 y:Float64. %fsub x y
+instance Add Float64
+  add = \x y. %fadd x y
+  sub = \x y. %fsub x y
   zero = FToF64 0.0
 
-instance float32Add : Add Float32 where
-  add = \x:Float32 y:Float32. %fadd x y
-  sub = \x:Float32 y:Float32. %fsub x y
+instance Add Float32
+  add = \x y. %fadd x y
+  sub = \x y. %fsub x y
   zero = FToF32 0.0
 
-instance int64Add : Add Int64 where
-  add = \x:Int64 y:Int64. %iadd x y
-  sub = \x:Int64 y:Int64. %isub x y
+instance Add Int64
+  add = \x y. %iadd x y
+  sub = \x y. %isub x y
   zero = IToI64 0
 
-instance int32Add : Add Int32 where
-  add = \x:Int32 y:Int32. %iadd x y
-  sub = \x:Int32 y:Int32. %isub x y
+instance Add Int32
+  add = \x y. %iadd x y
+  sub = \x y. %isub x y
   zero = IToI32 0
 
-instance word8Add : Add Word8 where
-  add = \x:Word8 y:Word8. %iadd x y
-  sub = \x:Word8 y:Word8. %isub x y
+instance Add Word8
+  add = \x y. %iadd x y
+  sub = \x y. %isub x y
   zero = IToW8 0
 
-instance unitAdd : Add Unit where
+instance Add Unit
   add = \x y. ()
   sub = \x y. ()
   zero = ()
 
-instance tabAdd : Add a ?=> Add (n=>a) where
+instance [Add a] Add (n=>a)
   add = \xs ys. for i. xs.i + ys.i
   sub = \xs ys. for i. xs.i - ys.i
   zero = for _. zero
 
-interface Mul a:Type where
+interface Mul a
   mul : a -> a -> a
   one : a
 
 def (*) [Mul a] : a -> a -> a = mul
 
-instance float64Mul : Mul Float64 where
-  mul = \x:Float64 y:Float64. %fmul x y
+instance Mul Float64
+  mul = \x y. %fmul x y
   one = FToF64 1.0
 
-instance float32Mul : Mul Float32 where
-  mul = \x:Float32 y:Float32. %fmul x y
+instance Mul Float32
+  mul = \x y. %fmul x y
   one = FToF32 1.0
 
-instance int64Mul : Mul Int64 where
-  mul = \x:Int64 y:Int64. %imul x y
+instance Mul Int64
+  mul = \x y. %imul x y
   one = IToI64 1
 
-instance int32Mul : Mul Int32 where
-  mul = \x:Int32 y:Int32. %imul x y
+instance Mul Int32
+  mul = \x y. %imul x y
   one = IToI32 1
 
-instance word8Mul : Mul Word8 where
-  mul = \x:Word8 y:Word8. %imul x y
+instance Mul Word8
+  mul = \x y. %imul x y
   one = IToW8 1
 
-instance unitMul : Mul Unit where
+instance Mul Unit
   mul = \x y. ()
   one = ()
 
 
-interface Integral a:Type where
-  idiv: a->a->a
-  rem: a->a->a
+interface Integral a
+  idiv : a->a->a
+  rem  : a->a->a
 
-instance int64Integral : Integral Int64 where
-  idiv = \x:Int64 y:Int64. %idiv x y
-  rem  = \x:Int64 y:Int64. %irem x y
+instance Integral Int64
+  idiv = \x y. %idiv x y
+  rem  = \x y. %irem x y
 
-instance int32Integral : Integral Int32 where
-  idiv = \x:Int32 y:Int32. %idiv x y
-  rem  = \x:Int32 y:Int32. %irem x y
+instance Integral Int32
+  idiv = \x y. %idiv x y
+  rem  = \x y. %irem x y
 
-instance word8Integral  : Integral Word8  where
-  idiv = \x:Word8  y:Word8.  %idiv x y
-  rem  = \x:Word8  y:Word8.  %irem x y
+instance Integral Word8
+  idiv = \x y.  %idiv x y
+  rem  = \x y.  %irem x y
 
 
-interface Fractional a:Type where
+interface Fractional a
   divide : a -> a -> a
 
-instance float64Fractional : Fractional Float64 where
-  divide = \x:Float64 y:Float64. %fdiv x y
+instance Fractional Float64
+  divide = \x y. %fdiv x y
 
-instance float32Fractional : Fractional Float32 where
-  divide = \x:Float32 y:Float32. %fdiv x y
+instance Fractional Float32
+  divide = \x y. %fdiv x y
 
 '## Basic polymorphic functions and types
 
@@ -157,19 +157,22 @@ const : a -> b -> a = \x _. x
 
 '## Vector spaces
 
-data VSpace a:Type = MkVSpace (Add a) (Float -> a -> a)
+interface [Add a] VSpace a
+  scaleVec : Float -> a -> a
 
-@superclass
-def addFromVSpace (d:VSpace a) : Add a = case d of MkVSpace addDict _ -> addDict
-
-def (.*) (d:VSpace a) ?=> : Float -> a -> a = case d of MkVSpace _ scale -> scale
-def (*.) [VSpace a]       : a -> Float -> a = flip (.*)
+def (.*) [VSpace a] : Float -> a -> a = scaleVec
+def (*.) [VSpace a] : a -> Float -> a = flip scaleVec
 def (/)  [VSpace a] (v:a) (s:Float) : a = divide 1.0 s .* v
 def neg  [VSpace a] (v:a) : a = (-1.0) .* v
 
-@instance floatVS : VSpace Float = MkVSpace float32Add (*)
-@instance tabVS  : VSpace a ?=> VSpace (n=>a) = MkVSpace tabAdd \s xs. for i. s .* xs.i
-@instance unitVS : VSpace Unit = MkVSpace unitAdd \s u. ()
+instance VSpace Float
+  scaleVec = \x y. x * y
+
+instance [VSpace a] VSpace (n=>a)
+  scaleVec = \s xs. for i. s .* xs.i
+
+instance VSpace Unit
+  scaleVec = \_ _. ()
 
 '## Boolean type
 
@@ -197,7 +200,7 @@ def not  (x:Bool) : Bool =
 
 '## Sum types
 
-data Maybe a:Type =
+data Maybe a =
   Nothing
   Just a
 
@@ -207,7 +210,7 @@ def isNothing (x:Maybe a) : Bool = case x of
 
 def isJust (x:Maybe a) : Bool = not $ isNothing x
 
-data (|) a:Type b:Type =
+data (|) a b =
   Left  a
   Right b
 
@@ -285,55 +288,76 @@ def unreachable (():Unit) : a = unsafeIO do
 
 '## Type classes
 
-data Eq  a:Type = MkEq  (a -> a -> Bool)
-data Ord a:Type = MkOrd (Eq a) (a -> a -> Bool) (a -> a -> Bool)  -- eq, gt, lt
+interface Eq a
+  (==) : a -> a -> Bool
 
-@superclass
-def eqFromOrd (d:Ord a) : Eq a = case d of MkOrd eq _ _ -> eq
-
-def (==) (d:Eq a) ?=> (x:a) (y:a) : Bool = case d of MkEq eq -> eq x y
 def (/=) [Eq a] (x:a) (y:a) : Bool = not $ x == y
 
-def (>)  (d:Ord a) ?=> (x:a) (y:a) : Bool = case d of MkOrd _ gt _  -> gt x y
-def (<)  (d:Ord a) ?=> (x:a) (y:a) : Bool = case d of MkOrd _ _  lt -> lt x y
+interface [Eq a] Ord a
+  (>) : a -> a -> Bool
+  (<) : a -> a -> Bool
+
 def (<=) [Ord a] (x:a) (y:a) : Bool = x<y || x==y
 def (>=) [Ord a] (x:a) (y:a) : Bool = x>y || x==y
 
-@instance float64Eq : Eq Float64 = MkEq \x:Float64 y:Float64. W8ToB $ %feq x y
-@instance float32Eq : Eq Float32 = MkEq \x:Float32 y:Float32. W8ToB $ %feq x y
-@instance int64Eq   : Eq Int64   = MkEq \x:Int64   y:Int64.   W8ToB $ %ieq x y
-@instance int32Eq   : Eq Int32   = MkEq \x:Int32   y:Int32.   W8ToB $ %ieq x y
-@instance word8Eq   : Eq Word8   = MkEq \x:Word8   y:Word8.   W8ToB $ %ieq x y
-@instance boolEq    : Eq Bool    = MkEq \x y. BToW8 x == BToW8 y
-@instance unitEq    : Eq Unit    = MkEq \x y. True
-@instance rawPtrEq  : Eq RawPtr  = MkEq \x y. RawPtrToI64 x == RawPtrToI64 y
+instance Eq Float64
+  (==) = \x y. W8ToB $ %feq x y
 
-@instance float64Ord : Ord Float64 = (MkOrd float64Eq (\x y. W8ToB $ %fgt x y)
-                                                      (\x y. W8ToB $ %flt x y))
-@instance float32Ord : Ord Float32 = (MkOrd float32Eq (\x y. W8ToB $ %fgt x y)
-                                                      (\x y. W8ToB $ %flt x y))
-@instance int64Ord   : Ord Int64   = (MkOrd int64Eq   (\x y. W8ToB $ %igt x y)
-                                                      (\x y. W8ToB $ %ilt x y))
-@instance int32Ord   : Ord Int32   = (MkOrd int32Eq   (\x y. W8ToB $ %igt x y)
-                                                      (\x y. W8ToB $ %ilt x y))
-@instance word8Ord   : Ord Word8   = (MkOrd word8Eq   (\x y. W8ToB $ %igt x y)
-                                                      (\x y. W8ToB $ %ilt x y))
-@instance unitOrd    : Ord Unit    = (MkOrd unitEq (\x y. False) (\x y. False))
+instance Eq Float32
+  (==) = \x y. W8ToB $ %feq x y
 
-@instance
-def pairEq [Eq a, Eq b] : Eq (a & b) = MkEq $
-  \(x1,x2) (y1,y2). x1 == y1 && x2 == y2
+instance Eq Int64
+  (==) = \x y. W8ToB $ %ieq x y
 
-@instance
-def pairOrd [Ord a, Ord b] : Ord (a & b) =
-  pairGt = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
-  pairLt = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
-  MkOrd pairEq pairGt pairLt
+instance Eq Int32
+  (==) = \x y. W8ToB $ %ieq x y
+
+instance Eq Word8
+  (==) = \x y. W8ToB $ %ieq x y
+
+instance Eq Bool
+  (==) = \x y. BToW8 x == BToW8 y
+
+instance Eq Unit
+  (==) = \x y. True
+
+instance Eq RawPtr
+  (==) = \x y. RawPtrToI64 x == RawPtrToI64 y
+
+instance Ord Float64
+  (>) = \x y. W8ToB $ %fgt x y
+  (<) = \x y. W8ToB $ %flt x y
+
+instance Ord Float32
+  (>) = \x y. W8ToB $ %fgt x y
+  (<) = \x y. W8ToB $ %flt x y
+
+instance Ord Int64
+  (>) = \x y. W8ToB $ %igt x y
+  (<) = \x y. W8ToB $ %ilt x y
+
+instance Ord Int32
+  (>) = \x y. W8ToB $ %igt x y
+  (<) = \x y. W8ToB $ %ilt x y
+
+instance Ord Word8
+  (>) = \x y. W8ToB $ %igt x y
+  (<) = \x y. W8ToB $ %ilt x y
+
+instance Ord Unit
+  (>) = \x y. False
+  (<) = \x y. False
+
+instance [Eq a, Eq b] Eq (a & b)
+  (==) = \(x1,x2) (y1,y2). x1 == y1 && x2 == y2
+
+instance [Ord a, Ord b] Ord (a & b)
+  (>) = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
+  (<) = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
 
 -- TODO: accumulate using the True/&& monoid
-@instance
-def tabEq [Eq a] : Eq (n=>a) = MkEq $
-  \xs ys.
+instance [Eq a] Eq (n=>a)
+  (==) = \xs ys.
     numDifferent : Float =
       yieldAccum \ref. for i.
         ref += (IToF (BToI (xs.i /= ys.i)))
@@ -341,7 +365,7 @@ def tabEq [Eq a] : Eq (n=>a) = MkEq $
 
 '## Transcencendental functions
 
-interface Floating a:Type where
+interface Floating a
   exp    : a -> a
   exp2   : a -> a
   log    : a -> a
@@ -375,45 +399,45 @@ def float64_cosh (x:Float64) : Float64 = %fdiv ((%exp x) + (%exp (%fsub (FToF64 
 def float64_tanh (x:Float64) : Float64 = %fdiv (%fsub (%exp x) (%exp (%fsub (FToF64 0.0) x))) ((%exp x) + (%exp (%fsub (FToF64 0.0) x)))
 
 
-instance float64Floating : Floating Float64 where
-  exp    = \x:Float64. %exp x
-  exp2   = \x:Float64. %exp2   x
-  log    = \x:Float64. %log    x
-  log2   = \x:Float64. %log2   x
-  log10  = \x:Float64. %log10  x
-  log1p  = \x:Float64. %log1p  x
-  sin    = \x:Float64. %sin    x
-  cos    = \x:Float64. %cos    x
-  tan    = \x:Float64. %tan    x
+instance Floating Float64
+  exp    = \x. %exp x
+  exp2   = \x. %exp2   x
+  log    = \x. %log    x
+  log2   = \x. %log2   x
+  log10  = \x. %log10  x
+  log1p  = \x. %log1p  x
+  sin    = \x. %sin    x
+  cos    = \x. %cos    x
+  tan    = \x. %tan    x
   sinh   = float64_sinh
   cosh   = float64_cosh
   tanh   = float64_tanh
-  floor  = \x:Float64. %floor  x
-  ceil   = \x:Float64. %ceil   x
-  round  = \x:Float64. %round  x
-  sqrt   = \x:Float64. %sqrt   x
-  pow    = \x:Float64 y:Float64. %fpow x y
-  lgamma = \x:Float64. %lgamma x
+  floor  = \x. %floor  x
+  ceil   = \x. %ceil   x
+  round  = \x. %round  x
+  sqrt   = \x. %sqrt   x
+  pow    = \x y. %fpow x y
+  lgamma = \x. %lgamma x
 
-instance float32Floating : Floating Float32 where
-  exp    = \x:Float32. %exp x
-  exp2   = \x:Float32. %exp2   x
-  log    = \x:Float32. %log    x
-  log2   = \x:Float32. %log2   x
-  log10  = \x:Float32. %log10  x
-  log1p  = \x:Float32. %log1p  x
-  sin    = \x:Float32. %sin    x
-  cos    = \x:Float32. %cos    x
-  tan    = \x:Float32. %tan    x
+instance Floating Float32
+  exp    = \x. %exp x
+  exp2   = \x. %exp2   x
+  log    = \x. %log    x
+  log2   = \x. %log2   x
+  log10  = \x. %log10  x
+  log1p  = \x. %log1p  x
+  sin    = \x. %sin    x
+  cos    = \x. %cos    x
+  tan    = \x. %tan    x
   sinh   = float32_sinh
   cosh   = float32_cosh
   tanh   = float32_tanh
-  floor  = \x:Float32. %floor  x
-  ceil   = \x:Float32. %ceil   x
-  round  = \x:Float32. %round  x
-  sqrt   = \x:Float32. %sqrt   x
-  pow    = \x:Float32 y:Float32. %fpow x y
-  lgamma = \x:Float32. %lgamma x
+  floor  = \x. %floor  x
+  ceil   = \x. %ceil   x
+  round  = \x. %round  x
+  sqrt   = \x. %sqrt   x
+  pow    = \x y. %fpow x y
+  lgamma = \x. %lgamma x
 
 '## Index set utilities
 
@@ -425,90 +449,66 @@ def unsafeFromOrdinal (n : Type) (i : Int) : n = %unsafeFromOrdinal n i
 def iota (n:Type) : n=>Int = view i. ordinal i
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`
-@instance
-def finEq (n:Int) ?-> : Eq (Fin n) = MkEq \x y. ordinal x == ordinal y
+instance (n:Int) ?-> Eq (Fin n)
+  (==) = \x y. ordinal x == ordinal y
 
-@instance
-def finOrd (n:Int) ?-> : Ord (Fin n) =
-  MkOrd finEq (\x y. ordinal x > ordinal y) (\x y. ordinal x < ordinal y)
+instance (n:Int) ?-> Ord (Fin n)
+  (>) = \x y. ordinal x > ordinal y
+  (<) = \x y. ordinal x < ordinal y
 
 '## Raw pointer operations
 
-data Ptr a:Type = MkPtr RawPtr
+data Ptr a = MkPtr RawPtr
 
 -- Is there a better way to select the right instance for `storageSize`??
-data TypeVehicle a:Type = MkTypeVehicle
+data TypeVehicle a = MkTypeVehicle
 def typeVehicle (a:Type) : TypeVehicle a = MkTypeVehicle
 
-interface Storable a:Type where
+interface Storable a
   store : Ptr a -> a -> {State World} Unit
   load  : Ptr a ->      {State World} a
-  storageSize : TypeVehicle a -> Int
+  storageSize_ : TypeVehicle a -> Int
 
--- TODO: we can't inline these into the instance definitions until we change
--- type inference to push types down into record constructors or allow `def` in
--- instance definitions.
-def word8Store ((MkPtr ptr): Ptr Word8) (x:Word8) : {State World} Unit  = %ptrStore ptr x
-def word8Load  ((MkPtr ptr): Ptr Word8)           : {State World} Word8 = %ptrLoad  ptr
+def storageSize (a:Type) -> (d:Storable a) ?=> : Int =
+  tv : TypeVehicle a = MkTypeVehicle
+  storageSize_ tv
 
-instance word8Storable : Storable Word8 where
-  store = word8Store
-  load  = word8Load
-  storageSize = const 1
+instance Storable Word8
+  store = \(MkPtr ptr) x. %ptrStore ptr x
+  load  = \(MkPtr ptr)  . %ptrLoad  ptr
+  storageSize_ = const 1
 
--- TODO: there's a bug preventing us inlining these definitions into the instance
-def int32Store ((MkPtr ptr): Ptr Int32) (x:Int32) : {State World} Unit  =
-  %ptrStore (internalCast %Int32Ptr ptr) x
-def int32Load  ((MkPtr ptr): Ptr Int32) : {State World} Int32 =
-  %ptrLoad (internalCast %Int32Ptr ptr)
-
-instance int32Storable : Storable Int32 where
-  store = int32Store
-  load  = int32Load
-  storageSize = const 4
+instance Storable Int32
+  store = \(MkPtr ptr) x. %ptrStore (internalCast %Int32Ptr ptr) x
+  load  = \(MkPtr ptr)  . %ptrLoad  (internalCast %Int32Ptr ptr)
+  storageSize_ = const 4
 
 def unpackPairPtr [Storable a, Storable b]
       (pairPtr: Ptr (a & b)) : (Ptr a & Ptr b) =
   (MkPtr rawPtrX) = pairPtr
-  rawPtrY = %ptrOffset rawPtrX (storageSize (typeVehicle a))
+  rawPtrY = %ptrOffset rawPtrX (storageSize a)
   (MkPtr rawPtrX, MkPtr rawPtrY)
 
-def pairStore [Storable a, Storable b]
-      (pairPtr:Ptr (a & b)) ((x, y):(a & b)) : {State World} Unit  =
-  (xPtr, yPtr) = unpackPairPtr pairPtr
-  store xPtr x
-  store yPtr y
+instance [Storable a, Storable b] Storable (a & b)
+  store = \pairPtr (x, y).
+    (xPtr, yPtr) = unpackPairPtr pairPtr
+    store xPtr x
+    store yPtr y
+  load = \pairPtr.
+    (xPtr, yPtr) = unpackPairPtr pairPtr
+    (load xPtr, load yPtr)
+  storageSize_ = \_.
+    storageSize a + storageSize b
 
-def pairLoad [Storable a, Storable b]
-      (pairPtr:Ptr (a & b)) : {State World} (a & b) =
-  (xPtr, yPtr) = unpackPairPtr pairPtr
-  (load xPtr, load yPtr)
-
-def pairStorageSize [Storable a, Storable b]
-    (_:TypeVehicle (a & b)) : Int =
-  storageSize (typeVehicle a) + storageSize (typeVehicle b)
-
-instance pairStorable : (Storable a) ?=> (Storable b) ?=> Storable (a & b) where
-  store = pairStore
-  load  = pairLoad
-  storageSize = pairStorageSize
-
-def ptrPtrStore ((MkPtr ptr): Ptr (Ptr a)) (x:(Ptr a)) : {State World} Unit  =
-  (MkPtr x') = x
-  %ptrStore (internalCast %PtrPtr ptr) x'
-
-def ptrPtrLoad  ((MkPtr ptr): Ptr (Ptr a)) : {State World} (Ptr a) =
-  MkPtr $ %ptrLoad (internalCast %PtrPtr ptr)
-
-instance ptrStorable : Storable (Ptr a) where
-  store = ptrPtrStore
-  load  = ptrPtrLoad
-  storageSize = const 8  -- TODO: something more portable?
+instance Storable (Ptr a)
+  store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internalCast %PtrPtr ptr) x
+  load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internalCast %PtrPtr ptr)
+  storageSize_ = const 8  -- TODO: something more portable?
 
 -- TODO: Storable instances for other types
 
 def malloc [Storable a] (n:Int) : {State World} (Ptr a) =
-  numBytes = storageSize (typeVehicle a) * n
+  numBytes = storageSize a * n
   MkPtr $ %alloc numBytes
 
 def free (ptr:Ptr a) : {State World} Unit =
@@ -517,7 +517,7 @@ def free (ptr:Ptr a) : {State World} Unit =
 
 def (+>>) [Storable a] (ptr:Ptr a) (i:Int) : Ptr a =
   (MkPtr ptr') = ptr
-  i' = i * storageSize (typeVehicle a)
+  i' = i * storageSize a
   MkPtr $ %ptrOffset ptr' i'
 
 -- TODO: generalize these brackets to allow other effects
@@ -601,7 +601,7 @@ def vdot (x:n=>Float) (y:n=>Float) : Float = fsum view i. x.i * y.i
 def dot [VSpace v] (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
-(**) : (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
+(**) :  (l=>m=>Float) -> (m=>n=>Float) -> (l=>n=>Float) = \x y.
   for i k. fsum view j. x.i.j * y.j.k
 
 (**.) : (n=>m=>Float) -> (m=>Float) -> (n=>Float) = \mat v. for i. vdot mat.i v
@@ -671,33 +671,33 @@ def deriv (f:Float->Float) (x:Float) : Float = jvp f x 1.0
 
 def derivRev (f:Float->Float) (x:Float) : Float = snd (vjp f x) 1.0
 
-interface HasAllClose a:Type where
+interface HasAllClose a
   allclose : a -> a -> a -> a -> Bool
 
-interface HasDefaultTolerance a:Type where
+interface HasDefaultTolerance a
   atol : a
   rtol : a
 
 def (~~) [HasAllClose a, HasDefaultTolerance a] : a -> a -> Bool = allclose atol rtol
 
-instance allCloseF32 : HasAllClose Float32 where
+instance HasAllClose Float32
   allclose = \atol rtol x y. abs (x - y) <= (atol + rtol * abs y)
 
-instance allCloseF64 : HasAllClose Float64 where
+instance HasAllClose Float64
   allclose = \atol rtol x y. abs (x - y) <= (atol + rtol * abs y)
 
-instance defaultToleranceF32 : HasDefaultTolerance Float32 where
+instance HasDefaultTolerance Float32
   atol = FToF32 0.00001
   rtol = FToF32 0.0001
 
-instance defaultToleranceF64 : HasDefaultTolerance Float64 where
+instance HasDefaultTolerance Float64
   atol = FToF64 0.00000001
   rtol = FToF64 0.00001
 
-instance allCloseTable : HasAllClose t ?=> HasDefaultTolerance t ?=> HasAllClose (n=>t) where
+instance [HasAllClose t, HasDefaultTolerance t] HasAllClose (n=>t)
   allclose = \atol rtol a b. all for i:n. (a.i ~~ b.i)
 
-instance defaultToleranceTable : (HasDefaultTolerance t) ?=> HasDefaultTolerance (n=>t) where
+instance [HasDefaultTolerance t] HasDefaultTolerance (n=>t)
   atol = for i. atol
   rtol = for i. rtol
 
@@ -776,7 +776,7 @@ def tile1 (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
 
 '## Monoid typeclass
 
-interface Monoid a:Type where
+interface Monoid a
   mempty : a
   mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
 
@@ -784,7 +784,7 @@ def (<>) [Monoid a] : a -> a -> a = mcombine
 
 '## Length-erased lists
 
-data List a:Type =
+data List a =
   AsList n:Int foo:(Fin n => a)
 
 def unsafeCastTable (m:Type) (xs:n=>a) : m=>a =
@@ -794,7 +794,7 @@ def toList (xs:n=>a) : List a =
   n' = size n
   AsList _ $ unsafeCastTable (Fin n') xs
 
-instance monoidList : Monoid (List a) where
+instance Monoid (List a)
   mempty = AsList _ []
   mcombine = \x y.
     (AsList nx xs) = x
@@ -808,7 +808,7 @@ instance monoidList : Monoid (List a) where
 
 '## Isomorphisms
 
-data Iso a:Type b:Type = MkIso { fwd: a -> b & bwd: b -> a }
+data Iso a b = MkIso { fwd: a -> b & bwd: b -> a }
 
 def appIso (iso: Iso a b) (x:a) : b =
   (MkIso {fwd, bwd}) = iso
@@ -890,7 +890,7 @@ def sliceFields (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
 
 -- TODO: should we be able to use `Ref World Int` instead of `Ptr Int`?
 -- TODO: would be nice to be able to use records here
-data DynBuffer a:Type = MkDynBuffer (Ptr (Int & Int & Ptr a))  -- size, max size, buf ptr
+data DynBuffer a = MkDynBuffer (Ptr (Int & Int & Ptr a))  -- size, max size, buf ptr
 
 def withDynamicBuffer [Storable a]
       (action: DynBuffer a -> {State World} b) : {State World} b =
@@ -945,29 +945,29 @@ def stringFromCharPtr (n:Int) (ptr:Ptr Char) : {State World} String =
 -- TODO. This is ASCII code point. It really should be Int32 for Unicode codepoint
 def codepoint (c:Char) : Int = W8ToI c
 
-interface Show a:Type where
+interface Show a
   show : a -> String
 
-instance showString : Show String where
+instance Show String
   show = id
 
-instance showInt32 : Show Int32 where
-  show = \x: Int32. unsafeIO do
+instance Show Int32
+  show = \x. unsafeIO do
     (n, ptr) = %ffi showInt32 (Int32 & RawPtr) x
     stringFromCharPtr n $ MkPtr ptr
 
-instance showInt64 : Show Int64 where
-  show = \x: Int64. unsafeIO do
+instance Show Int64
+  show = \x. unsafeIO do
     (n, ptr) = %ffi showInt64 (Int32 & RawPtr) x
     stringFromCharPtr n $ MkPtr ptr
 
-instance showFloat32 : Show Float32 where
-  show = \x: Float32.unsafeIO do
+instance Show Float32
+  show = \x. unsafeIO do
     (n, ptr) = %ffi showFloat32 (Int32 & RawPtr) x
     stringFromCharPtr n $ MkPtr ptr
 
-instance showFloat64 : Show Float64 where
-  show = \x: Float64.unsafeIO do
+instance Show Float64
+  show = \x. unsafeIO do
     (n, ptr) = %ffi showFloat64 (Int32 & RawPtr) x
     stringFromCharPtr n $ MkPtr ptr
 
@@ -1053,7 +1053,7 @@ def while (eff:Effects) ?-> (body: Unit -> {|eff} Bool) : {|eff} Unit =
   body' : Unit -> {|eff} Word8 = \_. BToW8 $ body ()
   %while body'
 
-data IterResult a:Type =
+data IterResult a =
   Continue
   Done a
 
@@ -1225,19 +1225,19 @@ def randIdx (k:Key) : n =
 
 'Type class for generating example values
 
-interface Arbitrary a:Type where
+interface Arbitrary a
   arb : Key -> a
 
-instance float32Arb : Arbitrary Float32 where
+instance Arbitrary Float32
   arb = randn
 
-instance in32Arb : Arbitrary Int32 where
+instance Arbitrary Int32
   arb = \key. FToI $ randn key * 5.0
 
-instance tabArb : Arbitrary a ?=> Arbitrary (n=>a) where
+instance [Arbitrary a] Arbitrary (n=>a)
   arb = \key. for i. arb $ ixkey key i
 
-instance finArb : n:Int ?-> Arbitrary (Fin n) where
+instance (n:Int) ?-> Arbitrary (Fin n)
   arb = randIdx
 
 'Control flow
@@ -1331,28 +1331,28 @@ def atan (x:Float) : Float = atan2 x 1.0
 
 data Complex = MkComplex Float Float  -- real, imaginary
 
-instance allCloseComplex : HasAllClose Complex where
+instance HasAllClose Complex
   allclose = \atol rtol (MkComplex a b) (MkComplex c d). (a ~~ c) && (b ~~ d)
 
-instance defaultToleranceComplex : HasDefaultTolerance Complex where
+instance HasDefaultTolerance Complex
   atol = MkComplex atol atol
   rtol = MkComplex rtol rtol
 
-@instance ComplexEq : Eq Complex =
-  MkEq \(MkComplex a b) (MkComplex c d). (a == c) && (b == d)
+instance Eq Complex
+  (==) = \(MkComplex a b) (MkComplex c d). (a == c) && (b == d)
 
-instance ComplexAdd : Add Complex where
+instance Add Complex
   add = \(MkComplex a b) (MkComplex c d). MkComplex (a + c) (b + d)
   sub = \(MkComplex a b) (MkComplex c d). MkComplex (a - c) (b - d)
   zero = MkComplex 0.0 0.0
 
-instance ComplexMul : Mul Complex where
+instance Mul Complex
   mul = \(MkComplex a b) (MkComplex c d).
     MkComplex (a * c - b * d) (a * d + b * c)
   one = MkComplex 1.0 0.0
 
-@instance complexVS : VSpace Complex =
-  MkVSpace ComplexAdd \a:Float (MkComplex c d):Complex. MkComplex (a * c) (a * d)
+instance VSpace Complex
+  scaleVec = \a:Float (MkComplex c d):Complex. MkComplex (a * c) (a * d)
 
 -- Todo: Hook up to (/) operator.  Might require two-parameter VSpace.
 def complex_division (MkComplex a b:Complex) (MkComplex c d:Complex): Complex =
@@ -1391,7 +1391,7 @@ def complex_tanh (MkComplex a b:Complex) : Complex =
   den = MkComplex (cosh a * cos b) (sinh a * sin  b)
   complex_division num den
 
-instance ComplexFractional : Fractional Complex where
+instance Fractional Complex
   divide = complex_division
 
 def complex_floor (MkComplex re im:Complex) : Complex =
@@ -1424,7 +1424,7 @@ def complex_log1p (x:Complex) : Complex =
         True -> complex_log u
         False -> divide ((complex_log u) * x) x
 
-instance complexFloating : Floating Complex where
+instance Floating Complex
   exp    = complex_exp
   exp2   = complex_exp2
   log    = complex_log

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -109,7 +109,7 @@ printLitProg TextDoc prog = do
   isatty <- queryTerminal stdOutput
   putStr $ foldMap (uncurry (printLitBlock isatty)) prog
 printLitProg JSONDoc prog =
-  forM_ prog $ \(_, result) -> case toJSONStr result of
+  forM_ prog \(_, result) -> case toJSONStr result of
     "{}" -> return ()
     s -> putStrLn s
 
@@ -146,7 +146,7 @@ parseMode = subparser $
     objectFileInfo = argument str (metavar "OBJFILE" <> help "Output path (.o file)")
 
 optionList :: [(String, a)] -> ReadM a
-optionList opts = eitherReader $ \s -> case lookup s opts of
+optionList opts = eitherReader \s -> case lookup s opts of
   Just x  -> Right x
   Nothing -> Left $ "Bad option. Expected one of: " ++ show (map fst opts)
 

--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -50,7 +50,7 @@ instance (Monoid env, Monad m) => MonadCat env (CatT env m) where
 instance MonadCat env m => MonadCat env (StateT s m) where
   look = lift look
   extend x = lift $ extend x
-  scoped m = StateT $ \s -> do
+  scoped m = StateT \s -> do
     ((ans, s'), env) <- scoped $ runStateT m s
     return $ ((ans, env), s')
 
@@ -145,7 +145,7 @@ catTraverse f inj xs env = runCatT (traverse (asCat f inj) xs) env
 
 catFoldM :: (Monoid env, Traversable t, Monad m)
         => (env -> a -> m env) -> env -> t a -> m env
-catFoldM f env xs = liftM snd $ flip runCatT env $ forM_ xs $ \x -> do
+catFoldM f env xs = liftM snd $ flip runCatT env $ forM_ xs \x -> do
   cur <- look
   new <- lift $ f cur x
   extend new
@@ -156,7 +156,7 @@ catFold f env xs = runIdentity $ catFoldM (\e x -> Identity $ f e x) env xs
 
 catMapM :: (Monoid env, Traversable t, Monad m)
         => (env -> a -> m (b, env)) -> env -> t a -> m (t b, env)
-catMapM f env xs = flip runCatT env $ forM xs $ \x -> do
+catMapM f env xs = flip runCatT env $ forM xs \x -> do
   cur <- look
   (y, new) <- lift $ f cur x
   extend new

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -17,7 +17,7 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               app,
               add, mul, sub, neg, div',
               iadd, imul, isub, idiv, ilt, ieq,
-              fpow, flog, fLitLike, recGet, buildImplicitNaryLam,
+              fpow, flog, fLitLike, recGetHead, buildImplicitNaryLam,
               select, substEmbed, substEmbedR, emitUnpack, getUnpacked,
               fromPair, getFst, getSnd, getFstRef, getSndRef,
               naryApp, appReduce, appTryReduce, buildAbs,
@@ -206,8 +206,8 @@ buildImplicitNaryLam (Nest b bs) body =
     bs' <- substEmbed (b@>x) bs
     buildImplicitNaryLam bs' \xs -> body $ x:xs
 
-recGet :: Label -> Atom -> Atom
-recGet l x = do
+recGetHead :: Label -> Atom -> Atom
+recGetHead l x = do
   let (RecordTy (Ext r _)) = getType x
   let i = fromJust $ elemIndex l $ map fst $ toList $ reflectLabels r
   getProjection [i] x

--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -39,6 +39,7 @@ data NameSpace =
      | InferenceName
      | SumName
      | FFIName
+     | TypeClassGenName   -- names generated for type class dictionaries
      | AbstractedPtrName  -- used in `abstractPtrLiterals` in Imp lowering
      | TopFunctionName    -- top-level Imp functions
      | AllocPtrName       -- used for constructing dests in Imp lowering
@@ -163,6 +164,7 @@ env ! v = case envLookup env v of
 isGlobal :: VarP ann -> Bool
 isGlobal (GlobalName _ :> _) = True
 isGlobal (GlobalArrayName _ :> _) = True
+isGlobal (Name TypeClassGenName _ _ :> _) = True
 isGlobal _ = False
 
 isGlobalBinder :: BinderP ann -> Bool

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -517,6 +517,7 @@ toImpHof env (maybeDest, hof) = do
       translateBlock env (maybeDest, body)
     Linearize _ -> error "Unexpected Linearize"
     Transpose _ -> error "Unexpected Transpose"
+    CatchException _ -> error "Unexpected CatchException"
 
 data LaunchInfo = LaunchInfo { numWorkgroups :: IExpr, workgroupSize :: IExpr }
 data ThreadInfo = ThreadInfo { tid :: IExpr, wid :: IExpr, threadRange :: Type }

--- a/src/lib/Logging.hs
+++ b/src/lib/Logging.hs
@@ -20,7 +20,7 @@ data Logger l = Logger (MVar l) (Maybe Handle)
 runLogger :: (Monoid l, MonadIO m) => Maybe FilePath -> (Logger l -> m a) -> m (a, l)
 runLogger maybePath m = do
   log <- liftIO $ newMVar mempty
-  logFile <- liftIO $ forM maybePath $ \path -> openFile path WriteMode
+  logFile <- liftIO $ forM maybePath \path -> openFile path WriteMode
   ans <- m $ Logger log logFile
   logged <- liftIO $ readMVar log
   return (ans, logged)
@@ -30,10 +30,10 @@ execLogger maybePath m = fst <$> runLogger maybePath m
 
 logThis :: (Pretty l, Monoid l, MonadIO m) => Logger l -> l -> m ()
 logThis (Logger log maybeLogHandle) x = liftIO $ do
-  forM_ maybeLogHandle $ \h -> do
+  forM_ maybeLogHandle \h -> do
     hPutStrLn h $ pprint x
     hFlush h
-  modifyMVar_ log $ \cur -> return (cur <> x)
+  modifyMVar_ log \cur -> return (cur <> x)
 
 readLog :: MonadIO m => Logger l -> m l
 readLog (Logger log _) = liftIO $ readMVar log

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -21,6 +21,7 @@ import Data.Foldable (toList)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Maybe (fromMaybe)
 import Data.String (fromString)
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
@@ -32,6 +33,7 @@ import Numeric
 
 import Env
 import Syntax
+import Util (enumerate)
 
 -- Specifies what kinds of operations are allowed to be printed at this point.
 -- Printing at AppPrec level means that applications can be printed
@@ -362,7 +364,7 @@ instance PrettyPrec Atom where
       "DataConRef" <+> p params <+> p args
     BoxedRef b ptr size body -> atPrec AppPrec $
       "Box" <+> p b <+> "<-" <+> p ptr <+> "[" <> p size <> "]" <+> hardline <> "in" <+> p body
-    ProjectElt idxs x -> atPrec LowestPrec $ "project" <+> p idxs <+> p x
+    ProjectElt idxs x -> prettyProjection idxs x
 
 instance Pretty DataConRefBinding where pretty = prettyFromPrettyPrec
 instance PrettyPrec DataConRefBinding where
@@ -373,6 +375,45 @@ fromInfix t = do
   ('(', t') <- uncons t
   (t'', ')') <- unsnoc t'
   return t''
+
+prettyProjection :: NE.NonEmpty Int -> Var -> DocPrec ann
+prettyProjection idxs (name :> ty) = prettyPrec uproj where
+  -- Builds a source expression that performs the given projection.
+  uproj = UApp (PlainArrow ()) (nosrc ulam) (nosrc uvar)
+  ulam = ULam (upat, Nothing) (PlainArrow ()) (nosrc $ UVar $ target :> ())
+  uvar = UVar $ name :> ()
+  (_, upat, target) = buildProj idxs
+
+  buildProj :: NE.NonEmpty Int -> (Type, UPat, Name)
+  buildProj (i NE.:| is) = let
+    -- Lazy Haskell trick: refer to `target` even though this function is
+    -- responsible for setting it!
+    (ty', pat', eltName) = case NE.nonEmpty is of
+      Just is' -> let (x, y, z) = buildProj is' in (x, y, Just z)
+      Nothing -> (ty, nosrc $ UPatBinder $ Bind $ target :> (), Nothing)
+    in case ty' of
+      TypeCon def params -> let
+        [DataConDef conName bs] = applyDataDefParams def params
+        b = toList bs !! i
+        pats = (\(j,_)-> if i == j then pat' else uignore) <$> enumerate bs
+        hint = case b of
+          Bind (n :> _) -> n
+          Ignore _ -> Name SourceName "elt" 0
+        in ( binderAnn b, nosrc $ UPatCon conName pats, fromMaybe hint eltName)
+      RecordTy (NoExt types) -> let
+        ty'' = toList types !! i
+        pats = (\(j,_)-> if i == j then pat' else uignore) <$> enumerate types
+        (fieldName, _) = toList (reflectLabels types) !! i
+        hint = Name SourceName (fromString fieldName) 0
+        in (ty'', nosrc $ UPatRecord $ NoExt pats, fromMaybe hint eltName)
+      PairTy x _ | i == 0 ->
+        (x, nosrc $ UPatPair pat' uignore, fromMaybe "a" eltName)
+      PairTy _ y | i == 1 ->
+        (y, nosrc $ UPatPair uignore pat', fromMaybe "b" eltName)
+      _ -> error "Bad projection"
+
+  nosrc = WithSrc Nothing
+  uignore = nosrc $ UPatBinder $ Ignore ()
 
 prettyExtLabeledItems :: (PrettyPrec a, PrettyPrec b)
   => ExtLabeledItems a b -> Doc ann -> Doc ann -> DocPrec ann

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -631,8 +631,11 @@ instance Pretty UDecl where
     "data" <+> p tyCon <+> "where" <> nest 2 (hardline <> prettyLines dataCons)
   pretty (UInterface cs def methods) =
     "interface" <+> p cs <+> p def <> hardline <> prettyLines methods
-  pretty (UInstance ty methods) =
-    "instance" <+> p ty <> hardline <> prettyLines methods
+  pretty (UInstance bs ty methods) =
+    "instance" <+> p bs <+> p ty <> hardline <> prettyLines methods
+
+instance Pretty UMethodDef where
+  pretty (UMethodDef b rhs) = p b <+> "=" <+> p rhs
 
 instance Pretty UConDef where
   pretty (UConDef con bs) = p con <+> spaced bs

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -21,7 +21,6 @@ import Data.Foldable (toList)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import qualified Data.ByteString.Lazy.Char8 as B
-import Data.Maybe (fromMaybe)
 import Data.String (fromString)
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
@@ -33,7 +32,6 @@ import Numeric
 
 import Env
 import Syntax
-import Util (enumerate)
 
 -- Specifies what kinds of operations are allowed to be printed at this point.
 -- Printing at AppPrec level means that applications can be printed
@@ -364,7 +362,7 @@ instance PrettyPrec Atom where
       "DataConRef" <+> p params <+> p args
     BoxedRef b ptr size body -> atPrec AppPrec $
       "Box" <+> p b <+> "<-" <+> p ptr <+> "[" <> p size <> "]" <+> hardline <> "in" <+> p body
-    ProjectElt idxs x -> prettyProjection idxs x
+    ProjectElt idxs x -> atPrec LowestPrec $ "project" <+> p idxs <+> p x
 
 instance Pretty DataConRefBinding where pretty = prettyFromPrettyPrec
 instance PrettyPrec DataConRefBinding where
@@ -375,45 +373,6 @@ fromInfix t = do
   ('(', t') <- uncons t
   (t'', ')') <- unsnoc t'
   return t''
-
-prettyProjection :: NE.NonEmpty Int -> Var -> DocPrec ann
-prettyProjection idxs (name :> ty) = prettyPrec uproj where
-  -- Builds a source expression that performs the given projection.
-  uproj = UApp (PlainArrow ()) (nosrc ulam) (nosrc uvar)
-  ulam = ULam (upat, Nothing) (PlainArrow ()) (nosrc $ UVar $ target :> ())
-  uvar = UVar $ name :> ()
-  (_, upat, target) = buildProj idxs
-
-  buildProj :: NE.NonEmpty Int -> (Type, UPat, Name)
-  buildProj (i NE.:| is) = let
-    -- Lazy Haskell trick: refer to `target` even though this function is
-    -- responsible for setting it!
-    (ty', pat', eltName) = case NE.nonEmpty is of
-      Just is' -> let (x, y, z) = buildProj is' in (x, y, Just z)
-      Nothing -> (ty, nosrc $ UPatBinder $ Bind $ target :> (), Nothing)
-    in case ty' of
-      TypeCon def params -> let
-        [DataConDef conName bs] = applyDataDefParams def params
-        b = toList bs !! i
-        pats = (\(j,_)-> if i == j then pat' else uignore) <$> enumerate bs
-        hint = case b of
-          Bind (n :> _) -> n
-          Ignore _ -> Name SourceName "elt" 0
-        in ( binderAnn b, nosrc $ UPatCon conName pats, fromMaybe hint eltName)
-      RecordTy (NoExt types) -> let
-        ty'' = toList types !! i
-        pats = (\(j,_)-> if i == j then pat' else uignore) <$> enumerate types
-        (fieldName, _) = toList (reflectLabels types) !! i
-        hint = Name SourceName (fromString fieldName) 0
-        in (ty'', nosrc $ UPatRecord $ NoExt pats, fromMaybe hint eltName)
-      PairTy x _ | i == 0 ->
-        (x, nosrc $ UPatPair pat' uignore, fromMaybe "a" eltName)
-      PairTy _ y | i == 1 ->
-        (y, nosrc $ UPatPair uignore pat', fromMaybe "b" eltName)
-      _ -> error "Bad projection"
-
-  nosrc = WithSrc Nothing
-  uignore = nosrc $ UPatBinder $ Ignore ()
 
 prettyExtLabeledItems :: (PrettyPrec a, PrettyPrec b)
   => ExtLabeledItems a b -> Doc ann -> Doc ann -> DocPrec ann
@@ -629,6 +588,10 @@ instance Pretty UDecl where
     align $ prettyUBinder b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
   pretty (UData tyCon dataCons) =
     "data" <+> p tyCon <+> "where" <> nest 2 (hardline <> prettyLines dataCons)
+  pretty (UInterface cs def methods) =
+    "interface" <+> p cs <+> p def <> hardline <> prettyLines methods
+  pretty (UInstance ty methods) =
+    "instance" <+> p ty <> hardline <> prettyLines methods
 
 instance Pretty UConDef where
   pretty (UConDef con bs) = p con <+> spaced bs

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -549,7 +549,7 @@ instance PrettyPrec UExpr' where
       where kw = case dir of Fwd -> "for"
                              Rev -> "rof"
     UPi binder arr ty -> atPrec LowestPrec $
-      prettyUPiBinder binder <+> pretty arr <+> pLowest ty
+      prettyUBinder binder <+> pretty arr <+> pLowest ty
     UDecl decl body -> atPrec LowestPrec $ align $ p decl <> hardline
                                                          <> pLowest body
     UHole -> atPrec ArgPrec "_"
@@ -612,12 +612,6 @@ prettyUBinder :: UPatAnn -> Doc ann
 prettyUBinder (pat, ann) = p pat <> annDoc where
   annDoc = case ann of
     Just ty -> ":" <> pApp ty
-    Nothing -> mempty
-
-prettyUPiBinder :: UPiPatAnn -> Doc ann
-prettyUPiBinder (pat, ann) = patDoc <> p ann where
-  patDoc = case pat of
-    Just pat' -> pApp pat' <> ":"
     Nothing -> mempty
 
 spaced :: (Foldable f, Pretty a) => f a -> Doc ann

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -383,8 +383,8 @@ funDefLet = label "function definition" $ mayBreak $ do
   let bs = map classAsBinder cs ++ argBinders
   let funTy = buildPiType bs eff ty
   let letBinder = (v, Just funTy)
-  let lamBinders = flip map bs $ \(p,_, arr) -> ((p,Nothing), arr)
-  return $ \body -> ULet PlainLet letBinder (buildLam lamBinders body)
+  let lamBinders = flip map bs \(p,_, arr) -> ((p,Nothing), arr)
+  return \body -> ULet PlainLet letBinder (buildLam lamBinders body)
   where
     classAsBinder :: UType -> (UPat, UType, UArrow)
     classAsBinder ty = (ns underscorePat, ty, ClassArrow)
@@ -892,7 +892,7 @@ prefixNegOp :: Operator Parser UExpr
 prefixNegOp = Prefix $ label "negation" $ do
   ((), pos) <- withPos $ sym "-"
   let f = WithSrc (Just pos) "neg"
-  return $ \case
+  return \case
     -- Special case: negate literals directly
     WithSrc litpos (IntLitExpr i)
       -> WithSrc (joinPos (Just pos) litpos) (IntLitExpr (-i))
@@ -914,7 +914,7 @@ infixArrow :: Parser (UType -> UType -> UType)
 infixArrow = do
   notFollowedBy (sym "=>")  -- table arrows have special fixity
   (arr, pos) <- withPos $ arrow effects
-  return $ \a b -> WithSrc (Just pos) $ UPi (Nothing, a) arr b
+  return \a b -> WithSrc (Just pos) $ UPi (Nothing, a) arr b
 
 mkArrow :: Arrow -> UExpr -> UExpr -> UExpr
 mkArrow arr a b = joinSrc a b $ UPi (Nothing, a) arr b
@@ -959,7 +959,7 @@ inpostfix' :: Parser a -> Parser (a -> Maybe a -> a) -> Operator Parser a
 inpostfix' p op = Postfix $ do
   f <- op
   rest <- optional p
-  return $ \x -> f x rest
+  return \x -> f x rest
 
 mkName :: String -> Name
 mkName s = Name SourceName (fromString s) 0

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -31,7 +31,7 @@ getDexString :: Val -> IO String
 getDexString (DataCon _ _ 0 [_, xs]) = do
   let (TabTy b _) = getType xs
   idxs <- indices $ getType b
-  forM idxs $ \i -> do
+  forM idxs \i -> do
     ~(Con (Lit (Word8Lit c))) <- evalBlock mempty (Block Empty (App xs i))
     return $ toEnum $ fromIntegral c
 getDexString x = error $ "Not a string: " ++ pprint x
@@ -49,7 +49,7 @@ prettyVal val = case val of
           _     -> "@" <> pretty idxSet -- Otherwise, show explicit index set
     -- Pretty-print elements.
     idxs <- indices idxSet
-    elems <- forM idxs $ \idx -> do
+    elems <- forM idxs \idx -> do
       atom <- evalBlock mempty $ snd $ applyAbs abs idx
       case atom of
         Con (Lit (Word8Lit c)) ->

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -61,7 +61,7 @@ hoistDepDataCons scope (Module Simp decls bindings) =
   where
     (bindings', (_, decls')) = flip runEmbed scope $ do
       mapM_ emitDecl decls
-      forM bindings $ \(ty, info) -> case info of
+      forM bindings \(ty, info) -> case info of
         LetBound ann x | isData ty -> do x' <- emit x
                                          return (ty, LetBound ann $ Atom x')
         _ -> return (ty, info)
@@ -89,7 +89,7 @@ simplifyDecl (Let ann b expr) = do
 simplifyStandalone :: Expr -> SimplifyM Atom
 simplifyStandalone (Atom (LamVal b body)) = do
   b' <- mapM substEmbedR b
-  buildLam b' PureArrow $ \x ->
+  buildLam b' PureArrow \x ->
     extendR (b@>x) $ simplifyBlock body
 simplifyStandalone block =
   error $ "@noinline decorator applied to non-function" ++ pprint block
@@ -139,9 +139,9 @@ simplifyAtom atom = case atom of
     case simplifyCase e' alts of
       Just (env, result) -> extendR env $ simplifyAtom result
       Nothing -> do
-        alts' <- forM alts $ \(Abs bs a) -> do
+        alts' <- forM alts \(Abs bs a) -> do
           bs' <- mapM (mapM substEmbedR) bs
-          (Abs bs'' b) <- buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ simplifyAtom a
+          (Abs bs'' b) <- buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ simplifyAtom a
           case b of
             Block Empty (Atom r) -> return $ Abs bs'' r
             _                    -> error $ "Nontrivial block in ACase simplification"
@@ -192,7 +192,7 @@ simplifyLams numArgs lam = do
         Left  res -> (res, Nothing)
         Right (dat, (ctx, recon), atomf) ->
           ( mkConsList $ (toList dat) ++ (toList ctx)
-          , Just $ \vals -> do
+          , Just \vals -> do
              (datEls', ctxEls') <- splitAt (length dat) <$> unpackConsList vals
              let dat' = restructure datEls' dat
              let ctx' = restructure ctxEls' ctx
@@ -200,7 +200,7 @@ simplifyLams numArgs lam = do
           )
     go n scope ~(Block Empty (Atom (Lam (Abs b (arr, body))))) = do
       b' <- mapM substEmbedR b
-      buildLamAux b' (\x -> extendR (b@>x) $ substEmbedR arr) $ \x@(Var v) -> do
+      buildLamAux b' (\x -> extendR (b@>x) $ substEmbedR arr) \x@(Var v) -> do
         let scope' = scope <> v @> (varType v, LamBound (void arr))
         extendR (b@>x) $ go (n-1) scope' body
 
@@ -278,7 +278,7 @@ separateDataComponent localVars v = do
           True  -> nubCtx t
           False -> h : (nubCtx t)
         result = nubCtx $ toList ll
-        inv ctx' result' = for ll $ \x -> case elemIndex x (toList ctx) of
+        inv ctx' result' = for ll \x -> case elemIndex x (toList ctx) of
           Just i  -> (toList ctx') !! i
           Nothing -> result' !! (fromJust $ elemIndex x result)
 
@@ -299,7 +299,7 @@ simplifyExpr expr = case expr of
         case all isCurriedFun alts of
           True -> return $ ACase e (fmap appAlt alts) rty'
           False -> do
-            let alts' = for alts $ \(Abs bs a) -> Abs bs $ Block Empty (App a x')
+            let alts' = for alts \(Abs bs a) -> Abs bs $ Block Empty (App a x')
             dropSub $ simplifyExpr $ Case e alts' rty'
         where
           isCurriedFun alt = case alt of
@@ -321,16 +321,16 @@ simplifyExpr expr = case expr of
       Nothing -> do
         if isData resultTy'
           then do
-            alts' <- forM alts $ \(Abs bs body) -> do
+            alts' <- forM alts \(Abs bs body) -> do
               bs' <-  mapM (mapM substEmbedR) bs
-              buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ simplifyBlock body
+              buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ simplifyBlock body
             emit $ Case e' alts' resultTy'
           else do
             -- Construct the blocks of new cases. The results will only get replaced
             -- later, once we learn the closures of the non-data component of each case.
-            (alts', facs) <- liftM unzip $ forM alts $ \(Abs bs body) -> do
+            (alts', facs) <- liftM unzip $ forM alts \(Abs bs body) -> do
               bs' <-  mapM (mapM substEmbedR) bs
-              buildNAbsAux bs' $ \xs -> do
+              buildNAbsAux bs' \xs -> do
                 ~(Right fac@(dat, (ctx, _), _)) <- extendR (newEnv bs' xs) $ defunBlock (boundVars bs') body
                 -- NB: The return value here doesn't really matter as we're going to replace it afterwards.
                 return (mkConsList $ toList dat ++ toList ctx, fac)
@@ -361,9 +361,9 @@ simplifyExpr expr = case expr of
             --       a single output. This can probably be made quite a bit faster.
             -- NB: All the non-data trees have the same structure, so we pick an arbitrary one.
             nondatTree <- (\(_, (ctx, rec), _) -> rec dat ctx) $ head facs
-            nondat <- forM (enumerate nondatTree) $ \(i, _) -> do
-              aalts <- forM facs $ \(_, (ctx, rec), _) -> do
-                Abs bs' b <- buildNAbs (toNest $ toList $ fmap (Ignore . getType) ctx) $ \ctxVals ->
+            nondat <- forM (enumerate nondatTree) \(i, _) -> do
+              aalts <- forM facs \(_, (ctx, rec), _) -> do
+                Abs bs' b <- buildNAbs (toNest $ toList $ fmap (Ignore . getType) ctx) \ctxVals ->
                   ((!! i) . toList) <$> rec dat (restructure ctxVals ctx)
                 case b of
                   Block Empty (Atom r) -> return $ Abs bs' r
@@ -441,7 +441,7 @@ simplifyHof hof = case hof of
     ans <- emit $ Hof $ For d lam'
     case recon of
       Nothing -> return ans
-      Just f  -> buildLam i TabArrow $ \i' -> app ans i' >>= f
+      Just f  -> buildLam i TabArrow \i' -> app ans i' >>= f
   Tile d fT fS -> do
     ~(fT', Nothing) <- simplifyLam fT
     ~(fS', Nothing) <- simplifyLam fS
@@ -495,7 +495,7 @@ exceptToMaybeBlock (Block (Nest (Let _ b expr) decls) result) = do
     JustAtom _ x  -> extendR (b@>x) $ exceptToMaybeBlock $ Block decls result
     NothingAtom _ -> return $ NothingAtom a
     _ -> do
-      emitMaybeCase maybeResult (return $ NothingAtom a) $ \x -> do
+      emitMaybeCase maybeResult (return $ NothingAtom a) \x -> do
         extendR (b@>x) $ exceptToMaybeBlock $ Block decls result
 
 exceptToMaybeExpr :: Expr -> SubstEmbed Atom
@@ -505,27 +505,27 @@ exceptToMaybeExpr expr = do
     Case e alts resultTy -> do
       e' <- substEmbedR e
       resultTy' <- substEmbedR $ MaybeTy resultTy
-      alts' <- forM alts $ \(Abs bs body) -> do
+      alts' <- forM alts \(Abs bs body) -> do
         bs' <-  substEmbedR bs
-        buildNAbs bs' $ \xs -> extendR (newEnv bs' xs) $ exceptToMaybeBlock body
+        buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ exceptToMaybeBlock body
       emit $ Case e' alts' resultTy'
     Atom x -> substEmbedR $ JustAtom (getType x) x
     Op (ThrowException _) -> return $ NothingAtom a
     Hof (For ann ~(Lam (Abs b (_, body)))) -> do
       b' <- substEmbedR b
-      maybes <- buildForAnn ann b' $ \i -> extendR (b@>i) $ exceptToMaybeBlock body
+      maybes <- buildForAnn ann b' \i -> extendR (b@>i) $ exceptToMaybeBlock body
       catMaybesE maybes
     Hof (RunState s lam) -> do
       s' <- substEmbedR s
       let BinaryFunVal _ b _ body = lam
-      result  <- emitRunState "ref" s' $ \ref ->
+      result  <- emitRunState "ref" s' \ref ->
         extendR (b@>ref) $ exceptToMaybeBlock body
       (maybeAns, newState) <- fromPair result
-      emitMaybeCase maybeAns (return $ NothingAtom a) $ \ans ->
+      emitMaybeCase maybeAns (return $ NothingAtom a) \ans ->
         return $ JustAtom a $ PairVal ans newState
     Hof (While ~(Lam (Abs _ (_, body)))) -> do
       eff <- getAllowedEffects
-      lam <- buildLam (Ignore UnitTy) (PlainArrow eff) $ \_ ->
+      lam <- buildLam (Ignore UnitTy) (PlainArrow eff) \_ ->
                exceptToMaybeBlock body
       runMaybeWhile lam
     _ | not (hasExceptions expr) -> do

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -39,7 +39,7 @@ module Syntax (
     freeVars, freeUVars, Subst, HasVars, BindsVars, Ptr, PtrType,
     AddressSpace (..), showPrimName, strToPrimName, primNameToStr,
     monMapSingle, monMapLookup, Direction (..), Limit (..),
-    UExpr, UExpr' (..), UType, UPatAnn, UPiPatAnn, UAnnBinder, UVar,
+    UExpr, UExpr' (..), UType, UPatAnn, UAnnBinder, UVar,
     UPat, UPat' (..), UModule (..), UDecl (..), UArrow, arrowEff,
     DataDef (..), DataConDef (..), UConDef (..), Nest (..), toNest,
     subst, deShadow, scopelessSubst, absArgType, applyAbs, makeAbs,
@@ -63,7 +63,7 @@ module Syntax (
     pattern Unlabeled, pattern NoExt, pattern LabeledRowKind,
     pattern NoLabeledItems, pattern InternalSingletonLabel, pattern EffKind,
     pattern NestOne, pattern NewTypeCon, pattern BinderAnn,
-    pattern ClassDictDef, pattern ClassDictCon)
+    pattern ClassDictDef, pattern ClassDictCon, pattern UnderscoreUPat)
   where
 
 import qualified Data.Map.Strict as M
@@ -225,7 +225,7 @@ prefixExtLabeledItems items (Ext items' rest) = Ext (items <> items') rest
 type UExpr = WithSrc UExpr'
 data UExpr' = UVar UVar
             | ULam UPatAnn UArrow UExpr
-            | UPi  UPiPatAnn Arrow UType
+            | UPi  UPatAnn  Arrow UType
             | UApp UArrow UExpr UExpr
             | UDecl UDecl UExpr
             | UFor Direction UPatAnn UExpr
@@ -257,7 +257,6 @@ type UVar    = VarP ()
 type UBinder = BinderP ()
 
 type UPatAnn   = (UPat, Maybe UType)
-type UPiPatAnn   = (Maybe UPat, UType)
 type UAnnBinder = BinderP UType
 
 data UAlt = UAlt UPat UExpr deriving (Show, Generic)
@@ -284,6 +283,9 @@ srcPos (WithSrc pos _) = pos
 
 instance IsString UExpr' where
   fromString s = UVar $ Name SourceName (fromString s) 0 :> ()
+
+pattern UnderscoreUPat :: UPat
+pattern UnderscoreUPat = WithSrc Nothing (UPatBinder (Ignore ()))
 
 -- === primitive constructors and operators ===
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -10,10 +10,8 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE StrictData #-}
 {-# LANGUAGE DeriveFunctor #-}
-{-# LANGUAGE PatternSynonyms #-}
 {-# LANGUAGE ViewPatterns #-}
 {-# LANGUAGE Rank2Types #-}
-{-# LANGUAGE LambdaCase #-}
 
 module Syntax (
     Type, Kind, BaseType (..), ScalarBaseType (..),
@@ -189,14 +187,14 @@ labeledSingleton label value = LabeledItems $ M.singleton label (value NE.:|[])
 
 reflectLabels :: LabeledItems a -> LabeledItems (Label, Int)
 reflectLabels (LabeledItems items) = LabeledItems $
-  flip M.mapWithKey items $ \k xs -> fmap (\(i,_) -> (k,i)) (enumerate xs)
+  flip M.mapWithKey items \k xs -> fmap (\(i,_) -> (k,i)) (enumerate xs)
 
 getLabels :: LabeledItems a -> [Label]
 getLabels labeledItems = map fst $ toList $ reflectLabels labeledItems
 
 withLabels :: LabeledItems a -> LabeledItems (Label, Int, a)
 withLabels (LabeledItems items) = LabeledItems $
-  flip M.mapWithKey items $ \k xs -> fmap (\(i,a) -> (k,i,a)) (enumerate xs)
+  flip M.mapWithKey items \k xs -> fmap (\(i,a) -> (k,i,a)) (enumerate xs)
 
 lookupLabel :: LabeledItems a -> Label -> Maybe a
 lookupLabel (LabeledItems items) l = case M.lookup l items of
@@ -684,10 +682,10 @@ throwIf True  e s = throw e s
 throwIf False _ _ = return ()
 
 modifyErr :: MonadError e m => m a -> (e -> e) -> m a
-modifyErr m f = catchError m $ \e -> throwError (f e)
+modifyErr m f = catchError m \e -> throwError (f e)
 
 addContext :: MonadError Err m => String -> m a -> m a
-addContext s m = modifyErr m $ \(Err e p s') -> Err e p (s' ++ "\n" ++ s)
+addContext s m = modifyErr m \(Err e p s') -> Err e p (s' ++ "\n" ++ s)
 
 addSrcContext :: MonadError Err m => SrcCtx -> m a -> m a
 addSrcContext ctx m = modifyErr m updateErr
@@ -698,9 +696,9 @@ addSrcContext ctx m = modifyErr m updateErr
 
 catchIOExcept :: (MonadIO m , MonadError Err m) => IO a -> m a
 catchIOExcept m = (liftIO >=> liftEither) $ (liftM Right m) `catches`
-  [ Handler $ \(e::Err)           -> return $ Left e
-  , Handler $ \(e::IOError)       -> return $ Left $ Err DataIOErr   Nothing $ show e
-  , Handler $ \(e::SomeException) -> return $ Left $ Err CompilerErr Nothing $ show e
+  [ Handler \(e::Err)           -> return $ Left e
+  , Handler \(e::IOError)       -> return $ Left $ Err DataIOErr   Nothing $ show e
+  , Handler \(e::SomeException) -> return $ Left $ Err CompilerErr Nothing $ show e
   ]
 
 liftEitherIO :: (Exception e, MonadIO m) => Either e a -> m a

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -216,7 +216,7 @@ def catLists (xs:List a) (ys:List a) : List a =
 def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
 
 :t listToTable
-> ((a:Type) ?-> (pat:(List a)) -> (Fin ((\((AsList n _)). n) pat)) => a)
+> ((a:Type) ?-> (pat:(List a)) -> (Fin (project [0] pat:(List a))) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -228,7 +228,7 @@ def listToTable2 (l: List a) : (Fin (listLength l))=>a =
   xs
 
 :t listToTable2
-> ((a:Type) ?-> (l:(List a)) -> (Fin ((\((AsList n _)). n) l)) => a)
+> ((a:Type) ?-> (l:(List a)) -> (Fin (project [0] l:(List a))) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -258,7 +258,7 @@ def graphToAdjacencyMatrix ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
 :t graphToAdjacencyMatrix
 > ((a:Type)
 >  ?-> (pat:(Graph a))
->  -> ((\((MkGraph n _ _ _)). n) pat) => ((\((MkGraph n _ _ _)). n) pat) => Bool)
+>  -> (project [0] pat:(Graph a)) => (project [0] pat:(Graph a)) => Bool)
 
 :p
   g : Graph Int = MkGraph (Fin 3) [5, 6, 7] (Fin 4) [(0@_, 1@_), (0@_, 2@_), (2@_, 0@_), (1@_, 1@_)]
@@ -269,15 +269,15 @@ def graphToAdjacencyMatrix ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
 
 def pairUnpack ((v, _):(Int & Float)) : Int = v
 :p pairUnpack
-> \pat:(Int32 & Float32). (\(a, _). a) pat
+> \pat:(Int32 & Float32). project [0] pat:(Int32 & Float32)
 
 def adtUnpack ((MkMyPair v _):MyPair Int Float) : Int = v
 :p adtUnpack
-> \pat:(MyPair Int32 Float32). (\((MkMyPair elt _)). elt) pat
+> \pat:(MyPair Int32 Float32). project [0] pat:(MyPair Int32 Float32)
 
 def recordUnpack ({a=v, b=_}:{a:Int & b:Float}) : Int = v
 :p recordUnpack
-> \pat:{a: Int32 & b: Float32}. (\{a = a, b = _}. a) pat
+> \pat:{a: Int32 & b: Float32}. project [0] pat:{a: Int32 & b: Float32}
 
 def nestedUnpack (x:MyPair Int (MyPair (MyIntish & Int) Int)) : Int =
   (MkMyPair _ (MkMyPair (MkIntish y, _) _)) = x
@@ -285,7 +285,7 @@ def nestedUnpack (x:MyPair Int (MyPair (MyIntish & Int) Int)) : Int =
 
 :p nestedUnpack
 > \x:(MyPair Int32 (MyPair (MyIntish & Int32) Int32)).
->   (\((MkIntish (((MkMyPair ((MkMyPair _ elt)) _)), _))). elt) x
+>   project [0, 0, 0, 1] x:(MyPair Int32 (MyPair (MyIntish & Int32) Int32))
 
 :p nestedUnpack (MkMyPair 3 (MkMyPair (MkIntish 4, 5) 6))
 > 4

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -216,7 +216,7 @@ def catLists (xs:List a) (ys:List a) : List a =
 def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
 
 :t listToTable
-> ((a:Type) ?-> (pat:(List a)) -> (Fin (project [0] pat:(List a))) => a)
+> ((a:Type) ?-> (pat:(List a)) -> (Fin ((\((AsList n _)). n) pat)) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -228,7 +228,7 @@ def listToTable2 (l: List a) : (Fin (listLength l))=>a =
   xs
 
 :t listToTable2
-> ((a:Type) ?-> (l:(List a)) -> (Fin (project [0] l:(List a))) => a)
+> ((a:Type) ?-> (l:(List a)) -> (Fin ((\((AsList n _)). n) l)) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -258,7 +258,7 @@ def graphToAdjacencyMatrix ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
 :t graphToAdjacencyMatrix
 > ((a:Type)
 >  ?-> (pat:(Graph a))
->  -> (project [0] pat:(Graph a)) => (project [0] pat:(Graph a)) => Bool)
+>  -> ((\((MkGraph n _ _ _)). n) pat) => ((\((MkGraph n _ _ _)). n) pat) => Bool)
 
 :p
   g : Graph Int = MkGraph (Fin 3) [5, 6, 7] (Fin 4) [(0@_, 1@_), (0@_, 2@_), (2@_, 0@_), (1@_, 1@_)]
@@ -269,15 +269,15 @@ def graphToAdjacencyMatrix ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
 
 def pairUnpack ((v, _):(Int & Float)) : Int = v
 :p pairUnpack
-> \pat:(Int32 & Float32). project [0] pat:(Int32 & Float32)
+> \pat:(Int32 & Float32). (\(a, _). a) pat
 
 def adtUnpack ((MkMyPair v _):MyPair Int Float) : Int = v
 :p adtUnpack
-> \pat:(MyPair Int32 Float32). project [0] pat:(MyPair Int32 Float32)
+> \pat:(MyPair Int32 Float32). (\((MkMyPair elt _)). elt) pat
 
 def recordUnpack ({a=v, b=_}:{a:Int & b:Float}) : Int = v
 :p recordUnpack
-> \pat:{a: Int32 & b: Float32}. project [0] pat:{a: Int32 & b: Float32}
+> \pat:{a: Int32 & b: Float32}. (\{a = a, b = _}. a) pat
 
 def nestedUnpack (x:MyPair Int (MyPair (MyIntish & Int) Int)) : Int =
   (MkMyPair _ (MkMyPair (MkIntish y, _) _)) = x
@@ -285,7 +285,7 @@ def nestedUnpack (x:MyPair Int (MyPair (MyIntish & Int) Int)) : Int =
 
 :p nestedUnpack
 > \x:(MyPair Int32 (MyPair (MyIntish & Int32) Int32)).
->   project [0, 0, 0, 1] x:(MyPair Int32 (MyPair (MyIntish & Int32) Int32))
+>   (\((MkIntish (((MkMyPair ((MkMyPair _ elt)) _)), _))). elt) x
 
 :p nestedUnpack (MkMyPair 3 (MkMyPair (MkIntish 4, 5) 6))
 > 4

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -38,7 +38,7 @@ unsafeIO \().
 > 9 is odd
 > [(), (), (), (), (), (), (), (), (), ()]
 
-:p storageSize (typeVehicle Int)
+:p storageSize Int
 > 4
 
 :p unsafeIO \().

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -158,11 +158,11 @@ MyPair : Type -> Type =
 -- TODO: put source annotation on effect for a better message here
 fEff : Unit -> {| a} a = todo
 > Type error:
-> Expected: EffKind
->   Actual: Type
+> Expected: Type
+>   Actual: EffKind
 >
 > fEff : Unit -> {| a} a = todo
->             ^^^^^^^^^
+>                      ^^
 
 :p
     for i:(Fin 7). sum for j:(Fin unboundName). 1.0

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -1,38 +1,43 @@
-interface InterfaceTest1 a:Type where
+
+
+interface InterfaceTest1 a
   InterfaceTest1 : a
 > Error: variable already defined: InterfaceTest1
 
-interface InterfaceTest2 typeName:Type where
-  typeName : typeName -> typeName
+interface InterfaceTest3 a
+  foo : a -> Int
+  foo : a -> Int
+> Error: variable already defined: foo
 
-interface InterfaceTest3 _:Type where
-  foo : Int32
-
-> Parse error:8:26:
->   |
-> 8 | interface InterfaceTest3 _:Type where
->   |                          ^^^^^
-> unexpected "_:Typ"
-> expecting "where" or named annoted binder
-interface InterfaceTest4 where
+interface InterfaceTest4 a
   foo : Int
+  bar : a -> Int
 
-instance instanceTest4 : InterfaceTest4 where
+instance InterfaceTest4 Float
   foo = 1
-
-instance instanceTest4 : InterfaceTest4 x -> InterfaceTest4 (n=>a) where
+  bar = \_. 1
   foo = 1
+> Type error:Duplicate method: foo
 
-> Parse error:23:68:
->    |
-> 23 | instance instanceTest4 : InterfaceTest4 x -> InterfaceTest4 (n=>a) where
->    |                                                                    ^
-> Met invalid arrow '->' in type annotation of instance. Only class arrows and implicit arrows are allowed.
-instance instanceTest5 : (..i) where
-  bar = bar
+instance InterfaceTest4 Float
+  foo = 1
+> Type error:Missing method: bar
 
-> Parse error:31:32:
->    |
-> 31 | instance instanceTest5 : (..i) where
->    |                                ^
-> Could not extract interface name from type annotation.
+instance InterfaceTest4 Float
+  baz = 1
+> Type error:baz is not a method of InterfaceTest4
+
+instance InterfaceTest4 Float
+  foo = 1
+  bar = \_. 'x'
+> Type error:
+> Expected: Int32
+>   Actual: Word8
+>
+>   bar = \_. 'x'
+>             ^^^
+
+instance InterfaceTest4 Float
+  foo = 1
+  bar = \_. 1
+


### PR DESCRIPTION
  * Lightweight syntax for class constraints in functions and instances:

         def (/=) [Eq a] (x:a) (y:a) : Bool = not $ x == y`


         instance [Eq a, Eq b] Eq (a & b)
           (==) = \(x1,x2) (y1,y2). x1 == y1 && x2 == y2

  * Handle superclasses in interface decls:

        interface [Eq a] Ord a
          (>) : a -> a -> Bool
          (<) : a -> a -> Bool

  * Remove the need to name instances explicitly
  * Push down types from interface definitions into instance methods, reducing the annotation burden for instance methods.
  * Improve error messages for missing/duplicated methods.
  * Infer types of implicit implicit args. (No more `(n:Int) ?-> n=>a -> ...`)
 
