### PR TITLE
Specify -threaded on the executable, not the library

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -83,7 +83,7 @@ library
     build-depends:     dex-resources
   default-language:    Haskell2010
   hs-source-dirs:      src/lib
-  ghc-options:         -Wall -fPIC -threaded -optP-Wno-nonportable-include-path
+  ghc-options:         -Wall -fPIC -optP-Wno-nonportable-include-path
                        -Wno-unticked-promoted-constructors
   cxx-sources:         src/lib/dexrt.cpp
   cxx-options:         -std=c++11 -fPIC
@@ -122,7 +122,7 @@ executable dex
   default-language:    Haskell2010
   hs-source-dirs:      src
   default-extensions:  CPP, LambdaCase, BlockArguments
-  ghc-options:         -optP-Wno-nonportable-include-path
+  ghc-options:         -threaded -optP-Wno-nonportable-include-path
   if flag(live)
     cpp-options:       -DDEX_LIVE
   if flag(optimized)


### PR DESCRIPTION
We need this to avoid deadlocks in the output, but the flag has no
effect when specified in library builds. The RTS flavor is only selected
by the final executables that depend on the library.