### PR TITLE
Gardening.

### DIFF
--- a/.hlint.yaml
+++ b/.hlint.yaml
@@ -1,0 +1,2 @@
+- arguments: [--color]
+- ignore: {name: "Use fmap"}

--- a/benchmarks/dexbench.py
+++ b/benchmarks/dexbench.py
@@ -55,15 +55,15 @@ def restore_machine():
 def run_benches(lang, backend):
   if lang == "dex":
     if backend == "CPU":
-      backend_args = ["--backend", "LLVM-MC"]
+      backend_args = ["--backend", "llvm-mc"]
       env = {}
     elif backend == "GPU":
-      backend_args = ["--backend", "LLVM-CUDA"]
+      backend_args = ["--backend", "llvm-cuda"]
       env = {"CUDA_LAUNCH_BLOCKING":"1"}
     else:
       raise Exception
     command = (["stack", "exec", "dex", "--"] + backend_args +
-               ["script", "--outfmt", "JSON", dex_microbench_file])
+               ["script", "--outfmt", "json", dex_microbench_file])
   elif lang == "jax":
     if backend == "CPU":
       env = {"CUDA_VISIBLE_DEVICES":""}

--- a/dex.cabal
+++ b/dex.cabal
@@ -78,7 +78,8 @@ executable dex
   main-is:             dex.hs
   other-extensions:    OverloadedStrings
   build-depends:       dex, base, haskeline, prettyprinter, mtl,
-                       optparse-applicative, unix, store, bytestring, directory
+                       optparse-applicative, ansi-wl-pprint,
+                       unix, store, bytestring, directory
   if os(darwin)
     build-depends:     dex-resources
   default-language:    Haskell2010

--- a/makefile
+++ b/makefile
@@ -137,11 +137,11 @@ update-examples-%: examples/%.dx build
 
 run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
 run-gpu-tests: tests/gpu-tests.dx build
-	misc/check-quine $< $(dex) --backend LLVM-CUDA script --allow-errors
+	misc/check-quine $< $(dex) --backend llvm-cuda script --allow-errors
 
 update-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0
 update-gpu-tests: tests/gpu-tests.dx build
-	$(dex) --backend LLVM-CUDA script --allow-errors $< > $<.tmp
+	$(dex) --backend llvm-cuda script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 
 uexpr-tests:
@@ -175,15 +175,15 @@ docs: doc-prelude $(doc-example-names) $(doc-lib-names) $(slow-docs)
 
 doc-prelude: lib/prelude.dx
 	mkdir -p doc
-	$(dex) --prelude /dev/null script lib/prelude.dx --outfmt HTML > doc/prelude.html
+	$(dex) --prelude /dev/null script lib/prelude.dx --outfmt html > doc/prelude.html
 
 doc/examples/%.html: examples/%.dx
 	mkdir -p doc/examples
-	$(dex) script $^ --outfmt HTML > $@
+	$(dex) script $^ --outfmt html > $@
 
 doc/lib/%.html: lib/%.dx
 	mkdir -p doc/lib
-	$(dex) script $^ --outfmt HTML > $@
+	$(dex) script $^ --outfmt html > $@
 
 clean:
 	$(STACK) clean

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -158,10 +158,10 @@ parseMode = subparser $
   <*> option
         (optionList [ ("literate"   , TextDoc)
                     , ("result-only", ResultOnly)
-                    , ("HTML"       , HTMLDoc)
-                    , ("JSON"       , JSONDoc)])
+                    , ("html"       , HTMLDoc)
+                    , ("json"       , JSONDoc)])
         (long "outfmt" <> value TextDoc <>
-         helpOption "Output format" "literate (default) | result-only | HTML | JSON")
+         helpOption "Output format" "literate (default) | result-only | html | json")
   <*> flag HaltOnErr ContinueOnErr (
                 long "allow-errors"
              <> help "Evaluate programs containing non-fatal type errors")))
@@ -177,12 +177,12 @@ optionList opts = eitherReader \s -> case lookup s opts of
 parseEvalOpts :: Parser EvalConfig
 parseEvalOpts = EvalConfig
   <$> option
-         (optionList [ ("LLVM", LLVM)
-                     , ("LLVM-CUDA", LLVMCUDA)
-                     , ("LLVM-MC", LLVMMC)
+         (optionList [ ("llvm", LLVM)
+                     , ("llvm-cuda", LLVMCUDA)
+                     , ("llvm-mc", LLVMMC)
                      , ("interpreter", Interpreter)])
          (long "backend" <> value LLVM <>
-          helpOption "Backend" "LLVM (default) | LLVM-CUDA | LLVM-MC | interpreter")
+          helpOption "Backend" "llvm (default) | llvm-cuda | llvm-mc | interpreter")
   <*> optional (strOption $ long "logto"
                     <> metavar "FILE"
                     <> help "File to log to" <> showDefault)

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -180,9 +180,9 @@ parseEvalOpts = EvalConfig
          (optionList [ ("LLVM", LLVM)
                      , ("LLVM-CUDA", LLVMCUDA)
                      , ("LLVM-MC", LLVMMC)
-                     , ("interp", Interp)])
+                     , ("interpreter", Interpreter)])
          (long "backend" <> value LLVM <>
-          helpOption "Backend" "LLVM (default) | LLVM-CUDA | LLVM-MC | interp")
+          helpOption "Backend" "LLVM (default) | LLVM-CUDA | LLVM-MC | interpreter")
   <*> optional (strOption $ long "logto"
                     <> metavar "FILE"
                     <> help "File to log to" <> showDefault)

--- a/src/lib/Actor.hs
+++ b/src/lib/Actor.hs
@@ -43,7 +43,7 @@ runActor (Actor m) = do
   linksRef   <- newIORef []
   chan <- newBackChan
   tid <- myThreadId
-  let p = (Proc Trap tid (asErrPChan chan))
+  let p = Proc Trap tid (asErrPChan chan)
   runReaderT m (ActorConfig p chan linksRef)
 
 subChan :: (a -> b) -> PChan b -> PChan a
@@ -123,7 +123,7 @@ receive :: MonadActor msg m => m msg
 receive = receiveF Just
 
 newBackChan :: IO (BackChan a)
-newBackChan = liftM2 BackChan (newIORef []) (newChan)
+newBackChan = liftM2 BackChan (newIORef []) newChan
 
 readBackChan :: BackChan a -> IO a
 readBackChan (BackChan ptr chan) = do xs <- readIORef ptr
@@ -173,6 +173,6 @@ logServer = flip evalStateT (mempty, []) $ forever $ do
     Push x -> do
       modify $ onFst (<> x)
       subscribers <- gets snd
-      mapM_ (flip send x) subscribers
+      mapM_ (`send` x) subscribers
 
 -- TODO: state machine?

--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -41,7 +41,7 @@ instance (Monoid env, Monad m) => MonadCat env (CatT env m) where
     put (fullState <> x, localState <> x)
   scoped (CatT m) = CatT $ do
     originalState <- get
-    put $ (fst originalState, mempty)
+    put (fst originalState, mempty)
     ans <- m
     newLocalState <- gets snd
     put originalState

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -866,10 +866,10 @@ chooseAddrSpace (backend, curDev, allocTy) numel = case allocTy of
                                                   else Heap mainDev
           | otherwise -> Heap mainDev
   where mainDev = case backend of
-          LLVM     -> CPU
-          LLVMMC   -> CPU
-          LLVMCUDA -> GPU
-          Interp   -> error "Shouldn't be compiling with interpreter backend"
+          LLVM      -> CPU
+          LLVMMC    -> CPU
+          LLVMCUDA  -> GPU
+          Interpreter -> error "Shouldn't be compiling with interpreter backend"
 
 isSmall :: Block -> Bool
 isSmall numel = case numel of

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -90,7 +90,7 @@ logLevel = do
   passes <- many passName
   eol
   case passes of
-    [] -> return $ LogAll
+    [] -> return LogAll
     _ -> return $ LogPasses passes
 
 logTime :: Parser LogLevel
@@ -131,7 +131,7 @@ proseBlock = label "prose block" $ char '\'' >> fmap (ProseBlock . fst) (withSou
 
 topLevelCommand :: Parser SourceBlock'
 topLevelCommand =
-      (liftM IncludeSourceFile includeSourceFile)
+      liftM IncludeSourceFile includeSourceFile
   <|> explicitCommand
   <?> "top-level command"
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -559,7 +559,7 @@ data ImpInstr = IFor Direction IBinder Size ImpBlock
               | IPrimOp IPrimOp
                 deriving (Show)
 
-data Backend = LLVM | LLVMCUDA | LLVMMC | Interp  deriving (Show, Eq)
+data Backend = LLVM | LLVMCUDA | LLVMMC | Interpreter  deriving (Show, Eq)
 newtype CUDAKernel = CUDAKernel B.ByteString deriving (Show)
 
 -- === base types ===

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -14,7 +14,6 @@ import Control.Monad.Reader
 import Control.Monad.Except hiding (Except)
 import Data.Text.Prettyprint.Doc
 import Data.String
-import Data.Maybe
 import Data.List (partition)
 import qualified Data.Map.Strict as M
 
@@ -119,7 +118,7 @@ processLogs :: LogLevel -> [Output] -> [Output]
 processLogs logLevel logs = case logLevel of
   LogAll -> logs
   LogNothing -> []
-  LogPasses passes -> flip filter logs \l -> case l of
+  LogPasses passes -> flip filter logs \case
                         PassInfo pass _ | pass `elem` passes -> True
                                         | otherwise          -> False
                         _ -> False
@@ -135,7 +134,7 @@ timesFromLogs logs = (totalTime - totalEvalTime, singleEvalTime, benchStats)
       case [(t, stats) | EvalTime t stats <- logs] of
         []           -> (0.0  , 0.0, Nothing)
         [(t, stats)] -> (total, t  , stats)
-          where total = fromMaybe t $ fmap snd stats
+          where total = maybe t snd stats
         _            -> error "Expect at most one result"
     totalTime = case [tTotal | TotalTime tTotal <- logs] of
         []  -> 0.0
@@ -221,7 +220,7 @@ evalBackend env block = do
 
 withCompileTime :: TopPassM a -> TopPassM a
 withCompileTime m = do
-  (ans, t) <- measureSeconds $ m
+  (ans, t) <- measureSeconds m
   logTop $ TotalTime t
   return ans
 


### PR DESCRIPTION
NFC changes:

- Address some hlint warnings.
- Add doc comments to `Dag` in `LiveOutput.hs` - added in passing while making sense of the source code.
- Improve `dex` help option printing with `helpOption` helper function.

Minor functional changes:

- Rename `dex --backend interp` flag to `--backend interpret`. `interpret` reads more naturally.