### PR TITLE
Fix the stupid zext bug

### DIFF
--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -801,7 +801,7 @@ asIntWidth :: Operand -> L.Type -> Compile Operand
 asIntWidth op ~expTy@(L.IntegerType expWidth) = case compare expWidth opWidth of
   LT -> emitInstr expTy $ L.Trunc op expTy []
   EQ -> return op
-  GT -> emitInstr expTy $ L.ZExt  op expTy []
+  GT -> emitInstr expTy $ L.SExt  op expTy []
   where ~(L.IntegerType opWidth) = L.typeOf op
 
 freshParamOpPair :: [L.ParameterAttribute] -> L.Type -> Compile (Parameter, Operand)

--- a/tests/show-tests.dx
+++ b/tests/show-tests.dx
@@ -20,10 +20,8 @@
 :p show (IToI64 1234: Int64)
 > (AsList 4 "1234")
 
--- FIXME(https://github.com/google-research/dex-lang/issues/317):
--- Unexpected zext from type conversion of negative Int32 to Int64.
 :p show (IToI64 (-1234): Int64)
-> (AsList 10 "4294966062")
+> (AsList 5 "-1234")
 
 -- Float32
 


### PR DESCRIPTION
Who knew that zero-extending two's complement integers could go badly.

Fixes #317 