### PR TITLE
Implement some prelude functions in Builder to avoid depending on the prelude

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1350,20 +1350,6 @@ def iter (body: Int -> {|eff} IterResult a) : {|eff} a  =
     Just ans -> ans
     Nothing -> unreachable ()
 
--- XXX: used internally by compiler for exceptional while
-def whileMaybe (eff:Effects) -> (body: Unit -> {|eff} (Maybe Word8)) : {|eff} Maybe Unit =
-  hadError = yieldState False \ref.
-    while do
-      ans = liftState ref body ()
-      case ans of
-        Nothing ->
-          ref := True
-          False
-        Just cond -> W8ToB cond
-  if hadError
-    then Nothing
-    else Just ()
-
 def boundedIter (maxIters:Int) (fallback:a)
   (body: Int -> {|eff} IterResult a) : {|eff} a  =
   iter \i.
@@ -1917,7 +1903,6 @@ def fromJust (x:Maybe a) : a = case x of Just x' -> x'
 
 def anySat (f:a -> Bool) (xs:n=>a) : Bool = any (map f xs)
 
--- XXX: we use this internally so it's important to make the type args explicit
 def seqMaybes (n:Type) ?-> (a:Type) ?-> (xs : n=>Maybe a) : Maybe (n => a) =
   -- is it possible to implement this safely? (i.e. without using partial
   -- functions)
@@ -2012,8 +1997,13 @@ def dex_test_mode (():Unit) : Bool = unsafeIO do checkEnv "DEX_TEST_MODE"
 '## Exception effect
 TODO: move `error` and `todo` to here.
 
+def internalMaybeToMaybe (maybeVal: {a:Unit|b:a}) : Maybe a =
+  case maybeVal of
+    {|a=() |} -> Nothing
+    {|b=val|} -> Just val
+
 def catch (f:Unit -> {Except|eff} a) : {|eff} Maybe a =
-  %catchException f
+  internalMaybeToMaybe (%catchException f)
 
 def throw (_:Unit) : {Except} a =
   %throwException a

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -330,8 +330,12 @@ toImpOp (maybeDest, op) = case op of
     (Con (SumAsProd _ tag _)) -> returnVal tag
     (DataCon _ _ i _) -> returnVal $ TagRepVal $ fromIntegral i
     _ -> error $ "Not a data constructor: " ++ pprint con
-  ToEnum ~ty@(TypeCon (DataDef _ _ cons) _) i ->
-    returnVal $ Con $ SumAsProd ty i (map (const []) cons)
+  ToEnum ty i -> case ty of
+    TypeCon (DataDef _ _ cons) _ ->
+      returnVal $ Con $ SumAsProd ty i (map (const []) cons)
+    VariantTy (NoExt labeledItems) ->
+      returnVal $ Con $ SumAsProd ty i (map (const [UnitVal]) $ toList labeledItems)
+    _ -> error $ "Not an enum: " ++ pprint ty
   FFICall name returnTy xs -> do
     let returnTys = fromScalarOrPairType returnTy
     let xTys = map (fromScalarType . getType) xs

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -51,7 +51,8 @@ module Syntax (
     BaseMonoidP (..), BaseMonoid, getBaseMonoidType,
     applyIntBinOp, applyIntCmpOp, applyFloatBinOp, applyFloatUnOp,
     getIntLit, getFloatLit, sizeOf, ptrSize, vectorWidth,
-    pattern MaybeTy, pattern JustAtom, pattern NothingAtom,
+    pattern SumTy, pattern MaybeTy, pattern JustAtom, pattern NothingAtom,
+    pattern BoolTy, pattern FalseAtom, pattern TrueAtom,
     pattern IdxRepTy, pattern IdxRepVal, pattern IIdxRepVal, pattern IIdxRepTy,
     pattern TagRepTy, pattern TagRepVal, pattern Word8Ty,
     pattern IntLitExpr, pattern FloatLitExpr,
@@ -72,6 +73,7 @@ import Control.Monad.Except hiding (Except)
 import qualified Data.ByteString.Char8 as B
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
+import Data.List (elemIndex)
 import Data.Store (Store)
 import Data.Tuple (swap)
 import Data.Foldable (toList, fold)
@@ -305,7 +307,7 @@ data PrimOp e =
       | UnsafeFromOrdinal e e   -- index set, ordinal index. XXX: doesn't check bounds
       | ToOrdinal e
       | IdxSetSize e
-      | ThrowError e
+      | ThrowError e                 -- Hard error (parameterized by result type)
       | ThrowException e             -- Catchable exceptions (unlike `ThrowError`)
       | CastOp e e                   -- Type, then value. See Type.hs for valid coercions.
       -- Extensible record and variant operations:
@@ -1254,6 +1256,68 @@ applyFloatBinOp f x y = case (x, y) of
 applyFloatUnOp :: (forall a. (Num a, Fractional a) => a -> a) -> Atom -> Atom
 applyFloatUnOp f x = applyFloatBinOp (\_ -> f) undefined x
 
+-- === nary sum type ===
+
+-- Here we're using variants to simulate an nary sum type. The plan is to
+-- eventually go the other way: lower variants to built-in n-way sums.
+
+makeSumTy :: [Type] -> Type
+makeSumTy tys
+  | length tyLists <= 26 = VariantTy $ NoExt $ LabeledItems $ M.fromList $ zip labels tyLists
+  -- TODO: a built-in sum type without this restriction
+  -- (it's currently only used for internal Bool/Maybe so it's not important)
+  | otherwise = error "ran out of letters!"
+  where
+    tyLists = map (NE.:| []) tys
+    labels = map (:[]) ['a'..]
+
+matchSumTy :: Type -> Maybe [Type]
+matchSumTy variantTy = do
+  VariantTy (NoExt (LabeledItems items)) <- return variantTy
+  forM (M.assocs items) \(_, tys) -> do
+    ty NE.:| [] <- return tys
+    return ty
+
+pattern SumTy :: [Type] -> Type
+pattern SumTy tys <- (matchSumTy -> Just tys)
+  where SumTy tys = makeSumTy tys
+
+makeSumVal :: Type -> Int -> Atom -> Atom
+makeSumVal (VariantTy variantTy) con x = let
+  NoExt (LabeledItems m) = variantTy
+  label = M.keys m !! con
+  in Variant variantTy label 0 x
+makeSumVal _ _ _ = error "not a variant type"
+
+matchSumVal :: Atom -> Maybe (Type, Int, Atom)
+matchSumVal variant = do
+  Variant types label 0 x <- return variant
+  let NoExt (LabeledItems labeledTypes) = types
+  con <- elemIndex label (M.keys labeledTypes)
+  return (VariantTy types, con, x)
+
+pattern SumVal :: Type -> Int -> Atom -> Atom
+pattern SumVal ty con val <- (matchSumVal -> Just (ty, con, val))
+  where SumVal ty con val = makeSumVal ty con val
+
+pattern MaybeTy :: Type -> Type
+pattern MaybeTy a = SumTy [UnitTy, a]
+
+pattern NothingAtom :: Type -> Atom
+pattern NothingAtom a = SumVal (MaybeTy a) 0 UnitVal
+
+pattern JustAtom :: Type -> Atom -> Atom
+pattern JustAtom a x = SumVal (MaybeTy a) 1 x
+
+pattern BoolTy :: Type
+pattern BoolTy = Word8Ty
+
+pattern FalseAtom :: Atom
+pattern FalseAtom = Con (Lit (Word8Lit 0))
+
+pattern TrueAtom :: Atom
+pattern TrueAtom = Con (Lit (Word8Lit 1))
+
 -- === Synonyms ===
 
 varType :: Var -> Type
@@ -1435,24 +1499,6 @@ pattern BinaryFunVal :: Binder -> Binder -> EffectRow -> Block -> Type
 pattern BinaryFunVal b1 b2 eff body =
           Lam (Abs b1 (PureArrow, Block Empty (Atom (
           Lam (Abs b2 (PlainArrow eff, body))))))
-
-maybeDataDef :: DataDef
-maybeDataDef = DataDef (GlobalName "Maybe") (Nest (Bind ("a":>TyKind)) Empty)
-  [ DataConDef (GlobalName "Nothing") Empty
-  , DataConDef (GlobalName "Just"   ) (Nest (Ignore (Var ("a":>TyKind))) Empty)]
-
-pattern MaybeTy :: Type -> Type
-pattern MaybeTy a = TypeCon MaybeDataDef [a]
-
-pattern MaybeDataDef :: DataDef
-pattern MaybeDataDef <- ((\def -> def == maybeDataDef) -> True)
-  where MaybeDataDef = maybeDataDef
-
-pattern NothingAtom :: Type -> Atom
-pattern NothingAtom ty = DataCon MaybeDataDef [ty] 0 []
-
-pattern JustAtom :: Type -> Atom -> Atom
-pattern JustAtom ty x = DataCon MaybeDataDef [ty] 1 [x]
 
 pattern NestOne :: a -> Nest a
 pattern NestOne x = Nest x Empty

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -815,14 +815,21 @@ typeCheckOp op = case op of
     return $ VariantTy $ NoExt $
       Unlabeled [ VariantTy $ NoExt types, VariantTy diff ]
   DataConTag x -> do
-    (TypeCon _ _) <- typeCheck x
+    ty <- typeCheck x
+    case ty of
+      TypeCon _ _ -> return ()
+      VariantTy _ -> return ()
+      _ -> throw TypeErr $ "Not a sum type: " ++ pprint ty
     return TagRepTy
   ToEnum t x -> do
     t |: TyKind
     x |: Word8Ty
-    (TypeCon (DataDef _ _ dataConDefs) _) <- return t
-    forM_ dataConDefs \(DataConDef _ binders) ->
-      assertEq binders Empty "Not an enum"
+    case t of
+      TypeCon (DataDef _ _ dataConDefs) _ ->
+        forM_ dataConDefs \(DataConDef _ binders) ->
+          assertEq binders Empty "Not an enum"
+      VariantTy _ -> return ()  -- TODO: check empty payload
+      _ -> throw TypeErr $ "Not an enum: " ++ pprint t
     return t
 
 typeCheckHof :: Hof -> TypeM Type


### PR DESCRIPTION
Previously we assumed that certain data types and functions were defined in the
prelude, like `Maybe` and `seqMaybes`, and we used these definitions in the
compiler. In some ways this was very convenient because we could take advantage
of terse syntax, type checking, etc (all the reasons we like standalone
languages versus embedded ones!). But having a cyclic dependency between the
prelude and the compiler was a headache in other ways. And it's not clear how it
was going to work with the new name system, which gets rid of global names
completely. This change breaks the dependency by reimplementing some of the
prelude functions in Builder.