### PR TITLE
Add a dependent pair type

### DIFF
--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -277,6 +277,8 @@ instance HasPtrs Atom where
     Var v   -> Var <$> traverse (tp f) v
     Lam lam -> Lam <$> tp f lam
     Pi  ty  -> Pi  <$> tp f ty
+    DepPairTy     ta -> DepPairTy <$> tp f ta
+    DepPair   x y ta -> DepPair <$> tp f x <*> tp f y <*> tp f ta
     TC  tc  -> TC  <$> traverse (tp f) tc
     Con (Lit (PtrLit ptrTy ptr)) -> (Con . Lit . PtrLit ptrTy) <$> f ptrTy ptr
     Con con -> Con <$> traverse (tp f) con
@@ -291,6 +293,7 @@ instance HasPtrs Atom where
     VariantTy row -> VariantTy <$> tp f row
     ACase v alts rty -> ACase <$> tp f v <*>  tp f alts <*> tp f rty
     DataConRef def params args -> DataConRef def <$> tp f params <*> tp f args
+    DepPairRef _ _ _ -> undefined  -- This is only used in Imp
     BoxedRef b ptr size body ->
       BoxedRef <$> tp f b <*> tp f ptr <*> tp f size <*> tp f body
     ProjectElt idxs v -> pure $ ProjectElt idxs v

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -301,7 +301,6 @@ evalBackend :: Bindings -> Block -> TopPassM Atom
 evalBackend env block = do
   backend <- asks (backendName . evalConfig)
   let eval = case backend of
-
                MLIR        -> evalMLIR
                LLVM        -> evalLLVM
                LLVMMC      -> evalLLVM


### PR DESCRIPTION
Short-term this lets us implement telescopes thanks to which we can
remove the constructor hoisting hack we've been using. It should also
make it possible to do AD of triangular for-loops, which was requested
in #587, but this is not part of this patch.

Longer-term we should be able to use it to get rid of DataConRef and
implement all ADTs as coerced sum, product and dependent pair types.