### PR TITLE
Add LaTeX rendering for HTML-rendered Dex via KaTeX.

### DIFF
--- a/examples/latex.dx
+++ b/examples/latex.dx
@@ -1,0 +1,41 @@
+'# $\href{https://katex.org/}{\KaTeX}$ rendering examples
+
+'This document demonstrates $\KaTeX$ rendering in literate Dex programs.
+
+'## Random examples
+
+'$$\text{This is a multiline equation:} \\\\ \textbf{A}\textbf{x} = \textbf{b}$$
+
+'$$f(\relax{x}) = \int_{-\infty}^\infty \hat{f}(\xi)\,e^{2 \pi i \xi x} \,d\xi$$
+
+'## [Environments](https://katex.org/docs/supported.html#environments)
+
+'$$\begin{matrix} a & b \\\\ c & d \end{matrix}$$
+
+'$$\begin{pmatrix} a & b \\\\ c & d \end{pmatrix}$$
+
+'$$\begin{bmatrix} a & b \\\\ c & d \end{bmatrix}$$
+
+'$$\def\arraystretch{1.5} \begin{array}{c:c:c} a & b & c \\\\ \hline d & e & f \\\\ \hdashline g & h & i \end{array}$$
+
+'$$\begin{aligned} a&=b+c \\\\ d+e&=f \end{aligned}$$
+
+'$$\begin{alignedat}{2} 10&x+ &3&y = 2 \\\\ 3&x+&13&y = 4 \end{alignedat}$$
+
+'$$\begin{gathered} a=b \\\\ e=b+c \end{gathered}$$
+
+'$$x = \begin{cases} a &\text{if } b \\\\ c &\text{if } d \end{cases}$$
+
+'$$\begin{rcases} a &\text{if } b \\\\ c &\text{if } d \end{rcases} \Rightarrow \dots$$
+
+'## [Layout annotation](https://katex.org/docs/supported.html#annotation)
+
+'$$\overbrace{a+b+c}^{\text{note}}$$
+
+'$$\underbrace{a+b+c}_{\text{note}}$$
+
+'$$\xcancel{\text{second-order array combinators}}$$
+
+'## [Logic and Set Theory](https://katex.org/docs/supported.html#logic-and-set-theory)
+
+'$$\begin{aligned} \forall \\; & \texttt{\textbackslash forall} & \complement \\; & \texttt{\textbackslash complement} & \therefore \\; & \texttt{\textbackslash therefore} & \emptyset \\; & \texttt{\textbackslash emptyset} \\\\ \exists \\; & \texttt{\textbackslash exists} & \subset \\; & \texttt{\textbackslash subset} & \because \\; & \texttt{\textbackslash because} & \empty \\; & \texttt{\textbackslash empty} \\\\ \exist \\; & \texttt{\textbackslash exist} & \supset \\; & \texttt{\textbackslash supset} & \mapsto \\; & \texttt{\textbackslash mapsto} & \varnothing \\; & \texttt{\textbackslash varnothing} \\\\ \nexists \\; & \texttt{\textbackslash nexists} & \mid \\; & \texttt{\textbackslash mid} & \to \\; & \texttt{\textbackslash to} & \implies \\; & \texttt{\textbackslash implies} \\\\ \in \\; & \texttt{\textbackslash in} & \land \\; & \texttt{\textbackslash land} & \gets \\; & \texttt{\textbackslash gets} & \impliedby \\; & \texttt{\textbackslash impliedby} \\\\ \isin \\; & \texttt{\textbackslash isin} & \lor \\; & \texttt{\textbackslash lor} & \leftrightarrow \\; & \texttt{\textbackslash leftrightarrow} & \iff \\; & \texttt{\textbackslash iff} \\\\ \notin \\; & \texttt{\textbackslash notin} & \ni \\; & \texttt{\textbackslash ni} & \notni \\; & \texttt{\textbackslash notni} & \neg \\; & \texttt{\textbackslash neg} \\\\ \lnot \\; & \texttt{\textbackslash lnot} \\\\ \end{aligned}$$

--- a/examples/pi.dx
+++ b/examples/pi.dx
@@ -1,5 +1,17 @@
 '# Monte Carlo estimates of pi
 
+'Consider the unit circle centered at the origin.
+
+'Consider the first quadrant: the unit circle quadrant and its $1 \times 1$ bounding unit square.
+
+'$$\text{Area of unit circle quadrant: } \\\\ A_{quadrant} = \frac{\pi r^2}{4} = \frac{\pi}{4}$$
+
+'$$\text{Area of unit square: } \\\\ A_{square} = 1$$
+
+'$$\text{Compute } \pi \text{ via ratios: } \\\\ \frac{A_{quadrant}}{A_{square}} = \frac{\pi}{4}, \\; \pi = 4 \thinspace \frac{A_{quadrant}}{A_{square}} $$
+
+'To compute $\pi$, randomly sample points in the first quadrant unit square to estimate the $\frac{A_{quadrant}}{A_{square}}$ ratio. Then, multiply by $4$.
+
 def estimatePiArea (key:Key) : Float =
   [k1, k2] = splitKey key
   x = rand k1

--- a/static/dynamic.js
+++ b/static/dynamic.js
@@ -4,6 +4,18 @@
 // license that can be found in the LICENSE file or at
 // https://developers.google.com/open-source/licenses/bsd
 
+var katexOptions = {
+    delimiters: [
+        {left: "$$", right: "$$", display: true},
+        {left: "\\[", right: "\\]", display: true},
+        {left: "$", right: "$", display: false},
+        {left: "\\(", right: "\\)", display: false}
+    ],
+    // Enable commands that load resources or change HTML attributes
+    // (e.g. hyperlinks): https://katex.org/docs/security.html.
+    trust: true
+};
+
 var cells = {};
 
 function append_contents(key, contents) {
@@ -65,4 +77,6 @@ source.onmessage = function(event) {
         }
         Object.assign(cells, new_cells);
     }
+    // Render LaTeX equations via KaTeX.
+    renderMathInElement(body, katexOptions);
 };

--- a/static/index.html
+++ b/static/index.html
@@ -4,7 +4,12 @@
   <meta charset="UTF-8">
   <title>Dex Output</title>
   <link rel="stylesheet" href="/style.css" type="text/css" />
+  <!-- Plotly: charts and graphing library -->
   <script src="https://cdn.plot.ly/plotly-1.2.0.min.js"></script>
+  <!-- KaTeX: LaTeX rendering -->
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" crossorigin="anonymous"></script>
 </head>
 
 <body>


### PR DESCRIPTION
This involves only web frontend changes via [KaTeX CSS and JS](https://katex.org/).
I chose KaTeX over MathJax because KaTeX seems more modern, more performant, and prettier.

Resolves https://github.com/google-research/dex-lang/issues/426.

<details>
<summary>Monte Carlo simulations of pi</summary>
<img width="975" alt="Monte Carlo simulations of pi" src="https://user-images.githubusercontent.com/5590046/104080096-1fa96f80-51f4-11eb-9a5c-6fd024a3bc72.png">
</details>

<details>
<summary>LaTeX rendering examples</summary>
<img width="914" alt="download" src="https://user-images.githubusercontent.com/5590046/104080267-f2a98c80-51f4-11eb-90a4-78ceff85bd70.png">
</details>