### PR TITLE
Fix differentiation of reference indexing

### DIFF
--- a/src/lib/Env.hs
+++ b/src/lib/Env.hs
@@ -165,6 +165,7 @@ isGlobal :: VarP ann -> Bool
 isGlobal (GlobalName _ :> _) = True
 isGlobal (GlobalArrayName _ :> _) = True
 isGlobal (Name TypeClassGenName _ _ :> _) = True
+isGlobal (Name CArgName _ _ :> _) = True
 isGlobal _ = False
 
 isGlobalBinder :: BinderP ann -> Bool

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -113,7 +113,7 @@ prepareFunctionForExport env nameStr func = do
     createTabArg vis idx ty = case ty of
       BaseTy bt@(Scalar sbt) -> do
         ~v@(Var (name:>_)) <- newCVar (ptrTy bt)
-        destAtom <- ptrLoad =<< applyIdxs v idx
+        destAtom <- unsafePtrLoad =<< applyIdxs v idx
         funcArgScope <- looks cargScope
         let exportArg = ExportArrayArg vis name $ case getRectShape funcArgScope idx of
               Just rectShape -> RectContArrayPtr sbt rectShape

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -303,3 +303,13 @@ vec = [1.]
     c
   checkDeriv f 1.0
 > True
+
+-- Test reference indexing
+:p
+  f = \x.
+    i = unsafeFromOrdinal (Fin 3) 0
+    mat = yieldState zero \m. m!i!i := x
+    mat.i.i
+
+  checkDeriv f 1.0
+> True


### PR DESCRIPTION
Reference indexing is particularly funny from the point of view of AD in
that it returns references which can be active, but don't have valid
tangent types. They're also the only operation that consumes a
reference, but doesn't induce any effect.