### PR TITLE
Automate HTML doc generation via GitHub Actions.

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   build:
+    runs-on: ${{ matrix.os }}
     strategy:
       matrix:
         os: [ubuntu-18.04, macos-latest]
@@ -18,8 +19,6 @@ jobs:
           - os: ubuntu-18.04
             install_deps: sudo apt-get install llvm-9-tools llvm-9-dev pkg-config
             path_extension: /usr/lib/llvm-9/bin
-
-    runs-on: ${{ matrix.os }}
 
     steps:
     - name: Checkout the repository
@@ -46,7 +45,8 @@ jobs:
         key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
         restore-keys: ${{ runner.os }}-
 
-      # See https://github.com/actions/cache/issues/445
+    # This step is a workaround.
+    # See issue for context: https://github.com/actions/cache/issues/445
     - name: Remove cached Setup executables
       run: rm -rf ~/.stack/setup-exe-cache
       if: runner.os == 'macOS'

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -48,10 +48,10 @@ jobs:
       run: make docs
 
     - name: Deploy to GitHub Pages
-      uses: "JamesIves/github-pages-deploy-action@3.7.1"
+      uses: "JamesIves/github-pages-deploy-action@3dbacc7e69578703f91f077118b3475862cb09b8" # 4.1.0
       with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages # The branch the action should deploy to.
-          FOLDER: doc      # The folder the action should deploy.
-          CLEAN: false     # If true, automatically remove deleted files from the deploy branch.
-          COMMIT_MESSAGE: Updating gh-pages from ${{ github.sha }}
+          token: ${{ secrets.GITHUB_TOKEN }}
+          branch: gh-pages # The branch the action should deploy to.
+          folder: doc      # The folder the action should deploy.
+          clean: false     # If true, automatically remove deleted files from the deploy branch.
+          commit-message: Updating gh-pages from ${{ github.sha }}

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -1,0 +1,57 @@
+name: Update HTML docs
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  build:
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-18.04]
+        include:
+          - os: ubuntu-18.04
+            install_deps: sudo apt-get install llvm-9-tools llvm-9-dev pkg-config
+            path_extension: /usr/lib/llvm-9/bin
+
+    steps:
+    - name: Checkout the repository
+      uses: actions/checkout@v2
+
+    - name: Setup Haskell Stack
+      uses: actions/setup-haskell@v1
+      with:
+        enable-stack: true
+        stack-no-global: true
+        stack-version: 'latest'
+
+    - name: Install system dependencies
+      run: |
+        ${{ matrix.install_deps }}
+        echo "${{ matrix.path_extension }}" >> $GITHUB_PATH
+
+    - name: Cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.stack
+          $GITHUB_WORKSPACE/.stack-work
+        key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
+        restore-keys: ${{ runner.os }}-
+
+    - name: Build
+      run: make build
+
+    - name: Generate docs
+      run: make docs
+
+    - name: Deploy to GitHub Pages
+      uses: "JamesIves/github-pages-deploy-action@3.7.1"
+      with:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          BRANCH: gh-pages # The branch the action should deploy to.
+          FOLDER: doc      # The folder the action should deploy.
+          CLEAN: false     # If true, automatically remove deleted files from the deploy branch.
+          COMMIT_MESSAGE: Updating gh-pages from ${{ github.sha }}


### PR DESCRIPTION
Add GitHub Action workflow to run `make docs` and push to `gh-pages` branch upon pushes to main branch.
This should greatly alleviate the need to manually update `gh-pages` branch.

---

Verified this workflow on my fork, it seems to work well.

`gh-pages` deployment options:

```yaml
    - name: Deploy to GitHub Pages
      uses: "JamesIves/github-pages-deploy-action@3dbacc7e69578703f91f077118b3475862cb09b8" # 4.1.0
      with:
          token: ${{ secrets.GITHUB_TOKEN }}
          branch: gh-pages # The branch the action should deploy to.
          folder: doc      # The folder the action should deploy.
          clean: false     # If true, automatically remove deleted files from the deploy branch.
          commit-message: Updating gh-pages from ${{ github.sha }}
```

The `clean` option is set to `false`, so ad-hoc added files ([like HTML redirection pages](https://github.com/google-research/dex-lang/pull/392)) won't be removed on deployments.

Resolves https://github.com/google-research/dex-lang/issues/291.