### PR TITLE
Fix for #348

### DIFF
--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -7,6 +7,7 @@ data Geom =
   Circle Float
   Rectangle Float Float  -- width, height
   Line Point
+  Text String
 
 HtmlColor : Type = Fin 3 => Word8
 
@@ -60,6 +61,7 @@ flipY : Diagram -> Diagram =
     Circle r      -> Circle r
     Rectangle w h -> Rectangle w h
     Line (x, y)   -> Line (x, -y)
+    Text x        -> Text x
 
 def scale (s:Float) : (Diagram -> Diagram) =
   applyTransformation ( \(x,y). (s * x, s * y) ) \geom. case geom of
@@ -67,6 +69,7 @@ def scale (s:Float) : (Diagram -> Diagram) =
     Circle r      -> Circle (s * r)
     Rectangle w h -> Rectangle (s * w) (s * h)
     Line (x, y)   -> Line (s * x, s * y)
+    Text x        -> Text x
 
 def moveXY ((offX, offY) : Point) : (Diagram -> Diagram) =
   applyTransformation (\(x,y). (x + offX, y + offY) ) id
@@ -78,6 +81,7 @@ def pointDiagram               : Diagram = singletonDefault PointGeom
 def circle (r:Float)           : Diagram = singletonDefault $ Circle r
 def rect   (w:Float) (h:Float) : Diagram = singletonDefault $ Rectangle w h
 def line   (p:Point)           : Diagram = singletonDefault $ Line p
+def text   (x:String)          : Diagram = singletonDefault $ Text x
 
 def updateGeom (update: GeomStyle -> GeomStyle) (d:Diagram) : Diagram =
   (MkDiagram (AsList _ objs)) = d
@@ -139,11 +143,14 @@ def attrString (attr:GeomStyle) : String =
   <+> ("stroke-width" <=> (getAt #strokeWidth attr)))
 
 def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
+  -- For things that are solid. SVG says they have fill=stroke.
+  solidAttr = setAt #fillColor (getAt #strokeColor attr) attr
+
   groupEle = \attr. tagBracketsAttr "g" (attrString attr)
   case geom of
     PointGeom ->
       pointAttr = setAt #fillColor (getAt #strokeColor attr) attr
-      groupEle pointAttr $ selfClosingBrackets $
+      groupEle solidAttr $ selfClosingBrackets $
         ("circle" <+>
          "cx" <=> x <.>
          "cy" <=> y <.>
@@ -161,6 +168,14 @@ def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
          "height" <=> h <.>
          "x"      <=> (x - (w/2.0)) <.>
          "y"      <=> (y - (h/2.0)))
+    Text content ->
+      textEle = tagBracketsAttr "text" $
+        ("x" <=> x <.>
+         "y" <=> y <.>
+         "text-anchor" <=> "middle" <.>    -- horizontal center
+         "dominant-baseline" <=> "middle"  -- vertical center
+        )
+      groupEle solidAttr $ textEle content
 
 BoundingBox : Type = (Point & Point)
 
@@ -185,11 +200,24 @@ def renderSVG (d:Diagram) (bounds:BoundingBox) : String =
 moveX : Float -> Diagram -> Diagram = \x. moveXY (x, 0.0)
 moveY : Float -> Diagram -> Diagram = \y. moveXY (0.0, y)
 
--- mydiagram : Diagram =
---   (  (circle 7.0 |> moveXY (20.0, 20.0) |> setFillColor blue |> setStrokeColor red)
---   <> (circle 5.0 |> moveXY (40.0, 40.0))
---   <> (rect  10.0 20.0 |> moveXY (5.0, 10.0) |> setStrokeColor red)
---   <> (pointDiagram |> moveXY (15.0, 5.0) |> setStrokeColor red)
---   )
+' A Demo showing all kind of features
+```
+mydiagram : Diagram =
+    (  (circle 7.0 |> moveXY (20.0, 20.0) |> setFillColor blue |> setStrokeColor red)
+    <> (circle 5.0 |> moveXY (40.0, 40.0))
+    <> (rect  10.0 20.0 |> moveXY (5.0, 10.0) |> setStrokeColor red)
+    <> (text "DexLang"  |> moveXY (30.0, 10.0) |> setStrokeColor green)
+    <> (pointDiagram |> moveXY (15.0, 5.0) |> setStrokeColor red)
+    )
+:html renderSVG mydiagram ((0.0, 0.0), (100.0, 50.0))
+```
 
--- :html renderSVG mydiagram ((0.0, 0.0), (100.0, 50.0))
+' Another demo that shows things are all center aligned:
+```
+concentricDiagram : Diagram = (
+     (rect 2.0 2.0 |> setFillColor red)
+  <> (circle 1.0 |> setFillColor blue)
+  <> (text "DexLang" |> setStrokeColor white)
+) |> moveXY (5.0, 5.0)
+:html renderSVG concentricDiagram ((0.0, 0.0), (10.0, 10.0))
+```

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -10,7 +10,7 @@ data Geom =
 
 HtmlColor : Type = Fin 3 => Word8
 
-def showHex (x:Int32) : String = unsafeIO \().
+def showHex (x:Word8) : String = unsafeIO \().
   (n, ptr) = %ffi showHex (Int32 & RawPtr) x
   stringFromCharPtr n (MkPtr ptr)
 
@@ -125,7 +125,7 @@ def (<=>) [Show b] (attr:String) (val:b) : String =
   attr <.> "=" <.> quote (show val)
 
 def htmlColor(cs:HtmlColor) : String =
-  "#" <> (concat $ for i. showHex (W8ToI cs.i))
+  "#" <> (concat $ for i. showHex cs.i)
 
 def optionalHtmlColor(c: Maybe HtmlColor) : String =
   case c of

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -8,19 +8,17 @@ data Geom =
   Rectangle Float Float  -- width, height
   Line Point
 
--- HTML color (no alpha)
--- TODO: replace with `Fin 3 => Word8` when we fix #348
-HtmlColor : Type = (Word8 & Word8 & Word8)
+HtmlColor : Type = Fin 3 => Word8
 
 def showHex (x:Int32) : String = unsafeIO \().
   (n, ptr) = %ffi showHex (Int32 & RawPtr) x
   stringFromCharPtr n (MkPtr ptr)
 
-black : HtmlColor = (IToW8   0, IToW8   0, IToW8   0)
-white : HtmlColor = (IToW8 255, IToW8 255, IToW8 255)
-red   : HtmlColor = (IToW8 255, IToW8   0, IToW8   0)
-green : HtmlColor = (IToW8   0, IToW8 255, IToW8   0)
-blue  : HtmlColor = (IToW8   0, IToW8   0, IToW8 255)
+black : HtmlColor = [IToW8   0, IToW8   0, IToW8   0]
+white : HtmlColor = [IToW8 255, IToW8 255, IToW8 255]
+red   : HtmlColor = [IToW8 255, IToW8   0, IToW8   0]
+green : HtmlColor = [IToW8   0, IToW8 255, IToW8   0]
+blue  : HtmlColor = [IToW8   0, IToW8   0, IToW8 255]
 
 GeomStyle : Type =
   { fillColor   : Maybe HtmlColor
@@ -127,8 +125,7 @@ def (<=>) [Show b] (attr:String) (val:b) : String =
   attr <.> "=" <.> quote (show val)
 
 def htmlColor(cs:HtmlColor) : String =
-  (r, g, b) = cs
-  "#" <> (showHex $ W8ToI r) <> (showHex $ W8ToI g) <> (showHex $ W8ToI b)
+  "#" <> (concat $ for i. showHex (W8ToI cs.i))
 
 def optionalHtmlColor(c: Maybe HtmlColor) : String =
   case c of
@@ -137,8 +134,8 @@ def optionalHtmlColor(c: Maybe HtmlColor) : String =
 
 @noinline
 def attrString (attr:GeomStyle) : String =
-  (  -- "stroke"      <=> (optionalHtmlColor $ getAt #strokeColor attr)
-      ("fill"         <=> (optionalHtmlColor $ getAt #fillColor   attr))
+  (   ("stroke"       <=> (optionalHtmlColor $ getAt #strokeColor attr))
+  <+> ("fill"         <=> (optionalHtmlColor $ getAt #fillColor   attr))
   <+> ("stroke-width" <=> (getAt #strokeWidth attr)))
 
 def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =

--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -54,8 +54,7 @@ def interpolate [VSpace a] (low:a) (high:a) (x:Float) : a =
   (x' .* low) + ((1.0 - x') .* high)
 
 def makeRGBColor (c : Color) : HtmlColor =
-  [r, g, b] = for i. IToW8 $ FToI $ floor (255.0 * c.i)
-  (r, g, b)
+  for i. IToW8 $ FToI $ floor (255.0 * c.i)
 
 def colorScale (x:Float) : HtmlColor =
   makeRGBColor $ interpolate lowColor highColor x

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1102,11 +1102,7 @@ def getEnv (name:String) : {IO} Maybe String =
     fromCString $ MkCString $ %ffi getenv RawPtr ptr
 
 def checkEnv (name:String) : {IO} Bool =
-  -- This should be just `isJust $ getEnv name` but that segfaults (only if the
-  -- env var *is* defined), possibly related to bug #348.
-  withCString name \(MkCString ptr).
-    resultPtr = %ffi getenv RawPtr ptr
-    not $ resultPtr == nullRawPtr
+  isJust $ getEnv name
 
 def fread (stream:Stream ReadMode) : {IO} String =
   (MkStream stream') = stream

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -148,9 +148,9 @@ double randunif(uint64_t keypair) {
   return out - 1;
 }
 
-void showHex(char **resultPtr, int x) {
+void showHex(char **resultPtr, char x) {
   auto p = reinterpret_cast<char*>(malloc_dex(100));  // TODO: something better!
-  auto n = sprintf(p, "%02x", x);
+  auto n = sprintf(p, "%02hhX", x);
   auto result1Ptr = reinterpret_cast<int32_t*>(resultPtr[0]);
   auto result2Ptr = reinterpret_cast<char**>(  resultPtr[1]);
   *result1Ptr = n;

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -289,3 +289,32 @@ def nestedUnpack (x:MyPair Int (MyPair (MyIntish & Int) Int)) : Int =
 
 :p nestedUnpack (MkMyPair 3 (MkMyPair (MkIntish 4, 5) 6))
 > 4
+
+data MySum =
+  Foo Float
+  Bar String
+
+-- bug #348
+:p
+  xs = for i:(Fin 3).
+    if ordinal i < 2
+      then Foo 2.0
+      else Foo 1.0
+  (xs, xs)
+> ([(Foo 2.), (Foo 2.), (Foo 1.)], [(Foo 2.), (Foo 2.), (Foo 1.)])
+
+data MySum2 =
+  Foo2
+  Bar2 (Fin 3 => Int)
+
+-- bug #348
+:p concat for i:(Fin 4). AsList _ [(Foo2, Foo2)]
+> (AsList 4 [(Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2)])
+
+-- reproducer for a shadowing bug
+:p concat $ for i:(Fin 2). toList [(Just [0,0,0], Just [0,0,0]),
+                                   (Just [0,0,0], Just [0,0,0])]
+> (AsList 4 [ ((Just [0, 0, 0]), (Just [0, 0, 0]))
+>           , ((Just [0, 0, 0]), (Just [0, 0, 0]))
+>           , ((Just [0, 0, 0]), (Just [0, 0, 0]))
+>           , ((Just [0, 0, 0]), (Just [0, 0, 0])) ])

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -311,7 +311,7 @@ data MySum2 =
 :p concat for i:(Fin 4). AsList _ [(Foo2, Foo2)]
 > (AsList 4 [(Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2)])
 
--- reproducer for a shadowing bug
+-- reproducer for a shadowing bug (PR #440)
 :p concat $ for i:(Fin 2). toList [(Just [0,0,0], Just [0,0,0]),
                                    (Just [0,0,0], Just [0,0,0])]
 > (AsList 4 [ ((Just [0, 0, 0]), (Just [0, 0, 0]))

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -67,9 +67,8 @@ unsafeIO \().
 :p unsafeIO do getEnv "NOT_AN_ENV_VAR"
 > Nothing
 
--- disabled because of bug #348
--- :p unsafeIO do getEnv "DEX_TEST_MODE"
--- > (Just (AsList 1 "t"))
+:p unsafeIO do getEnv "DEX_TEST_MODE"
+> (Just (AsList 1 "t"))
 
 :p dex_test_mode ()
 > True


### PR DESCRIPTION
Fixes #348 and un-reverts #367.

The fix is just to use a run-time switch to ensure we only read from the pointers associated with the occupied arm of a sum type.

Fixing this exposed an unrelated bug to do with variable name shadowing (always the hardest problem!) which is also fixed in this PR.