### PR TITLE
Add monoidal merge sort

### DIFF
--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -1,0 +1,60 @@
+'## Monoidal Merge Sort
+Because merging sorted lists is associative, we can expose the
+parallelism of merge sort to the Dex compiler by making a monoid
+and using reduce or yieldAccum.
+However, this approach puts a lot of pressure on the compiler.
+As noted on [StackOverflow](https://stackoverflow.com/questions/21877572/can-you-formulate-the-bubble-sort-as-a-monoid-or-semigroup),
+if the compiler does the reduction one element at a time,
+it's doing bubble / insertion sort with quadratic time cost.
+However, if breaks the list in half recursively, it'll be doing parallel mergesort.
+
+
+def concatTable (leftin: a=>v) (rightin: b=>v) : ({left:a | right:b }=>v) =
+  -- Note: It'd be nicer to use (a | b)=>v but it's not currently supported.
+  for idx. case idx of
+    {| left = i  |} -> leftin.i
+    {| right = i |} -> rightin.i
+
+def mergeTables [Ord a] (xs:m=>a) (ys:n=>a) : ({left:m | right:n }=>a) =
+  -- Possible improvements:
+  --  1) Using a SortedTable type.
+  --  2) Avoid initializing the return array.
+  init = concatTable xs ys
+  yieldState init \buf.
+    withState (0, 0) \countrefs.
+      for i.
+        (cur_x, cur_y) = get countrefs
+        noYsLeft = cur_y >= size n
+        stillXsLeft = cur_x < size m
+        cur_x_at_n = (unsafeFromOrdinal _ cur_x)
+        cur_y_at_n = (unsafeFromOrdinal _ cur_y)
+        xIsLess = xs.cur_x_at_n < ys.cur_y_at_n
+        if noYsLeft || (stillXsLeft && xIsLess)
+          then
+            countrefs := (cur_x + 1, cur_y)
+            buf!i := xs.cur_x_at_n
+          else
+            countrefs := (cur_x, cur_y + 1)
+            buf!i := ys.cur_y_at_n
+
+def mergeSortedLists [Ord a] (AsList nx xs: List a) (AsList ny ys: List a) : List a =
+  -- Need this wrapper because Dex can't automatically weaken
+  -- (a | b)=>c to ((Fin d)=>c)
+  sorted = mergeTables xs ys
+  newsize = (Fin (nx + ny)) 
+  AsList _ $ unsafeCastTable newsize sorted
+
+def sort [Ord a] (xs: n=>a) : n=>a =
+  xlists = for i:n. (AsList 1 [xs.i])
+  -- Merge sort monoid
+  mempty = AsList 0 []
+  mcombine = mergeSortedLists
+  (AsList _ r) = reduce mempty mcombine xlists
+  unsafeCastTable n r
+
+def (+|) (i:n) (delta:Int) : n =
+  i' = ordinal i + delta
+  fromOrdinal _ $ select (i' >= size n) (size n - 1) i'
+
+def isSorted [Ord a] (xs:n=>a) : Bool =
+  all for i. xs.i <= xs.(i +| 1)

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -1,4 +1,5 @@
 '## Monoidal Merge Sort
+Warning: Very slow for now!!
 Because merging sorted lists is associative, we can expose the
 parallelism of merge sort to the Dex compiler by making a monoid
 and using reduce or yieldAccum.
@@ -7,7 +8,7 @@ As noted on [StackOverflow](https://stackoverflow.com/questions/21877572/can-you
 if the compiler does the reduction one element at a time,
 it's doing bubble / insertion sort with quadratic time cost.
 However, if breaks the list in half recursively, it'll be doing parallel mergesort.
-
+Currently it'll do the quadratic time version.
 
 def concatTable (leftin: a=>v) (rightin: b=>v) : ({left:a | right:b }=>v) =
   -- Note: It'd be nicer to use (a | b)=>v but it's not currently supported.
@@ -15,7 +16,7 @@ def concatTable (leftin: a=>v) (rightin: b=>v) : ({left:a | right:b }=>v) =
     {| left = i  |} -> leftin.i
     {| right = i |} -> rightin.i
 
-def mergeTables [Ord a] (xs:m=>a) (ys:n=>a) : ({left:m | right:n }=>a) =
+def mergeSortedTables [Ord a] (xs:m=>a) (ys:n=>a) : ({left:m | right:n }=>a) =
   -- Possible improvements:
   --  1) Using a SortedTable type.
   --  2) Avoid initializing the return array.
@@ -40,15 +41,20 @@ def mergeTables [Ord a] (xs:m=>a) (ys:n=>a) : ({left:m | right:n }=>a) =
 def mergeSortedLists [Ord a] (AsList nx xs: List a) (AsList ny ys: List a) : List a =
   -- Need this wrapper because Dex can't automatically weaken
   -- (a | b)=>c to ((Fin d)=>c)
-  sorted = mergeTables xs ys
+  sorted = mergeSortedTables xs ys
   newsize = (Fin (nx + ny)) 
   AsList _ $ unsafeCastTable newsize sorted
 
 def sort [Ord a] (xs: n=>a) : n=>a =
+  -- Warning: Has quadratic runtime cost for now.
+
   xlists = for i:n. (AsList 1 [xs.i])
-  -- Merge sort monoid
+
+  -- Merge sort monoid:
   mempty = AsList 0 []
   mcombine = mergeSortedLists
+
+  -- reduce might someday recursively subdivide the problem.
   (AsList _ r) = reduce mempty mcombine xlists
   unsafeCastTable n r
 

--- a/makefile
+++ b/makefile
@@ -104,7 +104,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 quaternions
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
-             shadow-tests monad-tests io-tests exception-tests \
+             shadow-tests monad-tests io-tests exception-tests sort-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests
 

--- a/tests/sort-tests.dx
+++ b/tests/sort-tests.dx
@@ -1,0 +1,6 @@
+import sort
+
+:p isSorted $ sort []:((Fin 0)=>Int)
+> True
+:p isSorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
+> True


### PR DESCRIPTION
While thinking about how to fix the [quicksort demo](https://github.com/google-research/dex-lang/pull/297) to expose its parallelism to the compiler, I found out that merging sorted lists is associative.  So it's easy to expose the parallelism of merge sort to the Dex compiler by making a monoid and using reduce or yieldAccum.

This approach puts a lot of pressure on the compiler, but would make a great demonstration of the power of `Accum` if it can be made to work robustly.
As noted on [StackOverflow](https://stackoverflow.com/questions/21877572/can-you-formulate-the-bubble-sort-as-a-monoid-or-semigroup), if the compiler does the reduction one element at a time, it's doing bubble / insertion sort with quadratic time cost.  However, if breaks the list in half recursively, it'll be doing parallel mergesort.

I also won't be offended if this isn't put into `lib`, but I know @srush had asked for a sort function at one point, although I think he was able to work around it.
