### PR TITLE
Update benchmarks + a bundle of fixes

### DIFF
--- a/benchmarks/parboil/mriq.dx
+++ b/benchmarks/parboil/mriq.dx
@@ -13,12 +13,11 @@ def mriq (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
          (phiR : ks=>Float) (phiI : ks=>Float)
            : (cs=>Float & cs=>Float) =
   unzip $ for i.
-    snd $ withAccum \ref.
-      qr = fstRef ref
-      qi = sndRef ref
-      for j.
-        phiMag = phiR.j * phiR.j + phiI.j * phiI.j
-        expArg = kx.j * x.i + ky.j * y.i + kz.j * z.i
-        x = 2.0 * pi * expArg * phiMag
-        qr += cos x
-        qi += sin x
+    runAccum (AddMonoid Float) \qi.
+      yieldAccum (AddMonoid Float) \qr.
+        for j.
+          phiMag = phiR.j * phiR.j + phiI.j * phiI.j
+          expArg = kx.j * x.i + ky.j * y.i + kz.j * z.i
+          t = 2.0 * pi * expArg * phiMag
+          qr += cos t
+          qi += sin t

--- a/benchmarks/prepare-executables.py
+++ b/benchmarks/prepare-executables.py
@@ -68,15 +68,15 @@ def prepare_rodinia_hotspot():
     with open(case_exe_path, 'w') as f:
       emit_dex(f, 'rodinia', 'hotspot', [
           ('numIterations', 360),
-          ('T', format_matrix(ts)),
-          ('P', format_matrix(ps))
+          ('T', random_mat(f'(Fin {size})=>(Fin {size})=>Float')), # format_matrix(ts)),
+          ('P', random_mat(f'(Fin {size})=>(Fin {size})=>Float')), # format_matrix(ps))
         ])
       print(f'Created {case_exe_path}')
 
 def prepare_rodinia_backprop():
   exe_path = RODINIA_EXE_ROOT / 'backprop'
   exe_path.mkdir(parents=True, exist_ok=True)
-  exe_path_ad = RODINIA_EXE_ROOT / 'backprop-ad'
+  exe_path_ad = RODINIA_EXE_ROOT / 'backpropad'
   exe_path_ad.mkdir(parents=True, exist_ok=True)
   in_features = [128, 1048576]
 
@@ -85,7 +85,7 @@ def prepare_rodinia_backprop():
     hidf = 16
     case_exe_path = (exe_path_ad if use_ad else exe_path) / f'{inf}_{hidf}_{outf}.dx'
     with open(case_exe_path, 'w') as f:
-      emit_dex(f, 'rodinia', 'backprop', [
+      emit_dex(f, 'rodinia', ('backpropad' if use_ad else 'backprop'), [
           ('input', random_vec('in=>Float')),
           ('target', random_vec('out=>Float')),
           ('inputWeights', random_mat('{ b: Unit | w: in }=>hid=>Float')),
@@ -196,7 +196,7 @@ def emit_dex(f, suite, name, params, *, preamble=[]):
   for n, v in params:
     f.write(f'{n} = {v}\n')
   f.write('\n')
-  f.write(f'include "{suite}/{name}.dx"\n')
+  f.write(f'import {name}\n')
   f.write('\n')
   f.write(f'%bench "{name}"\n')
   f.write(f'result = {name} {(" ".join(n for n, v in params))}\n')

--- a/benchmarks/rodinia/backprop.dx
+++ b/benchmarks/rodinia/backprop.dx
@@ -7,8 +7,7 @@ def layerForward (input : in=>Float)
                  (params : { b: Unit| w: in }=>out=>Float)
                    : out=>Float =
   bias = params.{| b=() |}
-  -- TODO: Push the j loop into the sum or not?
-  total = (for j:out. sum $ for i:in. params.{| w=i |}.j  * input.i) + bias
+  total = (sum $ for i:in j:out. params.{| w=i |}.j * input.i) + bias
   for i. squash total.i
 
 def adjustWeights (delta : out=>Float)
@@ -27,7 +26,7 @@ def adjustWeights (delta : out=>Float)
 def outputError (target : out=>Float)
                 (output : out=>Float)
                   : (Float & out=>Float) =
-  swap $ withAccum \err.
+  swap $ runAccum (AddMonoid Float) \err.
     for i.
       o = output.i
       d = o * (1.0 - o) * (target.i - o)
@@ -38,7 +37,7 @@ def hiddenError (outputDelta : out=>Float)
                 (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
                 (hidden : hid=>Float)
                   : (Float & hid=>Float) =
-  swap $ withAccum \err.
+  swap $ runAccum (AddMonoid Float) \err.
     for i:hid.
       mult = sum $ for j. outputDelta.j * hiddenWeights.{| w = i |}.j
       r = hidden.i * (1.0 - hidden.i) * mult

--- a/benchmarks/rodinia/backpropad.dx
+++ b/benchmarks/rodinia/backpropad.dx
@@ -7,8 +7,7 @@ def layerForward (input : in=>Float)
                  (params : { b: Unit| w: in }=>out=>Float)
                    : out=>Float =
   bias = params.{| b=() |}
-  -- TODO: Push the j loop into the sum or not?
-  total = (for j:out. sum $ for i:in. params.{| w=i |}.j  * input.i) + bias
+  total = (sum $ for i:in j:out. params.{| w=i |}.j  * input.i) + bias
   for i. squash total.i
 
 def lossForward (input : n=>Float) (target : n=>Float) : Float =
@@ -22,14 +21,14 @@ def adjustWeights (gradWeight : { b: Unit | w: in }=>out=>Float)
     d = ETA * gradWeight.k.j + MOMENTUM * oldWeight.k.j
     weight.k.j + d
 
-def backprop (input : in=>Float)
-             (target : out=>Float)
-             (inputWeights : { b: Unit | w: in }=>hid=>Float)
-             (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
-             (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
-             (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
-               : ( { b: Unit | w: in }=>hid=>Float
-                 & { b: Unit | w: hid }=>out=>Float) =
+def backpropad (input : in=>Float)
+               (target : out=>Float)
+               (inputWeights : { b: Unit | w: in }=>hid=>Float)
+               (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
+               (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
+               (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
+                 : ( { b: Unit | w: in }=>hid=>Float
+                   & { b: Unit | w: hid }=>out=>Float) =
   (gradInputWeights, gradHiddenWeights) =
     flip grad (inputWeights, hiddenWeights) \(iw, hw).
       hidden = layerForward input  inputWeights

--- a/benchmarks/rodinia/hotspot.dx
+++ b/benchmarks/rodinia/hotspot.dx
@@ -37,12 +37,12 @@ def hotspot (numIterations: Int)
   Rz = tChip / (kSI * gridHeight * gridWidth)
   maxSlope = maxPD / (factorChip * tChip * specHeatSI)
   step = precision / maxSlope
-  snd $ withState tsInit $ \ts.
+  yieldState tsInit $ \tsRef.
     for _:(Fin numIterations).
-      ts' = for r c.
-         t = get ts!r!c
-         dc = (get ts!r!(c +| 1) + get ts!r!(c -| 1) - 2.0 * t) / Rx
-         dr = (get ts!(r +| 1)!c + get ts!(r -| 1)!c - 2.0 * t) / Ry
+      ts = get tsRef
+      tsRef := for r c.
+         t = ts.r.c
+         dc = (ts.r.(c +| 1) + ts.r.(c -| 1) - 2.0 * t) / Rx
+         dr = (ts.(r +| 1).c + ts.(r -| 1).c - 2.0 * t) / Ry
          d = (step / cap) * (p.r.c + dc + dr + (tAmb - t) / Rz)
          t + d
-      ts := ts'

--- a/benchmarks/rodinia/kmeans.dx
+++ b/benchmarks/rodinia/kmeans.dx
@@ -1,12 +1,11 @@
-
 def dist (x : d=>Float) (y : d=>Float) : Float =
   d = x - y
   sum $ for i. d.i * d.i
 
 def centroidsOf (points : n=>d=>Float) (membership : n=>k) : k=>d=>Float =
-  clusterSums = snd $ withAccum \clusterSums.
+  clusterSums = yieldAccum (AddMonoid Float) \clusterSums.
     for i. clusterSums!(membership.i) += points.i
-  clusterSizes = snd $ withAccum \clusterSizes.
+  clusterSizes = yieldAccum (AddMonoid Float) \clusterSizes.
     for i. clusterSizes!(membership.i) += 1.0
   for i. clusterSums.i / (max clusterSizes.i 1.0)
 
@@ -20,18 +19,13 @@ def kmeans (points : n=>d=>Float)
            : (Fin k)=>d=>Float =
   initCentroids = for i:(Fin k). points.(ordinal i@_)
   initMembership = for c:n. ((ordinal c `mod` k)@_)
-  initDelta = threshold + 1
-  final = snd $ withState (initMembership, initCentroids, initDelta, 0) \ref.
-    (while (\().
-            (_, _, delta, i) = get ref
-            delta > threshold && i < maxIterations)
-           (\().
-             (membership, centroids, _, i) = get ref
-             membership' = for i. argminBy (dist points.i) centroids
-             centroids' = centroidsOf points membership'
-             delta' = sum $ for i. BToI $ membership.i /= membership'.i
-             ref := (membership', centroids', delta', i + 1)
-             ()))
-    ()
-  (_, centroids, _, _) = final
+  final = yieldState (initMembership, initCentroids, 0) \ref.
+    while do
+      (membership, centroids, i) = get ref
+      membership' = for i. argminBy (dist points.i) centroids
+      centroids' = centroidsOf points membership'
+      delta = sum $ for i. BToI $ membership.i /= membership'.i
+      ref := (membership', centroids', i + 1)
+      delta > threshold && i < maxIterations
+  (_, centroids, _) = final
   centroids

--- a/benchmarks/rodinia/pathfinder.dx
+++ b/benchmarks/rodinia/pathfinder.dx
@@ -13,7 +13,8 @@ def (-|) (i:n) (off:Int) : n =
     False -> i
 
 def pathfinder (world : rows=>cols=>Int) : cols=>Int =
-  snd $ withState zero $ \costs.
+  yieldState zero $ \costsRef.
     for r.
-      costs := for c. world.r.c + (min (get costs!c) $ (min (get costs!(c -| 1))
-                                                            (get costs!(c +| 1))))
+      costs = get costsRef
+      costsRef := for c. world.r.c + (min costs.c $ (min costs.(c -| 1)
+                                                         costs.(c +| 1)))

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -732,11 +732,15 @@ def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
 '### Reductions
 
+-- `combine` should be a commutative and associative, and form a
+-- commutative monoid with `identity`
 def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
-  -- `combine` should be a commutative and associative, and form a
-  -- commutative monoid with `identity`
-  -- TODO: implement with a parallelizable monoid-parameterized writer
-  fold identity (\i c. combine c xs.i)
+  A = a -- XXX: Typing `Monoid a` below would quantify it over a,
+        --      which we don't want.
+  named-instance reduceMonoid : Monoid A
+    mempty = identity
+    mcombine = combine
+  yieldAccum reduceMonoid \total. for i. total += xs.i
 
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -26,6 +26,7 @@ module Builder (emit, emitTo, emitAnn, emitOp, buildDepEffLam, buildLamAux, buil
                 singletonTypeVal, scopedDecls, builderScoped, extendScope, checkBuilder,
                 builderExtend, applyPreludeFunction,
                 unpackConsList, unpackLeftLeaningConsList,
+                unpackBundle, unpackBundleTab,
                 emitRunWriter, emitRunWriters, mextendForRef, monoidLift,
                 emitRunState, emitMaybeCase, emitWhile, buildDataDef,
                 emitRunReader, tabGet, SubstBuilderT, SubstBuilder, runSubstBuilderT,
@@ -380,6 +381,22 @@ unpackLeftLeaningConsList depth atom = go depth atom []
     go remDepth curAtom xs = do
       (consTail, x) <- fromPair curAtom
       go (remDepth - 1) consTail (x : xs)
+
+unpackBundle :: MonadBuilder m => Atom -> BundleDesc -> m [Atom]
+unpackBundle b size = case size of
+  0 -> return []
+  1 -> return [b]
+  _ -> do
+    (h, t) <- fromPair b
+    (h:) <$> unpackBundle t (size - 1)
+
+unpackBundleTab :: MonadBuilder m => Atom -> BundleDesc -> m [Atom]
+unpackBundleTab tab size = case size of
+  0 -> return []
+  1 -> return [tab]
+  _ -> do
+    (h, t) <- unzipTab tab
+    (h:) <$> unpackBundleTab t (size - 1)
 
 emitWhile :: MonadBuilder m => m Atom -> m ()
 emitWhile body = do

--- a/src/lib/Parallelize.hs
+++ b/src/lib/Parallelize.hs
@@ -82,7 +82,9 @@ parallelTraverseExpr expr = case expr of
     liftM Atom $ emitRunWriter (binderNameHint b) accTy bm \ref@(Var refVar) -> do
       let RefTy h' _ = varType refVar
       modify \accEnv -> accEnv { activeAccs = activeAccs accEnv <> b @> (hName, (refVar, bm)) }
-      extendR (h @> h' <> b @> ref) $ evalBlockE parallelTrav body
+      res <- extendR (h @> h' <> b @> ref) $ evalBlockE parallelTrav body
+      modify \accEnv -> accEnv { activeAccs = activeAccs accEnv `envDiff` (b @> ()) }
+      return res
   -- TODO: Do some alias analysis. This is not fundamentally hard, but it is a little annoying.
   --       We would have to track not only the base references, but also all the aliases, along
   --       with their relationships. Then, when we emit local effects in emitLoops, we would have

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -350,13 +350,13 @@ void dex_cuLaunchKernel(char* kernel_func, int64_t iters, char** args) {
 char* dex_cuMemAlloc(int64_t size) {
   if (size == 0) return nullptr;
   CUdeviceptr ptr;
-  CHECK(cuMemAlloc, &ptr, size);
+  CHECK(cuMemAllocAsync, &ptr, size, CU_STREAM_LEGACY);
   return reinterpret_cast<char*>(ptr);
 }
 
 void dex_cuMemFree(char* ptr) {
   if (!ptr) return;
-  CHECK(cuMemFree, reinterpret_cast<CUdeviceptr>(ptr));
+  CHECK(cuMemFreeAsync, reinterpret_cast<CUdeviceptr>(ptr), CU_STREAM_LEGACY);
 }
 
 void dex_synchronizeCUDA() {


### PR DESCRIPTION
Our benchmark suite has bitrotted over the past few months, and we have regressed the performance a bit too. This bunch of fixes should it bring it up to speed!

#### Update some benchmarks to the latest language version

#### Gather all global destructors in a single global definition

I thought that the "appending" linkage would allow us to define the same
global multiple times, but apparently I was wrong. All destructors but
the first one were droped by LLVM instead when we internalized the
module.


#### Use "bundles" instead of cons lists in parallelization

We always know the length of the cons list statically and the units add
a lot of syntactic noise. To make matters worse, our current
optimizations don't deal with them very well, so removing some cons
lists actually improves performance on certain benchmarks.

This is not the right fix long-term, but it gets us somewhere.

#### Use the new monoid-parameterized accumulator effect to implement reduce

#### Add a missing region substitution in automatic parallelization

#### Improve Imp destination splitting to handle bijective table lambdas 

Automatic parallelization usually flattens the index set of multiple
nested loops and then returns a table lambda that inverts this change in
the rest of the code. Unfortunately, this ended up playing pretty badly
with destination propagation which bailed out whenever it saw a table
lambda. This adds a fallback that checks whether the lambda effectively
implements a bijective type cast and propagates the destination (after
adjusting its type).

#### Add an effect narrowing pass

At the moment we are very imprecise in the effect rows we use to
annotate core lambda expressions and usually just stick the full set of
allowed effects in there without any regard for whether the effects are
actually caused by the body. The new pass narrows those annotations as
much as possible, which can be useful for both inlining and
parallelization decisions.

#### Make copyAtom parallel when using parallel backends

At the moment any copy we emit in Imp results in a nest of sequential
parallel loops which unnecessarily pessimizes the performance of
parallel programs (and generally results in thousands if not millions of
scalar host-device transfers).

#### Use the asynchronous memory management APIs from CUDA 11.2

#### Remove inactive references form parallelization's env

#### Additionally synchronize CUDA before running benchmarks

Just to make sure we don't get any overlap with the warmup iteration.

#### Free result memory after running the benchmarks

Previously we would happily keep leaking, leading to OOMs on a few of
our benchmarks.