### PR TITLE
Add Ord instance for tables.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -221,6 +221,13 @@ def select (p:Bool) (x:a) (y:a) : a = case p of
 def BToI (x:Bool) : Int  = W8ToI $ BToW8 x
 def BToF (x:Bool) : Float = IToF (BToI x)
 
+data Ordering =
+  LT
+  EQ
+  GT
+
+def OToW8 (x : Ordering) : Word8 = %dataConTag x
+
 '## Effects
 
 def Ref (r:Type) (a:Type) : Type = %Ref r a
@@ -348,6 +355,39 @@ instance [Ord a, Ord b] Ord (a & b)
   (>) = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
   (<) = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
 
+instance Eq Ordering
+  (==) = \x y. OToW8 x == OToW8 y
+
+interface Monoid a
+  mempty : a
+  mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
+
+def (<>) [Monoid a] : a -> a -> a = mcombine
+
+def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
+  swap $ runState init \s. for i.
+    c = get s
+    (c', y) = body i c
+    s := c'
+    y
+
+def fold (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
+
+def compare [Ord a] (x:a) (y:a) : Ordering =
+  if x < y
+    then LT
+    else if x == y
+      then EQ
+      else GT
+
+instance Monoid Ordering
+  mempty = EQ
+  mcombine = \x y.
+    case x of
+      LT -> LT
+      GT -> GT
+      EQ -> y
+
 -- TODO: accumulate using the True/&& monoid
 instance [Eq a] Eq (n=>a)
   (==) = \xs ys.
@@ -355,6 +395,16 @@ instance [Eq a] Eq (n=>a)
       yieldAccum \ref. for i.
         ref += (IToF (BToI (xs.i /= ys.i)))
     numDifferent == 0.0
+
+instance [Ord a] Ord (n=>a)
+  (>) = \xs ys.
+    f: Ordering =
+        fold EQ $ \i c. c <> (compare xs.i ys.i)
+    f == GT
+  (<) = \xs ys.
+    f: Ordering =
+        fold EQ $ \i c. c <> (compare xs.i ys.i)
+    f == LT
 
 '## Transcencendental functions
 
@@ -539,14 +589,6 @@ def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
 
 def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
-def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
-  swap $ runState init \s. for i.
-    c = get s
-    (c', y) = body i c
-    s := c'
-    y
-
-def fold (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
 def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
   -- `combine` should be a commutative and associative, and form a
   -- commutative monoid with `identity`
@@ -749,14 +791,6 @@ def tile1 (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
 --              arr.(t +> UNSAFEFromOrdinal idx 1)
 --              arr.(t +> UNSAFEFromOrdinal idx 2)
 --              arr.(t +> UNSAFEFromOrdinal idx 3))
-
-'## Monoid typeclass
-
-interface Monoid a
-  mempty : a
-  mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
-
-def (<>) [Monoid a] : a -> a -> a = mcombine
 
 '## Length-erased lists
 

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -376,3 +376,16 @@ def weakerInferenceReduction (l : i:n=>(..i)=>Float) (j:n): Unit =
       l.i'.k
     ()
   ()
+
+-- Tests for table
+
+a = [0, 1]
+b = [0, 1]
+
+:p a == b
+> True
+
+c = [1, 2]
+
+:p a < c
+> True


### PR DESCRIPTION
Introduce an Ordering type, to use for compare operations.

Re-order some definitions to satisfy the compiler, including: merge the monoid typeclass definition into the main typeclass section, and move the scan and fold utilities also into the typeclass section.