### PR TITLE
Continue inlining after application

### DIFF
--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -27,9 +27,10 @@ module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildP
               embedExtend, unpackConsList, emitRunWriter, applyPreludeFunction,
               emitRunState,  emitMaybeCase, emitWhile,
               emitRunReader, tabGet, SubstEmbedT, SubstEmbed, runSubstEmbedT,
-              traverseAtom, ptrOffset, ptrLoad, unsafePtrLoad,
+              ptrOffset, ptrLoad, unsafePtrLoad,
               evalBlockE, substTraversalDef,
-              TraversalDef, traverseDecls, traverseDecl, traverseBlock, traverseExpr,
+              TraversalDef, traverseDecls, traverseDecl, traverseDeclsOpen,
+              traverseBlock, traverseExpr, traverseAtom,
               clampPositive, buildNAbs, buildNAbsAux, buildNestedLam, zeroAt,
               transformModuleAsBlock, dropSub, appReduceTraversalDef,
               indexSetSizeE, indexToIntE, intToIndexE, freshVarE) where


### PR DESCRIPTION
Turns out that the inlining pass had a pretty big gaping hole
previously: the inlineable tables originate not only from the `for`
loops, but also from applications with table lambdas! Previously we
completely ignored the second case, potentially failing to fully
reducing a table application, and blowing up the run-time complexity as
in #346.