### PR TITLE
Fix `stack build` on macOS.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -85,7 +85,7 @@ executable dex
   default-language:    Haskell2010
   hs-source-dirs:      src
   default-extensions:  CPP, LambdaCase, BlockArguments
-  ghc-options:         -threaded
+  ghc-options:         -threaded -optP-Wno-nonportable-include-path
   if flag(optimized)
     ghc-options:       -O3
   else


### PR DESCRIPTION
Disable `-Wnonportable-include-path` for executable dex in dex.cabal.

I am not sure caused this issue to surface. The same issue previously
occurred for other targets in dex.cabal: https://github.com/google-research/dex-lang/pull/378.

Workaround suggested by discussion: https://github.com/haskell/cabal/issues/4739#issuecomment-359209133