### PR TITLE
Center main output section in dex-web

### DIFF
--- a/static/style.css
+++ b/static/style.css
@@ -44,6 +44,7 @@ nav ol {
 
 #main-output {
   max-width: var(--main-width);
+  margin: auto;
 }
 
 .cell {


### PR DESCRIPTION
Follow up from #400.
I am not good at CSS
But this is better than the CSS in #400 

### Before
<img width="2070" alt="image" src="https://user-images.githubusercontent.com/5127634/118376115-f2b00380-b5bd-11eb-8230-7e0218895b02.png">

### After
<img width="2070" alt="image" src="https://user-images.githubusercontent.com/5127634/118376110-e88e0500-b5bd-11eb-8d61-f7886ba1d3a2.png">
