### PR TITLE
Revive safe-unsafe bridge

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -68,7 +68,7 @@ library
                        -- Text output
                        prettyprinter, text,
                        -- Portable system utilities
-                       filepath, directory, ansi-terminal, process, temporary,
+                       filepath, directory, ansi-terminal, process, temporary, haskeline,
                        -- Serialization
                        store, aeson
   if flag(live)

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -81,7 +81,7 @@ dexInsert ctxPtr namePtr atomPtr = do
   let freshName = genFresh (Name GenName (fromString name) 0) (topBindings $ topStateD env)
   let newBinding = AtomBinderInfo (getType atom) (LetBound PlainLet (Atom atom))
   let evaluated = EvaluatedModule (freshName @> newBinding) mempty
-                                  (SourceMap (M.singleton name freshName))
+                                  (SourceMap (M.singleton name (SrcAtomName freshName)))
   let envNew = extendTopStateD env evaluated
   toStablePtr $ Context evalConfig $ envNew
 

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -12,9 +12,6 @@ module Dex.Foreign.Context (
   dexEval, dexEvalExpr,
   ) where
 
-import Control.Monad.Reader
-import Control.Monad.State.Strict
-
 import Foreign.Ptr
 import Foreign.StablePtr
 import Foreign.C.String
@@ -35,7 +32,9 @@ import PPrint
 
 import Dex.Foreign.Util
 
-data Context = Context EvalConfig TopState
+import SaferNames.Bridge
+
+data Context = Context EvalConfig TopStateEx
 
 foreign import ccall "_internal_dexSetError" internalSetErrorPtr :: CString -> Int64 -> IO ()
 setError :: String -> IO ()
@@ -50,13 +49,13 @@ dexCreateContext = do
     Right preludeEnv -> toStablePtr $ Context evalConfig preludeEnv
     Left  err        -> nullPtr <$ setError ("Failed to initialize standard library: " ++ pprint err)
   where
-    evalPrelude :: EvalConfig -> String -> IO (Either Err TopState)
+    evalPrelude :: EvalConfig -> String -> IO (Either Err TopStateEx)
     evalPrelude opts sourceText = do
       (results, env) <- runInterblockM opts initTopState $
                             map snd <$> evalSourceText sourceText
       return $ env `unlessError` results
       where
-        unlessError :: TopState -> [Result] -> Except TopState
+        unlessError :: TopStateEx -> [Result] -> Except TopStateEx
         result `unlessError` []                        = Right result
         _      `unlessError` ((Result _ (Left err)):_) = Left err
         result `unlessError` (_:t                    ) = result `unlessError` t
@@ -76,13 +75,14 @@ dexEval ctxPtr sourcePtr = do
 
 dexInsert :: Ptr Context -> CString -> Ptr Atom -> IO (Ptr Context)
 dexInsert ctxPtr namePtr atomPtr = do
-  Context evalConfig env <- fromStablePtr ctxPtr
+  Context evalConfig (TopStateEx env) <- fromStablePtr ctxPtr
   name <- fromString <$> peekCString namePtr
   atom <- fromStablePtr atomPtr
-  let freshName = genFresh (Name GenName (fromString name) 0) (topBindings env)
+  let freshName = genFresh (Name GenName (fromString name) 0) (topBindings $ topStateD env)
   let newBinding = AtomBinderInfo (getType atom) (LetBound PlainLet (Atom atom))
-  let envNew = env { topSourceMap = topSourceMap env <> SourceMap (M.singleton name freshName)
-                   , topBindings  = topBindings  env <> freshName @> newBinding }
+  let evaluated = EvaluatedModule (freshName @> newBinding) mempty
+                                  (SourceMap (M.singleton name freshName))
+  let envNew = extendTopStateD env evaluated
   toStablePtr $ Context evalConfig $ envNew
 
 dexEvalExpr :: Ptr Context -> CString -> IO (Ptr Atom)
@@ -93,8 +93,7 @@ dexEvalExpr ctxPtr sourcePtr = do
     Right expr -> do
       let (v, m) = exprAsModule expr
       let block = SourceBlock 0 0 LogNothing source (RunModule m) Nothing
-      (Result [] maybeErr, newState) <-
-          runStateT (runReaderT (evalSourceBlock block) evalConfig) env
+      (Result [] maybeErr, newState) <- runInterblockM evalConfig env $ evalSourceBlock block
       case maybeErr of
         Right () -> do
           let Right (AtomBinderInfo _ (LetBound _ (Atom atom))) = lookupSourceName newState v

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -37,7 +37,8 @@ import LLVMExec
 import JIT
 import Syntax  hiding (sizeOf)
 import Export
-import TopLevel
+
+import SaferNames.Bridge
 
 import Dex.Foreign.Util
 import Dex.Foreign.Context
@@ -81,10 +82,10 @@ dexDestroyJIT jitPtr = do
 dexCompile :: Ptr JIT -> Ptr Context -> Ptr Atom -> IO NativeFunctionAddr
 dexCompile jitPtr ctxPtr funcAtomPtr = do
   ForeignJIT{..} <- fromStablePtr jitPtr
-  Context _ env <- fromStablePtr ctxPtr
+  Context _ (TopStateEx env) <- fromStablePtr ctxPtr
   funcAtom <- fromStablePtr funcAtomPtr
   let (impMod, nativeSignature) = prepareFunctionForExport
-                                    (topBindings env) "userFunc" funcAtom
+                                    (topBindings $ topStateD env) "userFunc" funcAtom
   nativeModule <- execLogger Nothing $ \logger -> do
     llvmAST <- impToLLVM logger impMod
     LLVM.JIT.compileModule jit llvmAST

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -56,7 +56,9 @@ runMode evalMode preludeFile opts = do
   key <- case preludeFile of
            Nothing   -> return $ show curResourceVersion -- memoizeFileEval already checks compiler version
            Just path -> show <$> getModificationTime path
-  env <- cachedWithSnapshot "prelude" key $ execInterblockM opts initTopState $ evalPrelude preludeFile
+  -- disabling cache while we don't have Generic instances for safe IR
+  -- env <- cachedWithSnapshot "prelude" key $ execInterblockM opts initTopState $ evalPrelude preludeFile
+  env <- execInterblockM opts initTopState $ evalPrelude preludeFile
   case evalMode of
     ReplMode prompt -> do
       let filenameAndDexCompletions = completeQuotedWord (Just '\\') "\"'" listFiles dexCompletions

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -265,14 +265,14 @@ emitMethodType classDef idx = do
 
 makeMethodGetter :: MonadBuilder m => ClassDefName -> Int -> m Atom
 makeMethodGetter classDefName methodIdx = do
-  ClassDef def@(DataDef _ paramBs _) _ <- getClassDef classDefName
+  ClassDef def@(_, DataDef _ paramBs _) _ <- getClassDef classDefName
   buildImplicitNaryLam paramBs \params -> do
     buildLam (Bind ("d":> TypeCon def params)) ClassArrow \dict -> do
       return $ getProjection [methodIdx] $ getProjection [1, 0] dict
 
 makeSuperclassGetter :: MonadBuilder m => DataDefName -> Int -> m Atom
 makeSuperclassGetter classDefName methodIdx = do
-  ClassDef def@(DataDef _ paramBs _) _ <- getClassDef classDefName
+  ClassDef def@(_, DataDef _ paramBs _) _ <- getClassDef classDefName
   buildImplicitNaryLam paramBs \params -> do
     buildLam (Bind ("d":> TypeCon def params)) PureArrow \dict -> do
       return $ getProjection [methodIdx] $ getProjection [0, 0] dict

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -224,7 +224,10 @@ emitBinding binfo = do
   return name
 
 emitDataDef :: MonadBuilder m => DataDef -> m DataDefName
-emitDataDef dataDef = emitBinding $ DataDefName dataDef
+emitDataDef dataDef =
+  -- XXX: the hint shouldn't be necssary but ...
+  withNameHint (Name GenName "_data_def_" 0) $
+    emitBinding $ DataDefName dataDef
 
 emitClassDef :: MonadBuilder m => ClassDef -> m ClassDefName
 emitClassDef classDef = emitBinding $ ClassDefName classDef

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -77,7 +77,7 @@ prepareFunctionForExport env nameStr func = do
         return (resultDest, cargs', ExportedSignature{..}, outputName)
 
   let coreModule = Module Core decls $ EvaluatedModule mempty mempty $
-                     SourceMap $ M.singleton outputSourceName resultName
+                     SourceMap $ M.singleton outputSourceName $ SrcAtomName resultName
   let defunctionalized = simplifyModule env coreModule
   let Module _ optDecls (EvaluatedModule optBindings _ (SourceMap sourceMap)) =
         optimizeModule defunctionalized

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -209,7 +209,7 @@ checkOrInferRho (WithSrc pos expr) reqTy = do
     scrutTy' <- zonk scrutTy
     scrut'' <- zonk scrut'
     case scrutTy' of
-      TypeCon def params -> do
+      TypeCon (_, def) params -> do
         let conDefs = applyDataDefParams def params
         altsSorted <- forM (enumerate conDefs) \(i, DataConDef _ bs) -> do
           case lookup (ConAlt i) alts' of
@@ -395,7 +395,8 @@ inferInterfaceDataDef className methodNames paramBs superclasses methods =
     let dictContents = PairTy (ProdTy superclasses') (ProdTy methods')
     let dictDef = DataDef className paramBs'
                     [DataConDef ("Mk"<>className) (Nest (Ignore dictContents) Empty)]
-    return $ ClassDef dictDef methodNames
+    defName <- emitDataDef dictDef
+    return $ ClassDef (defName, dictDef) methodNames
 
 withNestedBinders :: Nest UAnnBinder -> (Nest Binder -> UInferM a) -> UInferM a
 withNestedBinders Empty cont = cont Empty
@@ -448,7 +449,7 @@ checkInstance Empty className params methods = do
     Just (SubstVal _) -> throw TypeErr $ "Not a valid class: " ++ pprint className
   params' <- mapM checkUType params
   ClassDef def methodNames <- getClassDef className'
-  [ClassDictCon superclassTys methodTys] <- return $ applyDataDefParams def params'
+  [ClassDictCon superclassTys methodTys] <- return $ applyDataDefParams (snd def) params'
   let superclassHoles = fmap (Con . ClassDictHole Nothing) superclassTys
   methodsChecked <- mapM (checkMethodDef className' methodTys) methods
   let (idxs, methods') = unzip $ sortOn fst $ methodsChecked
@@ -462,7 +463,7 @@ checkInstance Empty className params methods = do
 checkMethodDef :: ClassDefName -> [Type] -> UMethodDef -> UInferM (Int, Atom)
 checkMethodDef className methodTys (UMethodDef ~(UInternalVar v) rhs) = do
   scope <- getScope
-  ClassDef (DataDef classSourceName _ _ ) _ <- getClassDef className
+  ClassDef (_, DataDef classSourceName _ _ ) _ <- getClassDef className
   case scope ! v of
     MethodName className' i _ | className == className' -> do
       let methodTy = methodTys !! i
@@ -507,7 +508,7 @@ checkCaseAlt reqTy scrutineeTy (UAlt pat body) = do
            in withBindPats (zip subPats vs) $ checkRho body reqTy
   return (conIdx, alt)
 
-lookupDataCon :: Name -> UInferM (DataDef, Int)
+lookupDataCon :: Name -> UInferM (NamedDataDef, Int)
 lookupDataCon conName = do
   substEnv <- ask
   conName' <- case envLookup substEnv conName of
@@ -518,14 +519,14 @@ lookupDataCon conName = do
   case envLookup scope conName' of
     Just (DataConName dataDefName con) -> do
       let DataDefName def = scope ! dataDefName
-      return (def, con)
+      return ((dataDefName, def), con)
     Just _  -> throw CompilerErr $ "Not a data constructor: " ++ pprint conName
     Nothing -> throw CompilerErr $ pprint conName
 
 checkCasePat :: UPat -> Type -> UInferM (CaseAltIndex, [(UPat, Type)])
 checkCasePat (WithSrc pos pat) scrutineeTy = addSrcContext' pos $ case pat of
   UPatCon ~(UInternalVar conName) ps -> do
-    (def@(DataDef _ paramBs cons), con) <- lookupDataCon conName
+    (def@(_, DataDef _ paramBs cons), con) <- lookupDataCon conName
     let (DataConDef _ argBs) = cons !! con
     when (length argBs /= length ps) $ throw TypeErr $
      "Unexpected number of pattern binders. Expected " ++ show (length argBs)
@@ -578,7 +579,7 @@ bindPat (WithSrc pos pat) val = addSrcContext pos $ case pat of
     env2 <- bindPat p2 x2
     return $ env1 <> env2
   UPatCon ~(UInternalVar conName) ps -> do
-    (def@(DataDef _ paramBs cons), con) <- lookupDataCon conName
+    (def@(_, DataDef _ paramBs cons), con) <- lookupDataCon conName
     when (length cons /= 1) $ throw TypeErr $
       "sum type constructor in can't-fail pattern"
     let (DataConDef _ argBs) = cons !! con

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -388,15 +388,15 @@ inferDataDef (UDataDef (tyConName, paramBs) dataCons) =
 
 inferInterfaceDataDef :: SourceName -> [SourceName] -> Nest UAnnBinder
                       -> [UType] -> [UType] -> UInferM ClassDef
-inferInterfaceDataDef className methodNames paramBs superclasses methods =
-  withNestedBinders paramBs \paramBs' -> do
+inferInterfaceDataDef className methodNames paramBs superclasses methods = do
+  dictDef <- withNestedBinders paramBs \paramBs' -> do
     superclasses' <- mapM checkUType superclasses
     methods'     <- mapM checkUType methods
     let dictContents = PairTy (ProdTy superclasses') (ProdTy methods')
-    let dictDef = DataDef className paramBs'
-                    [DataConDef ("Mk"<>className) (Nest (Ignore dictContents) Empty)]
-    defName <- emitDataDef dictDef
-    return $ ClassDef (defName, dictDef) methodNames
+    return $ DataDef className paramBs'
+               [DataConDef ("Mk"<>className) (Nest (Ignore dictContents) Empty)]
+  defName <- emitDataDef dictDef
+  return $ ClassDef (defName, dictDef) methodNames
 
 withNestedBinders :: Nest UAnnBinder -> (Nest Binder -> UInferM a) -> UInferM a
 withNestedBinders Empty cont = cont Empty

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -318,13 +318,13 @@ instance PrettyPrec Atom where
         parens $ p b <+> "&>" <+> p ty
     DepPair x y _ -> atPrec ArgPrec $ align $ group $
         parens $ p x <> ",>" <+> p y
-    DataCon (DataDef _ _ cons) _ con xs -> case xs of
+    DataCon (_, DataDef _ _ cons) _ con xs -> case xs of
       [] -> atPrec ArgPrec $ p name
       [l, r] | Just sym <- fromInfix (fromString name) -> atPrec ArgPrec $ align $ group $
         parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
       _ ->  atPrec LowestPrec $ pAppArg (p name) xs
       where (DataConDef name _) = cons !! con
-    TypeCon (DataDef name _ _) params -> case params of
+    TypeCon (_, DataDef name _ _) params -> case params of
       [] -> atPrec ArgPrec $ p name
       [l, r] | Just sym <- fromInfix (fromString name) -> atPrec ArgPrec $ align $ group $
         parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
@@ -370,7 +370,7 @@ prettyProjection idxs (name :> fullTy) = atPrec ArgPrec $ pretty uproj where
 
   buildProj :: Type -> NE.NonEmpty Int -> (UPat, UVar)
   buildProj ty (i NE.:| is) = case ty of
-      TypeCon def params ->
+      TypeCon (_, def) params ->
         rec subTy (UInternalVar hint) \pat ->
           UPatCon (USourceVar conName) $ enumerate bs <&> \(j, _) ->
             if i == j then pat else uignore

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -555,6 +555,14 @@ instance Pretty SynthCandidates where
 instance Pretty SourceMap where
   pretty (SourceMap m) = pretty $ M.toAscList m
 
+instance Pretty SourceNameDef where
+  pretty name = case name of
+    SrcAtomName    v -> "Let/lambda name"       <+> p v
+    SrcTyConName   v -> "Type constructor name" <+> p v
+    SrcDataConName v -> "Data constructor name" <+> p v
+    SrcClassName   v -> "Class name"            <+> p v
+    SrcMethodName  v -> "Method name"           <+> p v
+
 instance (Pretty a, Pretty b) => Pretty (Either a b) where
   pretty (Left  x) = "Left"  <+> p x
   pretty (Right x) = "Right" <+> p x

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -813,3 +813,9 @@ instance ToJSON Result where
           , "compile_time" .= toJSON compileTime
           , "run_time"     .= toJSON runTime ]
         out -> ["result" .= String (fromString $ pprint out)]
+
+instance Pretty TopState where
+  pretty s =
+    "bindings: "         <> hardline <> pretty (topBindings s)        <> hardline <>
+    "synth candidates: " <> hardline <> pretty (topSynthCandidates s) <> hardline <>
+    "source map: "       <> hardline <> pretty (topSourceMap s)       <> hardline

--- a/src/lib/SaferNames/Bridge.hs
+++ b/src/lib/SaferNames/Bridge.hs
@@ -93,7 +93,7 @@ extendTopStateD jointTopState evaluated = do
 -- bijections, so we have to do a lot of things manually.
 nameBijectionFromDBindings
     :: MonadToSafe m => FromSafeNameMap n -> D.Bindings
-    -> (forall l. Distinct l => BindingsFrag n l -> ToSafeNameMap l -> FromSafeNameMap l -> m l a)
+    -> (forall l. Distinct l => TopBindingsFrag n l -> ToSafeNameMap l -> FromSafeNameMap l -> m l a)
     -> m n a
 nameBijectionFromDBindings fromSafeMap bindings cont = do
   withFreshSafeRec fromSafeMap (envPairs bindings) \scopeFrag fromSafeMap' -> do
@@ -106,18 +106,18 @@ type ConstEnv n l = EnvFrag (ConstE UnitE) n l VoidS
 
 makeBindingsFrag :: forall n l. Distinct l =>
                     S.Scope l -> D.Bindings -> ToSafeNameMap l -> FromSafeNameMap l
-                 -> ConstEnv n l -> BindingsFrag n l
+                 -> ConstEnv n l -> TopBindingsFrag n l
 makeBindingsFrag scope bindings toSafeMap fromSafeMap constEnv =
   fmapEnvFrag (\name _ -> getSafeBinding name) constEnv
   where
-    getSafeBinding :: S.Name s (n:=>:l) -> IdE s l
+    getSafeBinding :: S.Name s (n:=>:l) -> TopBinding s l
     getSafeBinding name =
       case fromSafeMap S.! injectNamesR name of
         UnsafeAtomName name' -> case bindings D.! name' of
           AtomBinderInfo ty info ->
             let (ty', info') = runToSafeM toSafeMap scope $
                                  (,) <$> toSafeE ty <*> toSafeE info
-            in IdE $ S.AtomNameDef ty' info'
+            in TopBinding $ S.AtomNameDef ty' info'
 
 withFreshSafeRec :: MonadToSafe m
                  => FromSafeNameMap n

--- a/src/lib/SaferNames/Bridge.hs
+++ b/src/lib/SaferNames/Bridge.hs
@@ -9,10 +9,16 @@
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE UndecidableInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# OPTIONS_GHC -w #-}
 
-module SaferNames.Bridge (HasSafeVersionE (..), HasSafeVersionB (..),
-                          toSafeBindings)  where
+module SaferNames.Bridge
+  ( TopStateEx (..), JointTopState (..), initTopState
+  , toSafe, fromSafe, extendTopStateD
+  , HasSafeVersionE (..), HasSafeVersionB (..))  where
+
+import Control.Monad.Identity
+import Control.Monad.Reader
 
 import Data.Foldable (toList)
 import qualified Data.Set as Set
@@ -21,7 +27,10 @@ import LabeledItems
 import Syntax
 import Env
 import Type
+import Data.String (fromString)
 import Data.Maybe (fromJust)
+import Data.Store (Store)
+import GHC.Generics (Generic (..))
 
 import qualified Data.Map.Strict as M
 
@@ -30,201 +39,492 @@ import SaferNames.Name
 import SaferNames.Syntax
 import SaferNames.LazyMap as LM
 
+import Serialize (HasPtrs (..))
+
 import qualified Syntax as D  -- D for Danger
+import qualified Type   as D
 import qualified Env    as D
 
-import qualified SaferNames.NameCore  as S
 import qualified SaferNames.Name      as S
 import qualified SaferNames.Syntax    as S
 
-toSafeBindings :: D.Bindings -> S.Scope n
-toSafeBindings = undefined
--- toSafeBindings (Env bindings) = undefined
---   S.RecEnv $ S.UnsafeMakeEnv $ LM.newLazyMap (M.keysSet bindings) \v ->
---     toSafeBinderInfo $ fromJust (M.lookup v bindings)
 
-toSafeBinderInfo :: (D.Type, D.BinderInfo) -> S.TypedBinderInfo n
-toSafeBinderInfo (ty, info) = S.TypedBinderInfo (toSafeE ty) (toSafeE info)
+-- Hides the `n` parameter as an existential
+data TopStateEx where
+  TopStateEx :: JointTopState n -> TopStateEx
+
+initTopState :: TopStateEx
+initTopState = TopStateEx $ JointTopState
+    D.emptyTopState
+    S.emptyTopState
+    (ToSafeNameMap mempty)
+    voidEnv
+
+data JointTopState n = JointTopState
+  { topStateD   :: D.TopState
+  , topStateS   :: S.TopState n
+  , topToSafeMap   :: ToSafeNameMap n
+  , topFromSafeMap :: FromSafeNameMap n }
+
+extendTopStateD :: JointTopState n -> D.EvaluatedModule -> TopStateEx
+extendTopStateD jointTopState evaluated = do
+  let D.TopState bindingsD scsD sourceMapD = topStateD jointTopState
+  let S.TopState bindingsS scsS sourceMapS = topStateS jointTopState
+  -- ensure the internal bindings are fresh wrt top bindings
+  let D.EvaluatedModule bindingsD' scsD' sourceMapD' = D.subst (mempty, bindingsD) evaluated
+  runToSafeM (topToSafeMap jointTopState) (bindingsAsScope bindingsS) do
+    nameBijectionFromDBindings (topFromSafeMap jointTopState) bindingsD'
+     \bindingsFrag toSafeMap' fromSafeMap' -> do
+       scsS'       <- toSafeE scsD'
+       sourceMapS' <- toSafeE sourceMapD'
+       sourceMapSInj <- injectM bindingsFrag sourceMapS
+       scsSInj       <- injectM bindingsFrag scsS
+       return $ TopStateEx $ JointTopState
+         (D.TopState (bindingsD <> bindingsD') (scsD <> scsD') (sourceMapD <> sourceMapD'))
+         (S.TopState (appendBindings bindingsS bindingsFrag)
+                     (scsSInj <> scsS') (sourceMapSInj <> sourceMapS'))
+         toSafeMap'
+         fromSafeMap'
+
+-- This is pretty horrible. The name system isn't really designed for creating
+-- bijections, so we have to do a lot of things manually.
+nameBijectionFromDBindings
+    :: MonadToSafe m => FromSafeNameMap n -> D.Bindings
+    -> (forall l. BindingsFrag n l -> ToSafeNameMap l -> FromSafeNameMap l -> m l a)
+    -> m n a
+nameBijectionFromDBindings fromSafeMap bindings cont = do
+  withFreshSafeRec fromSafeMap (envPairs bindings) \scopeFrag fromSafeMap' -> do
+    toSafeMap' <- getToSafeNameMap
+    scope <- getScope
+    let bindingsFrag = makeBindingsFrag scope bindings toSafeMap' fromSafeMap' scopeFrag
+    cont bindingsFrag toSafeMap' fromSafeMap'
+
+type ConstNameMap n l = NameMap (ConstE UnitE) (n:=>:l) VoidS
+
+makeBindingsFrag :: forall n l. Distinct l =>
+                    S.Scope l -> D.Bindings -> ToSafeNameMap l -> FromSafeNameMap l
+                 -> ConstNameMap n l -> BindingsFrag n l
+makeBindingsFrag scope bindings toSafeMap fromSafeMap constNameMap =
+  BindingsFrag $ fmapNameMap (\name _ -> getSafeBinding name) constNameMap
+  where
+    getSafeBinding :: S.Name s (n:=>:l) -> IdE s l
+    getSafeBinding name =
+      case fromSafeMap S.! injectNamesR name of
+        UnsafeAtomName name' -> case bindings D.! name' of
+          AtomBinderInfo ty info ->
+            let (ty', info') = runToSafeM toSafeMap scope $
+                                 (,) <$> toSafeE ty <*> toSafeE info
+            in IdE $ S.TypedBinderInfo ty' info'
+
+withFreshSafeRec :: MonadToSafe m
+                 => FromSafeNameMap n
+                 -> [(D.Name, D.AnyBinderInfo)]
+                 -> (forall l. Distinct l => ConstNameMap n l -> FromSafeNameMap l -> m l a)
+                 -> m n a
+withFreshSafeRec fromSafeMap [] cont = do
+  withDistinct $ cont emptyNameMap fromSafeMap
+withFreshSafeRec fromSafeMap ((vD,info):rest) cont = do
+  withFreshBijectionD vD info \b valD -> do
+    frag <- return $ singletonNameMap b (ConstE UnitE)
+    withFreshSafeRec (fromSafeMap <>> (b S.@> valD)) rest
+      \frag' fromSafeMap' -> do
+        cont (frag `concatNameMaps` frag') fromSafeMap'
+
+withFreshBijectionD :: MonadToSafe m => D.Name -> D.AnyBinderInfo
+                    -> (forall l s. S.NameBinder s n l -> UnsafeName s -> m l a)
+                    -> m n a
+withFreshBijectionD name info cont = case info of
+  AtomBinderInfo _ _ ->
+    withFreshM \b ->
+      extendToSafeNameMap name (SafeAtomName $ S.binderName b) $
+        cont b (UnsafeAtomName name)
+
+extendTopStateS :: JointTopState n -> S.EvaluatedModule n -> TopStateEx
+extendTopStateS = error "not implemented"
+
+toSafe :: HasSafeVersionE e => JointTopState n -> e -> SafeVersionE e n
+toSafe jointTopState e =
+  runToSafeM (topToSafeMap jointTopState) scope $ toSafeE e
+  where scope = S.bindingsAsScope $ S.topBindings $ topStateS $ jointTopState
+
+fromSafe :: HasSafeVersionE e => JointTopState n -> SafeVersionE e n -> e
+fromSafe jointTopState e =
+  runFromSafeM (topFromSafeMap jointTopState) bindings $ fromSafeE e
+  where bindings = D.topBindings $ topStateD $ jointTopState
+
+-- === monad for translating from unsafe to safe names ===
+
+class ( S.ScopeReader m, S.ScopeExtender m
+      , MonadFail1 m, Monad1 m)
+      => MonadToSafe (m::MonadKind1) where
+  getToSafeNameMap :: m o (ToSafeNameMap o)
+  extendToSafeNameMap :: D.Name -> SafeName o -> m o a -> m o a
+
+
+data SafeName (n::S) =
+   SafeAtomName    (S.AtomName n)
+ | SafeDataDefName (S.Name S.DataDef n)
+
+newtype ToSafeNameMap o = ToSafeNameMap (D.Env (SafeName o))
+
+newtype ToSafeM o a =
+  ToSafeM { runToSafeM' :: ReaderT (ToSafeNameMap o) (ScopeReaderT Identity o) a }
+  deriving (Functor, Applicative, Monad)
+
+runToSafeM :: ToSafeNameMap o -> S.Scope o -> ToSafeM o a -> a
+runToSafeM nameMap scope m =
+  runIdentity $ runScopeReaderT scope $
+    flip runReaderT nameMap $
+      runToSafeM' m
+
+instance MonadToSafe ToSafeM where
+  getToSafeNameMap = ToSafeM ask
+  extendToSafeNameMap v v' (ToSafeM m) = ToSafeM $ flip withReaderT m
+    \(ToSafeNameMap env) -> ToSafeNameMap $ env <> (v D.@> v')
+
+lookupToSafeNameMap :: MonadToSafe m => D.Name -> m o (SafeName o)
+lookupToSafeNameMap v = do
+  ToSafeNameMap env <- getToSafeNameMap
+  return $ env D.! v
+
+-- === monad for translating from safe to unsafe names ===
+
+class (MonadFail1 m, Monad1 m) => MonadFromSafe (m::MonadKind1) where
+  lookupFromSafeNameMap :: S.Name s i -> m i (UnsafeName s)
+  getUnsafeBindings :: m i (D.Bindings)
+  withFreshUnsafeName :: D.AnyBinderInfo
+                      -> (D.Name -> m i a) -> m i a
+  extendFromSafeMap :: S.NameBinder s i i'
+                    -> UnsafeName s -> m i' a -> m i a
+
+type UnsafeName s = UnsafeNameE s VoidS
+data UnsafeNameE (s::E) (n::S) where
+  UnsafeAtomName :: D.Name -> UnsafeNameE S.TypedBinderInfo VoidS
+
+type FromSafeNameMap i = S.Env UnsafeNameE i VoidS
+
+newtype FromSafeM i a =
+  FromSafeM { runFromSafeM' :: ReaderT (FromSafeNameMap i) (Reader D.Bindings) a }
+  deriving (Functor, Applicative, Monad)
+
+runFromSafeM :: FromSafeNameMap i -> D.Bindings -> FromSafeM i a -> a
+runFromSafeM nameMap bindings m =
+  flip runReader bindings $ flip runReaderT nameMap $ runFromSafeM' m
+
+instance MonadFromSafe FromSafeM where
+  lookupFromSafeNameMap v = FromSafeM $ (S.! v) <$> ask
+  getUnsafeBindings = FromSafeM $ lift ask
+  withFreshUnsafeName info f =
+    FromSafeM $ ReaderT \m -> do
+      scope <- ask
+      let v' = genFresh "v" scope  -- TODO: preverse name hints
+      withReaderT (<> (v' D.@> info)) $
+        runReaderT (runFromSafeM' (f v')) m
+
+  extendFromSafeMap b v (FromSafeM m) = FromSafeM $ flip withReaderT m
+    \env -> env <>> b S.@> v
+
+-- === --- ===
 
 class HasSafeVersionE (e:: *) where
   type SafeVersionE e :: S.E
-  toSafeE   :: e -> SafeVersionE e n
-  fromSafeE :: SafeVersionE e n -> e
+  toSafeE   :: MonadToSafe   m => e -> m o (SafeVersionE e o)
+  fromSafeE :: MonadFromSafe m => SafeVersionE e i -> m i e
 
 class HasSafeVersionB (b:: *) where
   type SafeVersionB b :: S.B
-  toSafeB   :: b -> SafeVersionB b n l
-  fromSafeB :: SafeVersionB b n l -> b
+  toSafeB   :: MonadToSafe   m => b -> (forall o'. SafeVersionB b o o' -> m o' r) -> m o r
+  fromSafeB :: MonadFromSafe m => SafeVersionB b i i' -> (b -> m i' r) -> m i r
 
-instance HasSafeVersionE D.Name where
-  type SafeVersionE D.Name = S.AtomName
-  toSafeE name = UnsafeMakeName name
-  fromSafeE (UnsafeMakeName name) = name
+instance HasSafeVersionE D.Module where
+  type SafeVersionE D.Module = S.Module
+
+instance HasSafeVersionE D.SourceMap where
+  type SafeVersionE D.SourceMap = S.SourceNameMap
+
+instance HasSafeVersionE D.SynthCandidates where
+  type SafeVersionE D.SynthCandidates = S.SynthCandidates
 
 instance HasSafeVersionE D.Atom where
   type SafeVersionE D.Atom = S.Atom
 
   toSafeE atom = case atom of
-    D.Var v -> S.Var $ toSafeE v
-    -- D.Lam (D.Abs b (arr, body)) ->
-    --   S.Lam $ S.Abs (toSafeB b) (S.WithArrow (fmap toSafeE arr) (toSafeE body))
-    -- D.Pi  (D.Abs b (arr, body)) ->
-    --   S.Pi  $ S.Abs (toSafeB b) (S.WithArrow (fmap toSafeE arr) (toSafeE body))
-    -- D.DataCon dataDef params con args ->
-    --   S.DataCon (toSafeE dataDef) (map toSafeE params) con (map toSafeE args)
-    -- D.TypeCon dataDef params ->
-    --   S.TypeCon (toSafeE dataDef) (map toSafeE params)
-    D.LabeledRow (Ext items t) -> S.LabeledRow $ Ext (fmap toSafeE items) (fmap toSafeE t)
-    D.Record items -> S.Record $ fmap toSafeE items
-    D.RecordTy (Ext items t) -> S.RecordTy $ Ext (fmap toSafeE items) (fmap toSafeE t)
-    D.Variant (Ext items t) label idx val ->
-      S.Variant (Ext (fmap toSafeE items) (fmap toSafeE t)) label idx (toSafeE val)
-    D.VariantTy (Ext items t) -> S.VariantTy $ Ext (fmap toSafeE items) (fmap toSafeE t)
-    D.Con con -> S.Con $ fmap toSafeE con
-    D.TC  tc  -> S.TC  $ fmap toSafeE tc
-    D.Eff effs -> S.Eff $ toSafeE effs
-    -- D.ACase scrut alts ty -> S.ACase (toSafeE scrut) (map toSafeE alts) (toSafeE ty)
-    -- D.DataConRef dataDef params args ->
-    --   S.DataConRef (toSafeE dataDef) (map toSafeE params) (S.Abs (toSafeB args) S.UnitE)
-    -- D.BoxedRef b ptr size body ->
-    --   S.BoxedRef (toSafeE ptr) (toSafeE size) (S.Abs (toSafeB b) (toSafeE body))
-    D.ProjectElt idxs (v D.:> _) -> S.ProjectElt idxs $ (S.UnsafeMakeName v)
+    D.Var (v D.:> _) -> S.Var <$> toSafeAtomName v
+    D.Lam (D.Abs b (arr, body)) -> do
+      withFreshAtomBinderS b \b' -> do
+        (arr', eff') <- toSafeArrow arr
+        body' <- toSafeE body
+        return $ S.Lam $ S.LamExpr arr' b' eff' body'
+    D.Pi (D.Abs b (arr, body)) ->
+      withFreshAtomBinderS b \b' -> do
+        (arr', eff') <- toSafeArrow arr
+        body' <- toSafeE body
+        return $ S.Pi $ S.PiType arr' b' eff' body'
+    D.DataCon dataDef@(D.DataDef printName _ _ ) params con args ->
+      S.DataCon (rawName GenName $ fromString printName) <$>
+        toSafeE (DataDefRef dataDef) <*>
+        mapM toSafeE params <*> pure con <*> mapM toSafeE args
+    D.TypeCon dataDef params ->
+      S.TypeCon <$> toSafeE (DataDefRef dataDef) <*> mapM toSafeE params
+    D.LabeledRow (Ext items t) ->
+      S.LabeledRow <$> (Ext <$> mapM toSafeE items <*> mapM toSafeAtomName t)
+    D.Record items -> S.Record <$> mapM toSafeE items
+    D.RecordTy (Ext items t) -> S.RecordTy <$>
+       (Ext <$> mapM toSafeE items <*> mapM toSafeAtomName t)
+    D.Variant (Ext items t) label idx val -> S.Variant <$>
+      (Ext <$> mapM toSafeE items <*> mapM toSafeAtomName t) <*>
+      pure label <*> pure idx <*> toSafeE val
+    D.VariantTy (Ext items t) -> S.VariantTy <$>
+      (Ext <$> mapM toSafeE items <*> mapM toSafeAtomName t)
+    D.Con con  -> S.Con <$> mapM toSafeE con
+    D.TC  tc   -> S.TC  <$> mapM toSafeE tc
+    D.Eff effs -> S.Eff <$> toSafeE effs
+    D.ACase scrut alts ty -> S.ACase <$> toSafeE scrut <*> mapM toSafeE alts <*> toSafeE ty
+    D.DataConRef dataDef params args ->
+      S.DataConRef <$> toSafeE (DataDefRef dataDef) <*>
+        mapM toSafeE params <*> toSafeE (D.Abs args ())
+    D.BoxedRef b ptr size body ->
+      S.BoxedRef <$> toSafeE ptr <*> toSafeE size <*> toSafeE (D.Abs b body)
+    D.ProjectElt idxs (v D.:> _) -> S.ProjectElt idxs <$> toSafeAtomName v
+
   fromSafeE atom = case atom of
-    S.Var v -> D.Var $ fromSafeE v
-    -- S.Lam (S.Abs b (S.WithArrow arr body)) ->
-    --   D.Lam $ D.Abs (fromSafeB b) (fmap fromSafeE arr, fromSafeE body)
-    -- S.Pi  (S.Abs b (S.WithArrow arr body)) ->
-    --   D.Pi  $ D.Abs (fromSafeB b) (fmap fromSafeE arr, fromSafeE body)
-    -- S.DataCon dataDef params con args ->
-    --   D.DataCon (fromSafeE dataDef) (map fromSafeE params) con (map fromSafeE args)
-    -- S.TypeCon dataDef params ->
-    --   D.TypeCon (fromSafeE dataDef) (map fromSafeE params)
-    S.LabeledRow (Ext items t) -> D.LabeledRow $ Ext (fmap fromSafeE items) (fmap fromSafeE t)
-    S.Record items -> D.Record $ fmap fromSafeE items
-    S.RecordTy (Ext items t) -> D.RecordTy $ Ext (fmap fromSafeE items) (fmap fromSafeE t)
-    S.Variant (Ext items t) label idx val ->
-      D.Variant (Ext (fmap fromSafeE items) (fmap fromSafeE t)) label idx (fromSafeE val)
-    S.VariantTy (Ext items t) -> D.VariantTy $ Ext (fmap fromSafeE items) (fmap fromSafeE t)
-    S.Con con -> D.Con $ fmap fromSafeE con
-    S.TC  tc  -> D.TC  $ fmap fromSafeE tc
-    S.Eff effs -> D.Eff $ fromSafeE effs
-    -- S.ACase scrut alts ty -> D.ACase (fromSafeE scrut) (map fromSafeE alts) (fromSafeE ty)
-    -- S.DataConRef dataDef params (S.Abs args S.UnitE) ->
-    --   D.DataConRef (fromSafeE dataDef) (map fromSafeE params) (fromSafeB args)
-    -- S.BoxedRef ptr size (S.Abs b body) ->
-    --   D.BoxedRef (fromSafeB b) (fromSafeE ptr) (fromSafeE size) (fromSafeE body)
-    S.ProjectElt idxs v -> D.ProjectElt idxs $ fromSafeE v
+    S.Var v -> D.Var <$> fromSafeAtomNameVar v
+    S.Lam (S.LamExpr arr b eff body) -> do
+      withFreshAtomBinderD b \b' -> do
+        arr' <- fromSafeArrow arr eff
+        body' <- fromSafeE body
+        return $ D.Lam $ D.Abs b' (arr', body')
+    S.Pi (S.PiType arr b eff body) -> do
+      withFreshAtomBinderD b \b' -> do
+        arr' <- fromSafeArrow arr eff
+        body' <- fromSafeE body
+        return $ D.Pi $ D.Abs b' (arr', body')
+    S.DataCon _ dataDefName params con args -> do
+      dataDef <- fromDataDefRef <$> fromSafeE dataDefName
+      D.DataCon dataDef <$> mapM fromSafeE params <*> pure con <*> mapM fromSafeE args
+    S.TypeCon dataDefName params -> do
+      dataDef <- fromDataDefRef <$> fromSafeE dataDefName
+      D.TypeCon dataDef <$> mapM fromSafeE params
+    S.LabeledRow (Ext items t) -> D.LabeledRow <$>
+      (Ext <$> mapM fromSafeE items <*> mapM fromSafeAtomName t)
+    S.Record items -> D.Record <$> mapM fromSafeE items
+    S.RecordTy (Ext items t) -> D.RecordTy <$>
+      (Ext <$> mapM fromSafeE items <*> mapM fromSafeAtomName t)
+    S.Variant (Ext items t) label idx val -> D.Variant <$>
+      (Ext <$> mapM fromSafeE items <*> mapM fromSafeAtomName t) <*>
+      pure label <*> pure idx <*> fromSafeE val
+    S.VariantTy (Ext items t) -> D.VariantTy <$>
+      (Ext <$> mapM fromSafeE items <*> mapM fromSafeAtomName t)
+    S.Con con  -> D.Con <$> mapM fromSafeE con
+    S.TC  tc   -> D.TC  <$> mapM fromSafeE tc
+    S.Eff effs -> D.Eff <$> fromSafeE effs
+    S.ACase scrut alts ty -> D.ACase <$> fromSafeE scrut <*> mapM fromSafeE alts <*> fromSafeE ty
+    S.DataConRef dataDef params ab -> do
+      dataDef <- fromDataDefRef <$> fromSafeE dataDef
+      params' <- mapM fromSafeE params
+      D.Abs bs () <- fromSafeE ab
+      return $ D.DataConRef dataDef params' bs
+    S.BoxedRef ptr size ab -> do
+      ptr' <- fromSafeE ptr
+      size' <- fromSafeE size
+      D.Abs b body <- fromSafeE ab
+      return $ D.BoxedRef b ptr' size' body
+    S.ProjectElt idxs v -> D.ProjectElt idxs <$> fromSafeAtomNameVar v
 
-instance HasSafeVersionE e => HasSafeVersionE (VarP e) where
-  type SafeVersionE (VarP e) = AtomName
-  toSafeE (name D.:> _) = UnsafeMakeName name
-  fromSafeE (UnsafeMakeName name) = undefined -- name D.:> fromSafeE ty
+instance HasSafeVersionB D.Binder where
+  type SafeVersionB D.Binder = S.Binder
 
-instance HasSafeVersionE D.DataDef where
-  type SafeVersionE D.DataDef = S.DataDef
-  -- toSafeE (D.DataDef name paramBinders cons) =
-  --     S.DataDef name paramBinders' $ map toSafeE cons
-  --     where paramBinders' = dBinderListToSBinderList $ toList paramBinders
-  -- fromSafeE (S.DataDef name paramBinders cons) =
-  --   D.DataDef name (D.toNest $ sBinderListToDBinderList paramBinders) (map fromSafeE cons)
+withFreshAtomBinderS :: MonadToSafe m
+                     => D.Binder
+                     -> (forall o'. S.Binder o o' -> m o' r)
+                     -> m o r
+withFreshAtomBinderS (Ignore ty) cont = do
+  ty' <- toSafeE ty
+  withFreshM \b' -> do
+    cont (b' S.:> ty')
+withFreshAtomBinderS (Bind (b D.:> ty)) cont = do
+  ty' <- toSafeE ty
+  withFreshM \b' -> do
+    extendToSafeNameMap b (SafeAtomName $ S.binderName b') $
+      cont (b' S.:> ty')
 
-instance HasSafeVersionE D.BinderInfo where
-  type SafeVersionE D.BinderInfo = S.AtomBinderInfo
+withFreshAtomBinderD :: MonadFromSafe m
+                     => S.Binder i i'
+                     -> (D.Binder -> m i' r)
+                     -> m i r
+withFreshAtomBinderD (b S.:> ty) cont = do
+  ty' <- fromSafeE ty
+  withFreshUnsafeName (AtomBinderInfo ty' UnknownBinder) \v' ->
+    extendFromSafeMap b (UnsafeAtomName v') $
+      cont (Bind (v' D.:> ty'))
+
+toSafeAtomName :: MonadToSafe m => D.Name -> m o (S.AtomName o)
+toSafeAtomName name = do
+  SafeAtomName name' <- lookupToSafeNameMap name
+  return name'
+
+fromSafeAtomName :: MonadFromSafe m => S.AtomName i -> m i D.Name
+fromSafeAtomName name = do
+  name' <- lookupFromSafeNameMap name
+  case name' of
+    UnsafeAtomName v -> return v
+
+fromSafeAtomNameVar :: MonadFromSafe m => S.AtomName i -> m i D.Var
+fromSafeAtomNameVar name = do
+  name' <- fromSafeAtomName name
+  AtomBinderInfo ty _ <- (D.! name') <$> getUnsafeBindings
+  return $ name' D.:> ty
+
+toSafeArrow :: MonadToSafe m => D.Arrow -> m o (S.Arrow, S.EffectRow o)
+toSafeArrow arr = case arr of
+  D.PlainArrow eff -> do
+    eff' <- toSafeE eff
+    return $ (S.PlainArrow, eff')
+  D.TabArrow      -> return (S.TabArrow, S.Pure)
+  D.LinArrow      -> return (S.LinArrow, S.Pure)
+  D.ImplicitArrow -> return (S.ImplicitArrow, S.Pure)
+  D.ClassArrow    -> return (S.ClassArrow, S.Pure)
+
+fromSafeArrow :: MonadFromSafe m => S.Arrow -> S.EffectRow i -> m i D.Arrow
+fromSafeArrow arr eff = case arr of
+  S.PlainArrow -> do
+    eff' <- fromSafeE eff
+    return $ D.PlainArrow eff'
+  S.TabArrow      -> return D.TabArrow
+  S.LinArrow      -> return D.LinArrow
+  S.ImplicitArrow -> return D.ImplicitArrow
+  S.ClassArrow    -> return D.ClassArrow
+
+newtype DataDefRef = DataDefRef { fromDataDefRef :: D.DataDef }
+instance HasSafeVersionE DataDefRef where
+  type SafeVersionE DataDefRef = S.Name S.DataDef
+  -- TODO: to handle these we need the unsafe IR to keep around the data def
+  -- names rather than just inlining the definition.
   toSafeE = undefined
   fromSafeE = undefined
 
-unsafeToNest :: [b n' l'] -> S.Nest b n l
-unsafeToNest [] = unsafeCoerceB S.Empty
-unsafeToNest (b:bs) = S.Nest (unsafeCoerceB b) (unsafeCoerceB (unsafeToNest bs))
-
-unsafeFromNest :: S.Nest b n l -> [b n' l']
-unsafeFromNest S.Empty = []
-unsafeFromNest (S.Nest b bs) = unsafeCoerceB b : unsafeFromNest (unsafeCoerceB bs)
-
--- dBinderListToSBinderList :: [D.Binder] -> S.BinderList n l
--- dBinderListToSBinderList = undefined
--- dBinderListToSBinderList bs = unsafeToNest vs S.:> ListE tys
---   where (vs, tys) = unzip [ (v,ty) | (v S.:> ty) <- map toSafeB bs]
-
--- sBinderListToDBinderList :: S.BinderList n l -> [D.Binder]
--- sBinderListToDBinderList = undefined
--- sBinderListToDBinderList (vs S.:> ListE tys) =
---   map fromSafeB $ zipWith (S.:>) (unsafeFromNest vs) tys
-
-instance HasSafeVersionE D.DataConDef where
-  type SafeVersionE D.DataConDef = S.DataConDef
-  -- toSafeE (D.DataConDef name bs) = S.DataConDef name $ S.Abs (toSafeB bs) S.UnitE
-  -- fromSafeE (S.DataConDef name (S.Abs bs S.UnitE)) = D.DataConDef name $ fromSafeB bs
+instance HasSafeVersionE () where
+  type SafeVersionE () = S.UnitE
 
 instance HasSafeVersionB D.DataConRefBinding where
   type SafeVersionB D.DataConRefBinding = S.DataConRefBinding
-  toSafeB = undefined
-  fromSafeB = undefined
+  toSafeB (D.DataConRefBinding b ann) cont = do
+    ann' <- toSafeE ann
+    toSafeB b \b' -> cont $ S.DataConRefBinding b' ann'
+  fromSafeB (S.DataConRefBinding b ann) cont = do
+    ann' <- fromSafeE ann
+    fromSafeB b \b' -> cont $ D.DataConRefBinding b' ann'
 
 instance HasSafeVersionE D.Expr where
   type SafeVersionE D.Expr = S.Expr
   toSafeE expr = case expr of
-    D.App f x -> S.App (toSafeE f) (toSafeE x)
-    -- D.Case scrut alts ty -> S.Case (toSafeE scrut) (map toSafeE alts) (toSafeE ty)
-    D.Atom x -> S.Atom (toSafeE x)
-    D.Op op -> S.Op (fmap toSafeE op)
-    D.Hof hof -> S.Hof (fmap toSafeE hof)
+    D.App f x -> S.App  <$> toSafeE f <*> toSafeE x
+    D.Case scrut alts ty -> S.Case <$> toSafeE scrut <*> mapM toSafeE alts <*>  toSafeE ty
+    D.Atom x  -> S.Atom <$> toSafeE x
+    D.Op op   -> S.Op   <$> mapM toSafeE op
+    D.Hof hof -> S.Hof  <$> mapM toSafeE hof
 
   fromSafeE expr = case expr of
-    S.App f x -> D.App (fromSafeE f) (fromSafeE x)
-    -- S.Case scrut alts ty -> D.Case (fromSafeE scrut) (map fromSafeE alts) (fromSafeE ty)
-    S.Atom x -> D.Atom (fromSafeE x)
-    S.Op op -> D.Op (fmap fromSafeE op)
-    S.Hof hof -> D.Hof (fmap fromSafeE hof)
+    S.App f x -> D.App  <$> fromSafeE f <*> fromSafeE x
+    S.Case scrut alts ty -> D.Case <$> fromSafeE scrut <*>  mapM fromSafeE alts <*>  fromSafeE ty
+    S.Atom x  -> D.Atom <$> fromSafeE x
+    S.Op op   -> D.Op   <$> mapM fromSafeE op
+    S.Hof hof -> D.Hof  <$> mapM fromSafeE hof
 
 instance HasSafeVersionE D.Block where
   type SafeVersionE D.Block = S.Block
-  toSafeE (D.Block decls result) =
-    case toSafeE $ D.Abs decls result of
-      S.Abs decls' result' -> S.Block (toSafeE (getType result)) decls' result'
-  fromSafeE (S.Block _ decls result) =
-    case fromSafeE $ S.Abs decls result of
-      D.Abs decls' result' -> D.Block decls' result'
+  toSafeE (D.Block decls result) = do
+    S.Abs decls' result' <- toSafeE $ D.Abs decls result
+    ty <- toSafeE $ D.getType result
+    return $ S.Block ty decls' result'
+  fromSafeE (S.Block _ decls result) = do
+    D.Abs decls' result' <- fromSafeE $ S.Abs decls result
+    return $ D.Block decls' result'
 
 instance HasSafeVersionB D.Decl where
   type SafeVersionB D.Decl = S.Decl
-  -- toSafeB   (D.Let ann b expr) = S.Let ann (toSafeB   b) (toSafeE   expr)
-  -- fromSafeB (S.Let ann b expr) = D.Let ann (fromSafeB b) (fromSafeE expr)
+  toSafeB (D.Let ann b expr) cont = do
+    expr' <- toSafeE expr
+    toSafeB b \b' ->
+      cont $ S.Let ann b' expr'
 
-instance HasSafeVersionE e => HasSafeVersionB (D.BinderP e) where
-  -- type SafeVersionB (D.BinderP e) = S.AnnBinderP (S.NameBinder S.TypedBinderInfo) (SafeVersionE e)
-  -- toSafeB b = case b of
-  --   D.Bind (v D.:> ann) -> UnsafeMakeBinder v S.:> toSafeE ann
-  -- fromSafeB (b S.:> ann) = case b of
-  --   UnsafeMakeBinder v -> D.Bind (v D.:> fromSafeE ann)
+  fromSafeB (S.Let ann b expr) cont = do
+    expr' <- fromSafeE expr
+    fromSafeB b \b' -> do
+      cont $ D.Let ann b' expr'
+
+data AnnBinderP (ann::E) (n::S) (l::S) =
+  AnnBinderP (S.NameBinder S.TypedBinderInfo n l) (ann n)
 
 instance HasSafeVersionE D.Effect where
   type SafeVersionE D.Effect = S.Effect
   toSafeE eff = case eff of
-    D.RWSEffect rws h -> S.RWSEffect rws $ toSafeE h
-    D.ExceptionEffect -> S.ExceptionEffect
-    D.IOEffect -> S.IOEffect
+    D.RWSEffect rws h -> S.RWSEffect rws <$> toSafeAtomName h
+    D.ExceptionEffect -> return S.ExceptionEffect
+    D.IOEffect        -> return S.IOEffect
   fromSafeE eff = case eff of
-    S.RWSEffect rws h -> D.RWSEffect rws $ fromSafeE h
-    S.ExceptionEffect -> D.ExceptionEffect
-    S.IOEffect -> D.IOEffect
+    S.RWSEffect rws h -> D.RWSEffect rws <$> fromSafeAtomName h
+    S.ExceptionEffect -> return D.ExceptionEffect
+    S.IOEffect        -> return D.IOEffect
 
 instance HasSafeVersionE D.EffectRow where
   type SafeVersionE D.EffectRow = S.EffectRow
-  toSafeE (D.EffectRow effs v) = S.EffectRow (Set.map toSafeE effs) (fmap toSafeE v)
-  fromSafeE (S.EffectRow effs v) = D.EffectRow (Set.map fromSafeE effs) (fmap fromSafeE v)
+  toSafeE   (D.EffectRow effs v) = S.EffectRow <$> traverseSet toSafeE   effs <*> mapM toSafeAtomName   v
+  fromSafeE (S.EffectRow effs v) = D.EffectRow <$> traverseSet fromSafeE effs <*> mapM fromSafeAtomName v
 
 instance (HasSafeVersionB b, HasSafeVersionE e) => HasSafeVersionE (D.Abs b e) where
   type SafeVersionE (D.Abs b e) = S.Abs (SafeVersionB b) (SafeVersionE e)
-  toSafeE (D.Abs b e) = S.Abs (toSafeB b) (toSafeE e)
-  fromSafeE (S.Abs b e) = D.Abs (fromSafeB b) (fromSafeE e)
+  toSafeE   (D.Abs b e) = toSafeB   b \b' -> S.Abs b' <$> toSafeE e
+  fromSafeE (S.Abs b e) = fromSafeB b \b' -> D.Abs b' <$> fromSafeE e
 
 instance HasSafeVersionB b => HasSafeVersionB (D.Nest b) where
   type SafeVersionB (D.Nest b) = S.Nest (SafeVersionB b)
-  toSafeB nest = case nest of
-    D.Empty -> unsafeCoerceB $ S.Empty
-    D.Nest b rest -> S.Nest (toSafeB b) (toSafeB rest)
+  toSafeB nest cont = case nest of
+    D.Empty -> cont S.Empty
+    D.Nest b rest ->
+      toSafeB b \b' ->
+        toSafeB rest \rest' ->
+           cont $ S.Nest b' rest'
 
-  fromSafeB nest = case nest of
-    S.Empty -> D.Empty
-    S.Nest b rest -> D.Nest (fromSafeB b) (fromSafeB rest)
+instance HasSafeVersionE BinderInfo where
+  type SafeVersionE BinderInfo = AtomBinderInfo
+
+traverseSet :: (Ord a, Ord b, Monad m) => (a -> m b) -> Set.Set a -> m (Set.Set b)
+traverseSet f s = Set.fromList <$> mapM f (Set.toList s)
+
+-- === boilerplate instances ===
+
+instance Store TopStateEx
+
+-- TODO!
+instance Generic TopStateEx where
+  type Rep TopStateEx = Rep ()
+  to = undefined
+  from = undefined
+
+instance HasPtrs TopStateEx where
+  -- TODO: rather than implementing HasPtrs for safer names, let's just switch
+  --       to using names for pointers.
+  traversePtrs _ s = pure s
+
+instance ScopeReader ToSafeM where
+  getScope = ToSafeM $ ReaderT \_ -> getScope
+
+instance ScopeExtender ToSafeM where
+  extendScope frag (ToSafeM (ReaderT f)) =
+    ToSafeM $ ReaderT \env ->
+      extendScope frag do
+        env' <- injectM frag env
+        f env'
+
+instance MonadFail (ToSafeM o) where
+  fail s = error s
+
+instance MonadFail (FromSafeM i) where
+  fail s = error s
+
+instance InjectableE ToSafeNameMap
+
+instance InjectableE S.SynthCandidates
+instance InjectableE S.SourceNameMap
+

--- a/src/lib/SaferNames/Name.hs
+++ b/src/lib/SaferNames/Name.hs
@@ -31,7 +31,7 @@ module SaferNames.Name (
   withFreshM, inject, injectM, (!), (<>>), emptyEnv, envAsScope,
   EmptyAbs, pattern EmptyAbs, SubstVal (..), lookupEnv,
   NameGen (..), NameGenT (..), SubstGen (..), SubstGenT (..), withSubstB,
-  liftSG, forEachNestItemSG) where
+  liftSG, forEachNestItem, forEachNestItemSG) where
 
 import Prelude hiding (id, (.))
 import Control.Category

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -17,6 +17,7 @@ module SaferNames.NameCore (
 
 import Prelude hiding (id, (.))
 import Control.Category
+import Data.Foldable (fold)
 import Data.Text.Prettyprint.Doc  hiding (nest)
 import Data.Type.Equality
 import Type.Reflection
@@ -328,6 +329,10 @@ instance InjectableB b => InjectableB (Nest b) where
     injectionProofB fresh b \fresh' b' ->
       injectionProofB fresh' rest \fresh'' rest' ->
         cont fresh'' (Nest b' rest')
+
+instance (forall s n. Pretty (v s n)) => Pretty (EnvFrag v i i' o) where
+  pretty (UnsafeMakeEnv m _) =
+    fold [pretty v <+> "@>" <+> pretty x <> hardline | (v, EnvVal _ x) <- M.toList m ]
 
 -- === notes ===
 

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -110,11 +110,12 @@ data NameBinder (s::E)  -- static information for the name this binds (note
                 (l::S)  -- scope under the binder (`l` for "local")
   = UnsafeMakeBinder { nameBinderName :: Name s l }
 
-withFresh :: InjectableE s => Typeable s => Distinct n => Scope n
+withFresh :: (InjectableE s, Typeable s, Distinct n)
+          => RawName -> Scope n
           -> (forall l. Distinct l => NameBinder s n l -> a) -> a
-withFresh (UnsafeMakeScope scope) cont =
+withFresh hint (UnsafeMakeScope scope) cont =
   cont @UnsafeMakeDistinctS $ UnsafeMakeBinder freshName
-  where freshName = UnsafeMakeName $ freshRawName "v" scope
+  where freshName = UnsafeMakeName $ freshRawName (D.nameTag hint) scope
 
 freshRawName :: D.Tag -> S.Set RawName -> RawName
 freshRawName tag usedNames = D.Name D.GenName tag nextNum

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -118,7 +118,7 @@ data NameBinder (s::E)  -- static information for the name this binds (note
                 (l::S)  -- scope under the binder (`l` for "local")
   = UnsafeMakeBinder { nameBinderName :: Name s l }
 
-withFresh :: InjectableE s => Typeable s => Distinct n => NameSet n
+withFresh :: InjectableE s => Typeable s => Distinct n => NameSet (VoidS:=>:n)
           -> (forall l. Distinct l => NameBinder s n l -> a) -> a
 withFresh (UnsafeMakeNameSet scope) cont =
   cont @UnsafeMakeDistinctS $ UnsafeMakeBinder freshName

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -7,13 +7,13 @@
 {-# LANGUAGE FlexibleInstances #-}
 
 module SaferNames.NameCore (
-  S (..), RawName, Name (..), withFresh, injectNames, projectName,
+  S (..), RawName, Name (..), withFresh, injectNames, injectNamesR, projectName,
   NameBinder (..),
   NameSet (..), singletonNameSet, emptyNameSetFrag, emptyNameSet, extendNameSet, concatNameSets,
   NameMap (..), singletonNameMap, emptyNameMap, nameMapNames,
   lookupNameMap, extendNameMap,  concatNameMaps,
   Distinct, E, B, InjectableE (..), InjectableB (..), InjectableV, InjectionCoercion,
-  unsafeCoerceE, unsafeCoerceB, withNameClasses, getRawName, absurdNameFunction, fmapNameMap) where
+  unsafeCoerceE, unsafeCoerceB, withNameClasses, getRawName, absurdNameFunction, fmapNameMap, absurdNameMap) where
 
 import Prelude hiding (id, (.))
 import Data.Text.Prettyprint.Doc  hiding (nest)
@@ -159,6 +159,9 @@ getRawName (UnsafeMakeName rawName) = rawName
 injectNames :: InjectableE e => Distinct l => NameSet (n:=>:l) -> e n -> e l
 injectNames _ x = unsafeCoerceE x
 
+injectNamesR :: InjectableE e => e (n:=>:l) -> e l
+injectNamesR = unsafeCoerceE
+
 class InjectableE (e::E) where
   injectionProofE :: InjectionCoercion n l -> e n -> e l
 
@@ -211,6 +214,9 @@ lookupNameMap (UnsafeMakeNameMap m _) name@(UnsafeMakeName rawName) =
 
 emptyNameMap :: NameMap v (i:=>:i) o
 emptyNameMap = UnsafeMakeNameMap mempty mempty
+
+absurdNameMap :: NameMap v VoidS o
+absurdNameMap = UnsafeMakeNameMap mempty mempty
 
 singletonNameMap :: NameBinder s i i' -> v s o -> NameMap v (i:=>:i') o
 singletonNameMap (UnsafeMakeBinder (UnsafeMakeName name)) x =

--- a/src/lib/SaferNames/PPrint.hs
+++ b/src/lib/SaferNames/PPrint.hs
@@ -23,6 +23,7 @@ import qualified Data.Map.Strict as M
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
 import Data.Text (unpack)
+import Data.String (fromString)
 import System.IO.Unsafe
 import System.Environment
 
@@ -125,7 +126,7 @@ instance PrettyPrec (Atom n) where
     Eff e -> atPrec ArgPrec $ p e
     DataCon name _ _ _ xs -> case xs of
       [] -> atPrec ArgPrec $ p name
-      [l, r] | Just sym <- fromInfix (nameTag name) -> atPrec ArgPrec $ align $ group $
+      [l, r] | Just sym <- fromInfix (fromString name) -> atPrec ArgPrec $ align $ group $
         parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
       _ ->  atPrec LowestPrec $ pAppArg (p name) xs
     TypeCon name params -> case params of

--- a/src/lib/SaferNames/PPrint.hs
+++ b/src/lib/SaferNames/PPrint.hs
@@ -67,7 +67,7 @@ instance Pretty (Block n) where
   pretty (Block _ decls expr) = hardline <> prettyLines decls' <> pLowest expr
     where decls' = fromNest decls
 
-fromNest :: Nest b n l -> [b UnsafeMakeS UnsafeMakeS]
+fromNest :: Nest b n l -> [b UnsafeS UnsafeS]
 fromNest Empty = []
 fromNest (Nest b rest) = unsafeCoerceB b : fromNest rest
 

--- a/src/lib/SaferNames/PPrint.hs
+++ b/src/lib/SaferNames/PPrint.hs
@@ -20,6 +20,7 @@ import GHC.Exts (Constraint)
 import Data.Foldable (toList)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
+import Data.Foldable (fold)
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
 import Data.Text (unpack)

--- a/src/lib/SaferNames/PPrint.hs
+++ b/src/lib/SaferNames/PPrint.hs
@@ -129,7 +129,7 @@ instance PrettyPrec (Atom n) where
       [l, r] | Just sym <- fromInfix (fromString name) -> atPrec ArgPrec $ align $ group $
         parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
       _ ->  atPrec LowestPrec $ pAppArg (p name) xs
-    TypeCon name params -> case params of
+    TypeCon (name, _) params -> case params of
       [] -> atPrec ArgPrec $ p name
       [l, r] | Just sym <- fromInfix (nameTag (getRawName name)) ->
         atPrec ArgPrec $ align $ group $

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -410,7 +410,7 @@ instance (InjectableToAtomSubstVal AtomSubstVal) where
 instance (InjectableToAtomSubstVal Name) where
   injectToAtomSubstVal = Rename
 
-lookupAtomSubstVal :: EnvReader v m => InjectableToAtomSubstVal v
+lookupAtomSubstVal :: (EnvReader v m, Typeable s, InjectableE s, InjectableToAtomSubstVal v)
                    => Name s i -> m i o (AtomSubstVal s o)
 lookupAtomSubstVal name = injectToAtomSubstVal <$> lookupEnvM name
 

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -392,7 +392,7 @@ instance (InjectableToAtomSubstVal Name) where
 
 lookupAtomSubstVal :: EnvReader v m => InjectableToAtomSubstVal v
                    => Name s i -> m i o (AtomSubstVal s o)
-lookupAtomSubstVal name = injectToAtomSubstVal <$> lookupEnv name
+lookupAtomSubstVal name = injectToAtomSubstVal <$> lookupEnvM name
 
 -- right-biased, unlike the underlying Map
 instance Semigroup (SourceMap n) where

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -117,7 +117,7 @@ data TypedBinderInfo (n::S) = TypedBinderInfo (Type n) (AtomBinderInfo n)
 data Decl n l = Let LetAnn (Binder n l) (Expr n)
                 deriving (Show)
 
-type AtomName   = Name TypedBinderInfo
+type AtomName = Name TypedBinderInfo
 
 data Binder (n::S) (l::S) =
   (:>) (NameBinder TypedBinderInfo n l) (Type n)  deriving Show

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -80,7 +80,7 @@ prettyVal val = case val of
           TC (BaseType (Scalar Word8Type)) -> pretty ('"': concat elems ++ "\"")
           _      -> pretty elems
     return $ elemsDoc <> idxSetDoc
-  DataCon (DataDef _ _ dataCons) _ con args ->
+  DataCon (_, DataDef _ _ dataCons) _ con args ->
     case args of
       [] -> return $ pretty conName
       _  -> do
@@ -97,7 +97,7 @@ prettyVal val = case val of
     SumAsProd ty (TagRepVal trep) payload -> do
       let t = fromIntegral trep
       case ty of
-        TypeCon (DataDef _ _ dataCons) _ ->
+        TypeCon (_, DataDef _ _ dataCons) _ ->
           case args of
             [] -> return $ pretty conName
             _  -> do

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -43,7 +43,7 @@ module Syntax (
     SourceName, SourceMap (..), UExpr, UExpr' (..), UType, UPatAnn (..),
     UAnnBinder (..), UVar (..), UBinder (..), UMethodDef (..),
     UMethodTypeDef, UPatAnnArrow (..), UVars,
-    UPat, UPat' (..), SourceUModule (..),
+    UPat, UPat' (..), SourceUModule (..), SourceNameDef (..), sourceNameDefName,
     UModule (..), UDecl (..), UDataDef (..), UArrow, arrowEff,
     UEffect, UEffectRow, UEffArrow,
     DataDef (..), NamedDataDef, DataConDef (..), ClassDef (..), UConDef, Nest (..), toNest,
@@ -185,7 +185,23 @@ type Con = PrimCon Atom
 type Op  = PrimOp  Atom
 type Hof = PrimHof Atom
 
-data SourceMap = SourceMap { fromSourceMap :: M.Map SourceName Name }  deriving (Show, Generic)
+data SourceNameDef =
+   SrcAtomName    Name
+ | SrcTyConName   Name
+ | SrcDataConName Name
+ | SrcClassName   Name
+ | SrcMethodName  Name
+   deriving (Show, Generic)
+
+sourceNameDefName :: SourceNameDef -> Name
+sourceNameDefName def = case def of
+  SrcAtomName    v -> v
+  SrcTyConName   v -> v
+  SrcDataConName v -> v
+  SrcClassName   v -> v
+  SrcMethodName  v -> v
+
+data SourceMap = SourceMap { fromSourceMap :: M.Map SourceName SourceNameDef }  deriving (Show, Generic)
 
 data Module = Module IRVariant (Nest Decl) EvaluatedModule deriving (Show, Generic)
 
@@ -1841,6 +1857,7 @@ instance Store Device
 instance Store DataConRefBinding
 instance Store SourceMap
 instance Store SynthCandidates
+instance Store SourceNameDef
 
 instance IsString UVar where
   fromString = USourceVar . fromString
@@ -1887,3 +1904,6 @@ instance Semigroup SynthCandidates where
 
 instance Monoid SynthCandidates where
   mempty = SynthCandidates mempty mempty mempty
+
+instance HasName SourceNameDef where
+  getName srcName = Just $ sourceNameDefName srcName

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -23,7 +23,7 @@ module Syntax (
     BinOp (..), UnOp (..), CmpOp (..), SourceBlock (..),
     ReachedEOF, SourceBlock' (..), SubstEnv, ScopedSubstEnv, SubstVal (..),
     Scope, CmdName (..), HasIVars (..), ForAnn (..),
-    Val, Op, Con, Hof, TC, Module (..),
+    Val, Op, Con, Hof, TC, Module (..), TopState (..), emptyTopState,
     EvaluatedModule (..), SynthCandidates (..),
     emptyEvaluatedModule, DataConRefBinding (..),
     ImpModule (..), ImpBlock (..), ImpFunction (..), ImpDecl (..),
@@ -183,12 +183,20 @@ type Con = PrimCon Atom
 type Op  = PrimOp  Atom
 type Hof = PrimHof Atom
 
-data SourceMap = SourceMap (M.Map SourceName Name)  deriving (Show, Generic)
+data SourceMap = SourceMap { fromSourceMap :: M.Map SourceName Name }  deriving (Show, Generic)
 
 data Module = Module IRVariant (Nest Decl) EvaluatedModule deriving (Show, Generic)
 
 data EvaluatedModule =
   EvaluatedModule Bindings SynthCandidates SourceMap deriving (Show, Generic)
+
+data TopState = TopState
+  { topBindings        :: Bindings
+  , topSynthCandidates :: SynthCandidates
+  , topSourceMap       :: SourceMap }
+
+emptyTopState :: TopState
+emptyTopState = TopState mempty mempty mempty
 
 emptyEvaluatedModule :: EvaluatedModule
 emptyEvaluatedModule = EvaluatedModule mempty mempty mempty

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -212,6 +212,7 @@ data TopState = TopState
   { topBindings        :: Bindings
   , topSynthCandidates :: SynthCandidates
   , topSourceMap       :: SourceMap }
+  deriving (Show)
 
 emptyTopState :: TopState
 emptyTopState = TopState mempty mempty mempty

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -313,6 +313,7 @@ evalUModule sourceModule = do
   typed <- liftEither $ inferModule bindings renamed
   -- This is a (hopefully) no-op pass. It's here as a sanity check to test the
   -- safer names system while we're staging it in.
+  checkPass TypePass typed
   typed' <- roundtripSaferNamesPass typed
   checkPass TypePass typed'
   synthed <- liftEither $ synthModule bindings synthCandidates typed'

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -314,6 +314,7 @@ evalUModule sourceModule = do
   -- This is a (hopefully) no-op pass. It's here as a sanity check to test the
   -- safer names system while we're staging it in.
   checkPass TypePass typed
+  topState <- getTopState
   typed' <- roundtripSaferNamesPass typed
   checkPass TypePass typed'
   synthed <- liftEither $ synthModule bindings synthCandidates typed'

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -190,7 +190,7 @@ evalSourceBlock' block = case sbContents block of
       Nothing -> throw UnboundVarErr $ pprint v
       Just v' -> do
         bindings <- topBindings <$> topStateD <$> getTopState
-        case nameToAtom bindings v' of
+        case nameToAtom bindings (sourceNameDefName v') of
           Just x -> logTop $ TextOut $ pprint $ getType x
           Nothing -> throw TypeErr $ pprint v  ++ " doesn't have a type"
   ImportModule moduleName -> do

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -314,7 +314,6 @@ evalUModule sourceModule = do
   -- This is a (hopefully) no-op pass. It's here as a sanity check to test the
   -- safer names system while we're staging it in.
   checkPass TypePass typed
-  topState <- getTopState
   typed' <- roundtripSaferNamesPass typed
   checkPass TypePass typed'
   synthed <- liftEither $ synthModule bindings synthCandidates typed'

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -1178,8 +1178,17 @@ instance Subst EvaluatedModule where
     let (sourceMap', (_, bindings'')) = flip runCat envNew $ mapM substOrEmit sourceMap
     EvaluatedModule (bindings'<>bindings'') synthCandidates' $ SourceMap sourceMap'
 
-substOrEmit :: Name -> Cat ScopedSubstEnv Name
-substOrEmit name = do
+
+substOrEmit :: SourceNameDef -> Cat ScopedSubstEnv SourceNameDef
+substOrEmit def = case def of
+  SrcAtomName    v -> SrcAtomName    <$> substOrEmitName v
+  SrcTyConName   v -> SrcTyConName   <$> substOrEmitName v
+  SrcDataConName v -> SrcDataConName <$> substOrEmitName v
+  SrcClassName   v -> SrcClassName   <$> substOrEmitName v
+  SrcMethodName  v -> SrcMethodName  <$> substOrEmitName v
+
+substOrEmitName :: Name -> Cat ScopedSubstEnv Name
+substOrEmitName name = do
   (substEnv, scope) <- look
   case envLookup substEnv name of
     Nothing -> return name

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -905,15 +905,15 @@ typeCheckHof hof = case hof of
     -- PTileReduce n mapping : (n=>a, (acc1, ..., acc{n}))
     return $ PairTy (TabTy (Ignore n) tileElemTy) $ ProdTy accTys
   While body -> do
-    Pi (Abs (Ignore UnitTy) (arr , condTy)) <- typeCheck body
+    Pi (Abs (BinderAnn UnitTy) (arr , condTy)) <- typeCheck body
     declareEffs $ arrowEff arr
     checkEq (BaseTy $ Scalar Word8Type) condTy
     return UnitTy
   Linearize f -> do
-    Pi (Abs (Ignore a) (PlainArrow Pure, b)) <- typeCheck f
+    Pi (Abs (BinderAnn a) (PlainArrow Pure, b)) <- typeCheck f
     return $ a --> PairTy b (a --@ b)
   Transpose f -> do
-    Pi (Abs (Ignore a) (LinArrow, b)) <- typeCheck f
+    Pi (Abs (BinderAnn a) (LinArrow, b)) <- typeCheck f
     return $ b --@ a
   RunReader r f -> do
     (resultTy, readTy) <- checkRWSAction Reader f

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -126,7 +126,7 @@ instance HasType Atom where
     Con con  -> typeCheckCon con
     TC tyCon -> typeCheckTyCon tyCon
     Eff eff  -> checkEffRow eff $> EffKind
-    DataCon def@(DataDef _ paramBs cons) params con args -> do
+    DataCon def@(_, DataDef _ paramBs cons) params con args -> do
       let paramVars = fmap (\(Bind v) -> v) paramBs
       let (DataConDef _ argBs) = cons !! con
       let funTy = foldr
@@ -135,7 +135,7 @@ instance HasType Atom where
             (   zip (repeat ImplicitArrow) (toList paramBs)
              ++ zip (repeat PureArrow    ) (toList argBs))
       foldM checkApp funTy $ params ++ args
-    TypeCon (DataDef _ bs _) params -> do
+    TypeCon (_, DataDef _ bs _) params -> do
       let paramTys = map binderType $ toList bs
       zipWithM_ (|:) params paramTys
       let paramTysRemaining = drop (length params) paramTys
@@ -159,7 +159,7 @@ instance HasType Atom where
       return ty
     VariantTy row -> checkLabeledRow row $> TyKind
     ACase e alts resultTy -> checkCase e alts resultTy
-    DataConRef ~def@(DataDef _ paramBs [DataConDef _ argBs]) params args -> do
+    DataConRef ~def@(_, DataDef _ paramBs [DataConDef _ argBs]) params args -> do
       checkEq (length paramBs) (length params)
       forM_ (zip (toList paramBs) (toList params)) \(b, param) ->
         param |: binderAnn b
@@ -181,7 +181,7 @@ instance HasType Atom where
               Nothing -> Var v
               Just is' -> ProjectElt is' v
       case ty of
-        TypeCon def params -> do
+        TypeCon (_, def) params -> do
           [DataConDef _ bs'] <- return $ applyDataDefParams def params
           -- Users might be accessing a value whose type depends on earlier
           -- projected values from this constructor. Rewrite them to also
@@ -244,7 +244,7 @@ checkCase e alts resultTy = do
   checkWithEnv \_ -> do
     ety <- typeCheck e
     case ety of
-      TypeCon def params -> do
+      TypeCon (_, def) params -> do
         let cons = applyDataDefParams def params
         checkEq  (length cons) (length alts)
         forM_ (zip cons alts) \((DataConDef _ bs'), (Abs bs body)) -> do
@@ -844,7 +844,7 @@ typeCheckOp op = case op of
     t |: TyKind
     x |: Word8Ty
     case t of
-      TypeCon (DataDef _ _ dataConDefs) _ ->
+      TypeCon (_, DataDef _ _ dataConDefs) _ ->
         forM_ dataConDefs \(DataConDef _ binders) ->
           assertEq binders Empty "Not an enum"
       VariantTy _ -> return ()  -- TODO: check empty payload
@@ -1038,7 +1038,7 @@ checkDataLike msg ty = case ty of
   TabTy _ b -> recur b
   RecordTy (NoExt items)  -> traverse_ recur items
   VariantTy (NoExt items) -> traverse_ recur items
-  TypeCon def params ->
+  TypeCon (_, def) params ->
     mapM_ checkDataLikeDataCon $ applyDataDefParams def params
   TC con -> case con of
     BaseType _       -> return ()
@@ -1066,7 +1066,7 @@ isData ty = case checkData ty of
 
 projectLength :: Type -> Int
 projectLength ty = case ty of
-  TypeCon def params ->
+  TypeCon (_, def) params ->
     let [DataConDef _ bs] = applyDataDefParams def params
     in length bs
   RecordTy (NoExt types) -> length types
@@ -1102,7 +1102,7 @@ typeReduceAtom scope x = case x of
   TC con -> TC $ fmap (typeReduceAtom scope) con
   Pi (Abs b (arr, ty)) ->
     Pi $ Abs b (arr, typeReduceAtom (scope <> (fmap (flip AtomBinderInfo PiBound) $ binderAsEnv b)) ty)
-  TypeCon def params -> TypeCon (reduceDataDef def) (fmap rec params)
+  TypeCon (name, def) params -> TypeCon (name, reduceDataDef def) (fmap rec params)
   RecordTy (Ext tys ext) -> RecordTy $ Ext (fmap rec tys) ext
   VariantTy (Ext tys ext) -> VariantTy $ Ext (fmap rec tys) ext
   ACase _ _ _ -> error "Not implemented"
@@ -1141,16 +1141,14 @@ nameToAtom :: Scope -> Name -> Maybe Atom
 nameToAtom scope v = do
   case scope ! v of
     AtomBinderInfo ty _ -> return $ Var $ v :> ty
-    DataDefName dataDef ->
-      return $ TypeCon dataDef []
     ClassDefName (ClassDef dataDef _) ->
       return $ TypeCon dataDef []
     TyConName dataDefName -> do
       let DataDefName dataDef = scope ! dataDefName
-      return $ TypeCon dataDef []
+      return $ TypeCon (dataDefName, dataDef) []
     DataConName dataDefName conIdx -> do
       let DataDefName dataDef = scope ! dataDefName
-      return $ DataCon dataDef [] conIdx []
+      return $ DataCon (dataDefName, dataDef) [] conIdx []
     MethodName _ _ methodGetter -> return methodGetter
     binderInfo -> error $ "Not an atom name: " ++ pprint binderInfo
 


### PR DESCRIPTION
Previously we'd tried using unsafe casts to convert between the safe and unsafe IRs, without any renaming. But the scoping rules are sufficiently different in the safe IR that this didn't work. This time, I did a proper subst-carrying conversion in both directions, and added the name bijection between and the safe bindings to the top level. I also filled out some missing pieces, like instances for Pretty, Generic, and Store.
