### PR TITLE
experiment with highlighting on github

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.dx linguist-language=haskell


### PR DESCRIPTION
By adding this .gitattributes file, we can tell GitHub to highlight .dx files in this repo as any language supported by [github/linguist](https://github.com/githublinguist). [These linguist docs](https://github.com/github/linguist/blob/master/docs/overrides.md#using-gitattributes) explain how it works.

I started with Haskell and [it looks okay](https://github.com/google-research/dex-lang/tree/ea2a92731e9cda94354ce45ce4adb0e667cb913b/examples). Here's an example with GitHub's dark theme:

<img src="https://user-images.githubusercontent.com/1458824/112241115-dcfa0f80-8c06-11eb-97f4-eaf95897d9e1.png" alt="highlighting" width=300>

But maybe misleading highlighting is worse than no highlighting, and we should just close this PR? Thoughts? Has this been discussed already?

Once there are 200+ unique `:user/:repo` repositories using Dex [we can add our own highlighting definitions to Linguist](https://github.com/github/linguist/blob/master/CONTRIBUTING.md#adding-a-language).