### PR TITLE
Add instances for Add, Mul, and VSpace of functions.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -152,6 +152,11 @@ instance Add Unit
   sub = \x y. ()
   zero = ()
 
+instance [Add a] Add (n->a)
+  add = \f g. \x. (f x) + (g x)
+  sub = \f g. \x. (f x) - (g x)
+  zero = \x. zero
+
 '#### Mul
 Things that can be multiplied.
 This defines the `Mul` [Monoid](https://en.wikipedia.org/wiki/Monoid), and its operator.
@@ -185,6 +190,10 @@ instance Mul Word8
 instance Mul Unit
   mul = \x y. ()
   one = ()
+
+instance [Mul a] Mul (n->a)
+  mul = \f g. \x. (f x) * (g x)
+  one = \x. one
 
 '#### Integral
 Integer-like things.
@@ -347,6 +356,9 @@ instance VSpace Float
 
 instance {a n} [VSpace a] VSpace (n=>a)
   scaleVec = \s xs. for i. s .* xs.i
+
+instance [VSpace a] VSpace (n->a)
+  scaleVec = \s f. \x. s .* (f x)
 
 instance VSpace Unit
   scaleVec = \_ _. ()
@@ -1714,6 +1726,9 @@ Type class for generating example values
 
 interface Arbitrary a
   arb : Key -> a
+
+instance Arbitrary Bool
+  arb = \key. rand key < 0.5
 
 instance Arbitrary Float32
   arb = randn

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -433,3 +433,16 @@ def q (n : Int) : (Fin n)=>Int =
 
 q 5
 > [0, 2, 4, 6, 8]
+
+'### Tests for function VSpace
+
+:p (sin + cos) 5.0 ~~ (\x. sin x + cos x) 5.0
+> True
+:p (sin * cos) 5.0 ~~ (\x. sin x * cos x) 5.0
+> True
+:p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
+> True
+
+xbool : Bool = arb $ newKey 0
+:p xbool
+> True


### PR DESCRIPTION
I'm using these for the SDE demo, where I add and scale drift functions.  I also like the idea of maintaining the analogy between tables and functions as closely as possible.

Pleasingly, these instances also work for functions of multiple arguments.

Also added an instance of `Arb` for `Bool`.
