### PR TITLE
Moved linear algebra from examples to lib, and split out linalg tests.

### DIFF
--- a/examples/linear_algebra.dx
+++ b/examples/linear_algebra.dx
@@ -1,7 +1,5 @@
 '## LU Decomposition and Matrix Inversion
 
-def identity_matrix [Eq n, Add a, Mul a] : n=>n=>a =
-  for i j. select (i == j) one zero
 
 '### Triangular matrices
 
@@ -54,8 +52,8 @@ def swapInPlace (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
   permRef!i := tempj
   signRef := -(get signRef)
 
-def perToTable ((perm, _):Permutation n) : n=>n = perm
-def permSign   ((_, sign):Permutation n) : PermutationSign = sign
+def permToTable ((perm, _):Permutation n) : n=>n = perm
+def permSign    ((_, sign):Permutation n) : PermutationSign = sign
 
 
 
@@ -80,7 +78,7 @@ def lu [Eq n] (a: n=>n=>Float) :
 
   init_lower = for i:n. for j':(..i).
     select (i == (%inject j')) 1.0 0.0
-  init_upper = for i:n. for j'':(i..). 0.0
+  init_upper = zero
 
   (lower, upper) = yieldState (init_lower, init_upper) \stateRef.
     lRef = fstRef stateRef
@@ -146,7 +144,7 @@ def solve [Eq n, VSpace v] (a:n=>n=>Float) (b:n=>v) : n=>v =
   backward_substitute u y
 
 def invert [Eq n] (a:n=>n=>Float) : n=>n=>Float =
-  solve a identity_matrix
+  solve a eye
 
 def determinant [Eq n] (a:n=>n=>Float) : Float =
   (l, u, perm) = lu a

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -157,20 +157,3 @@ def sign_and_log_determinant [Eq n] (a:n=>n=>Float) : (Float & Float) =
   sum_of_log_abs = sum for i. log (abs diags.i)
   (sign, sum_of_log_abs)
 
-
-'### Numerical Tests
-
--- Check that the inverse of the inverse is identity.
-mat = [[11.,9.,24.,2.],[1.,5.,2.,6.],[3.,17.,18.,1.],[2.,5.,7.,1.]]
-:p mat ~~ (invert (invert mat))
-> True
-
--- Check that solving gives the inverse.
-v = [1., 2., 3., 4.]
-:p v ~~ (mat **. (solve mat v))
-> True
-
--- Check that det and exp(logdet) are the same.
-(s, logdet) = sign_and_log_determinant mat
-:p (determinant mat) ~~ (s * (exp logdet))
-> True

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -91,6 +91,16 @@ instance [Add a] Add (n=>a)
   sub = \xs ys. for i. xs.i - ys.i
   zero = for _. zero
 
+instance [Add a] Add (i:n => (i..) => a)  -- Upper triangular tables
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance [Add a] Add (i:n => (..i) => a)  -- Lower triangular tables
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
 '#### Mul
 Things that can be multiplied.
 This defines the `Mul` [Monoid](https://en.wikipedia.org/wiki/Monoid), and its operator.

--- a/makefile
+++ b/makefile
@@ -106,7 +106,8 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              shadow-tests monad-tests io-tests exception-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
-             record-variant-tests typeclass-tests complex-tests trig-tests
+             record-variant-tests typeclass-tests complex-tests trig-tests \
+             linalg-tests
 
 lib-names = diagram plot png
 

--- a/makefile
+++ b/makefile
@@ -99,7 +99,7 @@ dexrt-llvm: src/lib/dexrt.bc
 example-names = mandelbrot pi sierpinski rejection-sampler \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator mcmc ctc raytrace particle-filter \
-                isomorphisms ode-integrator linear_algebra fluidsim \
+                isomorphisms ode-integrator fluidsim \
                 sgd chol fft tutorial vega-plotting kernelregression \
                 quaternions
 

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -1,0 +1,16 @@
+import linalg
+
+-- Check that the inverse of the inverse is identity.
+mat = [[11.,9.,24.,2.],[1.,5.,2.,6.],[3.,17.,18.,1.],[2.,5.,7.,1.]]
+:p mat ~~ (invert (invert mat))
+> True
+
+-- Check that solving gives the inverse.
+v = [1., 2., 3., 4.]
+:p v ~~ (mat **. (solve mat v))
+> True
+
+-- Check that det and exp(logdet) are the same.
+(s, logdet) = sign_and_log_determinant mat
+:p (determinant mat) ~~ (s * (exp logdet))
+> True


### PR DESCRIPTION
I'm not sure if prelude should `import linalg`, but thought that linear algebra makes more sense in `lib` than `examples`. 

I also added `Add` instances for triangular tables.  Before I add any more, I wanted to check if there's a general way to specify instances for tables with dependent index types.