### PR TITLE
Add pair result types to export

### DIFF
--- a/python/tests/jit_test.py
+++ b/python/tests/jit_test.py
@@ -72,6 +72,19 @@ class JITTest(unittest.TestCase):
                [(np.arange(a*b, dtype=np.float32).reshape((a, b)),)
                 for a, b in it.product((2, 5, 10), repeat=2)])
 
+  def test_tuple_return(self):
+    dex_func = dex.eval(r"\x: ((Fin 10) => Float). (x, 2. .* x, 3. .* x)")
+    reference = lambda x: (x, 2 * x, 3 * x)
+    
+    x = np.arange(10, dtype=np.float32)
+
+    dex_output = dex_func.compile()(x)
+    reference_output = reference(x)
+
+    self.assertEqual(len(dex_output), len(reference_output))
+    for dex_array, ref_array in zip(dex_output, reference_output):
+      np.testing.assert_allclose(dex_array, ref_array)
+
 
 if __name__ == "__main__":
   unittest.main()

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -143,7 +143,7 @@ prepareFunctionForExport env nameStr func = do
           elemTy' <- substBuilder (b@>Var i) elemTy
           createDest (idx <> Nest (Bind i) Empty) elemTy'
         return (Con $ TabRef destTab, exportResult)
-      PairTy a b -> do
+      PairTy a b | idx == Empty -> do
         (atom_a, res_a) <- createDest idx a
         (atom_b, res_b) <- createDest idx b
         return (Con $ ConRef $ PairCon atom_a atom_b, ExportPairResult res_a res_b)

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -143,6 +143,10 @@ prepareFunctionForExport env nameStr func = do
           elemTy' <- substBuilder (b@>Var i) elemTy
           createDest (idx <> Nest (Bind i) Empty) elemTy'
         return (Con $ TabRef destTab, exportResult)
+      PairTy a b -> do
+        (atom_a, res_a) <- createDest idx a
+        (atom_b, res_b) <- createDest idx b
+        return (Con $ ConRef $ PairCon atom_a atom_b, ExportPairResult res_a res_b)
       _ -> unsupported
       where unsupported = error $ "Unsupported result type: " ++ pprint ty
 
@@ -174,6 +178,7 @@ data ExportArg = ExportArrayArg  ArgVisibility Name ExportArrayType
                | ExportScalarArg ArgVisibility Name ScalarBaseType
 data ExportResult = ExportArrayResult     Name ExportArrayType
                   | ExportScalarResultPtr Name ScalarBaseType
+                  | ExportPairResult      ExportResult ExportResult
 data ExportedSignature =
   ExportedSignature { exportedArgSig   :: [ExportArg]
                     , exportedResSig   :: ExportResult
@@ -222,5 +227,9 @@ instance Show ExportArg where
 
 instance Show ExportResult where
   show res = case res of
-    ExportArrayResult     name ty  -> showCArgName name <> ":" <> show ty
-    ExportScalarResultPtr name sbt -> showCArgName name <> ":" <> showExportSBT sbt
+    ExportArrayResult     name ty    -> showCArgName name <> ":" <> show ty
+    ExportScalarResultPtr name sbt   -> showCArgName name <> ":" <> showExportSBT sbt
+    -- Nested pairs / tuples are compiled down to a sequence of separate output
+    -- arguments, so a pair result is serialized to look like two separate
+    -- results.
+    ExportPairResult      left right -> show left <> "," <> show right


### PR DESCRIPTION
Small patch to add pair types to the function signature exporter. 

All the other pieces to translate tuple return types to Python were already in place.