### PR TITLE
Added Eq instance and Monoid helper for Lists, and a filter function.

### DIFF
--- a/examples/particle-filter.dx
+++ b/examples/particle-filter.dx
@@ -24,7 +24,7 @@ def simulate (model: Model s v) (t: Int) (key: Key) : Fin t=>(s & v) =
       s_ref := s_next
       (s, v)
 
-def filter
+def particleFilter
     (num_particles: Int) (num_timesteps: Int)
     (model: Model s v)
     (summarize: (Fin num_particles => s) -> a)
@@ -63,6 +63,6 @@ truth = for i:(Fin timesteps).
   s = IToF (ordinal i)
   (s, sample (normalDistn s 1.0) $ ixkey (newKey 0) i)
 
-filtered = filter num_particles _ gaussModel mean (map snd truth) (newKey 0)
+filtered = particleFilter num_particles _ gaussModel mean (map snd truth) (newKey 0)
 
 -- :p for i. (truth.i, filtered.i)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -775,8 +775,8 @@ def dot [VSpace v] (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 def inner (x:n=>Float) (mat:n=>m=>Float) (y:m=>Float) : Float =
   fsum view (i,j). x.i * mat.i.j * y.j
 
-def eye [Eq n] : n=>n=>Float =
-  for i j. select (i == j) 1.0 0.0
+def eye [Eq n, Add a, Mul a] : n=>n=>a =
+  for i j. select (i == j) one zero
 
 '## Pseudorandom number generator utilities
 Dex does not use a stateful random number generator.
@@ -964,6 +964,13 @@ def tile1 (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
 data List a =
   AsList n:Int elements:(Fin n => a)
 
+instance [Eq a] Eq (List a)
+  (==) = \(AsList nx xs) (AsList ny ys).
+    if nx /= ny
+      then False
+      else all for i:(Fin nx).
+        xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
+
 def unsafeCastTable (m:Type) (xs:n=>a) : m=>a =
   for i. xs.(unsafeFromOrdinal _ (ordinal i))
 
@@ -982,6 +989,32 @@ instance Monoid (List a)
       case i' < nx of
         True  -> xs.(unsafeFromOrdinal _ i')
         False -> ys.(unsafeFromOrdinal _ (i' - nx))
+
+def ListMonoid (a:Type) : Monoid (List a) =
+  A = a -- XXX: Typing `Monoid a` below would quantify it over a,
+        --      which we don't want.
+  named-instance result : Monoid (List A)
+    mempty = mempty
+    mcombine = mcombine
+  result
+
+def append [AccumMonoid h (List a)]
+  (list: Ref h (List a)) (x:a) : {Accum h} Unit =
+    list += AsList 1 [x]
+
+def filter (condition:a->Bool) (xs:n=>a) : List a =
+  yieldAccum (ListMonoid a) \list.
+    for i.
+      if condition xs.i
+        then append list xs.i
+
+def argFilter (condition:a->Bool) (xs:n=>a) : List n =
+  -- Returns all indices where the condition is true.
+  yieldAccum (ListMonoid n) \list.
+    for i.
+      if condition xs.i
+        then append list i
+
 
 '## Isomorphisms
 

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -177,3 +177,41 @@ def effectsAtZero (eff:Effects)?-> (f: Int ->{|eff} Unit) : {|eff} Unit =
 
 :p runState 0 \ref. effectsAtZero \_. ref := 1
 > ((), 1)
+
+:p filter (\x. x > 5) [0, 7, -1, 6]
+> (AsList 2 [7, 6])
+
+:p argFilter (\x. x > 5) [0, 7, -1, 6]
+> (AsList 2 [(1@Fin 4), (3@Fin 4)])
+
+-- Test list equality
+(AsList _ [1, 2]) == (AsList _ [1, 2])
+> True
+
+(AsList _ [1]) == (AsList _ [1, 2])
+> False
+
+(AsList _ [1, 2]) == (AsList _ [2, 2])
+> False
+
+-- Test custom list monoid with accum
+def adjacencyMatrixToEdgeList (mat: n=>n=>Bool) : List (n & n) =
+  yieldAccum (ListMonoid (n & n)) \list.
+    for (i, j).
+      if mat.i.j then
+        append list (i, j)
+
+test_edges = [[False, False, True, False],
+              [True, False, True, True],
+              [False, True, False, True],
+              [False, False, False, False]]
+
+edgelist = (AsList 6 [ ((0@Fin 4), (2@Fin 4))
+, ((1@Fin 4), (0@Fin 4))
+, ((1@Fin 4), (2@Fin 4))
+, ((1@Fin 4), (3@Fin 4))
+, ((2@Fin 4), (1@Fin 4))
+, ((2@Fin 4), (3@Fin 4)) ])
+
+:p edgelist == adjacencyMatrixToEdgeList test_edges
+> True


### PR DESCRIPTION
There was already an instance of `Monoid` for lists, but I had to add a helper function just like for the other parameterized Monoid instances.

This unlocks linear-time, parallelizable `filter`, which I also added.

If there's a more standard name for `argFilter` I'm happy to change it.

I also added an `Eq` instance for lists, and slightly generalized `eye`.

with @dougalm 

