### PR TITLE
Simplify variants away

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -61,7 +61,7 @@ import PPrint ()
 import Util (bindM2, scanM, restructure)
 
 newtype BuilderT m a = BuilderT (ReaderT BuilderEnvR (CatT BuilderEnvC m) a)
-  deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Alternative)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Alternative, MonadFix)
 
 type Builder = BuilderT Identity
 type BuilderEnv = (BuilderEnvR, BuilderEnvC)

--- a/src/lib/Cat.hs
+++ b/src/lib/Cat.hs
@@ -25,7 +25,7 @@ import Control.Monad.Identity
 import Control.Monad.Except hiding (Except)
 
 newtype CatT env m a = CatT (StateT (env, env) m a)
-  deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, MonadFail, Alternative)
+  deriving (Functor, Applicative, Monad, MonadTrans, MonadIO, MonadFail, Alternative, MonadFix)
 
 type Cat env = CatT env Identity
 

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -439,7 +439,10 @@ instance CoreVariant (PrimTC a) where
 instance CoreVariant (PrimOp a) where
   checkVariant e = case e of
     ThrowException _ -> goneBy Simp
-    Select _ _ _       -> alwaysAllowed  -- TODO: only scalar select after Simp
+    Select _ _ _     -> alwaysAllowed  -- TODO: only scalar select after Simp
+    VariantLift _ _  -> goneBy Simp
+    VariantSplit _ _ -> goneBy Simp
+    SumToVariant _   -> goneBy Simp
     _ -> alwaysAllowed
 
 instance CoreVariant (PrimCon a) where


### PR DESCRIPTION
We'd like simplification to heavily limit the subset of our language
that has to be consumed by backends and optimization passes, and
variants are equivalent to the newly added n-ary sum types. This adds a
post-simplification pass that desugars them in the local computation.
Global atoms in bindings will still use record and variant types, to
make the compilation unit boundary well-typed.