### PR TITLE
Remove output stream ptr name

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1398,7 +1398,7 @@ def fread (stream:Stream ReadMode) : {IO} String =
 '### Print
 
 def getOutputStream (_:Unit) : {IO} Stream WriteMode =
-  MkStream $ %ptrLoad OUT_STREAM_PTR
+  MkStream $ %ptrLoad %outputStreamPtr
 
 def print (s:String) : {IO} Unit =
   fwrite (getOutputStream ()) (s <> "\n")

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -184,6 +184,7 @@ linearizeOp op = case op of
   VariantSplit ts v      -> (VariantSplit ts <$> la v) `bindLin` emitOp
   FFICall _ _ _          -> error $ "Can't differentiate through an FFI call"
   ThrowException _       -> notImplemented
+  OutputStreamPtr        -> emitDiscrete
   where
     emitDiscrete = if isTrivialForAD (Op op)
       then LinA $ withZeroTangent <$> emitOp op
@@ -630,6 +631,7 @@ transposeOp op ct = case op of
   DataConTag _          -> notLinear
   ToEnum _ _            -> notLinear
   ThrowException _      -> notLinear
+  OutputStreamPtr       -> notLinear
   where
     -- Both nonlinear operations and operations on discrete types, where linearity doesn't make sense
     notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1277,7 +1277,6 @@ instance Checkable ImpFunction where
   checkValid f@(ImpFunction (_:> IFunType cc _ _) bs block) = addContext ctx $ do
     let scope = foldMap (binderAsEnv . fmap (const ())) bs
     let env   = foldMap (binderAsEnv                  ) bs
-             <> fmap (fromScalarType . fst) initBindings
     void $ flip runReaderT (env, deviceFromCallingConvention cc) $
       flip runStateT scope $ checkBlock block
     where ctx = "Checking:\n" ++ pprint f
@@ -1415,6 +1414,8 @@ checkImpOp op = do
     PtrOffset ref _ -> do  -- TODO: check offset too
       PtrType (addr, ty) <- return ref
       return $ PtrType (addr, ty)
+    OutputStreamPtr -> return $ hostPtrTy $ hostPtrTy $ Scalar Word8Type
+      where hostPtrTy ty = PtrType (Heap CPU, ty)
     _ -> error $ "Not allowed in Imp IR: " ++ pprint op
   where
     checkEq :: (Pretty a, Show a, Eq a) => a -> a -> ImpCheckM ()
@@ -1480,6 +1481,8 @@ impOpType pop = case pop of
   VectorIndex x _    -> Scalar ty  where Vector ty = getIType x
   PtrLoad ref        -> ty  where PtrType (_, ty) = getIType ref
   PtrOffset ref _    -> PtrType (addr, ty)  where PtrType (addr, ty) = getIType ref
+  OutputStreamPtr -> hostPtrTy $ hostPtrTy $ Scalar Word8Type
+    where hostPtrTy ty = PtrType (Heap CPU, ty)
   _ -> unreachable
   where unreachable = error $ "Not allowed in Imp IR: " ++ pprint pop
 

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -73,7 +73,7 @@ runTopPassM bench opts m = runLogger (logFile opts) \logger ->
   runExceptT $ catchIOExcept $ runReaderT m $ TopPassEnv logger bench opts
 
 initTopEnv :: TopEnv
-initTopEnv = TopEnv initBindings mempty
+initTopEnv = TopEnv mempty mempty
 
 evalDecl :: EvalConfig -> SourceBlock -> StateT TopEnv IO Result
 evalDecl opts block = do

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -831,6 +831,9 @@ typeCheckOp op = case op of
       VariantTy _ -> return ()  -- TODO: check empty payload
       _ -> throw TypeErr $ "Not an enum: " ++ pprint t
     return t
+  OutputStreamPtr ->
+    return $ BaseTy $ hostPtrTy $ hostPtrTy $ Scalar Word8Type
+    where hostPtrTy ty = PtrType (Heap CPU, ty)
 
 typeCheckHof :: Hof -> TypeM Type
 typeCheckHof hof = case hof of


### PR DESCRIPTION
Previously we relied on a global name `OUT_STREAM_PTR` being defined in an "initial env". The new naming system frowns upon that sort of thing. Also, it was just a hassle even in the current system. `OUT_STREAM_PTR` was the *only* name in our initial env. The change just makes it a built-in op instead, so we can start with a completely empty environment.