### PR TITLE
Harden CI checks

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -51,8 +51,12 @@ jobs:
       run: rm -rf ~/.stack/setup-exe-cache
       if: runner.os == 'macOS'
 
+    - name: Build, treating warnings as errors
+      run: make build-ci
+      if: runner.os == 'Linux'
+
     - name: Build
-      run: make
+      run: make build
 
     - name: Run tests
       run: make tests

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -7,7 +7,6 @@ data Geom =
   Circle Float
   Rectangle Float Float  -- width, height
   Line Point
-  Text String
 
 -- HTML color (no alpha)
 -- TODO: replace with `Fin 3 => Word8` when we fix #348
@@ -63,7 +62,6 @@ flipY : Diagram -> Diagram =
     Circle r      -> Circle r
     Rectangle w h -> Rectangle w h
     Line (x, y)   -> Line (x, -y)
-    Text x        -> Text x
 
 def scale (s:Float) : (Diagram -> Diagram) =
   applyTransformation ( \(x,y). (s * x, s * y) ) \geom. case geom of
@@ -71,7 +69,6 @@ def scale (s:Float) : (Diagram -> Diagram) =
     Circle r      -> Circle (s * r)
     Rectangle w h -> Rectangle (s * w) (s * h)
     Line (x, y)   -> Line (s * x, s * y)
-    Text x        -> Text x
 
 def moveXY ((offX, offY) : Point) : (Diagram -> Diagram) =
   applyTransformation (\(x,y). (x + offX, y + offY) ) id
@@ -83,7 +80,6 @@ def pointDiagram               : Diagram = singletonDefault PointGeom
 def circle (r:Float)           : Diagram = singletonDefault $ Circle r
 def rect   (w:Float) (h:Float) : Diagram = singletonDefault $ Rectangle w h
 def line   (p:Point)           : Diagram = singletonDefault $ Line p
-def text   (x:String)          : Diagram = singletonDefault $ Text x
 
 def updateGeom (update: GeomStyle -> GeomStyle) (d:Diagram) : Diagram =
   (MkDiagram (AsList _ objs)) = d
@@ -146,14 +142,11 @@ def attrString (attr:GeomStyle) : String =
   <+> ("stroke-width" <=> (getAt #strokeWidth attr)))
 
 def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
-  -- For things that are solid. SVG says they have fill=stroke.
-  solidAttr = setAt #fillColor (getAt #strokeColor attr) attr
-
   groupEle = \attr. tagBracketsAttr "g" (attrString attr)
   case geom of
     PointGeom ->
       pointAttr = setAt #fillColor (getAt #strokeColor attr) attr
-      groupEle solidAttr $ selfClosingBrackets $
+      groupEle pointAttr $ selfClosingBrackets $
         ("circle" <+>
          "cx" <=> x <.>
          "cy" <=> y <.>
@@ -171,14 +164,6 @@ def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
          "height" <=> h <.>
          "x"      <=> (x - (w/2.0)) <.>
          "y"      <=> (y - (h/2.0)))
-    Text content ->
-      textEle = tagBracketsAttr "text" $
-        ("x" <=> x <.>
-         "y" <=> y <.>
-         "text-anchor" <=> "middle" <.>    -- horizontal center
-         "dominant-baseline" <=> "middle"  -- vertical center
-        )
-      groupEle solidAttr $ textEle content
 
 BoundingBox : Type = (Point & Point)
 
@@ -203,24 +188,11 @@ def renderSVG (d:Diagram) (bounds:BoundingBox) : String =
 moveX : Float -> Diagram -> Diagram = \x. moveXY (x, 0.0)
 moveY : Float -> Diagram -> Diagram = \y. moveXY (0.0, y)
 
-' A Demo showing all kind of features
-```
-mydiagram : Diagram =
-    (  (circle 7.0 |> moveXY (20.0, 20.0) |> setFillColor blue |> setStrokeColor red)
-    <> (circle 5.0 |> moveXY (40.0, 40.0))
-    <> (rect  10.0 20.0 |> moveXY (5.0, 10.0) |> setStrokeColor red)
-    <> (text "DexLang"  |> moveXY (30.0, 10.0) |> setStrokeColor green)
-    <> (pointDiagram |> moveXY (15.0, 5.0) |> setStrokeColor red)
-    )
-:html renderSVG mydiagram ((0.0, 0.0), (100.0, 50.0))
-```
+-- mydiagram : Diagram =
+--   (  (circle 7.0 |> moveXY (20.0, 20.0) |> setFillColor blue |> setStrokeColor red)
+--   <> (circle 5.0 |> moveXY (40.0, 40.0))
+--   <> (rect  10.0 20.0 |> moveXY (5.0, 10.0) |> setStrokeColor red)
+--   <> (pointDiagram |> moveXY (15.0, 5.0) |> setStrokeColor red)
+--   )
 
-' Another demo that shows things are all center aligned:
-```
-concentricDiagram : Diagram = (
-     (rect 2.0 2.0 |> setFillColor red)
-  <> (circle 1.0 |> setFillColor blue)
-  <> (text "DexLang" |> setStrokeColor white)
-) |> moveXY (5.0, 5.0)
-:html renderSVG concentricDiagram ((0.0, 0.0), (10.0, 10.0))
-```
+-- :html renderSVG mydiagram ((0.0, 0.0), (100.0, 50.0))

--- a/makefile
+++ b/makefile
@@ -66,13 +66,16 @@ install: dexrt-llvm
 build-prof: dexrt-llvm
 	$(STACK) build $(PROF)
 
-dexrt-llvm: src/lib/dexrt.bc
-
 # For some reason stack fails to detect modifications to foreign library files
-build-python: build
+build-python: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS) --force-dirty
 	$(eval STACK_INSTALL_DIR=$(shell stack path --local-install-root))
 	cp $(STACK_INSTALL_DIR)/lib/libDex.so python/dex/
+
+build-ci: dexrt-llvm
+	$(STACK) build $(STACK_FLAGS) --force-dirty --ghc-options "-Werror -fforce-recomp"
+
+dexrt-llvm: src/lib/dexrt.bc
 
 %.bc: %.cpp
 	clang++ $(CXXFLAGS) -c -emit-llvm $^ -o $@

--- a/misc/check-quine
+++ b/misc/check-quine
@@ -26,6 +26,7 @@ if ${@:2} $1 > $tmpout 2> $errout ; then
     misc/check-no-diff $1 $tmpout
     status=$?
 else
+    status=$?
     cat $tmpout
 fi
 

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -296,6 +296,8 @@ exprEffs expr = case expr of
     PTileReduce _ _ -> mempty
     RunIO ~(Lam (Abs _ (PlainArrow (EffectRow effs t), _))) ->
       EffectRow (S.delete IOEffect effs) t
+    CatchException ~(Lam (Abs _ (PlainArrow (EffectRow effs t), _))) ->
+      EffectRow (S.delete ExceptionEffect effs) t
   Case _ alts _ -> foldMap (\(Abs _ block) -> blockEffs block) alts
   where
     handleRWSRunner rws ~(BinaryFunVal (Bind (h:>_)) _ (EffectRow effs t) _) =


### PR DESCRIPTION
We end up committing a whole bunch of warnings all the time, which
create unnecessary noise for others. This turns them into errors, to
make sure that none of those slip through the cracks.

Also, any segmentation faults or aborts didn't cause the tests to fail
in the past, which should hopefully be fixed now.

---

This has led me to discover that `main` has actually been broken since #376, due to our classic issue #348. I've included a revert of that PR here as well.