### PR TITLE
Link to HTML for tutorial in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ processing. The goal of the project is to explore:
 
 To learn more, check out our
 [workshop paper](https://openreview.net/pdf?id=rJxd7vsWPS),
-our [tutorial](https://github.com/google-research/dex-lang/blob/main/examples/tutorial.dx)
+our [tutorial](https://google-research.github.io/dex-lang/examples/tutorial.html)
 or these example programs:
 
   * [Dex prelude](https://google-research.github.io/dex-lang/prelude.html)


### PR DESCRIPTION
The HTML is better for a tutorial.

(other than https://github.com/google-research/dex-lang/issues/534)