### PR TITLE
Fix examples/nn.dx by fixing `grad maximum` and import statement.

### DIFF
--- a/examples/nn.dx
+++ b/examples/nn.dx
@@ -1,6 +1,6 @@
 ' # Neural Networks
 
-include "plot.dx"
+import plot
 
 ' ## NN Prelude
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -744,12 +744,8 @@ def reindex (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 -- `combine` should be a commutative and associative, and form a
 -- commutative monoid with `identity`
 def reduce (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
-  A = a -- XXX: Typing `Monoid a` below would quantify it over a,
-        --      which we don't want.
-  named-instance reduceMonoid : Monoid A
-    mempty = identity
-    mcombine = combine
-  yieldAccum reduceMonoid \total. for i. total += xs.i
+  -- TODO: implement with the accumulator effect
+  fold identity (\i c. combine c xs.i)
 
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)


### PR DESCRIPTION
Fixed `grad maximum` by reverting `reduce` to no longer use
`yieldAccum`. Reduce can be implemented with the accumulation effect,
but AD does not currently support this effect for reductions other than
add.

Also fixes the include statement to use import instead.

Fixes #542 