### PR TITLE
[NFC] Rename "Embed" to "Builder".

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -33,9 +33,9 @@ library dex-resources
 
 library
   exposed-modules:     Env, Syntax, Type, Inference, JIT, LLVMExec,
-                       Parser, Util, Imp, Imp.Embed, Imp.Optimize,
+                       Parser, Util, Imp, Imp.Builder, Imp.Optimize,
                        PPrint, Algebra, Parallelize, Optimize, Serialize
-                       Actor, Cat, Embed, Export,
+                       Actor, Builder, Cat, Export,
                        RenderHtml, LiveOutput, Simplify, TopLevel,
                        Autodiff, Interpreter, Logging, CUDA,
                        LLVM.JIT, LLVM.Shims

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -10,32 +10,32 @@
 {-# LANGUAGE MultiParamTypeClasses #-}
 {-# LANGUAGE UndecidableInstances #-}
 
-module Embed (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildPi,
-              getAllowedEffects, withEffects, modifyAllowedEffects,
-              buildLam, EmbedT, Embed, MonadEmbed, buildScoped, runEmbedT,
-              runSubstEmbed, runEmbed, getScope, embedLook, liftEmbed,
-              app,
-              add, mul, sub, neg, div',
-              iadd, imul, isub, idiv, ilt, ieq,
-              fpow, flog, fLitLike, recGetHead, buildImplicitNaryLam,
-              select, substEmbed, substEmbedR, emitUnpack, getUnpacked,
-              fromPair, getFst, getSnd, getFstRef, getSndRef,
-              naryApp, appReduce, appTryReduce, buildAbs,
-              buildFor, buildForAux, buildForAnn, buildForAnnAux,
-              emitBlock, unzipTab, isSingletonType, emitDecl, withNameHint,
-              singletonTypeVal, scopedDecls, embedScoped, extendScope, checkEmbed,
-              embedExtend, applyPreludeFunction,
-              unpackConsList, unpackLeftLeaningConsList,
-              emitRunWriter, emitRunWriters, mextendForRef, monoidLift,
-              emitRunState, emitMaybeCase, emitWhile, buildDataDef,
-              emitRunReader, tabGet, SubstEmbedT, SubstEmbed, runSubstEmbedT,
-              ptrOffset, ptrLoad, unsafePtrLoad,
-              evalBlockE, substTraversalDef,
-              TraversalDef, traverseDecls, traverseDecl, traverseDeclsOpen,
-              traverseBlock, traverseExpr, traverseAtom,
-              clampPositive, buildNAbs, buildNAbsAux, buildNestedLam,
-              transformModuleAsBlock, dropSub, appReduceTraversalDef,
-              indexSetSizeE, indexToIntE, intToIndexE, freshVarE) where
+module Builder (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buildPi,
+                getAllowedEffects, withEffects, modifyAllowedEffects,
+                buildLam, BuilderT, Builder, MonadBuilder, buildScoped, runBuilderT,
+                runSubstBuilder, runBuilder, getScope, builderLook, liftBuilder,
+                app,
+                add, mul, sub, neg, div',
+                iadd, imul, isub, idiv, ilt, ieq,
+                fpow, flog, fLitLike, recGetHead, buildImplicitNaryLam,
+                select, substBuilder, substBuilderR, emitUnpack, getUnpacked,
+                fromPair, getFst, getSnd, getFstRef, getSndRef,
+                naryApp, appReduce, appTryReduce, buildAbs,
+                buildFor, buildForAux, buildForAnn, buildForAnnAux,
+                emitBlock, unzipTab, isSingletonType, emitDecl, withNameHint,
+                singletonTypeVal, scopedDecls, builderScoped, extendScope, checkBuilder,
+                builderExtend, applyPreludeFunction,
+                unpackConsList, unpackLeftLeaningConsList,
+                emitRunWriter, emitRunWriters, mextendForRef, monoidLift,
+                emitRunState, emitMaybeCase, emitWhile, buildDataDef,
+                emitRunReader, tabGet, SubstBuilderT, SubstBuilder, runSubstBuilderT,
+                ptrOffset, ptrLoad, unsafePtrLoad,
+                evalBlockE, substTraversalDef,
+                TraversalDef, traverseDecls, traverseDecl, traverseDeclsOpen,
+                traverseBlock, traverseExpr, traverseAtom,
+                clampPositive, buildNAbs, buildNAbsAux, buildNestedLam,
+                transformModuleAsBlock, dropSub, appReduceTraversalDef,
+                indexSetSizeE, indexToIntE, intToIndexE, freshVarE) where
 
 import Control.Applicative
 import Control.Monad
@@ -58,84 +58,84 @@ import Type
 import PPrint
 import Util (bindM2, scanM, restructure)
 
-newtype EmbedT m a = EmbedT (ReaderT EmbedEnvR (CatT EmbedEnvC m) a)
+newtype BuilderT m a = BuilderT (ReaderT BuilderEnvR (CatT BuilderEnvC m) a)
   deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Alternative)
 
-type Embed = EmbedT Identity
-type EmbedEnv = (EmbedEnvR, EmbedEnvC)
+type Builder = BuilderT Identity
+type BuilderEnv = (BuilderEnvR, BuilderEnvC)
 
-type SubstEmbedT m = ReaderT SubstEnv (EmbedT m)
-type SubstEmbed    = SubstEmbedT Identity
+type SubstBuilderT m = ReaderT SubstEnv (BuilderT m)
+type SubstBuilder    = SubstBuilderT Identity
 
 -- Carries the vars in scope (with optional definitions) and the emitted decls
-type EmbedEnvC = (Scope, Nest Decl)
+type BuilderEnvC = (Scope, Nest Decl)
 -- Carries a name suggestion and the allowable effects
-type EmbedEnvR = (Tag, EffectRow)
+type BuilderEnvR = (Tag, EffectRow)
 
-runEmbedT :: Monad m => EmbedT m a -> Scope -> m (a, EmbedEnvC)
-runEmbedT (EmbedT m) scope = do
+runBuilderT :: Monad m => BuilderT m a -> Scope -> m (a, BuilderEnvC)
+runBuilderT (BuilderT m) scope = do
   (ans, env) <- runCatT (runReaderT m ("tmp", Pure)) (scope, Empty)
   return (ans, env)
 
-runEmbed :: Embed a -> Scope -> (a, EmbedEnvC)
-runEmbed m scope = runIdentity $ runEmbedT m scope
+runBuilder :: Builder a -> Scope -> (a, BuilderEnvC)
+runBuilder m scope = runIdentity $ runBuilderT m scope
 
-runSubstEmbedT :: Monad m => SubstEmbedT m a -> Scope -> m (a, EmbedEnvC)
-runSubstEmbedT m scope = runEmbedT (runReaderT m mempty) scope
+runSubstBuilderT :: Monad m => SubstBuilderT m a -> Scope -> m (a, BuilderEnvC)
+runSubstBuilderT m scope = runBuilderT (runReaderT m mempty) scope
 
-runSubstEmbed :: SubstEmbed a -> Scope -> (a, EmbedEnvC)
-runSubstEmbed m scope = runIdentity $ runEmbedT (runReaderT m mempty) scope
+runSubstBuilder :: SubstBuilder a -> Scope -> (a, BuilderEnvC)
+runSubstBuilder m scope = runIdentity $ runBuilderT (runReaderT m mempty) scope
 
-emit :: MonadEmbed m => Expr -> m Atom
+emit :: MonadBuilder m => Expr -> m Atom
 emit expr     = emitAnn PlainLet expr
 
-emitAnn :: MonadEmbed m => LetAnn -> Expr -> m Atom
+emitAnn :: MonadBuilder m => LetAnn -> Expr -> m Atom
 emitAnn ann expr = do
   v <- getNameHint
   emitTo v ann expr
 
 -- Guarantees that the name will be used, possibly with a modified counter
-emitTo :: MonadEmbed m => Name -> LetAnn -> Expr -> m Atom
+emitTo :: MonadBuilder m => Name -> LetAnn -> Expr -> m Atom
 emitTo name ann expr = do
   scope <- getScope
   -- Deshadow type because types from DataDef may have binders that shadow local vars
   let ty    = deShadow (getType expr) scope
   let expr' = deShadow expr scope
   v <- freshVarE (LetBound ann expr') $ Bind (name:>ty)
-  embedExtend $ asSnd $ Nest (Let ann (Bind v) expr') Empty
+  builderExtend $ asSnd $ Nest (Let ann (Bind v) expr') Empty
   return $ Var v
 
-emitOp :: MonadEmbed m => Op -> m Atom
+emitOp :: MonadBuilder m => Op -> m Atom
 emitOp op = emit $ Op op
 
-emitUnpack :: MonadEmbed m => Expr -> m [Atom]
+emitUnpack :: MonadBuilder m => Expr -> m [Atom]
 emitUnpack expr = getUnpacked =<< emit expr
 
-emitBlock :: MonadEmbed m => Block -> m Atom
+emitBlock :: MonadBuilder m => Block -> m Atom
 emitBlock block = emitBlockRec mempty block
 
-emitBlockRec :: MonadEmbed m => SubstEnv -> Block -> m Atom
+emitBlockRec :: MonadBuilder m => SubstEnv -> Block -> m Atom
 emitBlockRec env (Block (Nest (Let ann b expr) decls) result) = do
-  expr' <- substEmbed env expr
+  expr' <- substBuilder env expr
   x <- emitTo (binderNameHint b) ann expr'
   emitBlockRec (env <> b@>x) $ Block decls result
-emitBlockRec env (Block Empty (Atom atom)) = substEmbed env atom
-emitBlockRec env (Block Empty expr) = substEmbed env expr >>= emit
+emitBlockRec env (Block Empty (Atom atom)) = substBuilder env atom
+emitBlockRec env (Block Empty expr) = substBuilder env expr >>= emit
 
-freshVarE :: MonadEmbed m => BinderInfo -> Binder -> m Var
+freshVarE :: MonadBuilder m => BinderInfo -> Binder -> m Var
 freshVarE bInfo b = do
   v <- case b of
     Ignore _    -> getNameHint
     Bind (v:>_) -> return v
   scope <- getScope
   let v' = genFresh v scope
-  embedExtend $ asFst $ v' @> (binderType b, bInfo)
+  builderExtend $ asFst $ v' @> (binderType b, bInfo)
   return $ v' :> binderType b
 
-freshNestedBinders :: MonadEmbed m => Nest Binder -> m (Nest Var)
+freshNestedBinders :: MonadBuilder m => Nest Binder -> m (Nest Var)
 freshNestedBinders bs = freshNestedBindersRec mempty bs
 
-freshNestedBindersRec :: MonadEmbed m => Env Atom -> Nest Binder -> m (Nest Var)
+freshNestedBindersRec :: MonadBuilder m => Env Atom -> Nest Binder -> m (Nest Var)
 freshNestedBindersRec _ Empty = return Empty
 freshNestedBindersRec substEnv (Nest b bs) = do
   scope <- getScope
@@ -143,7 +143,7 @@ freshNestedBindersRec substEnv (Nest b bs) = do
   vs <- freshNestedBindersRec (substEnv <> b@>Var v) bs
   return $ Nest v vs
 
-buildPi :: (MonadError Err m, MonadEmbed m)
+buildPi :: (MonadError Err m, MonadBuilder m)
         => Binder -> (Atom -> m (Arrow, Type)) -> m Atom
 buildPi b f = do
   scope <- getScope
@@ -157,7 +157,7 @@ buildPi b f = do
     Nothing -> throw CompilerErr $
       "Unexpected irreducible decls in pi type: " ++ pprint decls
 
-buildAbs :: MonadEmbed m => Binder -> (Atom -> m a) -> m (Abs Binder (Nest Decl, a))
+buildAbs :: MonadBuilder m => Binder -> (Atom -> m a) -> m (Abs Binder (Nest Decl, a))
 buildAbs b f = do
   ((b', ans), decls) <- scopedDecls $ do
      v <- freshVarE UnknownBinder b
@@ -165,14 +165,14 @@ buildAbs b f = do
      return (b, ans)
   return (Abs b' (decls, ans))
 
-buildLam :: MonadEmbed m => Binder -> Arrow -> (Atom -> m Atom) -> m Atom
+buildLam :: MonadBuilder m => Binder -> Arrow -> (Atom -> m Atom) -> m Atom
 buildLam b arr body = buildDepEffLam b (const (return arr)) body
 
-buildDepEffLam :: MonadEmbed m
+buildDepEffLam :: MonadBuilder m
                => Binder -> (Atom -> m Arrow) -> (Atom -> m Atom) -> m Atom
 buildDepEffLam b fArr fBody = liftM fst $ buildLamAux b fArr \x -> (,()) <$> fBody x
 
-buildLamAux :: MonadEmbed m
+buildLamAux :: MonadBuilder m
             => Binder -> (Atom -> m Arrow) -> (Atom -> m (Atom, a)) -> m (Atom, a)
 buildLamAux b fArr fBody = do
   ((b', arr, ans, aux), decls) <- scopedDecls $ do
@@ -180,15 +180,15 @@ buildLamAux b fArr fBody = do
      let x = Var v
      arr <- fArr x
      -- overwriting the previous binder info know that we know more
-     embedExtend $ asFst $ v @> (varType v, LamBound (void arr))
+     builderExtend $ asFst $ v @> (varType v, LamBound (void arr))
      (ans, aux) <- withEffects (arrowEff arr) $ fBody x
      return (Bind v, arr, ans, aux)
   return (Lam $ makeAbs b' (arr, wrapDecls decls ans), aux)
 
-buildNAbs :: MonadEmbed m => Nest Binder -> ([Atom] -> m Atom) -> m Alt
+buildNAbs :: MonadBuilder m => Nest Binder -> ([Atom] -> m Atom) -> m Alt
 buildNAbs bs body = liftM fst $ buildNAbsAux bs \xs -> (,()) <$> body xs
 
-buildNAbsAux :: MonadEmbed m => Nest Binder -> ([Atom] -> m (Atom, a)) -> m (Alt, a)
+buildNAbsAux :: MonadBuilder m => Nest Binder -> ([Atom] -> m (Atom, a)) -> m (Alt, a)
 buildNAbsAux bs body = do
   ((bs', (ans, aux)), decls) <- scopedDecls $ do
      vs <- freshNestedBinders bs
@@ -196,7 +196,7 @@ buildNAbsAux bs body = do
      return (fmap Bind vs, result)
   return (Abs bs' $ wrapDecls decls ans, aux)
 
-buildDataDef :: MonadEmbed m
+buildDataDef :: MonadBuilder m
              => Name -> Nest Binder -> ([Atom] -> m [DataConDef]) -> m DataDef
 buildDataDef tyConName paramBinders body = do
   ((paramBinders', dataDefs), _) <- scopedDecls $ do
@@ -205,11 +205,11 @@ buildDataDef tyConName paramBinders body = do
      return (fmap Bind vs, result)
   return $ DataDef tyConName paramBinders' dataDefs
 
-buildImplicitNaryLam :: MonadEmbed m => (Nest Binder) -> ([Atom] -> m Atom) -> m Atom
+buildImplicitNaryLam :: MonadBuilder m => (Nest Binder) -> ([Atom] -> m Atom) -> m Atom
 buildImplicitNaryLam Empty body = body []
 buildImplicitNaryLam (Nest b bs) body =
   buildLam b ImplicitArrow \x -> do
-    bs' <- substEmbed (b@>x) bs
+    bs' <- substBuilder (b@>x) bs
     buildImplicitNaryLam bs' \xs -> body $ x:xs
 
 recGetHead :: Label -> Atom -> Atom
@@ -218,7 +218,7 @@ recGetHead l x = do
   let i = fromJust $ elemIndex l $ map fst $ toList $ reflectLabels r
   getProjection [i] x
 
-buildScoped :: MonadEmbed m => m Atom -> m Block
+buildScoped :: MonadBuilder m => m Atom -> m Block
 buildScoped m = do
   (ans, decls) <- scopedDecls m
   return $ wrapDecls decls ans
@@ -239,86 +239,86 @@ fLitLike x t = case getType t of
   BaseTy (Scalar Float32Type) -> Con $ Lit $ Float32Lit $ realToFrac x
   _ -> error "Expected a floating point scalar"
 
-neg :: MonadEmbed m => Atom -> m Atom
+neg :: MonadBuilder m => Atom -> m Atom
 neg x = emitOp $ ScalarUnOp FNeg x
 
-add :: MonadEmbed m => Atom -> Atom -> m Atom
+add :: MonadBuilder m => Atom -> Atom -> m Atom
 add x y = emitOp $ ScalarBinOp FAdd x y
 
 -- TODO: Implement constant folding for fixed-width integer types as well!
-iadd :: MonadEmbed m => Atom -> Atom -> m Atom
+iadd :: MonadBuilder m => Atom -> Atom -> m Atom
 iadd (Con (Lit l)) y | getIntLit l == 0 = return y
 iadd x (Con (Lit l)) | getIntLit l == 0 = return x
 iadd x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (+) x y
 iadd x y = emitOp $ ScalarBinOp IAdd x y
 
-mul :: MonadEmbed m => Atom -> Atom -> m Atom
+mul :: MonadBuilder m => Atom -> Atom -> m Atom
 mul x y = emitOp $ ScalarBinOp FMul x y
 
-imul :: MonadEmbed m => Atom -> Atom -> m Atom
+imul :: MonadBuilder m => Atom -> Atom -> m Atom
 imul   (Con (Lit l)) y               | getIntLit l == 1 = return y
 imul x                 (Con (Lit l)) | getIntLit l == 1 = return x
 imul x@(Con (Lit _)) y@(Con (Lit _))                    = return $ applyIntBinOp (*) x y
 imul x y = emitOp $ ScalarBinOp IMul x y
 
-sub :: MonadEmbed m => Atom -> Atom -> m Atom
+sub :: MonadBuilder m => Atom -> Atom -> m Atom
 sub x y = emitOp $ ScalarBinOp FSub x y
 
-isub :: MonadEmbed m => Atom -> Atom -> m Atom
+isub :: MonadBuilder m => Atom -> Atom -> m Atom
 isub x (Con (Lit l)) | getIntLit l == 0 = return x
 isub x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (-) x y
 isub x y = emitOp $ ScalarBinOp ISub x y
 
-select :: MonadEmbed m => Atom -> Atom -> Atom -> m Atom
+select :: MonadBuilder m => Atom -> Atom -> Atom -> m Atom
 select (Con (Lit (Word8Lit p))) x y = return $ if p /= 0 then x else y
 select p x y = emitOp $ Select p x y
 
-div' :: MonadEmbed m => Atom -> Atom -> m Atom
+div' :: MonadBuilder m => Atom -> Atom -> m Atom
 div' x y = emitOp $ ScalarBinOp FDiv x y
 
-idiv :: MonadEmbed m => Atom -> Atom -> m Atom
+idiv :: MonadBuilder m => Atom -> Atom -> m Atom
 idiv x (Con (Lit l)) | getIntLit l == 1 = return x
 idiv x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp div x y
 idiv x y = emitOp $ ScalarBinOp IDiv x y
 
-irem :: MonadEmbed m => Atom -> Atom -> m Atom
+irem :: MonadBuilder m => Atom -> Atom -> m Atom
 irem x y = emitOp $ ScalarBinOp IRem x y
 
-fpow :: MonadEmbed m => Atom -> Atom -> m Atom
+fpow :: MonadBuilder m => Atom -> Atom -> m Atom
 fpow x y = emitOp $ ScalarBinOp FPow x y
 
-flog :: MonadEmbed m => Atom -> m Atom
+flog :: MonadBuilder m => Atom -> m Atom
 flog x = emitOp $ ScalarUnOp Log x
 
-ilt :: MonadEmbed m => Atom -> Atom -> m Atom
+ilt :: MonadBuilder m => Atom -> Atom -> m Atom
 ilt x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (<) x y
 ilt x y = emitOp $ ScalarBinOp (ICmp Less) x y
 
-ieq :: MonadEmbed m => Atom -> Atom -> m Atom
+ieq :: MonadBuilder m => Atom -> Atom -> m Atom
 ieq x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (==) x y
 ieq x y = emitOp $ ScalarBinOp (ICmp Equal) x y
 
-fromPair :: MonadEmbed m => Atom -> m (Atom, Atom)
+fromPair :: MonadBuilder m => Atom -> m (Atom, Atom)
 fromPair pair = do
   ~[x, y] <- getUnpacked pair
   return (x, y)
 
-getFst :: MonadEmbed m => Atom -> m Atom
+getFst :: MonadBuilder m => Atom -> m Atom
 getFst p = fst <$> fromPair p
 
-getSnd :: MonadEmbed m => Atom -> m Atom
+getSnd :: MonadBuilder m => Atom -> m Atom
 getSnd p = snd <$> fromPair p
 
-getFstRef :: MonadEmbed m => Atom -> m Atom
+getFstRef :: MonadBuilder m => Atom -> m Atom
 getFstRef r = emitOp $ FstRef r
 
-getSndRef :: MonadEmbed m => Atom -> m Atom
+getSndRef :: MonadBuilder m => Atom -> m Atom
 getSndRef r = emitOp $ SndRef r
 
 -- XXX: getUnpacked must reduce its argument to enforce the invariant that
 -- ProjectElt atoms are always fully reduced (to avoid type errors between two
 -- equivalent types spelled differently).
-getUnpacked :: MonadEmbed m => Atom -> m [Atom]
+getUnpacked :: MonadBuilder m => Atom -> m [Atom]
 getUnpacked atom = do
   scope <- getScope
   let len = projectLength $ getType atom
@@ -326,19 +326,19 @@ getUnpacked atom = do
       res = map (\i -> getProjection [i] atom') [0..(len-1)]
   return res
 
-app :: MonadEmbed m => Atom -> Atom -> m Atom
+app :: MonadBuilder m => Atom -> Atom -> m Atom
 app x i = emit $ App x i
 
-naryApp :: MonadEmbed m => Atom -> [Atom] -> m Atom
+naryApp :: MonadBuilder m => Atom -> [Atom] -> m Atom
 naryApp f xs = foldM app f xs
 
-appReduce :: MonadEmbed m => Atom -> Atom -> m Atom
+appReduce :: MonadBuilder m => Atom -> Atom -> m Atom
 appReduce (Lam (Abs v (_, b))) a =
   runReaderT (evalBlockE substTraversalDef b) (v @> a)
 appReduce _ _ = error "appReduce expected a lambda as the first argument"
 
 -- TODO: this would be more convenient if we could add type inference too
-applyPreludeFunction :: MonadEmbed m => String -> [Atom] -> m Atom
+applyPreludeFunction :: MonadBuilder m => String -> [Atom] -> m Atom
 applyPreludeFunction s xs = do
   scope <- getScope
   case envLookup scope fname of
@@ -346,22 +346,22 @@ applyPreludeFunction s xs = do
     Just (ty, _) -> naryApp (Var (fname:>ty)) xs
   where fname = GlobalName (fromString s)
 
-appTryReduce :: MonadEmbed m => Atom -> Atom -> m Atom
+appTryReduce :: MonadBuilder m => Atom -> Atom -> m Atom
 appTryReduce f x = case f of
   Lam _ -> appReduce f x
   _     -> app f x
 
-ptrOffset :: MonadEmbed m => Atom -> Atom -> m Atom
+ptrOffset :: MonadBuilder m => Atom -> Atom -> m Atom
 ptrOffset x i = emitOp $ PtrOffset x i
 
-unsafePtrLoad :: MonadEmbed m => Atom -> m Atom
+unsafePtrLoad :: MonadBuilder m => Atom -> m Atom
 unsafePtrLoad x = emit $ Hof $ RunIO $ Lam $ Abs (Ignore UnitTy) $
   (PlainArrow (oneEffect IOEffect), Block Empty (Op (PtrLoad x)))
 
-ptrLoad :: MonadEmbed m => Atom -> m Atom
+ptrLoad :: MonadBuilder m => Atom -> m Atom
 ptrLoad x = emitOp $ PtrLoad x
 
-unpackConsList :: MonadEmbed m => Atom -> m [Atom]
+unpackConsList :: MonadBuilder m => Atom -> m [Atom]
 unpackConsList xs = case getType xs of
   UnitTy -> return []
   --PairTy _ UnitTy -> (:[]) <$> getFst xs
@@ -373,7 +373,7 @@ unpackConsList xs = case getType xs of
 -- ((...((ans, x{n}), x{n-1})..., x2), x1) -> (ans, [x1, ..., x{n}])
 -- This is useful for unpacking results of stacked effect handlers (as produced
 -- by e.g. emitRunWriters).
-unpackLeftLeaningConsList :: MonadEmbed m => Int -> Atom -> m (Atom, [Atom])
+unpackLeftLeaningConsList :: MonadBuilder m => Int -> Atom -> m (Atom, [Atom])
 unpackLeftLeaningConsList depth atom = go depth atom []
   where
     go 0        curAtom xs = return (curAtom, reverse xs)
@@ -381,13 +381,13 @@ unpackLeftLeaningConsList depth atom = go depth atom []
       (consTail, x) <- fromPair curAtom
       go (remDepth - 1) consTail (x : xs)
 
-emitWhile :: MonadEmbed m => m Atom -> m ()
+emitWhile :: MonadBuilder m => m Atom -> m ()
 emitWhile body = do
   eff <- getAllowedEffects
   lam <- buildLam (Ignore UnitTy) (PlainArrow eff) \_ -> body
   void $ emit $ Hof $ While lam
 
-emitMaybeCase :: MonadEmbed m => Atom -> m Atom -> (Atom -> m Atom) -> m Atom
+emitMaybeCase :: MonadBuilder m => Atom -> m Atom -> (Atom -> m Atom) -> m Atom
 emitMaybeCase scrut nothingCase justCase = do
   let (MaybeTy a) = getType scrut
   nothingAlt <- buildNAbs Empty                        \[]  -> nothingCase
@@ -404,7 +404,7 @@ monoidLift baseTy accTy = case baseTy == accTy of
     _         -> error $ "Base monoid type mismatch: can't lift " ++
                          pprint baseTy ++ " to " ++ pprint accTy
 
-mextendForRef :: MonadEmbed m => Atom -> BaseMonoid -> Atom -> m Atom
+mextendForRef :: MonadBuilder m => Atom -> BaseMonoid -> Atom -> m Atom
 mextendForRef ref (BaseMonoid _ combine) update = do
   buildLam (Bind $ "refVal":>accTy) PureArrow \refVal ->
     buildNestedFor (fmap (Fwd,) $ toList liftIndices) $ \indices -> do
@@ -416,67 +416,67 @@ mextendForRef ref (BaseMonoid _ combine) update = do
     FunTy (BinderAnn baseTy) _ _ = getType combine
     liftIndices = monoidLift baseTy accTy
 
-emitRunWriter :: MonadEmbed m => Name -> Type -> BaseMonoid -> (Atom -> m Atom) -> m Atom
+emitRunWriter :: MonadBuilder m => Name -> Type -> BaseMonoid -> (Atom -> m Atom) -> m Atom
 emitRunWriter v accTy bm body = do
   emit . Hof . RunWriter bm =<< mkBinaryEffFun Writer v accTy body
 
-emitRunWriters :: MonadEmbed m => [(Name, Type, BaseMonoid)] -> ([Atom] -> m Atom) -> m Atom
+emitRunWriters :: MonadBuilder m => [(Name, Type, BaseMonoid)] -> ([Atom] -> m Atom) -> m Atom
 emitRunWriters inits body = go inits []
   where
     go [] refs = body $ reverse refs
     go ((v, accTy, bm):rest) refs = emitRunWriter v accTy bm $ \ref -> go rest (ref:refs)
 
-emitRunReader :: MonadEmbed m => Name -> Atom -> (Atom -> m Atom) -> m Atom
+emitRunReader :: MonadBuilder m => Name -> Atom -> (Atom -> m Atom) -> m Atom
 emitRunReader v x0 body = do
   emit . Hof . RunReader x0 =<< mkBinaryEffFun Reader v (getType x0) body
 
-emitRunState :: MonadEmbed m => Name -> Atom -> (Atom -> m Atom) -> m Atom
+emitRunState :: MonadBuilder m => Name -> Atom -> (Atom -> m Atom) -> m Atom
 emitRunState v x0 body = do
   emit . Hof . RunState x0 =<< mkBinaryEffFun State v (getType x0) body
 
-mkBinaryEffFun :: MonadEmbed m => RWS -> Name -> Type -> (Atom -> m Atom) -> m Atom
+mkBinaryEffFun :: MonadBuilder m => RWS -> Name -> Type -> (Atom -> m Atom) -> m Atom
 mkBinaryEffFun rws v ty body = do
   eff <- getAllowedEffects
   buildLam (Bind ("h":>TyKind)) PureArrow \r@(Var (rName:>_)) -> do
     let arr = PlainArrow $ extendEffect (RWSEffect rws rName) eff
     buildLam (Bind (v:> RefTy r ty)) arr body
 
-buildForAnnAux :: MonadEmbed m => ForAnn -> Binder -> (Atom -> m (Atom, a)) -> m (Atom, a)
+buildForAnnAux :: MonadBuilder m => ForAnn -> Binder -> (Atom -> m (Atom, a)) -> m (Atom, a)
 buildForAnnAux ann i body = do
   -- TODO: consider only tracking the effects that are actually needed.
   eff <- getAllowedEffects
   (lam, aux) <- buildLamAux i (const $ return $ PlainArrow eff) body
   (,aux) <$> (emit $ Hof $ For ann lam)
 
-buildForAnn :: MonadEmbed m => ForAnn -> Binder -> (Atom -> m Atom) -> m Atom
+buildForAnn :: MonadBuilder m => ForAnn -> Binder -> (Atom -> m Atom) -> m Atom
 buildForAnn ann i body = fst <$> buildForAnnAux ann i (\x -> (,()) <$> body x)
 
-buildForAux :: MonadEmbed m => Direction -> Binder -> (Atom -> m (Atom, a)) -> m (Atom, a)
+buildForAux :: MonadBuilder m => Direction -> Binder -> (Atom -> m (Atom, a)) -> m (Atom, a)
 buildForAux = buildForAnnAux . RegularFor
 
 -- Do we need this variant?
-buildFor :: MonadEmbed m => Direction -> Binder -> (Atom -> m Atom) -> m Atom
+buildFor :: MonadBuilder m => Direction -> Binder -> (Atom -> m Atom) -> m Atom
 buildFor = buildForAnn . RegularFor
 
-buildNestedFor :: forall m. MonadEmbed m => [(Direction, Binder)] -> ([Atom] -> m Atom) -> m Atom
+buildNestedFor :: forall m. MonadBuilder m => [(Direction, Binder)] -> ([Atom] -> m Atom) -> m Atom
 buildNestedFor specs body = go specs []
   where
     go :: [(Direction, Binder)] -> [Atom] -> m Atom
     go []        indices = body $ reverse indices
     go ((d,b):t) indices = buildFor d b $ \i -> go t (i:indices)
 
-buildNestedLam :: MonadEmbed m => Arrow -> [Binder] -> ([Atom] -> m Atom) -> m Atom
+buildNestedLam :: MonadBuilder m => Arrow -> [Binder] -> ([Atom] -> m Atom) -> m Atom
 buildNestedLam _ [] f = f []
 buildNestedLam arr (b:bs) f =
   buildLam b arr \x -> buildNestedLam arr bs \xs -> f (x:xs)
 
-tabGet :: MonadEmbed m => Atom -> Atom -> m Atom
+tabGet :: MonadBuilder m => Atom -> Atom -> m Atom
 tabGet tab idx = emit $ App tab idx
 
-tabGetNd :: MonadEmbed m => Atom -> [Atom] -> m Atom
+tabGetNd :: MonadBuilder m => Atom -> [Atom] -> m Atom
 tabGetNd tab idxs = foldM (flip tabGet) tab idxs
 
-unzipTab :: MonadEmbed m => Atom -> m (Atom, Atom)
+unzipTab :: MonadBuilder m => Atom -> m (Atom, Atom)
 unzipTab tab = do
   fsts <- buildLam (Bind ("i":>binderType v)) TabArrow \i ->
             liftM fst $ app tab i >>= fromPair
@@ -485,20 +485,20 @@ unzipTab tab = do
   return (fsts, snds)
   where TabTy v _ = getType tab
 
-substEmbedR :: (MonadEmbed m, MonadReader SubstEnv m, Subst a)
+substBuilderR :: (MonadBuilder m, MonadReader SubstEnv m, Subst a)
            => a -> m a
-substEmbedR x = do
+substBuilderR x = do
   env <- ask
-  substEmbed env x
+  substBuilder env x
 
-substEmbed :: (MonadEmbed m, Subst a)
+substBuilder :: (MonadBuilder m, Subst a)
            => SubstEnv -> a -> m a
-substEmbed env x = do
+substBuilder env x = do
   scope <- getScope
   return $ subst (env, scope) x
 
-checkEmbed :: (HasCallStack, MonadEmbed m, HasVars a, HasType a) => a -> m a
-checkEmbed x = do
+checkBuilder :: (HasCallStack, MonadBuilder m, HasVars a, HasType a) => a -> m a
+checkBuilder x = do
   scope <- getScope
   let globals = freeVars x `envDiff` scope
   unless (all (isGlobal . (:>())) $ envNames globals) $
@@ -523,114 +523,114 @@ singletonTypeVal (TC con) = case con of
   _            -> Nothing
 singletonTypeVal _ = Nothing
 
-indexAsInt :: MonadEmbed m => Atom -> m Atom
+indexAsInt :: MonadBuilder m => Atom -> m Atom
 indexAsInt idx = emitOp $ ToOrdinal idx
 
-instance MonadTrans EmbedT where
-  lift m = EmbedT $ lift $ lift m
+instance MonadTrans BuilderT where
+  lift m = BuilderT $ lift $ lift m
 
-class Monad m => MonadEmbed m where
-  embedLook   :: m EmbedEnvC
-  embedExtend :: EmbedEnvC -> m ()
-  embedScoped :: m a -> m (a, EmbedEnvC)
-  embedAsk    :: m EmbedEnvR
-  embedLocal  :: (EmbedEnvR -> EmbedEnvR) -> m a -> m a
+class Monad m => MonadBuilder m where
+  builderLook   :: m BuilderEnvC
+  builderExtend :: BuilderEnvC -> m ()
+  builderScoped :: m a -> m (a, BuilderEnvC)
+  builderAsk    :: m BuilderEnvR
+  builderLocal  :: (BuilderEnvR -> BuilderEnvR) -> m a -> m a
 
-instance Monad m => MonadEmbed (EmbedT m) where
-  embedLook = EmbedT look
-  embedExtend env = EmbedT $ extend env
-  embedScoped (EmbedT m) = EmbedT $ scoped m
-  embedAsk = EmbedT ask
-  embedLocal f (EmbedT m) = EmbedT $ local f m
+instance Monad m => MonadBuilder (BuilderT m) where
+  builderLook = BuilderT look
+  builderExtend env = BuilderT $ extend env
+  builderScoped (BuilderT m) = BuilderT $ scoped m
+  builderAsk = BuilderT ask
+  builderLocal f (BuilderT m) = BuilderT $ local f m
 
-instance MonadEmbed m => MonadEmbed (ReaderT r m) where
-  embedLook = lift embedLook
-  embedExtend x = lift $ embedExtend x
-  embedScoped m = ReaderT \r -> embedScoped $ runReaderT m r
-  embedAsk = lift embedAsk
-  embedLocal v m = ReaderT \r -> embedLocal v $ runReaderT m r
+instance MonadBuilder m => MonadBuilder (ReaderT r m) where
+  builderLook = lift builderLook
+  builderExtend x = lift $ builderExtend x
+  builderScoped m = ReaderT \r -> builderScoped $ runReaderT m r
+  builderAsk = lift builderAsk
+  builderLocal v m = ReaderT \r -> builderLocal v $ runReaderT m r
 
-instance MonadEmbed m => MonadEmbed (StateT s m) where
-  embedLook = lift embedLook
-  embedExtend x = lift $ embedExtend x
-  embedScoped m = do
+instance MonadBuilder m => MonadBuilder (StateT s m) where
+  builderLook = lift builderLook
+  builderExtend x = lift $ builderExtend x
+  builderScoped m = do
     s <- get
-    ((x, s'), env) <- lift $ embedScoped $ runStateT m s
+    ((x, s'), env) <- lift $ builderScoped $ runStateT m s
     put s'
     return (x, env)
-  embedAsk = lift embedAsk
-  embedLocal v m = do
+  builderAsk = lift builderAsk
+  builderLocal v m = do
     s <- get
-    (x, s') <- lift $ embedLocal v $ runStateT m s
+    (x, s') <- lift $ builderLocal v $ runStateT m s
     put s'
     return x
 
-instance (Monoid env, MonadEmbed m) => MonadEmbed (CatT env m) where
-  embedLook = lift embedLook
-  embedExtend x = lift $ embedExtend x
-  embedScoped m = do
+instance (Monoid env, MonadBuilder m) => MonadBuilder (CatT env m) where
+  builderLook = lift builderLook
+  builderExtend x = lift $ builderExtend x
+  builderScoped m = do
     env <- look
-    ((ans, env'), scopeEnv) <- lift $ embedScoped $ runCatT m env
+    ((ans, env'), scopeEnv) <- lift $ builderScoped $ runCatT m env
     extend env'
     return (ans, scopeEnv)
-  embedAsk = lift embedAsk
-  embedLocal v m = do
+  builderAsk = lift builderAsk
+  builderLocal v m = do
     env <- look
-    (ans, env') <- lift $ embedLocal v $ runCatT m env
+    (ans, env') <- lift $ builderLocal v $ runCatT m env
     extend env'
     return ans
 
-instance (Monoid w, MonadEmbed m) => MonadEmbed (WriterT w m) where
-  embedLook = lift embedLook
-  embedExtend x = lift $ embedExtend x
-  embedScoped m = do
-    ((x, w), env) <- lift $ embedScoped $ runWriterT m
+instance (Monoid w, MonadBuilder m) => MonadBuilder (WriterT w m) where
+  builderLook = lift builderLook
+  builderExtend x = lift $ builderExtend x
+  builderScoped m = do
+    ((x, w), env) <- lift $ builderScoped $ runWriterT m
     tell w
     return (x, env)
-  embedAsk = lift embedAsk
-  embedLocal v m = WriterT $ embedLocal v $ runWriterT m
+  builderAsk = lift builderAsk
+  builderLocal v m = WriterT $ builderLocal v $ runWriterT m
 
-instance (Monoid env, MonadCat env m) => MonadCat env (EmbedT m) where
+instance (Monoid env, MonadCat env m) => MonadCat env (BuilderT m) where
   look = lift look
   extend x = lift $ extend x
-  scoped (EmbedT m) = EmbedT $ do
+  scoped (BuilderT m) = BuilderT $ do
     name <- ask
     env <- look
     ((ans, env'), scopeEnv) <- lift $ lift $ scoped $ runCatT (runReaderT m name) env
     extend env'
     return (ans, scopeEnv)
 
-instance MonadError e m => MonadError e (EmbedT m) where
+instance MonadError e m => MonadError e (BuilderT m) where
   throwError = lift . throwError
   catchError m catch = do
-    envC <- embedLook
-    envR <- embedAsk
-    (ans, envC') <- lift $ runEmbedT' m (envR, envC)
-                     `catchError` (\e -> runEmbedT' (catch e) (envR, envC))
-    embedExtend envC'
+    envC <- builderLook
+    envR <- builderAsk
+    (ans, envC') <- lift $ runBuilderT' m (envR, envC)
+                     `catchError` (\e -> runBuilderT' (catch e) (envR, envC))
+    builderExtend envC'
     return ans
 
-instance MonadReader r m => MonadReader r (EmbedT m) where
+instance MonadReader r m => MonadReader r (BuilderT m) where
   ask = lift ask
   local r m = do
-    envC <- embedLook
-    envR <- embedAsk
-    (ans, envC') <- lift $ local r $ runEmbedT' m (envR, envC)
-    embedExtend envC'
+    envC <- builderLook
+    envR <- builderAsk
+    (ans, envC') <- lift $ local r $ runBuilderT' m (envR, envC)
+    builderExtend envC'
     return ans
 
-instance MonadState s m => MonadState s (EmbedT m) where
+instance MonadState s m => MonadState s (BuilderT m) where
   get = lift get
   put = lift . put
 
-getNameHint :: MonadEmbed m => m Name
+getNameHint :: MonadBuilder m => m Name
 getNameHint = do
-  tag <- fst <$> embedAsk
+  tag <- fst <$> builderAsk
   return $ Name GenName tag 0
 
 -- This is purely for human readability. `const id` would be a valid implementation.
-withNameHint :: (MonadEmbed m, HasName a) => a -> m b -> m b
-withNameHint name m = embedLocal (\(_, eff) -> (tag, eff)) m
+withNameHint :: (MonadBuilder m, HasName a) => a -> m b -> m b
+withNameHint name m = builderLocal (\(_, eff) -> (tag, eff)) m
   where
     tag = case getName name of
       Just (Name _ t _)        -> t
@@ -638,53 +638,53 @@ withNameHint name m = embedLocal (\(_, eff) -> (tag, eff)) m
       Just (GlobalArrayName _) -> "arr"
       Nothing                  -> "tmp"
 
-runEmbedT' :: Monad m => EmbedT m a -> EmbedEnv -> m (a, EmbedEnvC)
-runEmbedT' (EmbedT m) (envR, envC) = runCatT (runReaderT m envR) envC
+runBuilderT' :: Monad m => BuilderT m a -> BuilderEnv -> m (a, BuilderEnvC)
+runBuilderT' (BuilderT m) (envR, envC) = runCatT (runReaderT m envR) envC
 
-getScope :: MonadEmbed m => m Scope
-getScope = fst <$> embedLook
+getScope :: MonadBuilder m => m Scope
+getScope = fst <$> builderLook
 
-extendScope :: MonadEmbed m => Scope -> m ()
-extendScope scope = embedExtend $ asFst scope
+extendScope :: MonadBuilder m => Scope -> m ()
+extendScope scope = builderExtend $ asFst scope
 
-getAllowedEffects :: MonadEmbed m => m EffectRow
-getAllowedEffects = snd <$> embedAsk
+getAllowedEffects :: MonadBuilder m => m EffectRow
+getAllowedEffects = snd <$> builderAsk
 
-withEffects :: MonadEmbed m => EffectRow -> m a -> m a
+withEffects :: MonadBuilder m => EffectRow -> m a -> m a
 withEffects effs m = modifyAllowedEffects (const effs) m
 
-modifyAllowedEffects :: MonadEmbed m => (EffectRow -> EffectRow) -> m a -> m a
-modifyAllowedEffects f m = embedLocal (\(name, eff) -> (name, f eff)) m
+modifyAllowedEffects :: MonadBuilder m => (EffectRow -> EffectRow) -> m a -> m a
+modifyAllowedEffects f m = builderLocal (\(name, eff) -> (name, f eff)) m
 
-emitDecl :: MonadEmbed m => Decl -> m ()
-emitDecl decl = embedExtend (bindings, Nest decl Empty)
+emitDecl :: MonadBuilder m => Decl -> m ()
+emitDecl decl = builderExtend (bindings, Nest decl Empty)
   where bindings = case decl of
           Let ann b expr -> b @> (binderType b, LetBound ann expr)
 
-scopedDecls :: MonadEmbed m => m a -> m (a, Nest Decl)
+scopedDecls :: MonadBuilder m => m a -> m (a, Nest Decl)
 scopedDecls m = do
-  (ans, (_, decls)) <- embedScoped m
+  (ans, (_, decls)) <- builderScoped m
   return (ans, decls)
 
-liftEmbed :: MonadEmbed m => Embed a -> m a
-liftEmbed action = do
-  envR <- embedAsk
-  envC <- embedLook
-  let (ans, envC') = runIdentity $ runEmbedT' action (envR, envC)
-  embedExtend envC'
+liftBuilder :: MonadBuilder m => Builder a -> m a
+liftBuilder action = do
+  envR <- builderAsk
+  envC <- builderLook
+  let (ans, envC') = runIdentity $ runBuilderT' action (envR, envC)
+  builderExtend envC'
   return ans
 
 -- === generic traversal ===
 
 type TraversalDef m = (Decl -> m SubstEnv, Expr -> m Expr, Atom -> m Atom)
 
-substTraversalDef :: (MonadEmbed m, MonadReader SubstEnv m) => TraversalDef m
+substTraversalDef :: (MonadBuilder m, MonadReader SubstEnv m) => TraversalDef m
 substTraversalDef = ( traverseDecl substTraversalDef
                     , traverseExpr substTraversalDef
                     , traverseAtom substTraversalDef
                     )
 
-appReduceTraversalDef :: (MonadEmbed m, MonadReader SubstEnv m) => TraversalDef m
+appReduceTraversalDef :: (MonadBuilder m, MonadReader SubstEnv m) => TraversalDef m
 appReduceTraversalDef = ( traverseDecl appReduceTraversalDef
                         , reduceAppExpr
                         , traverseAtom appReduceTraversalDef
@@ -701,11 +701,11 @@ appReduceTraversalDef = ( traverseDecl appReduceTraversalDef
       _ -> traverseExpr appReduceTraversalDef expr
 
 -- With `def = (traverseExpr def, traverseAtom def)` this should be a no-op
-traverseDecls :: (MonadEmbed m, MonadReader SubstEnv m)
+traverseDecls :: (MonadBuilder m, MonadReader SubstEnv m)
               => TraversalDef m -> Nest Decl -> m ((Nest Decl), SubstEnv)
 traverseDecls def decls = liftM swap $ scopedDecls $ traverseDeclsOpen def decls
 
-traverseDeclsOpen :: (MonadEmbed m, MonadReader SubstEnv m)
+traverseDeclsOpen :: (MonadBuilder m, MonadReader SubstEnv m)
                   => TraversalDef m -> Nest Decl -> m SubstEnv
 traverseDeclsOpen _ Empty = return mempty
 traverseDeclsOpen def@(fDecl, _, _) (Nest decl decls) = do
@@ -713,7 +713,7 @@ traverseDeclsOpen def@(fDecl, _, _) (Nest decl decls) = do
   env' <- extendR env $ traverseDeclsOpen def decls
   return (env <> env')
 
-traverseDecl :: (MonadEmbed m, MonadReader SubstEnv m)
+traverseDecl :: (MonadBuilder m, MonadReader SubstEnv m)
              => TraversalDef m -> Decl -> m SubstEnv
 traverseDecl (_, fExpr, _) decl = case decl of
   Let letAnn b expr -> do
@@ -722,11 +722,11 @@ traverseDecl (_, fExpr, _) decl = case decl of
       Atom a | not (isGlobalBinder b) && letAnn == PlainLet -> return $ b @> a
       _ -> (b@>) <$> emitTo (binderNameHint b) letAnn expr'
 
-traverseBlock :: (MonadEmbed m, MonadReader SubstEnv m)
+traverseBlock :: (MonadBuilder m, MonadReader SubstEnv m)
               => TraversalDef m -> Block -> m Block
 traverseBlock def block = buildScoped $ evalBlockE def block
 
-evalBlockE :: (MonadEmbed m, MonadReader SubstEnv m)
+evalBlockE :: (MonadBuilder m, MonadReader SubstEnv m)
               => TraversalDef m -> Block -> m Atom
 evalBlockE def@(_, fExpr, _) (Block decls result) = do
   env <- traverseDeclsOpen def decls
@@ -735,7 +735,7 @@ evalBlockE def@(_, fExpr, _) (Block decls result) = do
     Atom a -> return a
     _      -> emit resultExpr
 
-traverseExpr :: (MonadEmbed m, MonadReader SubstEnv m)
+traverseExpr :: (MonadBuilder m, MonadReader SubstEnv m)
              => TraversalDef m -> Expr -> m Expr
 traverseExpr def@(_, _, fAtom) expr = case expr of
   App g x -> App  <$> fAtom g <*> fAtom x
@@ -748,19 +748,19 @@ traverseExpr def@(_, _, fAtom) expr = case expr of
       bs' <- mapM (mapM fAtom) bs
       buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ evalBlockE def body
 
-traverseAtom :: forall m . (MonadEmbed m, MonadReader SubstEnv m)
+traverseAtom :: forall m . (MonadBuilder m, MonadReader SubstEnv m)
              => TraversalDef m -> Atom -> m Atom
 traverseAtom def@(_, _, fAtom) atom = case atom of
-  Var _ -> substEmbedR atom
+  Var _ -> substBuilderR atom
   Lam (Abs b (arr, body)) -> do
     b' <- mapM fAtom b
     buildDepEffLam b'
-      (\x -> extendR (b'@>x) (substEmbedR arr))
+      (\x -> extendR (b'@>x) (substBuilderR arr))
       (\x -> extendR (b'@>x) (evalBlockE def body))
-  Pi _ -> substEmbedR atom
+  Pi _ -> substBuilderR atom
   Con con -> Con <$> traverse fAtom con
   TC  tc  -> TC  <$> traverse fAtom tc
-  Eff _   -> substEmbedR atom
+  Eff _   -> substBuilderR atom
   DataCon dataDef params con args -> DataCon dataDef <$>
     traverse fAtom params <*> pure con <*> traverse fAtom args
   TypeCon dataDef params -> TypeCon dataDef <$> traverse fAtom params
@@ -788,13 +788,13 @@ traverseAtom def@(_, _, fAtom) atom = case atom of
     case decls of
       Empty -> return $ BoxedRef b' ptr' size' body'
       _ -> error "Traversing the body atom shouldn't produce decls"
-  ProjectElt _ _ -> substEmbedR atom
+  ProjectElt _ _ -> substBuilderR atom
   where
     traverseNestedArgs :: Nest DataConRefBinding -> m (Nest DataConRefBinding)
     traverseNestedArgs Empty = return Empty
     traverseNestedArgs (Nest (DataConRefBinding b ref) rest) = do
       ref' <- fAtom ref
-      b' <- substEmbedR b
+      b' <- substBuilderR b
       v <- freshVarE UnknownBinder b'
       rest' <- extendR (b @> Var v) $ traverseNestedArgs rest
       return $ Nest (DataConRefBinding (Bind v) ref') rest'
@@ -817,7 +817,7 @@ transformModuleAsBlock transform (Module ir decls bindings) = do
 dropSub :: MonadReader SubstEnv m => m a -> m a
 dropSub m = local mempty m
 
-indexSetSizeE :: MonadEmbed m => Type -> m Atom
+indexSetSizeE :: MonadBuilder m => Type -> m Atom
 indexSetSizeE (TC con) = case con of
   UnitType                   -> return $ IdxRepVal 1
   IntRange low high -> clampPositive =<< high `isub` low
@@ -842,7 +842,7 @@ indexSetSizeE (VariantTy (NoExt types)) = do
   foldM iadd (IdxRepVal 0) sizes
 indexSetSizeE ty = error $ "Not implemented " ++ pprint ty
 
-clampPositive :: MonadEmbed m => Atom -> m Atom
+clampPositive :: MonadBuilder m => Atom -> m Atom
 clampPositive x = do
   isNegative <- x `ilt` (IdxRepVal 0)
   select isNegative (IdxRepVal 0) x
@@ -851,7 +851,7 @@ clampPositive x = do
 --      IndexAsInt instruction, as for Int and IndexRanges it will
 --      generate the same instruction again, potentially leading to an
 --      infinite loop.
-indexToIntE :: MonadEmbed m => Atom -> m Atom
+indexToIntE :: MonadBuilder m => Atom -> m Atom
 indexToIntE (Con (IntRangeVal _ _ i))     = return i
 indexToIntE (Con (IndexRangeVal _ _ _ i)) = return i
 indexToIntE idx = case getType idx of
@@ -884,7 +884,7 @@ indexToIntE idx = case getType idx of
     emit $ Case idx alts IdxRepTy
   ty -> error $ "Unexpected type " ++ pprint ty
 
-intToIndexE :: MonadEmbed m => Type -> Atom -> m Atom
+intToIndexE :: MonadBuilder m => Type -> Atom -> m Atom
 intToIndexE (TC con) i = case con of
   IntRange        low high   -> return $ Con $ IntRangeVal        low high i
   IndexRange from low high   -> return $ Con $ IndexRangeVal from low high i

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -24,14 +24,14 @@ import Data.Text.Prettyprint.Doc
 
 import Syntax
 import Interpreter (indicesNoIO)
-import Embed  hiding (sub)
+import Builder  hiding (sub)
 import Env
 import Type
 import PPrint
 import Cat
 import Util
 
-type UInferM = ReaderT SubstEnv (ReaderT SrcCtx ((EmbedT (SolverT (Either Err)))))
+type UInferM = ReaderT SubstEnv (ReaderT SrcCtx ((BuilderT (SolverT (Either Err)))))
 
 type SigmaType = Type  -- may     start with an implicit lambda
 type RhoType   = Type  -- doesn't start with an implicit lambda
@@ -59,7 +59,7 @@ inferModule scope (UModule decls) = do
 runUInferM :: (Subst a, Pretty a)
            => SubstEnv -> Scope -> UInferM a -> Except (a, (Scope, Nest Decl))
 runUInferM env scope m = runSolverT $
-  runEmbedT (runReaderT (runReaderT m env) Nothing) scope
+  runBuilderT (runReaderT (runReaderT m env) Nothing) scope
 
 checkSigma :: UExpr -> (Type -> RequiredTy Type) -> SigmaType -> UInferM Atom
 checkSigma expr reqCon sTy = case sTy of
@@ -137,10 +137,10 @@ checkOrInferRho (WithSrc pos expr) reqTy = do
     --     is safe and doesn't make the type checking depend on the program order.
     infTy <- getType <$> zonk fVal
     piTy  <- addSrcContext' (srcPos f) $ fromPiType True arr infTy
-    (xVal, embedEnv@(_, xDecls)) <- embedScoped $ checkSigma x Suggest (absArgType piTy)
+    (xVal, builderEnv@(_, xDecls)) <- builderScoped $ checkSigma x Suggest (absArgType piTy)
     (xVal', arr') <- case piTy of
       Abs b rhs@(arr', _) -> case b `isin` freeVars rhs of
-        False -> embedExtend embedEnv $> (xVal, arr')
+        False -> builderExtend builderEnv $> (xVal, arr')
         True  -> do
           xValMaybeRed <- flip typeReduceBlock (Block xDecls (Atom xVal)) <$> getScope
           case xValMaybeRed of
@@ -380,11 +380,11 @@ inferUDecl topLevel (UInstance maybeName argBinders instanceTy methods) = do
 inferUDecl False (UData      _ _  ) = error "data definitions should be top-level"
 inferUDecl False (UInterface _ _ _) = error "interface definitions should be top-level"
 
-freshClassGenName :: MonadEmbed m => m Name
+freshClassGenName :: MonadBuilder m => m Name
 freshClassGenName = do
   scope <- getScope
   let v' = genFresh (Name TypeClassGenName "classgen" 0) scope
-  embedExtend $ asFst $ v' @> (UnitTy, UnknownBinder)
+  builderExtend $ asFst $ v' @> (UnitTy, UnknownBinder)
   return v'
 
 mkMethod :: UAnnBinder -> UInferM (Label, Type)
@@ -428,7 +428,7 @@ emitMethodGetters def@(DataDef _ paramBs (ClassDictDef _ _ methodTys)) = do
     emitTo methodName PlainLet $ Atom f
 emitMethodGetters (DataDef _ _ _) = error "Not a class dictionary"
 
-emitSuperclassGetters :: MonadEmbed m => DataDef -> m ()
+emitSuperclassGetters :: MonadBuilder m => DataDef -> m ()
 emitSuperclassGetters def@(DataDef _ paramBs (ClassDictDef _ superclassTys _)) = do
   forM_ (getLabels superclassTys) \l -> do
     f <- buildImplicitNaryLam paramBs \params -> do
@@ -457,7 +457,7 @@ checkShadows vs = do
 
 inferUConDef :: UConDef -> UInferM (Name, Nest Binder)
 inferUConDef (UConDef v bs) = do
-  (bs', _) <- embedScoped $ checkNestedBinders bs
+  (bs', _) <- builderScoped $ checkNestedBinders bs
   let v' = asGlobal v
   checkNotInScope v'
   return (v', bs')
@@ -811,12 +811,12 @@ getSrcCtx = lift ask
 
 -- We have two variants here because at the top level we want error messages and
 -- internally we want to consider all alternatives.
-type SynthPassM = SubstEmbedT (Either Err)
-type SynthDictM = SubstEmbedT []
+type SynthPassM = SubstBuilderT (Either Err)
+type SynthDictM = SubstBuilderT []
 
 synthModule :: Scope -> Module -> Except Module
 synthModule scope (Module Typed decls bindings) = do
-  decls' <- fst . fst <$> runSubstEmbedT
+  decls' <- fst . fst <$> runSubstBuilderT
               (traverseDecls (traverseHoles synthDictTop) decls) scope
   return $ Module Core decls' bindings
 synthModule _ _ = error $ "Unexpected IR variant"
@@ -824,19 +824,19 @@ synthModule _ _ = error $ "Unexpected IR variant"
 synthDictTop :: SrcCtx -> Type -> SynthPassM Atom
 synthDictTop ctx ty = do
   scope <- getScope
-  let solutions = runSubstEmbedT (synthDict ty) scope
+  let solutions = runSubstBuilderT (synthDict ty) scope
   addSrcContext ctx $ case solutions of
     [] -> throw TypeErr $ "Couldn't synthesize a class dictionary for: " ++ pprint ty
-    [(ans, env)] -> embedExtend env $> ans
+    [(ans, env)] -> builderExtend env $> ans
     _ -> throw TypeErr $ "Multiple candidate class dictionaries for: " ++ pprint ty
            ++ "\n" ++ pprint solutions
 
-traverseHoles :: (MonadReader SubstEnv m, MonadEmbed m)
+traverseHoles :: (MonadReader SubstEnv m, MonadBuilder m)
               => (SrcCtx -> Type -> m Atom) -> TraversalDef m
 traverseHoles fillHole = (traverseDecl recur, traverseExpr recur, synthPassAtom)
   where
     synthPassAtom atom = case atom of
-      Con (ClassDictHole ctx ty) -> fillHole ctx =<< substEmbedR ty
+      Con (ClassDictHole ctx ty) -> fillHole ctx =<< substBuilderR ty
       _ -> traverseAtom recur atom
     recur = traverseHoles fillHole
 
@@ -845,8 +845,8 @@ synthDict ty = case ty of
   PiTy b arr body -> synthesizeNow <|> introFirst
     where
       introFirst = buildDepEffLam b
-                      (\x -> extendR (b @> x) $ substEmbedR arr)
-                      (\x -> extendR (b @> x) $ substEmbedR body >>= synthDict)
+                      (\x -> extendR (b @> x) $ substBuilderR arr)
+                      (\x -> extendR (b @> x) $ substBuilderR body >>= synthDict)
   _ -> synthesizeNow
   where
     synthesizeNow = do
@@ -927,8 +927,8 @@ solveLocal :: Subst a => UInferM a -> UInferM a
 solveLocal m = do
   (ans, env@(SolverEnv freshVars sub)) <- scoped $ do
     -- This might get expensive. TODO: revisit once we can measure performance.
-    (ans, embedEnv) <- zonk =<< embedScoped m
-    embedExtend embedEnv
+    (ans, builderEnv) <- zonk =<< builderScoped m
+    builderExtend builderEnv
     return ans
   extend $ SolverEnv (unsolved env) (sub `envDiff` freshVars)
   return ans
@@ -1088,7 +1088,7 @@ instance Monoid SolverEnv where
   mempty = SolverEnv mempty mempty
   mappend = (<>)
 
-typeReduceScoped :: MonadEmbed m => m Atom -> m (Maybe Atom)
+typeReduceScoped :: MonadBuilder m => m Atom -> m (Maybe Atom)
 typeReduceScoped m = do
   block <- buildScoped m
   scope <- getScope

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -23,7 +23,7 @@ import Cat
 import Syntax
 import Env
 import PPrint
-import Embed
+import Builder
 import Util (enumerate, restructure)
 import LLVMExec
 
@@ -108,7 +108,7 @@ evalOp expr = case expr of
   ToOrdinal idxArg -> case idxArg of
     Con (IntRangeVal   _ _   i) -> return i
     Con (IndexRangeVal _ _ _ i) -> return i
-    _ -> evalEmbed (indexToIntE idxArg)
+    _ -> evalBuilder (indexToIntE idxArg)
   _ -> error $ "Not implemented: " ++ pprint expr
 
 -- We can use this when we know we won't be dereferencing pointers. A better
@@ -147,12 +147,12 @@ indices ty = do
 
 indexSetSize :: Type -> InterpM Int
 indexSetSize ty = do
-  IdxRepVal l <- evalEmbed (indexSetSizeE ty)
+  IdxRepVal l <- evalBuilder (indexSetSizeE ty)
   return $ fromIntegral l
 
-evalEmbed :: EmbedT InterpM Atom -> InterpM Atom
-evalEmbed embed = do
-  (atom, (_, decls)) <- runEmbedT embed mempty
+evalBuilder :: BuilderT InterpM Atom -> InterpM Atom
+evalBuilder builder = do
+  (atom, (_, decls)) <- runBuilderT builder mempty
   evalBlock mempty $ Block decls (Atom atom)
 
 pattern Int64Val :: Int64 -> Atom

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -13,7 +13,7 @@ import Data.Foldable
 import Data.Maybe
 
 import Syntax
-import Embed
+import Builder
 import Cat
 import Env
 import Type
@@ -83,7 +83,7 @@ dceAtom atom = case atom of
 
 -- === For inlining ===
 
-type InlineM = SubstEmbed
+type InlineM = SubstBuilder
 
 inlineTraversalDef :: TraversalDef InlineM
 inlineTraversalDef = (inlineTraverseDecl, inlineTraverseExpr, traverseAtom inlineTraversalDef)
@@ -91,7 +91,7 @@ inlineTraversalDef = (inlineTraverseDecl, inlineTraverseExpr, traverseAtom inlin
 inlineModule :: Module -> Module
 inlineModule m = transformModuleAsBlock inlineBlock (computeInlineHints m)
   where
-    inlineBlock block = fst $ runSubstEmbed (traverseBlock inlineTraversalDef block) mempty
+    inlineBlock block = fst $ runSubstBuilder (traverseBlock inlineTraversalDef block) mempty
 
 inlineTraverseDecl :: Decl -> InlineM SubstEnv
 inlineTraverseDecl decl = case decl of

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -22,16 +22,16 @@ import Autodiff
 import Env
 import Syntax
 import Cat
-import Embed
+import Builder
 import Type
 import PPrint
 import Util
 
-type SimplifyM = SubstEmbed
+type SimplifyM = SubstBuilder
 
 simplifyModule :: Bindings -> Module -> Module
 simplifyModule scope (Module Core decls bindings) = do
-  let simpDecls = snd $ snd $ runSubstEmbed (simplifyDecls decls) scope
+  let simpDecls = snd $ snd $ runSubstBuilder (simplifyDecls decls) scope
   -- We don't have to check that the binders are global here, since all local
   -- Atom binders have been inlined as part of the simplification.
   let isAtomDecl decl = case decl of Let _ _ (Atom _) -> True; _ -> False
@@ -46,10 +46,10 @@ splitSimpModule scope m = do
   let localVars = filter (not . isGlobal) $ bindingsAsVars $ freeVars bindings
   let block = Block decls $ Atom $ mkConsList $ map Var localVars
   let (Abs b (decls', bindings')) =
-        fst $ flip runEmbed scope $ buildAbs (Bind ("result":>getType block)) $
+        fst $ flip runBuilder scope $ buildAbs (Bind ("result":>getType block)) $
           \result -> do
              results <- unpackConsList result
-             substEmbed (newEnv localVars results) bindings
+             substBuilder (newEnv localVars results) bindings
   (block, Abs b (Module Evaluated decls' bindings'))
 
 -- Bundling up the free vars in a result with a dependent constructor like
@@ -59,7 +59,7 @@ hoistDepDataCons :: Bindings -> Module -> Module
 hoistDepDataCons scope (Module Simp decls bindings) =
   Module Simp decls' bindings'
   where
-    (bindings', (_, decls')) = flip runEmbed scope $ do
+    (bindings', (_, decls')) = flip runBuilder scope $ do
       mapM_ emitDecl decls
       forM bindings \(ty, info) -> case info of
         LetBound ann x | isData ty -> do x' <- emit x
@@ -88,7 +88,7 @@ simplifyDecl (Let ann b expr) = do
 
 simplifyStandalone :: Expr -> SimplifyM Atom
 simplifyStandalone (Atom (LamVal b body)) = do
-  b' <- mapM substEmbedR b
+  b' <- mapM substBuilderR b
   buildLam b' PureArrow \x ->
     extendR (b@>x) $ simplifyBlock body
 simplifyStandalone block =
@@ -109,8 +109,8 @@ simplifyAtom atom = case atom of
       Nothing -> case envLookup scope v of
         Just (_, info) -> case info of
           LetBound ann (Atom x) | ann /= NoInlineLet -> dropSub $ simplifyAtom x
-          _ -> substEmbedR atom
-        _   -> substEmbedR atom
+          _ -> substBuilderR atom
+        _   -> substBuilderR atom
   -- Tables that only contain data aren't necessarily getting inlined,
   -- so this might be the last chance to simplify them.
   TabVal _ _ -> do
@@ -118,34 +118,34 @@ simplifyAtom atom = case atom of
       True -> do
         ~(tab', Nothing) <- simplifyLam atom
         return tab'
-      False -> substEmbedR atom
+      False -> substBuilderR atom
   -- We don't simplify body of lam because we'll beta-reduce it soon.
-  Lam _ -> substEmbedR atom
-  Pi  _ -> substEmbedR atom
+  Lam _ -> substBuilderR atom
+  Pi  _ -> substBuilderR atom
   Con con -> Con <$> mapM simplifyAtom con
   TC tc -> TC <$> mapM simplifyAtom tc
-  Eff eff -> Eff <$> substEmbedR eff
+  Eff eff -> Eff <$> substBuilderR eff
   TypeCon def params          -> TypeCon def <$> mapM simplifyAtom params
   DataCon def params con args -> DataCon def <$> mapM simplifyAtom params
                                              <*> pure con <*> mapM simplifyAtom args
   Record items -> Record <$> mapM simplifyAtom items
   RecordTy items -> RecordTy <$> simplifyExtLabeledItems items
   Variant types label i value -> Variant <$>
-    substEmbedR types <*> pure label <*> pure i <*> simplifyAtom value
+    substBuilderR types <*> pure label <*> pure i <*> simplifyAtom value
   VariantTy items -> VariantTy <$> simplifyExtLabeledItems items
   LabeledRow items -> LabeledRow <$> simplifyExtLabeledItems items
   ACase e alts rty   -> do
-    e' <- substEmbedR e
+    e' <- substBuilderR e
     case simplifyCase e' alts of
       Just (env, result) -> extendR env $ simplifyAtom result
       Nothing -> do
         alts' <- forM alts \(Abs bs a) -> do
-          bs' <- mapM (mapM substEmbedR) bs
+          bs' <- mapM (mapM substBuilderR) bs
           (Abs bs'' b) <- buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ simplifyAtom a
           case b of
             Block Empty (Atom r) -> return $ Abs bs'' r
             _                    -> error $ "Nontrivial block in ACase simplification"
-        ACase e' alts' <$> (substEmbedR rty)
+        ACase e' alts' <$> (substBuilderR rty)
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _ _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> simplifyAtom (Var v)
@@ -153,7 +153,7 @@ simplifyAtom atom = case atom of
 simplifyExtLabeledItems :: ExtLabeledItems Atom Name -> SimplifyM (ExtLabeledItems Atom Name)
 simplifyExtLabeledItems (Ext items ext) = do
     items' <- mapM simplifyAtom items
-    ext' <- substEmbedR (Ext NoLabeledItems ext)
+    ext' <- substBuilderR (Ext NoLabeledItems ext)
     return $ prefixExtLabeledItems items' ext'
 
 simplifyCase :: Atom -> [AltP a] -> Maybe (SubstEnv, a)
@@ -180,10 +180,10 @@ simplifyLam = simplifyLams 1
 simplifyBinaryLam :: Atom -> SimplifyM (Atom, Reconstruct SimplifyM Atom)
 simplifyBinaryLam = simplifyLams 2
 
--- Unlike `substEmbedR`, this simplifies under the binder too.
+-- Unlike `substBuilderR`, this simplifies under the binder too.
 simplifyLams :: Int -> Atom -> SimplifyM (Atom, Reconstruct SimplifyM Atom)
 simplifyLams numArgs lam = do
-  lam' <- substEmbedR lam
+  lam' <- substBuilderR lam
   dropSub $ go numArgs mempty $ Block Empty $ Atom lam'
   where
     go 0 scope block = do
@@ -199,8 +199,8 @@ simplifyLams numArgs lam = do
              atomf dat' <$> recon dat' ctx'
           )
     go n scope ~(Block Empty (Atom (Lam (Abs b (arr, body))))) = do
-      b' <- mapM substEmbedR b
-      buildLamAux b' (\x -> extendR (b@>x) $ substEmbedR arr) \x@(Var v) -> do
+      b' <- mapM substBuilderR b
+      buildLamAux b' (\x -> extendR (b@>x) $ substBuilderR arr) \x@(Var v) -> do
         let scope' = scope <> v @> (varType v, LamBound (void arr))
         extendR (b@>x) $ go (n-1) scope' body
 
@@ -209,7 +209,7 @@ defunBlock localScope block = do
   if isData (getType block)
     then Left <$> simplifyBlock block
     else do
-      (result, (localScope', decls)) <- embedScoped $ simplifyBlock block
+      (result, (localScope', decls)) <- builderScoped $ simplifyBlock block
       mapM_ emitDecl decls
       Right <$> separateDataComponent (localScope <> localScope') result
 
@@ -233,7 +233,7 @@ type AtomFac m =
 -- TODO: Records
 -- Guarantees that data elements are entirely type driven (e.g. won't be deduplicated based on
 -- the supplied atom). The same guarantee doesn't apply to the non-data closures.
-separateDataComponent :: forall m. MonadEmbed m => Scope -> Atom -> m (AtomFac m)
+separateDataComponent :: forall m. MonadBuilder m => Scope -> Atom -> m (AtomFac m)
 separateDataComponent localVars v = do
   (dat, (ctx, recon), atomf) <- rec v
   let (ctx', ctxRec) = dedup dat ctx
@@ -315,21 +315,21 @@ simplifyExpr expr = case expr of
   Atom x  -> simplifyAtom x
   Case e alts resultTy -> do
     e' <- simplifyAtom e
-    resultTy' <- substEmbedR resultTy
+    resultTy' <- substBuilderR resultTy
     case simplifyCase e' alts of
       Just (env, body) -> extendR env $ simplifyBlock body
       Nothing -> do
         if isData resultTy'
           then do
             alts' <- forM alts \(Abs bs body) -> do
-              bs' <-  mapM (mapM substEmbedR) bs
+              bs' <-  mapM (mapM substBuilderR) bs
               buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ simplifyBlock body
             emit $ Case e' alts' resultTy'
           else do
             -- Construct the blocks of new cases. The results will only get replaced
             -- later, once we learn the closures of the non-data component of each case.
             (alts', facs) <- liftM unzip $ forM alts \(Abs bs body) -> do
-              bs' <-  mapM (mapM substEmbedR) bs
+              bs' <-  mapM (mapM substBuilderR) bs
               buildNAbsAux bs' \xs -> do
                 ~(Right fac@(dat, (ctx, _), _)) <- extendR (newEnv bs' xs) $ defunBlock (boundVars bs') body
                 -- NB: The return value here doesn't really matter as we're going to replace it afterwards.
@@ -490,10 +490,10 @@ simplifyHof hof = case hof of
     applyRecon Nothing x = return x
     applyRecon (Just f) x = f x
 
-exceptToMaybeBlock :: Block -> SubstEmbed Atom
+exceptToMaybeBlock :: Block -> SubstBuilder Atom
 exceptToMaybeBlock (Block Empty result) = exceptToMaybeExpr result
 exceptToMaybeBlock (Block (Nest (Let _ b expr) decls) result) = do
-  a <- substEmbedR $ getType result
+  a <- substBuilderR $ getType result
   maybeResult <- exceptToMaybeExpr expr
   case maybeResult of
     -- These two cases are just an optimization
@@ -503,25 +503,25 @@ exceptToMaybeBlock (Block (Nest (Let _ b expr) decls) result) = do
       emitMaybeCase maybeResult (return $ NothingAtom a) \x -> do
         extendR (b@>x) $ exceptToMaybeBlock $ Block decls result
 
-exceptToMaybeExpr :: Expr -> SubstEmbed Atom
+exceptToMaybeExpr :: Expr -> SubstBuilder Atom
 exceptToMaybeExpr expr = do
-  a <- substEmbedR $ getType expr
+  a <- substBuilderR $ getType expr
   case expr of
     Case e alts resultTy -> do
-      e' <- substEmbedR e
-      resultTy' <- substEmbedR $ MaybeTy resultTy
+      e' <- substBuilderR e
+      resultTy' <- substBuilderR $ MaybeTy resultTy
       alts' <- forM alts \(Abs bs body) -> do
-        bs' <-  substEmbedR bs
+        bs' <-  substBuilderR bs
         buildNAbs bs' \xs -> extendR (newEnv bs' xs) $ exceptToMaybeBlock body
       emit $ Case e' alts' resultTy'
-    Atom x -> substEmbedR $ JustAtom (getType x) x
+    Atom x -> substBuilderR $ JustAtom (getType x) x
     Op (ThrowException _) -> return $ NothingAtom a
     Hof (For ann ~(Lam (Abs b (_, body)))) -> do
-      b' <- substEmbedR b
+      b' <- substBuilderR b
       maybes <- buildForAnn ann b' \i -> extendR (b@>i) $ exceptToMaybeBlock body
       catMaybesE maybes
     Hof (RunState s lam) -> do
-      s' <- substEmbedR s
+      s' <- substBuilderR s
       let BinaryFunVal _ b _ body = lam
       result  <- emitRunState "ref" s' \ref ->
         extendR (b@>ref) $ exceptToMaybeBlock body
@@ -534,7 +534,7 @@ exceptToMaybeExpr expr = do
                exceptToMaybeBlock body
       runMaybeWhile lam
     _ | not (hasExceptions expr) -> do
-          x <- substEmbedR expr >>= emit
+          x <- substBuilderR expr >>= emit
           return $ JustAtom (getType x) x
       | otherwise ->
           error $ "Unexpected exception-throwing expression: " ++ pprint expr
@@ -545,17 +545,17 @@ hasExceptions expr = case t of
   Just _  -> error "Shouldn't have tail left"
   where (EffectRow effs t) = exprEffs expr
 
-catMaybesE :: MonadEmbed m => Atom -> m Atom
-catMaybesE maybes = simplifyEmbed $ do
+catMaybesE :: MonadBuilder m => Atom -> m Atom
+catMaybesE maybes = simplifyBuilder $ do
   let (TabTy b (MaybeTy a)) = getType maybes
   applyPreludeFunction "seqMaybes" [binderAnn b, a, maybes]
 
-runMaybeWhile :: MonadEmbed m => Atom -> m Atom
-runMaybeWhile lam = simplifyEmbed $ do
+runMaybeWhile :: MonadBuilder m => Atom -> m Atom
+runMaybeWhile lam = simplifyBuilder $ do
   let (Pi (Abs _ (PlainArrow eff, _))) = getType lam
   applyPreludeFunction "whileMaybe" [Eff eff, lam]
 
-simplifyEmbed :: MonadEmbed m => m Atom -> m Atom
-simplifyEmbed m = do
+simplifyBuilder :: MonadBuilder m => m Atom -> m Atom
+simplifyBuilder m = do
   block <- buildScoped m
-  liftEmbed $ runReaderT (simplifyBlock block) mempty
+  liftBuilder $ runReaderT (simplifyBlock block) mempty

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -112,7 +112,7 @@ data Atom = Var Var
           -- XXX: Variable name must not be an alias for another name or for
           -- a statically-known atom. This is because the variable name used
           -- here may also appear in the type of the atom. (We maintain this
-          -- invariant during substitution and in Embed.hs.)
+          -- invariant during substitution and in Builder.hs.)
           | ProjectElt (NE.NonEmpty Int) Var
             deriving (Show, Generic)
 

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -25,7 +25,7 @@ import System.FilePath
 import Paths_dex  (getDataFileName)
 
 import Syntax
-import Embed
+import Builder
 import Cat
 import Env
 import Type
@@ -294,7 +294,7 @@ abstractPtrLiterals block = flip evalState mempty $ do
   return (impBinders, vals, block')
 
 class HasTraversal a where
-  traverseCore :: (MonadEmbed m, MonadReader SubstEnv m) => TraversalDef m -> a -> m a
+  traverseCore :: (MonadBuilder m, MonadReader SubstEnv m) => TraversalDef m -> a -> m a
 
 instance HasTraversal Block where
   traverseCore = traverseBlock
@@ -304,7 +304,7 @@ instance HasTraversal Atom where
 
 traverseLiterals :: (HasTraversal e, Monad m) => e -> (LitVal -> m Atom) -> m e
 traverseLiterals block f =
-    liftM fst $ flip runSubstEmbedT mempty $ traverseCore def block
+    liftM fst $ flip runSubstBuilderT mempty $ traverseCore def block
   where
     def = (traverseDecl def, traverseExpr def, traverseAtomLiterals)
     traverseAtomLiterals atom = case atom of


### PR DESCRIPTION
`EmbedT` is really an IR builder type.
"Builder" is standard terminology and easier to understand.

There exist both user-facing ADT builders and Imp builders.

---

To be rebased after in-flight PRs are merged to fix merge conflicts.