### PR TITLE
Parametrize runAccum by a monoid used for the reduction

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -46,7 +46,7 @@ that produce isos. We will start with the first two:
 :t #b : Iso {a:Int & b:Float & c:Unit} _
 > (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
 > === parse ===
-> _ans_ =
+>  _ans_ =
 >   MkIso {bwd = \(x, r). {b = x, ...r}, fwd = \{b = x, ...r}. (,) x r}
 >   : Iso {a: Int & b: Float & c: Unit} _
 
@@ -54,7 +54,7 @@ that produce isos. We will start with the first two:
 :t #?b : Iso {a:Int | b:Float | c:Unit} _
 > (Iso {a: Int32 | b: Float32 | c: Unit} (Float32 | {a: Int32 | c: Unit}))
 > === parse ===
-> _ans_ =
+>  _ans_ =
 >   MkIso
 >     { bwd = \v. case v
 >                 ((Left x)) -> {| b = x |}
@@ -142,7 +142,7 @@ another. For instance:
 >    ({ &} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
 > === parse ===
-> _ans_ =
+>  _ans_ =
 >   MkIso
 >     { bwd = \({a = x, ...l}, {, ...r}). (,) {, ...l} {a = x, ...r}
 >     , fwd = \({, ...l}, {a = x, ...r}). (,) {a = x, ...l} {, ...r}}
@@ -212,7 +212,7 @@ zipper isomorphisms:
 >    ({ |} | {a: Int32 | b: Float32 | c: Unit})
 >    ({a: Int32} | {b: Float32 | c: Unit}))
 > === parse ===
-> _ans_ =
+>  _ans_ =
 >   MkIso
 >     { bwd = \v. case v
 >                 ((Left w)) -> (case w

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -212,7 +212,7 @@ def sampleLightRadiance
   (surfNor, surf) = osurf
   (rayPos, _) = inRay
   (MkScene objs) = scene
-  yieldAccum \radiance.
+  yieldAccum (AddMonoid Float) \radiance.
     for i. case objs.i of
       PassiveObject _ _ -> ()
       Light lightPos hw _ ->
@@ -227,7 +227,7 @@ def sampleLightRadiance
 
 def trace (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
   noFilter = [1.0, 1.0, 1.0]
-  yieldAccum \radiance.
+  yieldAccum (AddMonoid Float) \radiance.
     runState  noFilter \filter.
      runState initRay  \ray.
       boundedIter (getAt #maxBounces params) () \i.

--- a/examples/tiled-matmul.dx
+++ b/examples/tiled-matmul.dx
@@ -16,7 +16,7 @@ def matmul (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
   vectorTile = Fin VectorWidth
   colTile = (colVectors & vectorTile)
   (tile2d (\nt:(Tile n rowTile). \mt:(Tile m colTile).
-             ct = yieldAccum \acc.
+             ct = yieldAccum (AddMonoid Float) \acc.
                for l:k.
                  for i:rowTile.
                    ail = broadcastVector a.(nt +> i).l

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -309,8 +309,23 @@ def MulMonoid (a:Type) -> (_:Mul a) ?=> : Monoid a =
 def Ref (r:Type) (a:Type) : Type = %Ref r a
 def get  (ref:Ref h s)       : {State h} s    = %get  ref
 def (:=) (ref:Ref h s) (x:s) : {State h} Unit = %put  ref x
+
 def ask  (ref:Ref h r)       : {Read  h} r    = %ask  ref
-def (+=) (ref:Ref h w) (x:w) : {Accum h} Unit = %tell ref x
+
+data AccumMonoid h w = UnsafeMkAccumMonoid (Monoid w)
+
+@instance
+def tableAccumMonoid ((UnsafeMkAccumMonoid m):AccumMonoid h w) ?=> : AccumMonoid h (n=>w) =
+  %instance mHint = m
+  def liftTableMonoid (tm:Monoid (n=>w)) ?=> : Monoid (n=>w) = tm
+  UnsafeMkAccumMonoid liftTableMonoid
+
+def (+=) (am:AccumMonoid h w) ?=> (ref:Ref h w) (x:w) : {Accum h} Unit =
+  (UnsafeMkAccumMonoid m) = am
+  %instance mHint = m
+  updater = \v. mcombine v x
+  %mextend ref updater
+
 def (!)  (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
 def fstRef (ref: Ref h (a & b)) : Ref h a = %fstRef ref
 def sndRef (ref: Ref h (a & b)) : Ref h b = %sndRef ref
@@ -328,16 +343,29 @@ def withReader
       : {|eff} a =
     runReader init action
 
+def MonoidLifter (b:Type) (w:Type) : Type = h:Type -> AccumMonoid h b ?=> AccumMonoid h w
+
 def runAccum
-      (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
+      (mlift:MonoidLifter b w) ?=>
+      (bm:Monoid b)
+      (action: (h:Type ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} (a & w) =
-    def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a = action ref
-    %runWriter explicitAction
+    -- Normally, only the ?=> lambda binders participate in dictionary synthesis,
+    -- so we need to explicitly declare `m` as a hint.
+    %instance bmHint = bm
+    empty : b = mempty
+    combine : b -> b -> b = mcombine
+    def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a =
+      %instance accumBaseMonoidHint : AccumMonoid h' b = UnsafeMkAccumMonoid bm
+      action ref
+    %runWriter empty combine explicitAction
 
 def yieldAccum
-      (action: (h:Type ?-> Ref h w -> {Accum h|eff} a))
+      (mlift:MonoidLifter b w) ?=>
+      (m:Monoid b)
+      (action: (h:Type ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} w =
-  snd $ runAccum action
+  snd $ runAccum m action
 
 def runState
       (init:s)
@@ -471,13 +499,10 @@ instance Monoid Ordering
       GT -> GT
       EQ -> y
 
--- TODO: accumulate using the True/&& monoid
 instance [Eq a] Eq (n=>a)
   (==) = \xs ys.
-    numDifferent : Float =
-      yieldAccum \ref. for i.
-        ref += (IToF (BToI (xs.i /= ys.i)))
-    numDifferent == 0.0
+    yieldAccum AndMonoid \ref.
+      for i. ref += xs.i == ys.i
 
 instance [Ord a] Ord (n=>a)
   (>) = \xs ys.
@@ -716,7 +741,7 @@ def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
-def fsum (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs i
+def fsum (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs i
 def sum  [Add v] (xs:n=>v) : v = reduce zero (+) xs
 def prod [Mul v] (xs:n=>v) : v = reduce one  (*) xs
 def mean [VSpace v] (xs:n=>v) : v = sum xs / IToF (size n)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -263,6 +263,47 @@ data Ordering =
 
 def OToW8 (x : Ordering) : Word8 = %dataConTag x
 
+'### Monoid
+A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.
+This is a very useful and general calls of things.
+It includes:
+ - Addition and Multiplication of Numbers
+ - Boolean Logic
+ - Concatenation of Lists (including strings)
+Monoids support `fold` operations, and similar.
+
+interface Monoid a
+  mempty : a
+  mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
+
+def (<>) [Monoid a] : a -> a -> a = mcombine
+
+instance [Monoid a] Monoid (n=>a)
+  mempty = for i. mempty
+  mcombine = \x y. for i. mcombine x.i y.i
+
+named-instance AndMonoid : Monoid Bool
+  mempty = True
+  mcombine = (&&)
+
+named-instance OrMonoid : Monoid Bool
+  mempty = False
+  mcombine = (||)
+
+def AddMonoid (a:Type) -> (_:Add a) ?=> : Monoid a =
+  A = a -- XXX: Typing `Monoid a` below would quantify it over a, which we don't want
+  named-instance result : Monoid A
+    mempty = zero
+    mcombine = add
+  result
+
+def MulMonoid (a:Type) -> (_:Mul a) ?=> : Monoid a =
+  A = a -- XXX: Typing `Monoid a` below would quantify it over a, which we don't want
+  named-instance result : Monoid A
+    mempty = one
+    mcombine = mul
+  result
+
 '## Effects
 
 def Ref (r:Type) (a:Type) : Type = %Ref r a
@@ -405,21 +446,6 @@ instance [Ord a, Ord b] Ord (a & b)
 
 instance Eq Ordering
   (==) = \x y. OToW8 x == OToW8 y
-
-'### Monoid
-A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.
-This is a very useful and general calls of things.
-It includes:
- - Addition and Multiplication of Numbers
- - Boolean Logic
- - Concatenation of Lists (including strings)
-Monoids support `fold` operations, and similar.
-
-interface Monoid a
-  mempty : a
-  mcombine : a -> a -> a  -- can't use `<>` just for parser reasons?
-
-def (<>) [Monoid a] : a -> a -> a = mcombine
 
 def scan (init:a) (body:n->a->(a&b)) : (a & n=>b) =
   swap $ runState init \s. for i.

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -124,13 +124,26 @@ linearizeOp :: Op -> LinA Atom
 linearizeOp op = case op of
   ScalarUnOp  uop x       -> linearizeUnOp  uop x
   ScalarBinOp bop x y     -> linearizeBinOp bop x y
+  PrimEffect refArg (MExtend ~(LamVal b body)) -> LinA $ do
+    (primalRef, mkTangentRef) <- runLinA $ la refArg
+    (primalUpdate, mkTangentUpdate) <-
+      buildLamAux b (const $ return PureArrow) \x@(Var v) ->
+        extendWrt [v] [] $ runLinA $ linearizeBlock (b @> x) body
+    let LamVal (Bind primalStateVar) _ = primalUpdate
+    ans <- emitOp $ PrimEffect primalRef $ MExtend primalUpdate
+    return (ans, do
+      tangentRef <- mkTangentRef
+      -- TODO: Assert that tangent update doesn't close over anything?
+      tangentUpdate <- buildLam (Bind $ "t":>tangentType (varType primalStateVar)) PureArrow \tx ->
+        extendTangentEnv (primalStateVar @> tx) [] $ mkTangentUpdate
+      emitOp $ PrimEffect tangentRef $ MExtend tangentUpdate)
   PrimEffect refArg m ->
     liftA2 PrimEffect (la refArg)
       (case m of
-         MAsk    -> pure MAsk
-         MTell x -> liftA MTell $ la x
-         MGet    -> pure MGet
-         MPut  x -> liftA MPut $ la x) `bindLin` emitOp
+         MAsk      -> pure MAsk
+         MExtend _ -> error "Unhandled MExtend"
+         MGet      -> pure MGet
+         MPut    x -> liftA MPut $ la x) `bindLin` emitOp
   IndexRef ref i         -> (IndexRef <$> la ref <*> pure i) `bindLin` emitOp
   FstRef   ref           -> (FstRef   <$> la ref           ) `bindLin` emitOp
   SndRef   ref           -> (SndRef   <$> la ref           ) `bindLin` emitOp
@@ -261,9 +274,17 @@ linearizeHof env hof = case hof of
     (ans, linTab) <- unzipTab ansWithLinTab
     return (ans, buildFor d i' \i'' -> provideRemat vi'' i'' $ app linTab i'' >>= applyLinToTangents)
   Tile _ _ _        -> notImplemented
-  RunWriter     lam -> linearizeEff Nothing    lam True  (const RunWriter) (emitRunWriter "r") Writer
-  RunReader val lam -> linearizeEff (Just val) lam False RunReader         (emitRunReader "r") Reader
-  RunState  val lam -> linearizeEff (Just val) lam True  RunState          (emitRunState  "r") State
+  RunWriter bm ~lam@(BinaryFunVal _ refBinder _ _) -> LinA $ do
+    unless (checkZeroPlusFloatMonoid bm) $
+      error "AD of Accum effect only supported when the base monoid is (0, +) on Float"
+    let RefTy _ accTy = binderType refBinder
+    linearizeEff lam Writer (RunWriter bm) (emitRunWriter "r" accTy bm)
+  RunReader val lam -> LinA $ do
+    (val', mkLinInit) <- runLinA <$> linearizeAtom =<< substEmbed env val
+    linearizeEff lam Reader (RunReader val') \f -> mkLinInit >>= emitRunReader "r" `flip` f
+  RunState val lam -> LinA $ do
+    (val', mkLinInit) <- runLinA <$> linearizeAtom =<< substEmbed env val
+    linearizeEff lam State (RunState val') \f -> mkLinInit >>= emitRunState "r" `flip` f
   RunIO ~(Lam (Abs _ (arrow, body))) -> LinA $ do
     arrow' <- substEmbed env arrow
     -- TODO: consider the possibility of other effects here besides IO
@@ -279,30 +300,19 @@ linearizeHof env hof = case hof of
   CatchException _ -> notImplemented
   Linearize _ -> error "Unexpected linearization"
   Transpose _ -> error "Unexpected transposition"
-  PTileReduce _ _ -> error "Unexpected PTileReduce"
+  PTileReduce _ _ _ -> error "Unexpected PTileReduce"
   where
-    linearizeEff maybeInit lam hasResult hofMaker emitter eff = LinA $ do
-      (valHofMaker, maybeLinInit) <- case maybeInit of
-          Just val -> do
-            (val', linVal) <- runLinA <$> linearizeAtom =<< substEmbed env val
-            return (hofMaker val', Just linVal)
-          Nothing -> return (hofMaker undefined, Nothing)
+    linearizeEff lam eff primalHofCon tangentEmitter = do
       (lam', ref)    <- linearizeEffectFun eff lam
-      (ans, linBody) <- case hasResult of
-          True -> do
-            (ansLin, w)    <- fromPair =<< emit (Hof $ valHofMaker lam')
+      -- The reader effect doesn't return any additional values
+      (ans, linBody) <- case eff of
+          Reader -> fromPair =<< emit (Hof $ primalHofCon lam')
+          _      -> do
+            (ansLin, w)    <- fromPair =<< emit (Hof $ primalHofCon lam')
             (ans, linBody) <- fromPair ansLin
             return (PairVal ans w, linBody)
-          False -> fromPair =<< emit (Hof $ valHofMaker lam')
-      let lin = do
-                  valEmitter <- case maybeLinInit of
-                    Just linVal -> emitter <$> linVal
-                    Nothing     -> do
-                      let (BinaryFunTy _ b _ _) = getType lam'
-                      let RefTy _ wTy = binderType b
-                      return $ emitter $ tangentType wTy
-                  valEmitter \ref'@(Var (_:> RefTy (Var (h:>_)) _)) -> do
-                      extendTangentEnv (ref @> ref') [h] $ applyLinToTangents linBody
+      let lin = tangentEmitter \ref'@(Var (_:> RefTy (Var (h:>_)) _)) -> do
+                  extendTangentEnv (ref @> ref') [h] $ applyLinToTangents linBody
       return (ans, lin)
 
     linearizeEffectFun :: RWS -> Atom -> PrimalM (Atom, Var)
@@ -390,24 +400,6 @@ tangentType ty = case ty of
     _ -> unsupported
   _ -> unsupported
   where unsupported = error $ "Can't differentiate wrt type " ++ pprint ty
-
-addTangent :: MonadEmbed m => Atom -> Atom -> m Atom
-addTangent x y = case getType x of
-  RecordTy (NoExt tys) -> do
-    elems <- bindM2 (zipWithT addTangent) (getUnpacked x) (getUnpacked y)
-    return $ Record $ restructure elems tys
-  TabTy b _  -> buildFor Fwd b \i -> bindM2 addTangent (tabGet x i) (tabGet y i)
-  TC con -> case con of
-    BaseType (Scalar _) -> emitOp $ ScalarBinOp FAdd x y
-    BaseType (Vector _) -> emitOp $ VectorBinOp FAdd x y
-    UnitType            -> return UnitVal
-    PairType _ _        -> do
-      (xa, xb) <- fromPair x
-      (ya, yb) <- fromPair y
-      PairVal <$> addTangent xa ya <*> addTangent xb yb
-    _ -> notTangent
-  _ -> notTangent
-  where notTangent = error $ "Not a tangent type: " ++ pprint (getType x)
 
 isTrivialForAD :: Expr -> Bool
 isTrivialForAD expr = isSingletonType tangentTy && exprEffs expr == mempty
@@ -614,12 +606,16 @@ transposeOp op ct = case op of
     refArg' <- substTranspose linRefSubst refArg
     let emitEff = emitOp . PrimEffect refArg'
     case m of
-      MAsk    -> void $ emitEff $ MTell ct
-      MTell x -> transposeAtom x =<< emitEff MAsk
+      MAsk      -> void $ emitEff . MExtend =<< (updateAddAt ct)
+      -- XXX: This assumes that the update function uses a tangent (0, +) monoid,
+      --      which is why we can ignore the binder (we even can't; we only have a
+      --      reader reference!). This should have been checked in the transposeHof
+      --      rule for RunWriter.
+      MExtend ~(LamVal _ body) -> transposeBlock body =<< emitEff MAsk
       -- TODO: Do something more efficient for state. We should be able
       --       to do in-place addition, just like we do for the Writer effect.
-      MGet    -> void $ emitEff . MPut =<< addTangent ct =<< emitEff MGet
-      MPut  x -> do
+      MGet      -> void $ emitEff . MPut =<< addTangent ct =<< emitEff MGet
+      MPut  x   -> do
         transposeAtom x =<< emitEff MGet
         void $ emitEff $ MPut $ zeroAt $ getType x
   TabCon ~(TabTy b _) es -> forM_ (enumerate es) \(i, e) -> do
@@ -685,11 +681,16 @@ transposeHof hof ct = case hof of
       return UnitVal
     where flipDir dir = case dir of Fwd -> Rev; Rev -> Fwd
   RunReader r ~(BinaryFunVal (Bind (h:>_)) b _ body) -> do
-    (_, ctr) <- (fromPair =<<) $ emitRunWriter "w" (getType r) \ref -> do
+    let RefTy _ valTy = binderType b
+    let baseTy = getBaseMonoidType valTy
+    baseMonoid <- tangentBaseMonoidFor baseTy
+    (_, ctr) <- (fromPair =<<) $ emitRunWriter "w" valTy baseMonoid \ref -> do
       localLinRegion h $ localLinRefSubst (b@>ref) $ transposeBlock body ct
       return UnitVal
     transposeAtom r ctr
-  RunWriter ~(BinaryFunVal (Bind (h:>_)) b _ body) -> do
+  RunWriter bm ~(BinaryFunVal (Bind (h:>_)) b _ body) -> do
+    unless (checkZeroPlusFloatMonoid bm) $
+      error "AD of Accum effect only supported when the base monoid is (0, +) on Float"
     (ctBody, ctEff) <- fromPair ct
     void $ emitRunReader "r" ctEff \ref -> do
       localLinRegion h $ localLinRefSubst (b@>ref) $ transposeBlock body ctBody
@@ -706,7 +707,7 @@ transposeHof hof ct = case hof of
   CatchException _ -> notImplemented
   Linearize     _  -> error "Unexpected linearization"
   Transpose     _  -> error "Unexpected transposition"
-  PTileReduce _ _  -> error "Unexpected PTileReduce"
+  PTileReduce _ _ _  -> error "Unexpected PTileReduce"
 
 transposeAtom :: Atom -> Atom -> TransposeM ()
 transposeAtom atom ct = case atom of
@@ -776,7 +777,7 @@ isLinEff _ = error "Can't transpose polymorphic effects"
 
 emitCTToRef :: Maybe Atom -> Atom -> TransposeM ()
 emitCTToRef mref ct = case mref of
-  Just ref -> void $ emitOp $ PrimEffect ref (MTell ct)
+  Just ref -> void . emitOp . PrimEffect ref . MExtend =<< updateAddAt ct
   Nothing  -> return ()
 
 substTranspose :: Subst a => (TransposeEnv -> SubstEnv) -> a -> TransposeM a
@@ -789,13 +790,15 @@ substNonlin :: Subst a => a -> TransposeM a
 substNonlin = substTranspose nonlinSubst
 
 withLinVar :: Binder -> TransposeM a -> TransposeM (a, Atom)
-withLinVar b body = case
-  singletonTypeVal (binderType b) of
-    Nothing -> flip evalStateT Nothing $ do
-      ans <- emitRunWriter "ref" (binderType b) \ref -> do
-        lift (localLinRef (b@>Just ref) body) >>= put . Just >> return UnitVal
-      (,) <$> (fromJust <$> get) <*> (getSnd ans)
-    Just x -> (,x) <$> (localLinRef (b@>Nothing) body)  -- optimization to avoid accumulating into unit
+withLinVar b body = case singletonTypeVal (binderType b) of
+  Nothing -> flip evalStateT Nothing $ do
+    let accTy = binderType b
+    let baseTy = getBaseMonoidType accTy
+    baseMonoid <- tangentBaseMonoidFor baseTy
+    ans <- emitRunWriter "ref" accTy baseMonoid \ref -> do
+      lift (localLinRef (b@>Just ref) body) >>= put . Just >> return UnitVal
+    (,) <$> (fromJust <$> get) <*> (getSnd ans)
+  Just x -> (,x) <$> (localLinRef (b@>Nothing) body)  -- optimization to avoid accumulating into unit
 
 localLinRef :: Env (Maybe Atom) -> TransposeM a -> TransposeM a
 localLinRef refs = local (<> mempty { linRefs = refs })
@@ -808,3 +811,54 @@ localLinRefSubst s = local (<> mempty { linRefSubst = s })
 
 localNonlinSubst :: SubstEnv -> TransposeM a -> TransposeM a
 localNonlinSubst s = local (<> mempty { nonlinSubst = s })
+
+-- === The (0, +) monoid for tangent types ===
+
+zeroAt :: Type -> Atom
+zeroAt ty = case ty of
+  BaseTy bt  -> Con $ Lit $ zeroLit bt
+  TabTy i a  -> TabValA i $ zeroAt a
+  UnitTy     -> UnitVal
+  PairTy a b -> PairVal (zeroAt a) (zeroAt b)
+  RecordTy (Ext tys Nothing) -> Record $ fmap zeroAt tys
+  _          -> unreachable
+  where
+    unreachable = error $ "Missing zero case for a tangent type: " ++ pprint ty
+    zeroLit bt = case bt of
+      Scalar Float64Type -> Float64Lit 0.0
+      Scalar Float32Type -> Float32Lit 0.0
+      Vector st          -> VecLit $ replicate vectorWidth $ zeroLit $ Scalar st
+      _                  -> unreachable
+
+updateAddAt :: MonadEmbed m => Atom -> m Atom
+updateAddAt x = buildLam (Bind ("t":>getType x)) PureArrow $ addTangent x
+
+addTangent :: MonadEmbed m => Atom -> Atom -> m Atom
+addTangent x y = case getType x of
+  RecordTy (NoExt tys) -> do
+    elems <- bindM2 (zipWithT addTangent) (getUnpacked x) (getUnpacked y)
+    return $ Record $ restructure elems tys
+  TabTy b _  -> buildFor Fwd b \i -> bindM2 addTangent (tabGet x i) (tabGet y i)
+  TC con -> case con of
+    BaseType (Scalar _) -> emitOp $ ScalarBinOp FAdd x y
+    BaseType (Vector _) -> emitOp $ VectorBinOp FAdd x y
+    UnitType            -> return UnitVal
+    PairType _ _        -> do
+      (xa, xb) <- fromPair x
+      (ya, yb) <- fromPair y
+      PairVal <$> addTangent xa ya <*> addTangent xb yb
+    _ -> notTangent
+  _ -> notTangent
+  where notTangent = error $ "Not a tangent type: " ++ pprint (getType x)
+
+tangentBaseMonoidFor :: MonadEmbed m => Type -> m BaseMonoid
+tangentBaseMonoidFor ty = BaseMonoid (zeroAt ty) <$> buildLam (Bind ("t":>ty)) PureArrow updateAddAt
+
+checkZeroPlusFloatMonoid :: BaseMonoid -> Bool
+checkZeroPlusFloatMonoid (BaseMonoid zero plus) = checkZero zero && checkPlus plus
+  where
+    checkZero z = z == (Con (Lit (Float32Lit 0.0)))
+    checkPlus f = case f of
+      BinaryFunVal (Bind x) (Bind y) Pure (Block Empty (Op (ScalarBinOp FAdd (Var x') (Var y')))) ->
+        (x == x' && y == y') || (x == y' && y == x')
+      _ -> False

--- a/src/lib/Embed.hs
+++ b/src/lib/Embed.hs
@@ -686,8 +686,7 @@ traverseDecl (_, fExpr, _) decl = case decl of
   Let letAnn b expr -> do
     expr' <- fExpr expr
     case expr' of
-      Atom a | not (isGlobalBinder b) -> return $ b @> a
-      -- TODO: Do we need to use the name hint here?
+      Atom a | not (isGlobalBinder b) && letAnn == PlainLet -> return $ b @> a
       _ -> (b@>) <$> emitTo (binderNameHint b) letAnn expr'
 
 traverseBlock :: (MonadEmbed m, MonadReader SubstEnv m)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -865,8 +865,8 @@ synthDict ty = case ty of
 
 -- TODO: this doesn't de-dup, so we'll get multiple results if we have a
 -- diamond-shaped hierarchy.
-superclass :: Atom -> SynthDictM Atom
-superclass dict = return dict <|> do
+withSuperclasses :: Atom -> SynthDictM Atom
+withSuperclasses dict = return dict <|> do
   (f, LetBound SuperclassLet _) <- getBinding
   inferToSynth $ tryApply f dict
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -638,8 +638,10 @@ instance Pretty UDecl where
     "data" <+> p tyCon <+> "where" <> nest 2 (hardline <> prettyLines dataCons)
   pretty (UInterface cs def methods) =
     "interface" <+> p cs <+> p def <> hardline <> prettyLines methods
-  pretty (UInstance bs ty methods) =
+  pretty (UInstance Nothing bs ty methods) =
     "instance" <+> p bs <+> p ty <> hardline <> prettyLines methods
+  pretty (UInstance (Just v) bs ty methods) =
+    "named-instance" <+> p v <+> ":" <+> p bs <+> p ty <> hardline <> prettyLines methods
 
 instance Pretty UMethodDef where
   pretty (UMethodDef b rhs) = p b <+> "=" <+> p rhs

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -252,8 +252,8 @@ prettyPrecPrimCon con = case con of
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where
   prettyPrec op = case op of
-    PrimEffect ref (MPut val ) -> atPrec LowestPrec $ pApp ref <+> ":=" <+> pApp val
-    PrimEffect ref (MTell val) -> atPrec LowestPrec $ pApp ref <+> "+=" <+> pApp val
+    PrimEffect ref (MPut    val   ) -> atPrec LowestPrec $ pApp ref <+> ":=" <+> pApp val
+    PrimEffect ref (MExtend update) -> atPrec LowestPrec $ "extend" <+> pApp ref <+> "using" <+> pLowest update
     PtrOffset ptr idx -> atPrec LowestPrec $ pApp ptr <+> "+>" <+> pApp idx
     PtrLoad   ptr     -> atPrec AppPrec $ pAppArg "load" [ptr]
     RecordCons items rest ->

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -287,10 +287,17 @@ instance Pretty ClassName where
 
 instance Pretty Decl where
   pretty decl = case decl of
-    Let _ (Ignore _) bound -> pLowest bound
+    Let ann (Ignore _) bound -> p ann <+> pLowest bound
     -- This is just to reduce clutter a bit. We can comment it out when needed.
     -- Let (v:>Pi _)   bound -> p v <+> "=" <+> p bound
-    Let _  b  rhs -> align $ p b  <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+    Let ann b rhs -> align $ p ann <+> p b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+
+instance Pretty LetAnn where
+  pretty ann = case ann of
+    PlainLet      -> ""
+    InstanceLet   -> "%instance"
+    SuperclassLet -> "%superclass"
+    NoInlineLet   -> "%noinline"
 
 prettyPiTypeHelper :: PiType -> Doc ann
 prettyPiTypeHelper (Abs binder (arr, body)) = let
@@ -625,8 +632,8 @@ instance Pretty a => Pretty (Limit a) where
   pretty (InclusiveLim x) = "incLim" <+> p x
 
 instance Pretty UDecl where
-  pretty (ULet _ b rhs) =
-    align $ prettyUBinder b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+  pretty (ULet ann b rhs) =
+    align $ p ann <+> prettyUBinder b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
   pretty (UData tyCon dataCons) =
     "data" <+> p tyCon <+> "where" <> nest 2 (hardline <> prettyLines dataCons)
   pretty (UInterface cs def methods) =

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -365,9 +365,10 @@ instanceMethod = do
 
 simpleLet :: Parser (UExpr -> UDecl)
 simpleLet = label "let binding" $ do
+  letAnn <- (InstanceLet <$ string "%instance" <* sc) <|> (pure PlainLet)
   p <- try $ (letPat <|> leafPat) <* lookAhead (sym "=" <|> sym ":")
-  ann <- optional $ annot uType
-  return $ ULet PlainLet (p, ann)
+  typeAnn <- optional $ annot uType
+  return $ ULet letAnn (p, typeAnn)
 
 letPat :: Parser UPat
 letPat = withSrc $ nameToPat <$> anyName

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -1,6 +1,6 @@
 
 -- TODO: use prelude sum instead once we can differentiate state effect
-def sum'  (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs.i
+def sum'  (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs.i
 
 :p
    f : Float -> Float = \x. x
@@ -69,7 +69,7 @@ def sum'  (xs:n=>Float) : Float = yieldAccum \ref. for i. ref += xs.i
 :p jvp sum' [1., 2.] [10.0, 20.0]
 > 30.
 
-f : Float -> Float = \x. yieldAccum \ref. ref += x
+f : Float -> Float = \x. yieldAccum (AddMonoid Float) \ref. ref += x
 :p jvp f 1.0 1.0
 > 1.
 
@@ -167,7 +167,7 @@ tripleit : Float --o Float = \x. x + x + x
 > [2., 4.]
 
 myOtherSquare : Float -> Float =
-  \x. yieldAccum \w. w += x * x
+  \x. yieldAccum (AddMonoid Float) \w. w += x * x
 
 :p checkDeriv myOtherSquare 3.0
 > True
@@ -225,7 +225,7 @@ vec = [1.]
 :p
   f : Float -> Float = \x.
     y = x * 2.0
-    yieldAccum \a.
+    yieldAccum (AddMonoid Float) \a.
       a += x * 2.0
       a += y
   grad f 1.0

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -102,7 +102,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 > Runtime error
 
 :p
-  yieldAccum \ref.
+  yieldAccum (AddMonoid Float) \ref.
     for i. case myTab.i of
       MyLeft tmp -> ()
       MyRight val -> ref += 1.0 + val
@@ -110,7 +110,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 
 :p
   -- check that the order of the case alternatives doesn't matter
-  yieldAccum \ref.
+  yieldAccum (AddMonoid Float) \ref.
     for i. case myTab.i of
       MyRight val -> ref += 1.0 + val
       MyLeft tmp -> ()
@@ -128,7 +128,7 @@ threeCaseTab : (Fin 4)=>ThreeCases =
 > [(TheIntCase 3), TheEmptyCase, (ThePairCase 2 0.1), TheEmptyCase]
 
 :p
-  yieldAccum \ref.
+  yieldAccum (AddMonoid Float) \ref.
     for i. case threeCaseTab.i of
       TheEmptyCase    -> ref += 1000.0
       ThePairCase x y -> ref +=  100.0 + y + IToF x

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -698,7 +698,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 > 415
 
 :p
-  (f, w) = runAccum \ref.
+  (f, w) = runAccum (AddMonoid Float) \ref.
     ref += 2.0
     w = 2
     \z. z + w
@@ -715,17 +715,6 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 arr2d = for i:(Fin 2). for j:(Fin 2). (iota _).(i,j)
 arr2d.(1@_)
 > [2, 3]
-
-:p
-  runState (1,2) \ref.
-    r1 = fstRef ref
-    r2 = sndRef ref
-    x = get r1
-    y = get r2
-    r2 := x
-    r1 := y
-> ((), (2, 1))
-
 
 :p any [True, False]
 > True

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -27,6 +27,7 @@
 :p
   def rwsAction
         (rh:Type) ?-> (wh:Type) ?-> (sh:Type) ?->
+        (_:AccumMonoid wh Float) ?=>
         (r:Ref rh Int) (w:Ref wh Float) (s:Ref sh Bool)
         : {Read rh, Accum wh, State sh} Int =
     x = get s
@@ -38,7 +39,7 @@
 
   withReader 2 \r.
     runState True \s.
-      runAccum \w.
+      runAccum (AddMonoid Float) \w.
         rwsAction r w s
 > ((4, 6.), False)
 
@@ -56,29 +57,31 @@
 
 :p
   def m (wh:Type) ?-> (sh:Type) ?->
+        (_:AccumMonoid wh Float) ?=>
         (w:Ref wh Float) (s:Ref sh Float)
         : {Accum wh, State sh} Unit =
     x = get s
     w += x
-  runState 1.0 \s. runAccum \w . m w s
+  runState 1.0 \s. runAccum (AddMonoid Float) \w . m w s
 > (((), 1.), 1.)
 
-def myAction  (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
+def myAction [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
   x = ask r
   w += x
   w += 2.0
 
-:p withReader 1.5 \r. runAccum \w. myAction w r
+:p withReader 1.5 \r. runAccum (AddMonoid Float) \w. myAction w r
 > ((), 3.5)
 
 :p
   def m (h1:Type) ?-> (h2:Type) ?->
+        (_:AccumMonoid h1 Float) ?=> (_:AccumMonoid h2 Float) ?=>
         (w1:Ref h1 Float) (w2:Ref h2 Float)
         : {Accum h1, Accum h2} Unit =
     w1 += 1.0
     w2 += 3.0
     w1 += 1.0
-  runAccum \w1. runAccum \w2. m w1 w2
+  runAccum (AddMonoid Float) \w1. runAccum (AddMonoid Float) \w2. m w1 w2
 > (((), 3.), 2.)
 
 def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
@@ -125,8 +128,8 @@ def foom (h:Type) ?-> (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 --       (maybe just explicit implicit args)
 :p
   withReader 2.0 \r.
-    runAccum \w.
-      runAccum \w'.
+    runAccum (AddMonoid Float) \w.
+      runAccum (AddMonoid Float) \w'.
         runState 3 \s.
           x = ask r
           y = get s
@@ -151,19 +154,19 @@ symmetrizeInPlace [[1.,2.],[3.,4.]]
 :p withReader 5 \r. ()
 > ()
 
-:p yieldAccum \w.
+:p yieldAccum (AddMonoid Float) \w.
   for i:(Fin 2).
     w += 1.0
     w += 1.0
 > 4.
 
-:p yieldAccum \w.
+:p yieldAccum (AddMonoid Float) \w.
   for i:(Fin 2).
     w += 1.0
   w += 1.0
 > 3.
 
-:p yieldAccum \ref.
+:p yieldAccum (AddMonoid Float) \ref.
      ref += [1.,2.,3.]
      ref += [2.,4.,5.]
 > [3., 6., 8.]

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -113,7 +113,7 @@ def myInt : {State h} Int = 1
 > Nullary def can't have effects
 
 :p
-  yieldAccum \ref.
+  yieldAccum (AddMonoid Float) \ref.
     x = if True then 1. else 3.
     if True then ref += x
 


### PR DESCRIPTION
#### Parametrize runAccum by a monoid used for the reduction

This makes it possible to express (parallel) reductions over arbitrary
monoids. Thanks to this, we can start removing some nasty hacks (like
the one used for `Eq (n=>a)`) and make the (work-in-progress) FFT example
parallel!

Anyway, this whole change turned out to be surprisingly difficult, but
thanks to many chats with @dougalm, I think that we've arrived at a
particularly nice solution.

The crux of the matter is the fact that Dex, unlike most other
languages with some form of a built-in reduction operator, allows
slicing the accumulator. This poses an interesting problem: if the user
was to specify the `Monoid` instance for the full accumulator (e.g. a
matrix), then what monoid are we supposed to use for its slice?! As it
turns out, this might not even be well defined! For example, the type of square
matrices with identity matrix and matrix multiplication forms a monoid,
but there is no natural "sub-monoid" we could use in an expression
of the form `ref!i += ...`.

So, unless we're ok with giving up reference slicing (which we know we
want for sure, since this is a way to express e.g. parallel scatters and
histograms), we have to come up with a way of constructing those
sub-monoids. And here, and answer is to turn the problem around: instead
of asking the users to provide us the monoids for the full references,
we expect the monoid to refer to some _base type_ (and we call it a
_base monoid_). That is, when the `Accum` reference is of type
`n=>m=>...=>k=>a`, then any of `m=>...=>k=>a`, ..., `k=>a` and even
`a` are considered base types. While this is a bit surprising at first,
it turns out to actually be quite convenient, since it does seem more
straightforward to say "I want this to be a reduction over `(Float, 0.0, +)`"
instead of mentioning the full table type, a broadcast version of `0.0`
and a pointwise-lifted version of `+`.

Finally, because many data types have multiple valid monoids (`Float`
has at least four: `+`, `*`, `min`, `max`), the monoid argument is
explicit and those instances can be obtained via the `named-instance`
syntax added in the previous commits. Note that I've also included some
helper functions which make it possible to synthesize `Monoid` instances
automatically from `Add` and `Mul` instance for any given type (see
`AddMonoid` and `MulMonoid`).

I haven't been fully able to verify the correctness of the
parallelization change, because the CUDA backend seems to be broken
anyway (sigh...), but the code it generates looks ok.

#### Make it possible to define named instances

Think of this as a user-visible way to construct instance dictionaries.
Named instances don't participate in the syntheis by default. We've made
that choice, because they are the most useful when there are multiple valid
candidates, such as when considering `Monoid Float` (which can be `(0, +)`,
`(1, *)`, `(-inf, max)`, ...).