### PR TITLE
Add a builtin sum type and constructor

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1997,13 +1997,11 @@ def dex_test_mode (():Unit) : Bool = unsafeIO do checkEnv "DEX_TEST_MODE"
 '## Exception effect
 TODO: move `error` and `todo` to here.
 
-def internalMaybeToMaybe (maybeVal: {a:Unit|b:a}) : Maybe a =
-  case maybeVal of
-    {|a=() |} -> Nothing
-    {|b=val|} -> Just val
-
 def catch (f:Unit -> {Except|eff} a) : {|eff} Maybe a =
-  internalMaybeToMaybe (%catchException f)
+  ans = %catchException f
+  case %sumToVariant ans of
+    {|c=()   |} -> Nothing
+    {|c|c=val|} -> Just val
 
 def throw (_:Unit) : {Except} a =
   %throwException a

--- a/src/lib/Autodiff.hs
+++ b/src/lib/Autodiff.hs
@@ -184,6 +184,7 @@ linearizeOp op = case op of
   VariantSplit ts v      -> (VariantSplit ts <$> la v) `bindLin` emitOp
   FFICall _ _ _          -> error $ "Can't differentiate through an FFI call"
   ThrowException _       -> notImplemented
+  SumToVariant _         -> notImplemented
   OutputStreamPtr        -> emitDiscrete
   where
     emitDiscrete = if isTrivialForAD (Op op)
@@ -330,6 +331,7 @@ linearizePrimCon :: Con -> LinA Atom
 linearizePrimCon con = case con of
   Lit _                 -> emitWithZero
   PairCon x y           -> PairVal <$> linearizeAtom x <*> linearizeAtom y
+  SumCon  _ _ _         -> notImplemented
   UnitCon               -> emitWithZero
   SumAsProd ty tg elems -> Con . SumAsProd ty tg <$> traverse (traverse linearizeAtom) elems
   IntRangeVal _ _ _     -> emitWithZero
@@ -615,6 +617,7 @@ transposeOp op ct = case op of
   RecordSplit  _ _      -> notImplemented
   VariantLift  _ _      -> notImplemented
   VariantSplit _ _      -> notImplemented
+  SumToVariant _        -> notImplemented
   PtrStore _ _          -> notLinear
   PtrLoad    _          -> notLinear
   PtrOffset _ _         -> notLinear
@@ -732,6 +735,7 @@ transposeCon con ct = case con of
   PairCon x y       -> do
     getFst ct >>= transposeAtom x
     getSnd ct >>= transposeAtom y
+  SumCon _ _ _      -> notImplemented
   SumAsProd _ _ _   -> notImplemented
   ClassDictHole _ _ -> notTangent
   IntRangeVal _ _ _     -> notTangent

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -168,6 +168,8 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
     BaseType b     -> prettyPrec b
     PairType a b  -> atPrec ArgPrec $ align $ group $
       parens $ flatAlt " " "" <> pApp a <> line <> "&" <+> pApp b
+    SumType  cs  -> atPrec ArgPrec $ align $ group $
+      encloseSep "(" ")" " | " $ fmap pApp cs
     UnitType       -> atPrec ArgPrec "Unit"
     IntRange a b -> if docAsStr (pArg a) == "0"
       then atPrec AppPrec ("Fin" <+> pArg b)
@@ -197,6 +199,7 @@ prettyPrecPrimCon con = case con of
   Lit l       -> prettyPrec l
   PairCon x y -> atPrec ArgPrec $ align $ group $
     parens $ flatAlt " " "" <> pApp x <> line' <> "," <+> pApp y
+  SumCon _ tag payload -> atPrec LowestPrec $ "C" <> p tag <+> pApp payload
   UnitCon     -> atPrec ArgPrec "()"
   SumAsProd ty tag payload -> atPrec LowestPrec $
     "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
@@ -211,6 +214,7 @@ prettyPrecPrimCon con = case con of
   TabRef tab -> atPrec ArgPrec $ "Ref" <+> pApp tab
   ConRef conRef -> atPrec AppPrec $ "Ref" <+> pApp conRef
   RecordRef _ -> atPrec ArgPrec "Record ref"  -- TODO
+
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where


### PR DESCRIPTION
This is part of an ongoing simplification that aims to eliminate all
references to record types, variant types, and `data` types after
simplification.