### PR TITLE
Remove extra CSS bottom padding in HTML-rendered Dex.

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -11,7 +11,6 @@ body {
   font-family: Helvetica, sans-serif;
   font-size: 100%;
   color: #333;
-  padding-bottom: 500px;
 }
 
 .cell {


### PR DESCRIPTION
The bottom padding adds unnecessary empty bottom scrolling, which slightly hurts UX.

---

I wonder if the bottom padding was added for some reason in https://github.com/google-research/dex-lang/commit/33afb4a6? I couldn't tell.