### PR TITLE
Add special case to fix plot errors for constant matrices.

### DIFF
--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -121,6 +121,9 @@ def yPlot (ys:n=>Float) : Plot n Float Float Unit =
 def matshow (img:n=>m=>Float) : Html =
   low  = minimum  $ for (i,j). img.i.j
   high = maximum $ for (i,j). img.i.j
+  range = high - low
   imgToHtml $ makePNG for i j.
-    x = floatTo8Bit $ (img.i.j - low) / (high - low)
+    x = if range == 0.0
+      then floatTo8Bit $ 0.5
+      else floatTo8Bit $ (img.i.j - low) / range
     [x, x, x]


### PR DESCRIPTION
Currently, when a constant matrix is passed to matshow, it sometimes displays non-constant output, and uses colors even though it should be grayscale (screenshot from the tutorial below). This is likely due to the division by zero, which may result in undesired behavior when converting to 8 bit.

This PR checks for the 0 range case explicitly, and sets all pixels to the middle color if this is the case.

Example of erroneous plotting:
\
\
![f7c9cdSjqHPmick](https://user-images.githubusercontent.com/7674950/122374592-685f1480-cf5a-11eb-8e11-a7ce9c9e89f8.png)
