### PR TITLE
Fix stack build warning for dex executable target.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -85,7 +85,7 @@ executable dex
   default-language:    Haskell2010
   hs-source-dirs:      src
   default-extensions:  CPP, LambdaCase, BlockArguments
-  ghc-options:         -threaded -optP-Wno-nonportable-include-path
+  ghc-options:         -optP-Wno-nonportable-include-path
   if flag(optimized)
     ghc-options:       -O3
   else


### PR DESCRIPTION
Fixes warning:
```console
$ make
clang++ -fPIC -I/usr/local/include -std=c++11 -fno-exceptions -fno-rtti -c -emit-llvm src/lib/dexrt.cpp -o src/lib/dexrt.bc
stack --stack-yaml=stack-macos.yaml build
dex-0.1.0.0: unregistering (local file changes: dex.cabal src/lib/Embed.hs src/lib/Imp.hs src/lib/JIT.hs)
dex> configure (lib + internal-lib + exe)
Configuring dex-0.1.0.0...
Warning: 'ghc-options: -threaded' has no effect for libraries. It should only
be used for executables.
```