### PR TITLE
Do not perform `dex web` LaTeX rendering for non-prose blocks.

### DIFF
--- a/examples/latex.dx
+++ b/examples/latex.dx
@@ -28,6 +28,17 @@
 
 '$$\begin{rcases} a &\text{if } b \\\\ c &\text{if } d \end{rcases} \Rightarrow \dots$$
 
+'## No LaTeX rendering in non-prose-blocks
+
+'LaTeX rendering should not occur in code blocks, not in error output cells.
+
+def arraySum (x:a=>Int32) : Int32 =
+  initAcc = 0
+  -- Note: the following line has `$ ... $`, but it should not trigger KaTeX.
+  snd $ withState initAcc $ \acc.
+    for i.
+      acc := (get acc) + x.i
+
 '## [Layout annotation](https://katex.org/docs/supported.html#annotation)
 
 '$$\overbrace{a+b+c}^{\text{note}}$$

--- a/static/dynamic.js
+++ b/static/dynamic.js
@@ -77,6 +77,9 @@ source.onmessage = function(event) {
         }
         Object.assign(cells, new_cells);
     }
-    // Render LaTeX equations via KaTeX.
-    renderMathInElement(body, katexOptions);
+    // Render LaTeX equations in prose blocks via KaTeX.
+    var proseBlocks = document.querySelectorAll(".prose-block");
+    Array.from(proseBlocks).map((proseBlock) =>
+        renderMathInElement(proseBlock, katexOptions)
+    );
 };


### PR DESCRIPTION
Apply KaTeX `renderMathInElement` render function only to `.prose-block` HTML elements.
Skip code blocks (`.code-block`) and error-output blocks (`err-block`).

Add "test case" (example) to `examples/latex.dx`.

---

Fixes this bug: https://github.com/google-research/dex-lang/issues/426#issuecomment-757116749.

Before:

<img width="359" alt="KaTeX for Dex bug" src="https://user-images.githubusercontent.com/5590046/104087142-957cfd80-522b-11eb-9282-79025c6c4b41.png">

After (fixed):

<img width="650" alt="KaTeX for Dex fix" src="https://user-images.githubusercontent.com/5590046/104093625-a6446800-5259-11eb-9033-5878115bc9a7.png">