### PR TITLE
Add an n-ary product type

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -80,7 +80,8 @@ offsets idxs = case idxs of
 
 indexSetSize :: Type -> ClampPolynomial
 indexSetSize (TC con) = case con of
-  UnitType              -> liftC $ toPolynomial $ IdxRepVal 1
+  ProdType tys          -> foldl mulC (liftC $ toPolynomial $ IdxRepVal 1) $
+    indexSetSize <$> F.toList tys
   IntRange low high     -> clamp $ toPolynomial high `sub` toPolynomial low
   IndexRange n low high -> case (low, high) of
     -- When one bound is left unspecified, the size expressions are guaranteed
@@ -100,7 +101,6 @@ indexSetSize (TC con) = case con of
         InclusiveLim h -> add1 $ toPolynomial h
         ExclusiveLim h -> toPolynomial h
         Unlimited      -> undefined
-  PairType l r -> mulC (indexSetSize l) (indexSetSize r)
   _ -> error $ "Not implemented " ++ pprint con
 indexSetSize (RecordTy (NoExt types)) = let
   sizes = map indexSetSize (F.toList types)

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -146,7 +146,7 @@ prepareFunctionForExport env nameStr func = do
       PairTy a b | idx == Empty -> do
         (atom_a, res_a) <- createDest idx a
         (atom_b, res_b) <- createDest idx b
-        return (Con $ ConRef $ PairCon atom_a atom_b, ExportPairResult res_a res_b)
+        return (Con $ ConRef $ ProdCon [atom_a, atom_b], ExportPairResult res_a res_b)
       _ -> unsupported
       where unsupported = error $ "Unsupported result type: " ++ pprint ty
 

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -122,11 +122,9 @@ indices ty = do
   case ty of
     TC (IntRange l h)      -> return $ fmap (Con . IntRangeVal     l h . IdxRepVal) [0..(fromIntegral $ n - 1)]
     TC (IndexRange t l h)  -> return $ fmap (Con . IndexRangeVal t l h . IdxRepVal) [0..(fromIntegral $ n - 1)]
-    TC (PairType lt rt)    -> do
-      lt' <- indices lt
-      rt' <- indices rt
-      return $ [PairVal l r | l <- lt', r <- rt']
-    TC UnitType            -> return [UnitVal]
+    -- NB: sequence below computes the cartesian product using the list monad
+    TC (ProdType [])       -> return [ProdVal []]
+    TC (ProdType tys)      -> fmap ProdVal . sequence <$> mapM indices tys
     RecordTy (NoExt types) -> do
       subindices <- mapM indices (toList types)
       -- Earlier indices change faster than later ones, so we need to first

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -165,12 +165,12 @@ instance PrettyPrec e => PrettyPrec (PrimExpr e) where
 instance PrettyPrec e => Pretty (PrimTC e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimTC e) where
   prettyPrec con = case con of
-    BaseType b     -> prettyPrec b
-    PairType a b  -> atPrec ArgPrec $ align $ group $
-      parens $ flatAlt " " "" <> pApp a <> line <> "&" <+> pApp b
+    BaseType b   -> prettyPrec b
+    ProdType []  -> atPrec ArgPrec $ "Unit"
+    ProdType as  -> atPrec ArgPrec $ align $ group $
+      encloseSep "(" ")" " & " $ fmap pApp as
     SumType  cs  -> atPrec ArgPrec $ align $ group $
-      encloseSep "(" ")" " | " $ fmap pApp cs
-    UnitType       -> atPrec ArgPrec "Unit"
+      encloseSep "(|" "|)" " | " $ fmap pApp cs
     IntRange a b -> if docAsStr (pArg a) == "0"
       then atPrec AppPrec ("Fin" <+> pArg b)
       else prettyExprDefault $ TCExpr con
@@ -197,10 +197,10 @@ instance PrettyPrec e => PrettyPrec (PrimCon e) where
 prettyPrecPrimCon :: PrettyPrec e => PrimCon e -> DocPrec ann
 prettyPrecPrimCon con = case con of
   Lit l       -> prettyPrec l
-  PairCon x y -> atPrec ArgPrec $ align $ group $
-    parens $ flatAlt " " "" <> pApp x <> line' <> "," <+> pApp y
-  SumCon _ tag payload -> atPrec LowestPrec $ "C" <> p tag <+> pApp payload
-  UnitCon     -> atPrec ArgPrec "()"
+  ProdCon xs  -> atPrec ArgPrec $ align $ group $
+    encloseSep "(" ")" ", " $ fmap pLowest xs
+  SumCon _ tag payload -> atPrec ArgPrec $
+    "(" <> p tag <> "|" <+> pApp payload <+> "|)"
   SumAsProd ty tag payload -> atPrec LowestPrec $
     "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
   ClassDictHole _ _ -> atPrec ArgPrec "_"

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -485,7 +485,7 @@ nameToPat :: Name -> UPat'
 nameToPat v = UPatBinder (Bind (v:>()))
 
 unitExpr :: UExpr'
-unitExpr = UPrimExpr $ ConExpr UnitCon
+unitExpr = UPrimExpr $ ConExpr $ ProdCon []
 
 ns :: a -> WithSrc a
 ns = WithSrc Nothing

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -260,16 +260,16 @@ pattern Word8Ty :: Type n
 pattern Word8Ty = TC (BaseType (Scalar Word8Type))
 
 pattern PairVal :: Atom n -> Atom n -> Atom n
-pattern PairVal x y = Con (PairCon x y)
+pattern PairVal x y = Con (ProdCon [x, y])
 
 pattern PairTy :: Type n -> Type n -> Type n
-pattern PairTy x y = TC (PairType x y)
+pattern PairTy x y = TC (ProdType [x, y])
 
 pattern UnitVal :: Atom n
-pattern UnitVal = Con UnitCon
+pattern UnitVal = Con (ProdCon [])
 
 pattern UnitTy :: Type n
-pattern UnitTy = TC UnitType
+pattern UnitTy = TC (ProdType [])
 
 pattern BaseTy :: BaseType -> Type n
 pattern BaseTy b = TC (BaseType b)

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -88,10 +88,12 @@ prettyVal val = case val of
         return $ parens $ pretty conName <+> hsep ans
     where DataConDef conName _ = dataCons !! con
   Con con -> case con of
-    PairCon x y -> do
+    ProdCon [] -> return $ pretty ()
+    ProdCon [x, y] -> do
       xStr <- pprintVal x
       yStr <- pprintVal y
       return $ pretty (xStr, yStr)
+    ProdCon _ -> error "Unexpected product type: only binary products available in surface language."
     SumAsProd ty (TagRepVal trep) payload -> do
       let t = fromIntegral trep
       case ty of


### PR DESCRIPTION
It's not exposed to the surface language, but only having pairs is
really annoying at times. For example, we use cons lists all over the
place, which makes the intermediate programs completely unreadable.

This comes with a slight downside in that we have to be careful to never
return anything of this type to user-land, but we should be good for as
long as we preserve the types in our transforms.

Note that this does not use the product types in any significant ways,
but mostly replaces the unit and pair type as a special case. I wanted
to leave the simplifications we can get using this relaxed type to a
subsequent change.