### PR TITLE
Class-dict synthesis algorithm refactor with errors and logging

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -50,7 +50,9 @@ library
                        -- Serialization
                        store,
                        -- Notebook support
-                       warp, wai, blaze-html, aeson, http-types, cmark, binary
+                       warp, wai, blaze-html, aeson, http-types, cmark, binary,
+                       -- Monad utilities
+                       free
   other-modules:       Paths_dex
   if !os(darwin)
     exposed-modules:   Resources

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -59,7 +59,8 @@ import PPrint
 import Util (bindM2, scanM, restructure)
 
 newtype BuilderT m a = BuilderT (ReaderT BuilderEnvR (CatT BuilderEnvC m) a)
-  deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Alternative)
+  deriving ( Functor, Applicative, Monad, MonadIO, MonadFail, MonadWriter w
+           , Alternative)
 
 type Builder = BuilderT Identity
 type BuilderEnv = (BuilderEnvR, BuilderEnvC)

--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -25,7 +25,8 @@ import Control.Monad.Identity
 import Control.Monad.Except hiding (Except)
 
 newtype CatT env m a = CatT (StateT (env, env) m a)
-  deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, MonadFail, Alternative)
+  deriving ( Functor, Applicative, Monad, MonadTrans, MonadIO, MonadFail
+           , MonadWriter w, Alternative)
 
 type Cat env = CatT env Identity
 

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -970,7 +970,7 @@ synthesize ctx ty = do
       "Multiple candidate class dictionaries for: " ++ pprint ty''
         ++ "\nAny of these steps lead to a dictionary:"
         ++ foldMap ("\n  " ++) choices
-        ++ if null steps then "" else (
+        ++ (if null steps then "" else
               "\n\nThis error occured while synthesizing a class dictionary for " ++ pprint ty
               ++ foldMap ("\n  after " ++) steps
            )

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -197,7 +197,7 @@ evalUModule env untyped = do
   logPass Parse untyped
   typed <- liftExceptWithOutputsIO logTop $ inferModule env untyped
   checkPass TypePass typed
-  synthed <- liftEitherIO $ synthModule env typed
+  synthed <- liftExceptWithOutputsIO logTop $ synthModule env typed
   -- TODO: check that the type of module exports doesn't change from here on
   checkPass SynthPass synthed
   let defunctionalized = simplifyModule env synthed

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -195,7 +195,7 @@ lookupBindings scope v = x
 evalUModule :: Bindings -> UModule -> TopPassM Bindings
 evalUModule env untyped = do
   logPass Parse untyped
-  typed <- liftEitherIO $ inferModule env untyped
+  typed <- liftExceptWithOutputsIO logTop $ inferModule env untyped
   checkPass TypePass typed
   synthed <- liftEitherIO $ synthModule env typed
   -- TODO: check that the type of module exports doesn't change from here on

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -336,8 +336,7 @@ bad_range : Int = (1@Fin 3)..(2@_)
 > Type error:Couldn't synthesize a class dictionary for: (Eq (Int32 -> Int32))
 > Failed attempts:
 >
->   Couldn't make progress on (Ord (Int32 -> Int32))
->     after using a superclass ((a:Type) ?-> (Ord a) ?=> Eq a)
+>   Couldn't make progress on (Eq (Int32 -> Int32))
 >
 > :p (\x:Int. x) == (\x:Int. x)
 >                ^^^

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -232,6 +232,9 @@ g1 : (a -> Int) -> (a -> Int) = \x. x
 
 g2 : a -> a = \x. idiv x x
 > Type error:Couldn't synthesize a class dictionary for: (Integral a)
+> Failed attempts:
+>
+>   Couldn't make progress on (Integral a)
 >
 > g2 : a -> a = \x. idiv x x
 >                   ^^^^^
@@ -243,6 +246,9 @@ h : (a -> b) -> (a -> b) = \x. x
 
 fun : a -> a = \x. sin x
 > Type error:Couldn't synthesize a class dictionary for: (Floating a)
+> Failed attempts:
+>
+>   Couldn't make progress on (Floating a)
 >
 > fun : a -> a = \x. sin x
 >                    ^^^^
@@ -328,6 +334,10 @@ bad_range : Int = (1@Fin 3)..(2@_)
 
 :p (\x:Int. x) == (\x:Int. x)
 > Type error:Couldn't synthesize a class dictionary for: (Eq (Int32 -> Int32))
+> Failed attempts:
+>
+>   Couldn't make progress on (Ord (Int32 -> Int32))
+>     after using a superclass ((a:Type) ?-> (Ord a) ?=> Eq a)
 >
 > :p (\x:Int. x) == (\x:Int. x)
 >                ^^^

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -61,6 +61,8 @@ instance [Add Float] InterfaceSynthesisTest Float
 >   using an instance (InterfaceSynthesisTest Float32)
 >   using an instance ((Add Float32) ?=> InterfaceSynthesisTest Float32)
 >
+> (there may be additional ambiguities as well)
+>
 >   x : Float = runTest
 >               ^^^^^^^
 
@@ -178,6 +180,8 @@ def go2 [InterfaceSynthesisSuperclassTest2 Foo] : Foo = runTest
 > Any of these steps lead to a dictionary:
 >   using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
 >   using an instance (InterfaceSynthesisTest Foo)
+>
+> (there may be additional ambiguities as well)
 >
 > def go2 [InterfaceSynthesisSuperclassTest2 Foo] : Foo = runTest
 >                                                         ^^^^^^^

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -59,8 +59,8 @@ instance InterfaceSynthesisTest Float
   x : Float = runTest
   x
 > Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
->   - (instance77 : (InterfaceSynthesisTest Float32))
->   - (instance78 : (InterfaceSynthesisTest Float32))
+>   - an instance (InterfaceSynthesisTest Float32)
+>   - an instance (InterfaceSynthesisTest Float32)
 >
 >   x : Float = runTest
 >               ^^^^^^^
@@ -73,9 +73,9 @@ instance [InterfaceSynthesisTest Float] InterfaceSynthesisTest Int
   x : Int = runTest
   x
 > Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
->   - (instance77 : (InterfaceSynthesisTest Float32))
->   - (instance78 : (InterfaceSynthesisTest Float32))
-> While synthesizing (InterfaceSynthesisTest Int32) using (instance79 : ((InterfaceSynthesisTest Float32) ?=> InterfaceSynthesisTest Int32))
+>   - an instance (InterfaceSynthesisTest Float32)
+>   - an instance (InterfaceSynthesisTest Float32)
+> While synthesizing (InterfaceSynthesisTest Int32) using an instance ((InterfaceSynthesisTest Float32) ?=> InterfaceSynthesisTest Int32)
 >
 >   x : Int = runTest
 >             ^^^^^^^
@@ -96,8 +96,8 @@ instance [InterfaceSynthesisTest Bar] InterfaceSynthesisTest Foo
   x : Foo = runTest
   x
 > Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Foo)
->   - (instance80 : (InterfaceSynthesisTest Foo))
->   - (instance81 : ((InterfaceSynthesisTest Bar) ?=> InterfaceSynthesisTest Foo))
+>   - an instance (InterfaceSynthesisTest Foo)
+>   - an instance ((InterfaceSynthesisTest Bar) ?=> InterfaceSynthesisTest Foo)
 >
 >   x : Foo = runTest
 >             ^^^^^^^
@@ -115,7 +115,7 @@ instance [InterfaceSynthesisTest Baz] InterfaceSynthesisTest Qux
   x : Qux = runTest
   x
 > Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Baz)
-> While synthesizing (InterfaceSynthesisTest Qux) using (instance82 : ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux))
+> While synthesizing (InterfaceSynthesisTest Qux) using an instance ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux)
 >
 >   x : Qux = runTest
 >             ^^^^^^^

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -52,15 +52,16 @@ interface InterfaceSynthesisTest a
 instance InterfaceSynthesisTest Float
   runTest = 1.0
 
-instance InterfaceSynthesisTest Float
+instance [Add Float] InterfaceSynthesisTest Float
   runTest = 2.0
 
 :p 
   x : Float = runTest
   x
 > Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
->   - an instance (InterfaceSynthesisTest Float32)
->   - an instance (InterfaceSynthesisTest Float32)
+> Any of these steps lead to a dictionary:
+>   using an instance (InterfaceSynthesisTest Float32)
+>   using an instance ((Add Float32) ?=> InterfaceSynthesisTest Float32)
 >
 >   x : Float = runTest
 >               ^^^^^^^
@@ -68,14 +69,21 @@ instance InterfaceSynthesisTest Float
 instance [InterfaceSynthesisTest Float] InterfaceSynthesisTest Int
   runTest = 2
 
--- error shows Float32, since that is where the duplicate instance arises
+-- In this case, we have a single instance for `InterfaceSynthesisTest Int`
+-- but multiple for `InterfaceSynthesisTest Float32`, which is required by
+-- the original instance. The error shows both types:
 :p 
   x : Int = runTest
   x
 > Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
->   - an instance (InterfaceSynthesisTest Float32)
->   - an instance (InterfaceSynthesisTest Float32)
-> While synthesizing (InterfaceSynthesisTest Int32) using an instance ((InterfaceSynthesisTest Float32) ?=> InterfaceSynthesisTest Int32)
+> Any of these steps lead to a dictionary:
+>   using an instance (InterfaceSynthesisTest Float32)
+>   using an instance ((Add Float32) ?=> InterfaceSynthesisTest Float32)
+>
+> This error occured while synthesizing a class dictionary for (InterfaceSynthesisTest Int32)
+>   after using an instance ((InterfaceSynthesisTest Float32) ?=> InterfaceSynthesisTest Int32)
+>
+> (there may be additional ambiguities as well)
 >
 >   x : Int = runTest
 >             ^^^^^^^
@@ -90,32 +98,83 @@ instance [InterfaceSynthesisTest Bar] InterfaceSynthesisTest Foo
   runTest = MkFoo 2
 
 
--- we should still have a duplicate interface error here, even though the
--- `InterfaceSynthesisTest Bar` constraint can't be solved
+-- This is NOT a duplicate instance, because we will backtrack after not
+-- finding an instance for `InterfaceSynthesisTest Bar`.
 :p 
   x : Foo = runTest
   x
-> Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Foo)
->   - an instance (InterfaceSynthesisTest Foo)
->   - an instance ((InterfaceSynthesisTest Bar) ?=> InterfaceSynthesisTest Foo)
->
->   x : Foo = runTest
->             ^^^^^^^
+> (MkFoo 1)
 
 '## Missing instances
 
 data Baz = MkBaz Int
 data Qux = MkQux Int
+data Zzz = MkZzz Int
 
 instance [InterfaceSynthesisTest Baz] InterfaceSynthesisTest Qux
   runTest = MkQux 1
 
--- missing an instance for Baz, not Qux
-:p 
+instance [InterfaceSynthesisTest Zzz] InterfaceSynthesisTest Qux
+  runTest = MkQux 2
+
+-- Synthesis here runs into three dead-ends, since neither Baz nor Zzz have an
+-- instance.
+:p
   x : Qux = runTest
   x
-> Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Baz)
-> While synthesizing (InterfaceSynthesisTest Qux) using an instance ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux)
+> Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Qux)
+> Failed attempts:
+>
+>   Couldn't make progress on (InterfaceSynthesisTest Baz)
+>     after using an instance ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux)
+>
+>   Couldn't make progress on (InterfaceSynthesisTest Zzz)
+>     after using an instance ((InterfaceSynthesisTest Zzz) ?=> InterfaceSynthesisTest Qux)
 >
 >   x : Qux = runTest
 >             ^^^^^^^
+
+-- If we introduce a superclass, it tries to use it if it can
+
+interface [InterfaceSynthesisTest a] InterfaceSynthesisSuperclassTest a
+  unused : Unit
+
+
+:p
+  x : Qux = runTest
+  x
+> Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Qux)
+> Failed attempts:
+>
+>   Couldn't make progress on (InterfaceSynthesisSuperclassTest Qux)
+>     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>
+>   Couldn't make progress on (InterfaceSynthesisSuperclassTest Baz)
+>     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>     after using an instance ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux)
+>
+>   Couldn't make progress on (InterfaceSynthesisSuperclassTest Zzz)
+>     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>     after using an instance ((InterfaceSynthesisTest Zzz) ?=> InterfaceSynthesisTest Qux)
+>
+>   x : Qux = runTest
+>             ^^^^^^^
+
+
+'Superclass of a superclass
+
+interface [InterfaceSynthesisSuperclassTest a] InterfaceSynthesisSuperclassTest2 a
+  unused2 : Unit
+
+instance InterfaceSynthesisSuperclassTest Foo
+  unused = ()
+
+instance InterfaceSynthesisSuperclassTest2 Foo
+  unused2 = ()
+
+def go [InterfaceSynthesisSuperclassTest2 a] : a = runTest
+
+:p
+  x : Foo = go
+  x
+> (MkFoo 1)

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -44,8 +44,6 @@ instance InterfaceTest4 Float
 
 '# Synthesis errors
 
-'## Duplicate instances
-
 interface InterfaceSynthesisTest a
   runTest : a
 
@@ -105,7 +103,6 @@ instance [InterfaceSynthesisTest Bar] InterfaceSynthesisTest Foo
   x
 > (MkFoo 1)
 
-'## Missing instances
 
 data Baz = MkBaz Int
 data Qux = MkQux Int
@@ -117,7 +114,7 @@ instance [InterfaceSynthesisTest Baz] InterfaceSynthesisTest Qux
 instance [InterfaceSynthesisTest Zzz] InterfaceSynthesisTest Qux
   runTest = MkQux 2
 
--- Synthesis here runs into three dead-ends, since neither Baz nor Zzz have an
+-- Synthesis here runs into two dead-ends, since neither Baz nor Zzz have an
 -- instance.
 :p
   x : Qux = runTest
@@ -134,11 +131,10 @@ instance [InterfaceSynthesisTest Zzz] InterfaceSynthesisTest Qux
 >   x : Qux = runTest
 >             ^^^^^^^
 
--- If we introduce a superclass, it tries to use it if it can
+-- Irrelevant superclass constraints aren't shown.
 
 interface [InterfaceSynthesisTest a] InterfaceSynthesisSuperclassTest a
   unused : Unit
-
 
 :p
   x : Qux = runTest
@@ -146,22 +142,17 @@ interface [InterfaceSynthesisTest a] InterfaceSynthesisSuperclassTest a
 > Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Qux)
 > Failed attempts:
 >
->   Couldn't make progress on (InterfaceSynthesisSuperclassTest Qux)
->     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
->
->   Couldn't make progress on (InterfaceSynthesisSuperclassTest Baz)
->     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>   Couldn't make progress on (InterfaceSynthesisTest Baz)
 >     after using an instance ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux)
 >
->   Couldn't make progress on (InterfaceSynthesisSuperclassTest Zzz)
->     after using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>   Couldn't make progress on (InterfaceSynthesisTest Zzz)
 >     after using an instance ((InterfaceSynthesisTest Zzz) ?=> InterfaceSynthesisTest Qux)
 >
 >   x : Qux = runTest
 >             ^^^^^^^
 
 
-'Superclass of a superclass
+-- Superclass of a superclass is OK
 
 interface [InterfaceSynthesisSuperclassTest a] InterfaceSynthesisSuperclassTest2 a
   unused2 : Unit
@@ -178,3 +169,15 @@ def go [InterfaceSynthesisSuperclassTest2 a] : a = runTest
   x : Foo = go
   x
 > (MkFoo 1)
+
+-- Superclasses show up in the error if there are multiple solutions.
+-- (TODO: should local superclasses take priority over global instances?)
+
+def go2 [InterfaceSynthesisSuperclassTest2 Foo] : Foo = runTest
+> Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Foo)
+> Any of these steps lead to a dictionary:
+>   using a superclass ((a:Type) ?-> (InterfaceSynthesisSuperclassTest a) ?=> InterfaceSynthesisTest a)
+>   using an instance (InterfaceSynthesisTest Foo)
+>
+> def go2 [InterfaceSynthesisSuperclassTest2 Foo] : Foo = runTest
+>                                                         ^^^^^^^

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -41,3 +41,81 @@ instance InterfaceTest4 Float
   foo = 1
   bar = \_. 1
 
+
+'# Synthesis errors
+
+'## Duplicate instances
+
+interface InterfaceSynthesisTest a
+  runTest : a
+
+instance InterfaceSynthesisTest Float
+  runTest = 1.0
+
+instance InterfaceSynthesisTest Float
+  runTest = 2.0
+
+:p 
+  x : Float = runTest
+  x
+> Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
+>   - (instance77 : (InterfaceSynthesisTest Float32))
+>   - (instance78 : (InterfaceSynthesisTest Float32))
+>
+>   x : Float = runTest
+>               ^^^^^^^
+
+instance [InterfaceSynthesisTest Float] InterfaceSynthesisTest Int
+  runTest = 2
+
+-- error shows Float32, since that is where the duplicate instance arises
+:p 
+  x : Int = runTest
+  x
+> Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Float32)
+>   - (instance77 : (InterfaceSynthesisTest Float32))
+>   - (instance78 : (InterfaceSynthesisTest Float32))
+> While synthesizing (InterfaceSynthesisTest Int32) using (instance79 : ((InterfaceSynthesisTest Float32) ?=> InterfaceSynthesisTest Int32))
+>
+>   x : Int = runTest
+>             ^^^^^^^
+
+data Foo = MkFoo Int
+data Bar = MkBar Int
+
+instance InterfaceSynthesisTest Foo
+  runTest = MkFoo 1
+
+instance [InterfaceSynthesisTest Bar] InterfaceSynthesisTest Foo
+  runTest = MkFoo 2
+
+
+-- we should still have a duplicate interface error here, even though the
+-- `InterfaceSynthesisTest Bar` constraint can't be solved
+:p 
+  x : Foo = runTest
+  x
+> Type error:Multiple candidate class dictionaries for: (InterfaceSynthesisTest Foo)
+>   - (instance80 : (InterfaceSynthesisTest Foo))
+>   - (instance81 : ((InterfaceSynthesisTest Bar) ?=> InterfaceSynthesisTest Foo))
+>
+>   x : Foo = runTest
+>             ^^^^^^^
+
+'## Missing instances
+
+data Baz = MkBaz Int
+data Qux = MkQux Int
+
+instance [InterfaceSynthesisTest Baz] InterfaceSynthesisTest Qux
+  runTest = MkQux 1
+
+-- missing an instance for Baz, not Qux
+:p 
+  x : Qux = runTest
+  x
+> Type error:Couldn't synthesize a class dictionary for: (InterfaceSynthesisTest Baz)
+> While synthesizing (InterfaceSynthesisTest Qux) using (instance82 : ((InterfaceSynthesisTest Baz) ?=> InterfaceSynthesisTest Qux))
+>
+>   x : Qux = runTest
+>             ^^^^^^^


### PR DESCRIPTION
edit: This PR now maintains the backtracking behavior, while still adding better errors and logging (see https://github.com/google-research/dex-lang/pull/480#issuecomment-769554704)

---

**Generate logging outputs while running inference.**

Adds a new typeclass ExceptWithOutputs, which is just a combination of the
except and writer monads. This makes it possible to log outputs during type
inference, which can be useful for debugging.

**Redesign synthesis algorithm to make it more interpretable.**
The old synthesis algorithm essentially did a big exhaustive depth-first search
over all possible ways of building an instance, then finally raised an error if
there wasn't exactly one solution. This has a few non-ideal consequences:
- Errors always show up for the requested instance, instead of showing up for
  the child instance that we couldn't solve.
- There's no way to observe the sequence of synthesis decisions taken by the
  algorithm.
- Part of determining whether an instance matches involves solving for all of
  its own constraints. Thus if one of an instance's new constraints can't be
  solved, we might conclude that this instance doesn't apply, and continue
  searching for other instances instead of throwing an error. Effectively,
  we perform an unlimited amount of backtracking while solving instances.

This algorithm instead synthesizes constraints one at a time, without
recursively solving for all newly-introduced constraints immediately. It also
modifies the synthesis process to produce human-readable names for all of the
steps of synthesis, and writes them to the output when `%passes synth` is
active.

In the future, we may want to add a principled form of backtracking that keeps
the interpretability of this algorithm.

**Add solver context to error messages, and add tests for new errors.**

---

Issue #289 is an example of where the old synthesis algorithm's errors can lead people (including me) astray! After this PR, it looks like:
```
:t a
> ({left: Fin 3 | right: Fin 3} => Int32)

:p neg a
> Type error:Couldn't synthesize a class dictionary for: (VSpace Int32)
> While synthesizing (VSpace ({left: Fin 3 | right: Fin 3} => Int32)) using (instance20 : ((a:Type) ?-> (n:Type) ?-> (VSpace a) ?=> VSpace (n => a)))
>
> :p neg a
>    ^^^^
```
This makes it clear that the problem was that `Int32` isn't a `VSpace` under our definition (since you can't scale it by a float). Before, the error was just `Couldn't synthesize a class dictionary for: (VSpace ({left: Fin 3 | right: Fin 3} => Int32))`.

If you turn on `%passes synth` you can watch it solve things:
```
%passes synth
:p yieldAccum (AddMonoid Float) \ref.
     ref += [1.,2.,3.]
     ref += [2.,4.,5.]
> [3., 6., 8.]
> === synth ===
> Synthesizing ((h:Type) -> (AccumMonoid h Float32) ?=> AccumMonoid h ((Fin 3) => Float32)) using (tableAccumMonoid : ((h:Type)
>  ?-> (n:Type) ?-> (w:Type) ?-> (AccumMonoid h w) ?=> AccumMonoid h (n => w)))
> (after assuming premise:(AccumMonoid h Float32))
> (after assuming h:Type)
> === synth ===
> Synthesizing (AccumMonoid h Float32) using (tmp4 : (AccumMonoid h Float32))
> === synth ===
> Synthesizing (Add Float32) using (instance1 : (Add Float32))
> === synth ===
> Synthesizing (AccumMonoid a ((Fin 3) => Float32)) using (tableAccumMonoid : ((h:Type)
>  ?-> (n:Type) ?-> (w:Type) ?-> (AccumMonoid h w) ?=> AccumMonoid h (n => w)))
> === synth ===
> Synthesizing (AccumMonoid a Float32) using (tmp8 : (AccumMonoid a Float32))
> === synth ===
> Synthesizing (AccumMonoid a ((Fin 3) => Float32)) using (tableAccumMonoid : ((h:Type)
>  ?-> (n:Type) ?-> (w:Type) ?-> (AccumMonoid h w) ?=> AccumMonoid h (n => w)))
> === synth ===
> Synthesizing (AccumMonoid a Float32) using (tmp8 : (AccumMonoid a Float32))
> === synth ===
> Module (Core)
>   unevaluated decls:
     ...
>    _ans_:((Fin 3) => Float32) = tmp8
>
>   evaluated bindings:
>   ()
```