### PR TITLE
Query for GPU architecture before CUDA compilation

### DIFF
--- a/src/lib/CUDA.hs
+++ b/src/lib/CUDA.hs
@@ -1,8 +1,12 @@
 
-module CUDA (hasCUDA, loadCUDAArray, synchronizeCUDA) where
+module CUDA (hasCUDA, loadCUDAArray, synchronizeCUDA, getCudaArchitecture) where
 
 import Data.Int
 import Foreign.Ptr
+#ifdef DEX_CUDA
+import Foreign.C
+#else
+#endif
 
 hasCUDA :: Bool
 
@@ -11,6 +15,12 @@ hasCUDA = True
 
 foreign import ccall "dex_cuMemcpyDtoH"    cuMemcpyDToH    :: Int64 -> Ptr () -> Ptr () -> IO ()
 foreign import ccall "dex_synchronizeCUDA" synchronizeCUDA :: IO ()
+foreign import ccall "dex_get_cuda_architecture" dex_getCudaArchitecture :: Int -> CString -> IO ()
+
+getCudaArchitecture :: Int -> IO String
+getCudaArchitecture dev = 
+  withCString "sm_00" $ \cs ->
+      dex_getCudaArchitecture dev cs >> peekCString cs
 #else
 hasCUDA = False
 
@@ -19,6 +29,9 @@ cuMemcpyDToH = error "Dex built without CUDA support"
 
 synchronizeCUDA :: IO ()
 synchronizeCUDA = return ()
+
+getCudaArchitecture :: Int -> IO String
+getCudaArchitecture _ = error "Dex built without CUDA support"
 #endif
 
 loadCUDAArray :: Ptr () -> Ptr () -> Int -> IO ()

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -40,6 +40,7 @@ import GHC.Stack
 import qualified Data.Set as S
 import qualified Data.Text as T
 
+import CUDA (getCudaArchitecture)
 import Syntax
 import Env
 import PPrint
@@ -121,7 +122,8 @@ compileFunction logger fun@(ImpFunction f bs body) = case cc of
     return ([L.GlobalDefinition mainFun, outputStreamPtrDef], extraSpecs, [])
     where attrs = [L.NoAlias, L.NoCapture, L.NonNull]
   CUDAKernelLaunch -> do
-    (CUDAKernel kernelText) <- compileCUDAKernel logger $ impKernelToLLVMGPU fun
+    arch <- getCudaArchitecture 0
+    (CUDAKernel kernelText) <- compileCUDAKernel logger (impKernelToLLVMGPU fun) arch
     let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) (B.unpack kernelText) ++ [0]
     let textArr = C.Array i8 chars
     let textArrTy = L.typeOf textArr

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -346,8 +346,8 @@ linkDexrt m = do
 
 data LLVMKernel = LLVMKernel L.Module
 
-compileCUDAKernel :: Logger [Output] -> LLVMKernel -> IO CUDAKernel
-compileCUDAKernel logger (LLVMKernel ast) = do
+compileCUDAKernel :: Logger [Output] -> LLVMKernel -> String -> IO CUDAKernel
+compileCUDAKernel logger (LLVMKernel ast) arch = do
   T.initializeAllTargets
   withContext \ctx ->
     Mod.withModuleFromAST ctx ast \m -> do
@@ -373,7 +373,6 @@ compileCUDAKernel logger (LLVMKernel ast) = do
           else return $ CUDAKernel ptx
   where
     ptxasPath = "/usr/local/cuda/bin/ptxas"
-    arch = "sm_60"
 
 {-# NOINLINE libdevice #-}
 libdevice :: L.Module

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -380,6 +380,20 @@ void dex_ensure_has_cuda_context() {
   }
 }
 
+void dex_get_cuda_architecture(int device, char* arch) {
+  int majorVersion, minorVersion;
+  cuInit(0);
+  CUdevice dev;
+  CHECK(cuDeviceGet, &dev, device);
+  cuDeviceGetAttribute(&majorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
+  cuDeviceGetAttribute(&minorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
+  if (majorVersion > 9 || majorVersion < 0 || minorVersion > 9 || minorVersion < 0) {
+    printf("Invalid CUDA architecture version: %d.%d", majorVersion, minorVersion);
+    std::abort();
+  }
+  snprintf(arch, 5, "sm_%d%d", majorVersion, minorVersion);
+}
+
 #undef CHECK
 
 #endif // DEX_CUDA


### PR DESCRIPTION
This change uses a CUDA query to get the architecture instead of using a hardcoded one. I wasn't sure of the best place to put the call to CUDA (it requires a `cuInit`) so we should definitely iterate on this to find the best solution.