### PR TITLE
Added fast generic integer power routine, and moved utilities to prelude.

### DIFF
--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -6,47 +6,7 @@ For non-power-of-2 sized arrays, it uses
 which calls the power-of-2 FFT as a subroutine.
 
 
-'## General helper functions
-
-def isPowerOf2 (x:Int) : Bool =
-  -- A fast trick based on bitwise AND.
-  -- Note: The bitwise and operator (.&.)
-  -- is only defined for Byte, which is why
-  -- I use %and here.
-  -- A test below verifies that this works on
-  -- more than 8 bit integers.
-  -- TODO: Make (.&.) polymorphic.
-  if x == 0
-    then False
-    else 0 == %and x (x - 1)
-
-def intpow [Mul a] (base:a) (power:Int) : a =
-  -- Todo: Use Knuth's power trick,
-  -- which can give an asymptotic speedup.
-  reduce one (*) (for a:(Fin power). base)
-
-def intlog2 (x:Int) : Int =
-  yieldState (-1) \ansRef.
-    runState 1 \cmpRef.
-      while do
-        if x >= (get cmpRef)
-          then 
-            ansRef := (get ansRef) + 1
-            cmpRef := %shl (get cmpRef) 1
-            True
-          else
-            False
-
-def intpow2 (power:Int) : Int = %shl 1 power
-
-def nextpow2 (x:Int) : Int = case isPowerOf2 x of
-  True -> x
-  False -> intpow2 (1 + intlog2 x)
-
-def reflect (i:n) : n =
-  unsafeFromOrdinal n ((size n) - 1 - ordinal i)
-
-def listToTable ((AsList n xs): List a) : (Fin n)=>a = xs
+'### Helper functions
 
 def odd_sized_palindrome (mid:a) (seq:n=>a) :
   ({backward:n | mid:Unit | zforward:n}=>a) =  -- Alphabetical order matters here.
@@ -145,8 +105,8 @@ def fft (x: n=>Complex): n=>Complex =
         i_squared = IToF $ sq $ ordinal i
         exp $ (-im) * (MkComplex (pi * i_squared / (IToF (size n))) 0.0)
 
-      tailList = tail wks 1
-      back_and_forth = odd_sized_palindrome (head wks) (listToTable tailList)
+      (AsList _ tailTable) = tail wks 1
+      back_and_forth = odd_sized_palindrome (head wks) tailTable
       xq = for i. x.i * wks.i
       back_and_forth_conj = for i. complex_conj back_and_forth.i
       convolution = convolve_complex xq back_and_forth_conj
@@ -188,32 +148,3 @@ b = for i:(Fin 20) j:(Fin 70).
 > True
 :p b ~~ (fft2 $ ifft2 b)
 > True
-
--- Integer utility tests
-
-:p map isPowerOf2 [0, 1, 2, 3, 256, 1024, 1024*1024, 1024*1024 + 1]
-> [False, True, True, False, True, True, True, False]
-
-:p intpow 0 0
-> 1
-
-:p intpow 0 1
-> 0
-
-:p intpow 1 0
-> 1
-
-:p intpow 1 1
-> 1
-
-:p intpow 2 1
-> 2
-
-:p intpow 2 3
-> 8
-
-:p map intlog2 [-1, 0, 1, 2, 3, 4, 5, 1023, 1024, 1025]
-> [-1, -1, 0, 1, 1, 2, 2, 9, 10, 10]
-
-:p map nextpow2 [-1, 0, 1, 2, 3, 4, 7, 8, 9, 1023, 1024, 1025]
-> [1, 1, 1, 2, 4, 4, 8, 8, 16, 1024, 1024, 2048]

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -157,3 +157,8 @@ def sign_and_log_determinant [Eq n] (a:n=>n=>Float) : (Float & Float) =
   sum_of_log_abs = sum for i. log (abs diags.i)
   (sign, sum_of_log_abs)
 
+def matrix_power [Eq n] (base:n=>n=>Float) (power:Int) : n=>n=>Float =
+  generalIntegerPower (**) eye base power
+
+def trace [Add a] (x:n=>n=>a) : a =
+  sum for i. x.i.i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1772,9 +1772,11 @@ def (.&.) (x:Byte) (y:Byte) : Byte = %and x y
 '## Miscellaneous utilities
 TODO: all of these should be in some other section
 
+def reflect (i:n) : n =
+  unsafeFromOrdinal n ((size n) - 1 - ordinal i)
+
 def reverse (x:n=>a) : n=>a =
-  s = size n
-  for i. x.((s - 1 - ordinal i)@_)
+  for i. x.(reflect i)
 
 def padTo (m:Type) (x:a) (xs:n=>a) : (m=>a) =
   n' = size n
@@ -1785,6 +1787,57 @@ def padTo (m:Type) (x:a) (xs:n=>a) : (m=>a) =
       False -> x
 
 def idivCeil (x:Int) (y:Int) : Int = idiv x y + BToI (rem x y /= 0)
+def intdiv2 (x:Int) : Int = %shr x 1
+def intpow2 (power:Int) : Int = %shl 1 power
+def isOdd  (x:Int) : Bool = rem x 2 == 1
+def isEven (x:Int) : Bool = rem x 2 == 0
+
+def isPowerOf2 (x:Int) : Bool =
+  -- A fast trick based on bitwise AND.
+  -- This works on integer types larger than 8 bits.
+  -- Note: The bitwise and operator (.&.)
+  -- is only defined for Byte, which is why
+  -- we use %and here. TODO: Make (.&.) polymorphic.
+  if x == 0
+    then False
+    else 0 == %and x (x - 1)
+
+def intlog2 (x:Int) : Int =
+  yieldState (-1) \ansRef.
+    runState 1 \cmpRef.
+      while do
+        if x >= (get cmpRef)
+          then
+            ansRef := (get ansRef) + 1
+            cmpRef := %shl (get cmpRef) 1
+            True
+          else
+            False
+
+def nextpow2 (x:Int) : Int = case isPowerOf2 x of
+  True -> x
+  False -> intpow2 (1 + intlog2 x)
+
+def generalIntegerPower (times:a->a->a) (one:a) (base:a) (power:Int) : a =
+  -- Implements exponentiation by squaring.
+  -- Todo: Make power a Nat when it's available.
+  -- This could be nicer if there were a way to explicitly
+  -- specify which typelcass instance to use for Mul.
+  yieldState one \ans.
+    withState power \pow. withState base \z.
+      while do
+        if get pow > 0
+          then
+            if isOdd (get pow)
+              then ans := times (get ans) (get z)
+            z := times (get z) (get z)
+            pow := intdiv2 (get pow)
+            True
+          else
+            False
+
+def intpow [Mul a] (base:a) (power:Int) : a =
+  generalIntegerPower (*) one base power
 
 def fromJust (x:Maybe a) : a = case x of Just x' -> x'
 

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -835,6 +835,37 @@ def f5 (x:Int) : Int = f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ x
 @noinline
 def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 
+-- Testing integer powers
+
+:p intpow 10 2
+> 100
+:p intpow 0 0
+> 1
+:p intpow 0 1
+> 0
+:p intpow 1 0
+> 1
+:p intpow 1 1
+> 1
+:p intpow 2 1
+> 2
+:p intpow 2 3
+> 8
+:p intpow 2 17
+> 131072
+
+-- Integer utility tests
+
+:p map isPowerOf2 [0, 1, 2, 3, 256, 1024, 1024*1024, 1024*1024 + 1]
+> [False, True, True, False, True, True, True, False]
+
+:p map intlog2 [-1, 0, 1, 2, 3, 4, 5, 1023, 1024, 1025]
+> [-1, -1, 0, 1, 1, 2, 2, 9, 10, 10]
+
+:p map nextpow2 [-1, 0, 1, 2, 3, 4, 7, 8, 9, 1023, 1024, 1025]
+> [1, 1, 1, 2, 4, 4, 8, 8, 16, 1024, 1024, 2048]
+
+
 -- This will compile extremely slowly if non-inlining is broken
 :p f6 0
 > 100000

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -14,3 +14,16 @@ v = [1., 2., 3., 4.]
 (s, logdet) = sign_and_log_determinant mat
 :p (determinant mat) ~~ (s * (exp logdet))
 > True
+
+-- Matrix integer powers.
+:p matrix_power mat 0 ~~ eye
+> True
+:p matrix_power mat 1 ~~ mat
+> True
+:p matrix_power mat 2 ~~ (mat ** mat)
+> True
+:p matrix_power mat 5 ~~ (mat ** mat ** mat ** mat ** mat)
+> True
+
+:p trace mat == (11. + 5. + 18. + 1.)
+> True


### PR DESCRIPTION
Added `matrix_power` and `trace` to the linear algebra library.

I also re-used the matrix power code for fast integer powers in the FFT demo, and moved most of its one-liner utilities to the prelude.

Let me know if I'm adding too many small routines to the prelude.
