### PR TITLE
Port the parser and source-name renamer to SaferNames.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -57,7 +57,8 @@ library
                        Err, LabeledItems, SourceRename,
                        SaferNames.NameCore, SaferNames.Name, SaferNames.LazyMap,
                        SaferNames.Syntax, SaferNames.Bridge,
-                       SaferNames.PPrint, SaferNames.Parser
+                       SaferNames.PPrint, SaferNames.Parser,
+                       SaferNames.ResolveImplicitNames, SaferNames.SourceRename
   if flag(live)
     exposed-modules:   Actor, RenderHtml, LiveOutput
   other-modules:       Paths_dex

--- a/dex.cabal
+++ b/dex.cabal
@@ -57,7 +57,7 @@ library
                        Err, LabeledItems, SourceRename,
                        SaferNames.NameCore, SaferNames.Name, SaferNames.LazyMap,
                        SaferNames.Syntax, SaferNames.Bridge,
-                       SaferNames.PPrint
+                       SaferNames.PPrint, SaferNames.Parser
   if flag(live)
     exposed-modules:   Actor, RenderHtml, LiveOutput
   other-modules:       Paths_dex

--- a/src/lib/LabeledItems.hs
+++ b/src/lib/LabeledItems.hs
@@ -10,6 +10,7 @@
 module LabeledItems
   ( Label, LabeledItems (..), labeledSingleton, reflectLabels, getLabels
   , withLabels, lookupLabelHead, ExtLabeledItems (..), prefixExtLabeledItems
+  , unzipExtLabeledItems
   , pattern NoLabeledItems, pattern NoExt, pattern InternalSingletonLabel
   , pattern Unlabeled ) where
 
@@ -70,6 +71,14 @@ data ExtLabeledItems a b = Ext (LabeledItems a) (Maybe b)
 -- Adds more items to the front of an ExtLabeledItems.
 prefixExtLabeledItems :: LabeledItems a -> ExtLabeledItems a b -> ExtLabeledItems a b
 prefixExtLabeledItems items (Ext items' rest) = Ext (items <> items') rest
+
+-- The returned list is parallel to the input LabeledItems, following
+-- the sort order of the labels.
+unzipExtLabeledItems :: ExtLabeledItems a b -> (ExtLabeledItems () (), [a], Maybe b)
+unzipExtLabeledItems (Ext items (Just b)) =
+  (Ext ((const ()) <$> items) (Just ()), (toList items), Just b)
+unzipExtLabeledItems (Ext items Nothing) =
+  (Ext ((const ()) <$> items) Nothing, (toList items), Nothing)
 
 pattern NoLabeledItems :: LabeledItems a
 pattern NoLabeledItems <- ((\(LabeledItems items) -> M.null items) -> True)

--- a/src/lib/SaferNames/Bridge.hs
+++ b/src/lib/SaferNames/Bridge.hs
@@ -818,7 +818,6 @@ instance MonadFail (FromSafeM i) where
 instance InjectableE ToSafeNameMap
 
 instance InjectableE S.SynthCandidates
-instance InjectableE S.SourceMap
 
 instance D.HasName (UnsafeName s) where
   getName (UnsafeAtomName       v) = Just v

--- a/src/lib/SaferNames/Name.hs
+++ b/src/lib/SaferNames/Name.hs
@@ -345,7 +345,11 @@ data SubstVal (sMatch::E) (atom::E) (s::E) (n::S) where
   SubstVal :: atom n   -> SubstVal s      atom s n
   Rename   :: Name s n -> SubstVal sMatch atom s n
 
-withFreshM :: (ScopeReader m, ScopeExtender m, Typeable s, InjectableE s, HasNameHint hint)
+-- TODO Presumably this wanted the constraints Typeable s and
+-- InjectableE s only because it used `withFresh`; but I don't know
+-- why `withFresh` wanted them, so I don't know whether `withFreshM`
+-- may want to add them back.
+withFreshM :: (ScopeReader m, ScopeExtender m, HasNameHint hint)
            => hint
            -> (forall o'. NameBinder s o o' -> m o' a)
            -> m o a

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -115,7 +115,8 @@ data NameBinder (s::E)  -- static information for the name this binds (note
                 (l::S)  -- scope under the binder (`l` for "local")
   = UnsafeMakeBinder { nameBinderName :: Name s l }
 
-withFresh :: (InjectableE s, Typeable s, Distinct n)
+-- TODO Why did this want the constraints Typable s and InjectableE s?
+withFresh :: (Distinct n)
           => RawName -> Scope n
           -> (forall l. Distinct l => NameBinder s n l -> a) -> a
 withFresh hint (UnsafeMakeScope scope) cont =

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -297,7 +297,7 @@ instance Eq (Name s n) where
   UnsafeMakeName rawName == UnsafeMakeName rawName' = rawName == rawName'
 
 instance Ord (Name s n) where
-  compare (UnsafeMakeName name) (UnsafeMakeName name')= compare name name'
+  compare (UnsafeMakeName name) (UnsafeMakeName name') = compare name name'
 
 instance Show (Name s n) where
   show (UnsafeMakeName rawName) = show rawName

--- a/src/lib/SaferNames/Parser.hs
+++ b/src/lib/SaferNames/Parser.hs
@@ -1,0 +1,1189 @@
+-- Copyright 2019 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module SaferNames.Parser (Parser, parseit, parseProg, runTheParser, parseData,
+               parseTopDeclRepl, uint, withSource, parseExpr, exprAsModule,
+               emptyLines, brackets, symbol, symChar, keyWordStrs) where
+
+import Control.Monad
+import Control.Monad.Combinators.Expr
+import Control.Monad.Reader
+import Text.Megaparsec hiding (Label, State)
+import Text.Megaparsec.Char hiding (space, eol)
+import qualified Text.Megaparsec.Char as MC
+import Data.Foldable (toList)
+import Data.Functor
+import Data.List.NonEmpty (NonEmpty (..))
+import Data.Maybe (fromMaybe)
+import Data.Void
+import qualified Data.Set as S
+import Data.String (IsString, fromString)
+import qualified Text.Megaparsec.Char.Lexer as L
+import qualified Text.Megaparsec.Debug
+
+import Err
+import LabeledItems
+import SaferNames.Name
+import SaferNames.Syntax
+
+-- canPair is used for the ops (,) (|) (&) which should only appear inside
+-- parentheses (to avoid conflicts with records and other syntax)
+data ParseCtx = ParseCtx { curIndent :: Int
+                         , canPair   :: Bool
+                         , canBreak  :: Bool }
+type Parser = ReaderT ParseCtx (Parsec Void String)
+
+parseProg :: String -> [SourceBlock]
+parseProg s = mustParseit s $ manyTill (sourceBlock <* outputLines) eof
+
+parseData :: String -> Except (UExpr VoidS)
+parseData s = parseit s $ expr <* (optional eol >> eof)
+
+parseTopDeclRepl :: String -> Maybe SourceBlock
+parseTopDeclRepl s = case sbContents b of
+  UnParseable True _ -> Nothing
+  _ -> Just b
+  where b = mustParseit s sourceBlock
+
+parseExpr :: String -> Except (UExpr VoidS)
+parseExpr s = parseit s (expr <* eof)
+
+parseit :: String -> Parser a -> Except a
+parseit s p = case runTheParser s (p <* (optional eol >> eof)) of
+  Left e -> throw ParseErr (errorBundlePretty e)
+  Right x -> return x
+
+mustParseit :: String -> Parser a -> a
+mustParseit s p  = case parseit s p of
+  Right ans -> ans
+  Left e -> error $ "This shouldn't happen:\n" ++ pprint e
+
+importModule :: Parser SourceBlock'
+importModule = ImportModule <$> do
+  keyWord ImportKW
+  s <- (:) <$> letterChar <*> many alphaNumChar
+  eol
+  return s
+
+sourceBlock :: Parser SourceBlock
+sourceBlock = do
+  offset <- getOffset
+  pos <- getSourcePos
+  (src, (level, b)) <- withSource $ withRecovery recover $ do
+    level <- logLevel <|> logTime <|> logBench <|> return LogNothing
+    b <- sourceBlock'
+    return (level, b)
+  return $ SourceBlock (unPos (sourceLine pos)) offset level src b Nothing
+
+recover :: ParseError String Void -> Parser (LogLevel, SourceBlock')
+recover e = do
+  pos <- liftM statePosState getParserState
+  reachedEOF <-  try (mayBreak sc >> eof >> return True)
+             <|> return False
+  consumeTillBreak
+  let errmsg = errorBundlePretty (ParseErrorBundle (e :| []) pos)
+  return (LogNothing, UnParseable reachedEOF errmsg)
+
+consumeTillBreak :: Parser ()
+consumeTillBreak = void $ manyTill anySingle $ eof <|> void (try (eol >> eol))
+
+logLevel :: Parser LogLevel
+logLevel = do
+  void $ try $ lexeme $ char '%' >> string "passes"
+  passes <- many passName
+  eol
+  case passes of
+    [] -> return LogAll
+    _ -> return $ LogPasses passes
+
+logTime :: Parser LogLevel
+logTime = do
+  void $ try $ lexeme $ char '%' >> string "time"
+  eol
+  return PrintEvalTime
+
+logBench :: Parser LogLevel
+logBench = do
+  void $ try $ lexeme $ char '%' >> string "bench"
+  benchName <- stringLiteral
+  eol
+  return $ PrintBench benchName
+
+passName :: Parser PassName
+passName = choice [thisNameString s $> x | (s, x) <- passNames]
+
+passNames :: [(String, PassName)]
+passNames = [(show x, x) | x <- [minBound..maxBound]]
+
+sourceBlock' :: Parser SourceBlock'
+sourceBlock' =
+      proseBlock
+  <|> topLevelCommand
+  <|> liftM declToModule (topDecl <* eolf)
+  <|> liftM declToModule (instanceDef True  <* eolf)
+  <|> liftM declToModule (instanceDef False <* eolf)
+  <|> liftM declToModule (interfaceDef <* eolf)
+  <|> liftM (Command (EvalExpr Printed) . exprAsModule) (expr <* eol)
+  <|> hidden (some eol >> return EmptyLines)
+  <|> hidden (sc >> eol >> return CommentLine)
+  where declToModule = RunModule . SourceUModule
+
+proseBlock :: Parser SourceBlock'
+proseBlock = label "prose block" $ char '\'' >> fmap (ProseBlock . fst) (withSource consumeTillBreak)
+
+topLevelCommand :: Parser SourceBlock'
+topLevelCommand =
+      importModule
+  <|> explicitCommand
+  <?> "top-level command"
+
+explicitCommand :: Parser SourceBlock'
+explicitCommand = do
+  cmdName <- char ':' >> nameString
+  cmd <- case cmdName of
+    "p"       -> return $ EvalExpr Printed
+    "t"       -> return $ GetType
+    "html"    -> return $ EvalExpr RenderHtml
+    "export"  -> ExportFun <$> nameString
+    _ -> fail $ "unrecognized command: " ++ show cmdName
+  e <- blockOrExpr <* eolf
+  return $ case (e, cmd) of
+    (WithSrcE _ (UVar (SourceName v)), GetType) -> GetNameType v
+    _ -> Command cmd (exprAsModule e)
+
+exprAsModule :: UExpr VoidS -> (SourceName, SourceUModule)
+exprAsModule e = (v, SourceUModule d)
+  where
+    v = "_ans_"
+    d = ULet PlainLet (UPatAnn (WithSrcB (srcPos e) (fromString v)) Nothing) e
+
+-- === uexpr ===
+
+expr :: Parser (UExpr VoidS)
+expr = mayNotPair $ makeExprParser leafExpr ops
+
+-- expression without exposed infix operators
+leafExpr :: Parser (UExpr VoidS)
+leafExpr = parens (mayPair $ makeExprParser leafExpr ops)
+         <|> uTabCon
+         <|> uVarOcc
+         <|> uHole
+         <|> uString
+         <|> uLit
+         <|> uPiType
+         <|> uLamExpr
+         <|> uViewExpr
+         <|> uForExpr
+         <|> caseExpr
+         <|> ifExpr
+         <|> uPrim
+         <|> unitCon
+         <|> (uLabeledExprs `fallBackTo` uVariantExpr)
+         <|> uIsoSugar
+         <|> uDoSugar
+         <?> "expression"
+
+containedExpr :: Parser (UExpr VoidS)
+containedExpr =   parens (mayPair $ makeExprParser leafExpr ops)
+              <|> uVarOcc
+              <|> uLabeledExprs
+              <?> "contained expression"
+
+uType :: Parser (UType VoidS)
+uType = expr
+
+uString :: Lexer (UExpr VoidS)
+uString = do
+  (s, pos) <- withPos $ strLit
+  let addSrc = WithSrcE (Just pos)
+  let cs = map (addSrc . charExpr) s
+  return $ mkApp (addSrc "toList") $ addSrc $ UTabCon cs
+
+uLit :: Parser (UExpr VoidS)
+uLit = withSrc $ uLitParser
+  where uLitParser = charExpr <$> charLit
+                 <|> UIntLit  <$> intLit
+                 <|> UFloatLit <$> doubleLit
+                 <?> "literal"
+
+charExpr :: Char -> (UExpr' VoidS)
+charExpr c = UPrimExpr $ ConExpr $ Lit $ Word8Lit $ fromIntegral $ fromEnum c
+
+uVarOcc :: Parser (UExpr VoidS)
+uVarOcc = withSrc $ try $ fromString <$> (anyName <* notFollowedBy (sym ":"))
+
+uHole :: Parser (UExpr VoidS)
+uHole = withSrc $ underscore $> UHole
+
+letAnnStr :: Parser LetAnn
+letAnnStr =   (string "instance"   $> InstanceLet)
+          <|> (string "noinline"   $> NoInlineLet)
+
+topDecl :: Parser (UDecl VoidS VoidS)
+topDecl = dataDef <|> topLet
+
+topLet :: Parser (UDecl VoidS VoidS)
+topLet = do
+  lAnn <- (char '@' >> letAnnStr <* (eol <|> sc)) <|> return PlainLet
+  ~(ULet _ p rhs) <- decl
+  return $ ULet lAnn p rhs
+
+superclassConstraints :: Parser [(UType VoidS)]
+superclassConstraints = optionalMonoid $ brackets $ uType `sepBy` sym ","
+
+interfaceDef :: Parser (UDecl VoidS VoidS)
+interfaceDef = do
+  keyWord InterfaceKW
+  superclasses <- superclassConstraints
+  (tyConName, tyConParams) <- tyConDef
+  (methodNames, methodTys) <- unzip <$> onePerLine do
+    v <- anyName
+    ty <- annot uType
+    return (fromString v, ty)
+  let methodNames' :: Nest (UBinder MethodDef) VoidS VoidS
+      methodNames' = toNest methodNames
+  let tyConParams' = tyConParams
+  return $ UInterface tyConParams' superclasses methodTys (fromString tyConName) methodNames'
+
+toNest :: (IsString (a VoidS VoidS)) => [String] -> Nest a VoidS VoidS
+toNest = toNestParsed . map fromString
+
+toNestParsed :: [a VoidS VoidS] -> Nest a VoidS VoidS
+toNestParsed = foldr Nest Empty
+
+toNestPair :: forall a b. (IsString (a VoidS VoidS), IsString (b VoidS VoidS))
+           => String -> String -> NestPair a b VoidS VoidS
+toNestPair s1 s2 = NestPair parse1 parse2 where
+  parse1 :: a VoidS VoidS
+  parse1 = fromString s1
+  parse2 :: b VoidS VoidS
+  parse2 = fromString s2
+
+dataDef :: Parser (UDecl VoidS VoidS)
+dataDef = do
+  keyWord DataKW
+  tyCon <- tyConDef
+  sym "="
+  dataCons <- onePerLine dataConDef
+  return $ UDataDefDecl
+    (UDataDef tyCon $ map (\(nm, cons) -> (nm, UDataDefTrail cons)) dataCons)
+    (fromString $ fst tyCon)
+    (toNest $ map (fromString . fst) $ dataCons)
+
+tyConDef :: Parser (UConDef VoidS VoidS)
+tyConDef = do
+  con <- upperName <|> symName
+  bs <- manyNested $ label "type constructor parameter" do
+    v <- lowerName
+    ty <- annot containedExpr <|> return tyKind
+    return $  UAnnBinder (fromString v) ty
+  return (fromString con, bs)
+  where tyKind = ns $ UPrimExpr $ TCExpr TypeKind
+
+-- TODO: dependent types
+dataConDef :: Parser (UConDef VoidS VoidS)
+dataConDef = (,) <$> upperName <*> manyNested dataConDefBinder
+
+dataConDefBinder :: Parser (UAnnBinder AtomNameDef VoidS VoidS)
+dataConDefBinder = annBinder <|> (UAnnBinder UIgnore <$> containedExpr)
+
+decl :: Parser (UDecl VoidS VoidS)
+decl = do
+  lhs <- simpleLet <|> funDefLet
+  rhs <- sym "=" >> blockOrExpr
+  return $ lhs rhs
+
+instanceDef :: Bool -> Parser (UDecl VoidS VoidS)
+instanceDef isNamed = do
+  name <- case isNamed of
+    False -> keyWord InstanceKW $> NothingB
+    True  -> keyWord NamedInstanceKW *> (JustB . fromString <$> anyName) <* sym ":"
+  explicitArgs <- many defArg
+  constraints <- classConstraints
+  className <- upperName
+  params <- many leafExpr
+  let argBinders = explicitArgs
+                 ++ [UPatAnnArrow (UPatAnn (nsB UPatIgnore) (Just c)) ClassArrow | c <- constraints]
+  methods <- onePerLine instanceMethod
+  return $ UInstance (toNestParsed argBinders) (fromString className) params methods name
+
+instanceMethod :: Parser (UMethodDef VoidS)
+instanceMethod = do
+  v <- anyName
+  sym "="
+  rhs <- blockOrExpr
+  return $ UMethodDef (fromString v) rhs
+
+simpleLet :: Parser (UExpr VoidS -> UDecl VoidS VoidS)
+simpleLet = label "let binding" $ do
+  letAnn <- (InstanceLet <$ string "%instance" <* sc) <|> (pure PlainLet)
+  p <- try $ (letPat <|> leafPat) <* lookAhead (sym "=" <|> sym ":")
+  typeAnn <- optional $ annot uType
+  return $ ULet letAnn (UPatAnn p typeAnn)
+
+letPat :: Parser (UPat VoidS VoidS)
+letPat = withSrcB $ fromString <$> anyName
+
+funDefLet :: Parser (UExpr VoidS -> UDecl VoidS VoidS)
+funDefLet = label "function definition" $ mayBreak $ do
+  keyWord DefKW
+  v <- letPat
+  cs <- classConstraints
+  argBinders <- many defArg
+  (eff, ty) <- label "result type annotation" $ annot effectiveType
+  when (null argBinders && eff /= Pure) $ fail "Nullary def can't have effects"
+  let bs = map classAsBinder cs ++ argBinders
+  let funTy = buildPiType bs eff ty
+  let letBinder = UPatAnn v (Just funTy)
+  let lamBinders = flip map bs \(UPatAnnArrow (UPatAnn p _) arr) -> (UPatAnnArrow (UPatAnn p Nothing) arr)
+  return \body -> ULet PlainLet letBinder (buildLam lamBinders body)
+  where
+    classAsBinder :: (UType (n::S)) -> UPatAnnArrow n n
+    classAsBinder ty = UPatAnnArrow (UPatAnn (nsB UPatIgnore) (Just ty)) ClassArrow
+
+defArg :: Parser (UPatAnnArrow VoidS VoidS)
+defArg = label "def arg" $ do
+  (p, ty) <- parens ((,) <$> pat <*> annot uType)
+  arr <- bareArrow <|> return PlainArrow
+  return $ UPatAnnArrow (UPatAnn p (Just ty)) arr
+
+classConstraints :: Parser [(UType VoidS)]
+classConstraints = label "class constraints" $
+  optionalMonoid $ brackets $ mayNotPair $ uType `sepBy` sym ","
+
+buildPiType :: [UPatAnnArrow VoidS VoidS] -> UEffectRow VoidS -> UType VoidS -> UType VoidS
+buildPiType [] Pure ty = ty
+buildPiType [] _ _ = error "shouldn't be possible"
+buildPiType (UPatAnnArrow p arr : bs) eff resTy = ns case bs of
+  [] -> UPi $ UPiExpr arr p eff resTy
+  _  -> UPi $ UPiExpr arr p Pure $ buildPiType bs eff resTy
+
+effectiveType :: Parser (UEffectRow VoidS, UType VoidS)
+effectiveType = (,) <$> effects <*> uType
+
+effects :: Parser (UEffectRow VoidS)
+effects = braces someEffects <|> return Pure
+  where
+    someEffects = do
+      effs <- effect `sepBy` sym ","
+      v <- optional $ symbol "|" >> lowerName
+      return $ EffectRow (S.fromList effs) $ fmap fromString v
+
+effect :: Parser (UEffect VoidS)
+effect =   (RWSEffect <$> rwsName <*> (fromString <$> anyCaseName))
+       <|> (keyWord ExceptKW $> ExceptionEffect)
+       <|> (keyWord IOKW     $> IOEffect)
+       <?> "effect (Accum h | Read h | State h | Except | IO)"
+
+rwsName :: Parser RWS
+rwsName =   (keyWord WriteKW $> Writer)
+        <|> (keyWord ReadKW  $> Reader)
+        <|> (keyWord StateKW $> State)
+
+uLamExpr :: Parser (UExpr VoidS)
+uLamExpr = do
+  sym "\\"
+  bs <- some patAnn
+  arrowType <-
+    (argTerm >> return PlainArrow)
+    <|> (bareArrow >>= \case
+          PlainArrow -> fail
+            "To construct an explicit lambda function, use '.' instead of '->'\n"
+          TabArrow -> fail
+            "To construct a table, use 'for i. body' instead of '\\i => body'\n"
+          arr -> return arr)
+  body <- blockOrExpr
+  return $ buildLam (map (flip UPatAnnArrow arrowType) bs) body
+
+-- TODO Does this generalize?  Swap list for Nest?
+buildLam :: [UPatAnnArrow VoidS VoidS] -> UExpr VoidS -> UExpr VoidS
+buildLam binders body@(WithSrcE pos _) = case binders of
+  [] -> body
+  -- TODO: join with source position of binders too
+  (UPatAnnArrow b arr):bs -> WithSrcE (joinPos pos' pos) $ ULam lam
+     where UPatAnn (WithSrcB pos' _) _ = b
+           lam = ULamExpr arr b $ buildLam bs body
+
+-- TODO Does this generalize?  Swap list for Nest?
+buildFor :: SrcPos -> Direction -> [UPatAnn VoidS VoidS] -> UExpr VoidS -> UExpr VoidS
+buildFor pos dir binders body = case binders of
+  [] -> body
+  b:bs -> WithSrcE (Just pos) $ UFor dir $ UForExpr b $ buildFor pos dir bs body
+
+uViewExpr :: Parser (UExpr VoidS)
+uViewExpr = do
+  keyWord ViewKW
+  bs <- some patAnn
+  argTerm
+  body <- blockOrExpr
+  return $ buildLam (zipWith UPatAnnArrow bs (repeat TabArrow)) body
+
+uForExpr :: Parser (UExpr VoidS)
+uForExpr = do
+  ((dir, trailingUnit), pos) <- withPos $
+          (keyWord ForKW  $> (Fwd, False))
+      <|> (keyWord For_KW $> (Fwd, True ))
+      <|> (keyWord RofKW  $> (Rev, False))
+      <|> (keyWord Rof_KW $> (Rev, True ))
+  e <- buildFor pos dir <$> (some patAnn <* argTerm) <*> blockOrExpr
+  if trailingUnit
+    then return $ ns $ UDecl $ UDeclExpr (ULet PlainLet (UPatAnn (nsB UPatIgnore) Nothing) e) $
+                                 ns unitExpr
+    else return e
+
+unitExpr :: UExpr' VoidS
+unitExpr = UPrimExpr $ ConExpr $ ProdCon []
+
+ns :: (a n) -> WithSrcE a n
+ns = WithSrcE Nothing
+
+nsB :: (b n l) -> WithSrcB b n l
+nsB = WithSrcB Nothing
+
+blockOrExpr :: Parser (UExpr VoidS)
+blockOrExpr =  block <|> expr
+
+unitCon :: Parser (UExpr VoidS)
+unitCon = withSrc $ symbol "()" $> unitExpr
+
+uTabCon :: Parser (UExpr VoidS)
+uTabCon = withSrc $ do
+  xs <- brackets $ expr `sepBy` sym ","
+  return $ UTabCon xs
+
+type UStatement (n::S) (l::S) = (EitherBE UDecl UExpr n l, SrcPos)
+
+block :: Parser (UExpr VoidS)
+block = withIndent $ do
+  statements <- mayNotBreak $ uStatement `sepBy1` (semicolon <|> try nextLine)
+  case last statements of
+    (LeftBE _, _) -> fail "Last statement in a block must be an expression."
+    _             -> return $ wrapUStatements statements
+
+-- TODO Generalize to Nest UStatement n l -> UExpr n ?
+wrapUStatements :: [UStatement VoidS VoidS] -> UExpr VoidS
+wrapUStatements statements = case statements of
+  [(RightBE e, _)] -> e
+  (s, pos):rest -> WithSrcE (Just pos) $ case s of
+    LeftBE  d -> UDecl $ UDeclExpr d $ wrapUStatements rest
+    RightBE e -> UDecl $ UDeclExpr d $ wrapUStatements rest
+      where d = ULet PlainLet (UPatAnn (nsB UPatIgnore) Nothing) e
+  [] -> error "Shouldn't be reachable"
+
+uStatement :: Parser (UStatement VoidS VoidS)
+uStatement = withPos $   liftM LeftBE  (instanceDef True <|> decl)
+                     <|> liftM RightBE expr
+
+-- TODO: put the `try` only around the `x:` not the annotation itself
+uPiType :: Parser (UExpr VoidS)
+uPiType = withSrc $ upi <$> piBinderPat <*> arrow effects <*> uType
+  where
+    upi binder (arr, eff) ty = UPi $ UPiExpr arr binder (fromMaybe Pure eff) ty
+    piBinderPat :: Parser (UPatAnn VoidS VoidS)
+    piBinderPat = do
+      UAnnBinder b ty@(WithSrcE pos _) <- annBinder
+      return case b of
+        UBindSource n -> (UPatAnn (WithSrcB pos (fromString n))       (Just ty))
+        UIgnore       -> (UPatAnn (WithSrcB pos (UPatBinder UIgnore)) (Just ty))
+        UBind _       -> error "Shouldn't have UBind at parsing stage"
+
+annBinder :: Parser (UAnnBinder (s::E) VoidS VoidS)
+annBinder = try $ namedBinder <|> anonBinder
+
+namedBinder :: Parser (UAnnBinder (s::E) VoidS VoidS)
+namedBinder = label "named annoted binder" $ do
+  v <- lowerName
+  ty <- annot containedExpr
+  return $ UAnnBinder (fromString v) ty
+
+anonBinder :: Parser (UAnnBinder (s::E) VoidS VoidS)
+anonBinder =
+  label "anonymous annoted binder" $ UAnnBinder UIgnore <$>
+    (underscore >> sym ":" >> containedExpr)
+
+arrow :: Parser eff -> Parser (Arrow, Maybe eff)
+arrow p =   (sym "->"  >> liftM ((PlainArrow,) . Just) p)
+        <|> (sym "=>"  $> (TabArrow, Nothing))
+        <|> (sym "--o" $> (LinArrow, Nothing))
+        <|> (sym "?->" $> (ImplicitArrow, Nothing))
+        <|> (sym "?=>" $> (ClassArrow, Nothing))
+        <?> "arrow"
+
+bareArrow :: Parser Arrow
+bareArrow = fst <$> arrow (return ())
+
+caseExpr :: Parser (UExpr VoidS)
+caseExpr = withSrc $ do
+  keyWord CaseKW
+  e <- expr
+  keyWord OfKW
+  alts <- onePerLine $ UAlt <$> pat <*> (sym "->" *> blockOrExpr)
+  return $ UCase e alts
+
+ifExpr :: Parser (UExpr VoidS)
+ifExpr = withSrc $ do
+  keyWord IfKW
+  e <- expr
+  (alt1, maybeAlt2) <- oneLineThenElse <|> blockThenElse
+  let alt2 = case maybeAlt2 of
+        Nothing  -> ns unitExpr
+        Just alt -> alt
+  return $ UCase e
+      [ UAlt (nsB $ UPatCon "True"  Empty)  alt1
+      , UAlt (nsB $ UPatCon "False" Empty) alt2]
+
+oneLineThenElse :: Parser (UExpr VoidS, Maybe (UExpr VoidS))
+oneLineThenElse = do
+  keyWord ThenKW
+  alt1 <- eitherP block expr
+  case alt1 of
+    Left  e -> return (e, Nothing)
+    Right e -> do
+      alt2 <- optional $ keyWord ElseKW >> blockOrExpr
+      return (e, alt2)
+
+blockThenElse :: Parser (UExpr VoidS, Maybe (UExpr VoidS))
+blockThenElse = withIndent $ mayNotBreak $ do
+  alt1 <- keyWord ThenKW >> blockOrExpr
+  alt2 <- optional $ do
+    try $ nextLine >> keyWord ElseKW
+    blockOrExpr
+  return (alt1, alt2)
+
+onePerLine :: Parser a -> Parser [a]
+onePerLine p =   liftM (:[]) p
+             <|> (withIndent $ mayNotBreak $ p `sepBy1` try nextLine)
+
+pat :: Parser (UPat VoidS VoidS)
+pat = mayNotPair $ makeExprParser leafPat patOps
+
+leafPat :: Parser (UPat VoidS VoidS)
+leafPat =
+      (withSrcB (symbol "()" $> (UPatUnit UnitB)))
+  <|> parens (mayPair $ makeExprParser leafPat patOps)
+  <|> (withSrcB $
+          (UPatBinder <$>  (   (fromString <$> lowerName)
+                           <|> (underscore $> UIgnore)))
+      <|> (UPatCon    <$> (fromString <$> upperName) <*> manyNested pat)
+      <|> (variantPat `fallBackTo` recordPat)
+      <|> brackets (UPatTable <$> toNestParsed <$> leafPat `sepBy` sym ",")
+  )
+  where pun pos l = WithSrcB (Just pos) $ fromString l
+        def pos = WithSrcB (Just pos) $ UPatIgnore
+        variantPat = parseVariant leafPat UPatVariant UPatVariantLift
+        recordPat = unzipUPatRecord
+                    <$> parseLabeledItems "," "=" leafPat (Just pun) (Just def)
+        unzipUPatRecord :: ExtLabeledItems (UPat VoidS VoidS) (UPat VoidS VoidS)
+                        -> UPat' VoidS VoidS
+        unzipUPatRecord labeled = UPatRecord labels nest where
+          (labels, items, rest) = unzipExtLabeledItems labeled
+          nest = toNestParsed $ items ++ toList rest
+
+-- TODO: add user-defined patterns
+patOps :: [[Operator Parser (UPat VoidS VoidS)]]
+patOps = [[InfixR patPairOp]]
+
+patPairOp :: Parser (UPat (n::S) (l::S) -> UPat l (l'::S) -> UPat n l')
+patPairOp = do
+  allowed <- asks canPair
+  if allowed
+    then sym "," $> \x y -> joinSrcB x y $ UPatPair $ NestPair x y
+    else fail "pair pattern not allowed outside parentheses"
+
+annot :: Parser a -> Parser a
+annot p = label "type annotation" $ sym ":" >> p
+
+patAnn :: Parser (UPatAnn VoidS VoidS)
+patAnn = label "pattern" $ UPatAnn <$> pat <*> optional (annot containedExpr)
+
+uPrim :: Parser (UExpr VoidS)
+uPrim = withSrc $ do
+  s <- primName
+  case s of
+    "ffi" -> do
+      f <- lexeme $ some nameTailChar
+      retTy <- leafExpr
+      args <- some leafExpr
+      return $ UPrimExpr $ OpExpr $ FFICall f retTy args
+    _ -> case strToPrimName s of
+      Just prim -> UPrimExpr <$> traverse (const leafExpr) prim
+      Nothing -> fail $ "Unrecognized primitive: " ++ s
+
+uVariantExpr :: Parser (UExpr VoidS)
+uVariantExpr = withSrc $ parseVariant expr UVariant UVariantLift
+
+parseVariant :: Parser a -> (LabeledItems () -> Label -> a -> b) -> (LabeledItems () -> a -> b) -> Parser b
+parseVariant subparser buildLabeled buildExt =
+  bracketed (symbol "{|") (symbol "|}") $ do
+    let parseInactive = try $ fieldLabel <* notFollowedBy (symbol "=")
+    inactiveLabels <- parseInactive `endBy1` (symbol "|") <|> pure []
+    let inactiveItems = foldr (<>) NoLabeledItems $ map (flip labeledSingleton ()) inactiveLabels
+    let parseLabeled = do l <- fieldLabel
+                          symbol "="
+                          buildLabeled inactiveItems l <$> subparser
+    let parseExt = do symbol "..."
+                      buildExt inactiveItems <$> subparser
+    parseLabeled <|> parseExt
+
+uLabeledExprs :: Parser (UExpr VoidS)
+uLabeledExprs = withSrc $
+    (URecord <$> build "," "=" (Just varPun) Nothing)
+    `fallBackTo` (URecordTy <$> build "&" ":" Nothing Nothing)
+    `fallBackTo` (UVariantTy <$> build "|" ":" Nothing Nothing)
+  where build sep bindwith = parseLabeledItems sep bindwith expr
+
+varPun :: SrcPos -> Label -> (UExpr VoidS)
+varPun pos str = WithSrcE (Just pos) $ UVar (fromString str)
+
+uDoSugar :: Parser (UExpr VoidS)
+uDoSugar = withSrc $ do
+  keyWord DoKW
+  body <- blockOrExpr
+  return $ ULam $ ULamExpr PlainArrow (UPatAnn (nsB $ UPatUnit UnitB) Nothing) body
+
+uIsoSugar :: Parser (UExpr VoidS)
+uIsoSugar = withSrc (char '#' *> options) where
+  options = (recordFieldIso <$> fieldLabel)
+            <|> char '?' *> (variantFieldIso <$> fieldLabel)
+            <|> char '&' *> (recordZipIso <$> fieldLabel)
+            <|> char '|' *> (variantZipIso <$> fieldLabel)
+  plain = PlainArrow
+  -- Explicitly specify types for `lam` and `alt` to prevent
+  -- ambiguous type variable errors referring to the inner scopes
+  -- defined thereby.
+  lam :: UPat VoidS VoidS -> UExpr VoidS -> WithSrcE UExpr' VoidS
+  lam p b = ns $ ULam $ ULamExpr plain (UPatAnn p Nothing) b
+  alt :: UPat VoidS VoidS -> UExpr VoidS -> UAlt VoidS
+  alt = UAlt
+  recordFieldIso :: Label -> UExpr' VoidS
+  recordFieldIso field =
+    UApp plain (ns "MkIso") $
+      ns $ URecord $ NoExt $
+        labeledSingleton "fwd" (lam
+          (nsB $ UPatRecord
+                   (Ext (labeledSingleton field ()) (Just ()))
+                   (toNest ["x", "r"]))
+          $ (ns "(,)") `mkApp` (ns "x") `mkApp` (ns "r")
+        )
+        <> labeledSingleton "bwd" (lam
+          (nsB $ UPatPair $ toNestPair "x" "r")
+          $ ns $ URecord $ Ext (labeledSingleton field $ "x")
+                               $ Just $ "r"
+        )
+  variantFieldIso :: Label -> UExpr' VoidS
+  variantFieldIso field =
+    UApp plain "MkIso" $
+      ns $ URecord $ NoExt $
+        labeledSingleton "fwd" (lam "v" $ ns $ UCase "v"
+            [ alt (nsB $ UPatVariant NoLabeledItems field "x")
+                $ "Left" `mkApp` "x"
+            , alt (nsB $ UPatVariantLift (labeledSingleton field ()) "r")
+                $ "Right" `mkApp` "r"
+            ]
+        )
+        <> labeledSingleton "bwd" (lam "v" $ ns $ UCase "v"
+            [ alt (nsB $ UPatCon "Left" (toNest ["x"]))
+                $ ns $ UVariant NoLabeledItems field $ "x"
+            , alt (nsB $ UPatCon "Right" (toNest ["r"]))
+                $ ns $ UVariantLift (labeledSingleton field ()) $ "r"
+            ]
+        )
+  recordZipIso field =
+    UApp plain "MkIso" $
+      ns $ URecord $ NoExt $
+        labeledSingleton "fwd" (lam
+          (nsB $ UPatPair $ NestPair
+            (nsB $ UPatRecord (Ext NoLabeledItems $ Just $ ()) $ toNest ["l"])
+            (nsB $ (UPatRecord (Ext (labeledSingleton field ()) $ Just ())
+                               (toNest ["x", "r"]))))
+          $ "(,)"
+            `mkApp` (ns $ URecord $ (Ext (labeledSingleton field $ "x")
+                                         $ Just $ "l"))
+            `mkApp` (ns $ URecord $ Ext NoLabeledItems $ Just $ "r")
+        )
+        <> labeledSingleton "bwd" (lam
+          (nsB $ UPatPair $ NestPair
+            (nsB $ (UPatRecord (Ext (labeledSingleton field ()) $ Just ())
+                               (toNest ["x", "l"])))
+            (nsB $ UPatRecord (Ext NoLabeledItems $ Just ()) $ toNest ["r"]))
+          $ "(,)"
+            `mkApp` (ns $ URecord $ Ext NoLabeledItems $ Just $ "l")
+            `mkApp` (ns $ URecord $ Ext (labeledSingleton field $ "x")
+                                        $ Just $ "r")
+        )
+  variantZipIso :: Label -> UExpr' VoidS
+  variantZipIso field =
+    UApp plain "MkIso" $
+      ns $ URecord $ NoExt $
+        labeledSingleton "fwd" (lam "v" $ ns $ UCase "v"
+            [ alt (nsB $ UPatCon "Left" (toNest ["l"]))
+                $ "Left" `mkApp` (ns $
+                    UVariantLift (labeledSingleton field ()) $ "l")
+            , alt (nsB $ UPatCon "Right" (toNest ["w"]))
+                $ ns $ UCase "w"
+                [ alt (nsB $ UPatVariant NoLabeledItems field "x")
+                    $ "Left" `mkApp` (ns $
+                        UVariant NoLabeledItems field $ "x")
+                , alt (nsB $ UPatVariantLift (labeledSingleton field ()) "r")
+                    $ "Right" `mkApp` "r"
+                ]
+            ]
+        )
+        <> labeledSingleton "bwd" (lam "v" $ ns $ UCase "v"
+            [ alt (nsB $ UPatCon "Left" (toNest ["w"]))
+                $ ns $ UCase "w"
+                [ alt (nsB $ UPatVariant NoLabeledItems field "x")
+                    $ "Right" `mkApp` (ns $
+                        UVariant NoLabeledItems field $ "x")
+                , alt (nsB $ UPatVariantLift (labeledSingleton field ())
+                                             "r")
+                    $ "Left" `mkApp` "r"
+                ]
+            , alt (nsB $ UPatCon "Right" (toNest ["l"]))
+                $ "Right" `mkApp` (ns $
+                    UVariantLift (labeledSingleton field ()) "l")
+            ]
+        )
+
+parseLabeledItems
+  :: String -> String -> Parser a
+  -> Maybe (SrcPos -> Label -> a) -> Maybe (SrcPos -> a)
+  -> Parser (ExtLabeledItems a a)
+parseLabeledItems sep bindwith itemparser punner tailDefault =
+  bracketed lBrace rBrace $ atBeginning
+  where
+    atBeginning = someItems
+                  <|> (symbol sep >> (stopAndExtend <|> stopWithoutExtend))
+                  <|> stopWithoutExtend
+    stopWithoutExtend = return $ NoExt NoLabeledItems
+    stopAndExtend = do
+      ((), pos) <- withPos $ symbol "..."
+      rest <- case tailDefault of
+        Just def -> itemparser <|> pure (def pos)
+        Nothing -> itemparser
+      return $ Ext NoLabeledItems (Just rest)
+    beforeSep = (symbol sep >> afterSep) <|> stopWithoutExtend
+    afterSep = someItems <|> stopAndExtend <|> stopWithoutExtend
+    someItems = do
+      (l, pos) <- withPos fieldLabel
+      let explicitBound = symbol bindwith *> itemparser
+      itemVal <- case punner of
+        Just punFn -> explicitBound <|> pure (punFn pos l)
+        Nothing -> explicitBound
+      rest <- beforeSep
+      return $ prefixExtLabeledItems (labeledSingleton l itemVal) rest
+
+-- Combine two parsers such that if the first fails, we try the second one.
+-- If both fail, consume the same amount of input as the parser that
+-- consumed the most input, and use its error message. Useful if you want
+-- to parse multiple things, but they share some common starting symbol, and
+-- you don't want the first one failing to prevent the second from succeeding.
+-- Unlike using `try` and/or (<|>), if both parsers fail and either one consumes
+-- input, parsing is aborted. Also, if both parsers consume the same amount of
+-- input, we combine the symbols each was expecting.
+fallBackTo :: Parser a -> Parser a -> Parser a
+fallBackTo optionA optionB = do
+  startState <- getParserState
+  resA <- observing $ optionA
+  case resA of
+    Right val -> return val
+    Left errA -> do
+      stateA <- getParserState
+      updateParserState $ const startState
+      resB <- observing $ optionB
+      case resB of
+        Right val -> return val
+        Left errB -> case compare (errorOffset errA) (errorOffset errB) of
+          LT -> parseError errB
+          GT -> updateParserState (const stateA) >> parseError errA
+          EQ -> case (errA, errB) of
+            -- Combine what each was expecting.
+            (TrivialError offset unexpA expA, TrivialError _ unexpB expB)
+                -> parseError $ TrivialError offset (unexpA <|> unexpB)
+                                                    (expA <> expB)
+            _ -> fail $ "Multiple failed parse attempts:\n"
+                  <> parseErrorPretty errA <> "\n" <> parseErrorPretty errB
+
+-- === infix ops ===
+
+-- literal symbols here must only use chars from `symChars`
+ops :: [[Operator Parser (UExpr VoidS)]]
+ops =
+  [ [InfixL $ sym "." $> mkGenApp TabArrow, symOp "!"]
+  , [InfixL $ sc $> mkApp]
+  , [prefixNegOp]
+  , [anySymOp] -- other ops with default fixity
+  , [symOp "+", symOp "-", symOp "||", symOp "&&",
+     InfixR $ sym "=>" $> mkArrow TabArrow Pure,
+     InfixL $ opWithSrc $ backquoteName >>= (return . binApp),
+     symOp "<<<", symOp ">>>", symOp "<<&", symOp "&>>"]
+  , [annotatedExpr]
+  , [InfixR $ mayBreak (infixSym "$") $> mkApp]
+  , [symOp "+=", symOp ":=", InfixL $ pairingSymOpP "|", InfixR infixArrow]
+  , [InfixR $ pairingSymOpP "&", InfixR $ pairingSymOpP ","]
+  , indexRangeOps
+  ]
+
+opWithSrc :: Parser (SrcPos -> a -> a -> a)
+          -> Parser (a -> a -> a)
+opWithSrc p = do
+  (f, pos) <- withPos p
+  return $ f pos
+
+anySymOp :: Operator Parser (UExpr VoidS)
+anySymOp = InfixL $ opWithSrc $ do
+  s <- label "infix operator" (mayBreak anySym)
+  return $ binApp s
+
+infixSym :: SourceName -> Parser ()
+infixSym s = mayBreak $ sym s
+
+symOp :: SourceName -> Operator Parser (UExpr VoidS)
+symOp s = InfixL $ symOpP s
+
+symOpP :: SourceName -> Parser (UExpr VoidS -> UExpr VoidS -> UExpr VoidS)
+symOpP s = opWithSrc $ do
+  label "infix operator" (infixSym s)
+  return $ binApp $ "(" <> s <> ")"
+
+pairingSymOpP :: String -> Parser (UExpr VoidS -> UExpr VoidS -> UExpr VoidS)
+pairingSymOpP s = opWithSrc $ do
+  allowed <- asks canPair
+  if allowed
+    then infixSym s >> return (binApp (fromString $ "("<>s<>")"))
+    else fail $ "Unexpected delimiter " <> s
+
+prefixNegOp :: Operator Parser (UExpr VoidS)
+prefixNegOp = Prefix $ label "negation" $ do
+  ((), pos) <- withPos $ sym "-"
+  let f = WithSrcE (Just pos) "neg"
+  return \case
+    -- Special case: negate literals directly
+    WithSrcE litpos (IntLitExpr i)
+      -> WithSrcE (joinPos (Just pos) litpos) (IntLitExpr (-i))
+    WithSrcE litpos (FloatLitExpr i)
+      -> WithSrcE (joinPos (Just pos) litpos) (FloatLitExpr (-i))
+    x -> mkApp f x
+
+binApp :: SourceName -> SrcPos -> UExpr VoidS -> UExpr VoidS -> UExpr VoidS
+binApp f pos x y = (f' `mkApp` x) `mkApp` y
+  where f' = WithSrcE (Just pos) $ fromString f
+
+mkGenApp :: Arrow -> UExpr (n::S) -> UExpr n -> UExpr n
+mkGenApp arr f x = joinSrc f x $ UApp arr f x
+
+mkApp :: UExpr (n::S) -> UExpr n -> UExpr n
+mkApp = mkGenApp PlainArrow
+
+infixArrow :: Parser (UType VoidS -> UType VoidS -> UType VoidS)
+infixArrow = do
+  notFollowedBy (sym "=>")  -- table arrows have special fixity
+  ((arr, eff), pos) <- withPos $ arrow effects
+  return \a b -> WithSrcE (Just pos) $ UPi $ UPiExpr arr (UPatAnn (nsB UPatIgnore) (Just a)) (fromMaybe Pure eff) b
+
+mkArrow :: Arrow -> UEffectRow VoidS -> UExpr VoidS -> UExpr VoidS -> UExpr VoidS
+mkArrow arr eff a b = joinSrc a b $ UPi $ UPiExpr arr (UPatAnn (nsB UPatIgnore) (Just a)) eff b
+
+withSrc :: Parser (a n) -> Parser (WithSrcE a n)
+withSrc p = do
+  (x, pos) <- withPos p
+  return $ WithSrcE (Just pos) x
+
+withSrcB :: Parser (b n l) -> Parser (WithSrcB b n l)
+withSrcB p = do
+  (x, pos) <- withPos p
+  return $ WithSrcB (Just pos) x
+
+joinSrc :: WithSrcE a1 n1 -> WithSrcE a2 n2 -> a3 n3 -> WithSrcE a3 n3
+joinSrc (WithSrcE p1 _) (WithSrcE p2 _) x = WithSrcE (joinPos p1 p2) x
+
+joinSrcB :: WithSrcB a1 n1 l1 -> WithSrcB a2 n2 l2 -> a3 n3 l3 -> WithSrcB a3 n3 l3
+joinSrcB (WithSrcB p1 _) (WithSrcB p2 _) x = WithSrcB (joinPos p1 p2) x
+
+joinPos :: Maybe SrcPos -> Maybe SrcPos -> Maybe SrcPos
+joinPos Nothing p = p
+joinPos p Nothing = p
+joinPos (Just (l, h)) (Just (l', h')) = Just (min l l', max h h')
+
+indexRangeOps :: [Operator Parser (UExpr VoidS)]
+indexRangeOps =
+  [ Prefix    $ symPos ".."   <&> \pos h   -> range pos  Unlimited       (InclusiveLim h)
+  , inpostfix $ symPos ".."   <&> \pos l h -> range pos (InclusiveLim l) (limFromMaybe h)
+  , inpostfix $ symPos "<.."  <&> \pos l h -> range pos (ExclusiveLim l) (limFromMaybe h)
+  , Prefix    $ symPos "..<"  <&> \pos h   -> range pos  Unlimited       (ExclusiveLim h)
+  , InfixL    $ symPos "..<"  <&> \pos l h -> range pos (InclusiveLim l) (ExclusiveLim h)
+  , InfixL    $ symPos "<..<" <&> \pos l h -> range pos (ExclusiveLim l) (ExclusiveLim h) ]
+  where
+    range pos l h = WithSrcE (Just pos) $ UIndexRange l h
+    symPos s = snd <$> withPos (sym s)
+
+limFromMaybe :: Maybe a -> Limit a
+limFromMaybe Nothing = Unlimited
+limFromMaybe (Just x) = InclusiveLim x
+
+annotatedExpr :: Operator Parser (UExpr VoidS)
+annotatedExpr = InfixL $ opWithSrc $
+  sym ":" $> (\pos v ty -> WithSrcE (Just pos) $ UTypeAnn v ty)
+
+inpostfix :: Parser (UExpr VoidS -> Maybe (UExpr VoidS) -> UExpr VoidS)
+          -> Operator Parser (UExpr VoidS)
+inpostfix = inpostfix' expr
+
+inpostfix' :: Parser a -> Parser (a -> Maybe a -> a) -> Operator Parser a
+inpostfix' p op = Postfix $ do
+  f <- op
+  rest <- optional p
+  return \x -> f x rest
+
+-- === lexemes ===
+
+-- These `Lexer` actions must be non-overlapping and never consume input on failure
+type Lexer = Parser
+
+data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
+             | ReadKW | WriteKW | StateKW | DataKW | InterfaceKW
+             | InstanceKW | WhereKW | IfKW | ThenKW | ElseKW | DoKW
+             | ExceptKW | IOKW | ViewKW | ImportKW | NamedInstanceKW
+
+upperName :: Lexer SourceName
+upperName = label "upper-case name" $ lexeme $
+  checkNotKeyword $ (:) <$> upperChar <*> many nameTailChar
+
+lowerName  :: Lexer SourceName
+lowerName = label "lower-case name" $ lexeme $
+  checkNotKeyword $ (:) <$> lowerChar <*> many nameTailChar
+
+anyCaseName  :: Lexer SourceName
+anyCaseName = lowerName <|> upperName
+
+anyName  :: Lexer SourceName
+anyName = lowerName <|> upperName <|> symName
+
+checkNotKeyword :: Parser String -> Parser String
+checkNotKeyword p = try $ do
+  s <- p
+  failIf (s `elem` keyWordStrs) $ show s ++ " is a reserved word"
+  return s
+
+keyWord :: KeyWord -> Lexer ()
+keyWord kw = lexeme $ try $ string s >> notFollowedBy nameTailChar
+  where
+    s = case kw of
+      DefKW  -> "def"
+      ForKW  -> "for"
+      RofKW  -> "rof"
+      For_KW  -> "for_"
+      Rof_KW  -> "rof_"
+      CaseKW -> "case"
+      IfKW   -> "if"
+      ThenKW -> "then"
+      ElseKW -> "else"
+      OfKW   -> "of"
+      ReadKW  -> "Read"
+      WriteKW -> "Accum"
+      StateKW -> "State"
+      ExceptKW -> "Except"
+      IOKW     -> "IO"
+      DataKW -> "data"
+      InterfaceKW -> "interface"
+      InstanceKW -> "instance"
+      NamedInstanceKW -> "named-instance"
+      WhereKW -> "where"
+      DoKW   -> "do"
+      ViewKW -> "view"
+      ImportKW -> "import"
+
+keyWordStrs :: [String]
+keyWordStrs = ["def", "for", "for_", "rof", "rof_", "case", "of", "llam",
+               "Read", "Write", "Accum", "Except", "IO", "data", "interface",
+               "instance", "named-instance", "where", "if", "then", "else", "do", "view", "import"]
+
+fieldLabel :: Lexer Label
+fieldLabel = label "field label" $ lexeme $
+  checkNotKeyword $ (:) <$> (lowerChar <|> upperChar) <*> many nameTailChar
+
+primName :: Lexer String
+primName = lexeme $ try $ char '%' >> some alphaNumChar
+
+charLit :: Lexer Char
+charLit = lexeme $ char '\'' >> L.charLiteral <* char '\''
+
+strLit :: Lexer String
+strLit = lexeme $ char '"' >> manyTill L.charLiteral (char '"')
+
+intLit :: Lexer Int
+intLit = lexeme $ try $ L.decimal <* notFollowedBy (char '.')
+
+doubleLit :: Lexer Double
+doubleLit = lexeme $
+      try L.float
+  <|> try (fromIntegral <$> (L.decimal :: Parser Int) <* char '.')
+
+knownSymStrs :: [String]
+knownSymStrs = [".", ":", "!", "=", "-", "+", "||", "&&", "$", "&", "|", ",", "+=", ":=",
+                "->", "=>", "?->", "?=>", "--o", "--", "<<<", ">>>", "<<&", "&>>",
+                "..", "<..", "..<", "..<", "<..<"]
+
+-- string must be in `knownSymStrs`
+sym :: String -> Lexer ()
+sym s = lexeme $ try $ string s >> notFollowedBy symChar
+
+anySym :: Lexer String
+anySym = lexeme $ try $ do
+  s <- some symChar
+  -- TODO: consider something faster than linear search here
+  failIf (s `elem` knownSymStrs) ""
+  return $ "(" <> s <> ")"
+
+symName :: Lexer SourceName
+symName = label "symbol name" $ lexeme $ try $ do
+  s <- between (char '(') (char ')') $ some symChar
+  return $ "(" <> s <> ")"
+
+backquoteName :: Lexer SourceName
+backquoteName = label "backquoted name" $
+  lexeme $ try $ between (char '`') (char '`') (upperName <|> lowerName)
+
+-- brackets and punctuation
+-- (can't treat as sym because e.g. `((` is two separate lexemes)
+lParen, rParen, lBracket, rBracket, lBrace, rBrace, semicolon, underscore :: Lexer ()
+
+lParen    = notFollowedBy symName >> notFollowedBy unitCon >> charLexeme '('
+rParen    = charLexeme ')'
+lBracket  = charLexeme '['
+rBracket  = charLexeme ']'
+lBrace    = charLexeme '{'
+rBrace    = charLexeme '}'
+semicolon = charLexeme ';'
+underscore = charLexeme '_'
+
+charLexeme :: Char -> Parser ()
+charLexeme c = void $ lexeme $ char c
+
+nameTailChar :: Parser Char
+nameTailChar = alphaNumChar <|> char '\'' <|> char '_'
+
+symChar :: Parser Char
+symChar = choice $ map char symChars
+
+symChars :: [Char]
+symChars = ".,!$^&*:-~+/=<>|?\\@"
+
+-- === Util ===
+
+runTheParser :: String -> Parser a -> Either (ParseErrorBundle String Void) a
+runTheParser s p = parse (runReaderT p (ParseCtx 0 False False)) "" s
+
+sc :: Parser ()
+sc = L.space space lineComment empty
+
+lineComment :: Parser ()
+lineComment = do
+  try $ string "--" >> notFollowedBy (void (char 'o'))
+  void (takeWhileP (Just "char") (/= '\n'))
+
+emptyLines :: Parser ()
+emptyLines = void $ many (sc >> eol)
+
+outputLines :: Parser ()
+outputLines = void $ many (symbol ">" >> takeWhileP Nothing (/= '\n') >> ((eol >> return ()) <|> eof))
+
+stringLiteral :: Parser String
+stringLiteral = char '"' >> manyTill L.charLiteral (char '"') <* sc
+
+space :: Parser ()
+space = do
+  consumeNewLines <- asks canBreak
+  if consumeNewLines
+    then space1
+    else void $ takeWhile1P (Just "white space") (`elem` (" \t" :: String))
+
+mayBreak :: Parser a -> Parser a
+mayBreak p = local (\ctx -> ctx { canBreak = True }) p
+
+mayNotBreak :: Parser a -> Parser a
+mayNotBreak p = local (\ctx -> ctx { canBreak = False }) p
+
+mayPair :: Parser a -> Parser a
+mayPair p = local (\ctx -> ctx { canPair = True }) p
+
+mayNotPair :: Parser a -> Parser a
+mayNotPair p = local (\ctx -> ctx { canPair = False }) p
+
+optionalMonoid :: Monoid a => Parser a -> Parser a
+optionalMonoid p = p <|> return mempty
+
+nameString :: Parser String
+nameString = lexeme . try $ (:) <$> lowerChar <*> many alphaNumChar
+
+thisNameString :: String -> Parser ()
+thisNameString s = lexeme $ try $ string s >> notFollowedBy alphaNumChar
+
+uint :: Parser Int
+uint = L.decimal <* sc
+
+lexeme :: Parser a -> Parser a
+lexeme = L.lexeme sc
+
+symbol :: String -> Parser ()
+symbol s = void $ L.symbol sc s
+
+argTerm :: Parser ()
+argTerm = mayNotBreak $ sym "."
+
+bracketed :: Parser () -> Parser () -> Parser a -> Parser a
+bracketed left right p = between left right $ mayBreak $ sc >> p
+
+parens :: Parser a -> Parser a
+parens p = bracketed lParen rParen p
+
+brackets :: Parser a -> Parser a
+brackets p = bracketed lBracket rBracket p
+
+braces :: Parser a -> Parser a
+braces p = bracketed lBrace rBrace p
+
+manyNested :: Parser (a VoidS VoidS) -> Parser (Nest a VoidS VoidS)
+manyNested p = toNestParsed <$> many p
+
+withPos :: Parser a -> Parser (a, SrcPos)
+withPos p = do
+  n <- getOffset
+  x <- p
+  n' <- getOffset
+  return $ (x, (n, n'))
+
+nextLine :: Parser ()
+nextLine = do
+  eol
+  n <- asks curIndent
+  void $ mayNotBreak $ many $ try (sc >> eol)
+  void $ replicateM n (char ' ')
+
+withSource :: Parser a -> Parser (String, a)
+withSource p = do
+  s <- getInput
+  (x, (start, end)) <- withPos p
+  return (take (end - start) s, x)
+
+withIndent :: Parser a -> Parser a
+withIndent p = do
+  nextLine
+  indent <- liftM length $ some (char ' ')
+  local (\ctx -> ctx { curIndent = curIndent ctx + indent }) $ p
+
+eol :: Parser ()
+eol = void MC.eol
+
+eolf :: Parser ()
+eolf = eol <|> eof
+
+failIf :: Bool -> String -> Parser ()
+failIf True s = fail s
+failIf False _ = return ()
+
+_debug :: Show a => String -> Parser a -> Parser a
+_debug s m = mapReaderT (Text.Megaparsec.Debug.dbg s) m

--- a/src/lib/SaferNames/ResolveImplicitNames.hs
+++ b/src/lib/SaferNames/ResolveImplicitNames.hs
@@ -1,0 +1,198 @@
+-- Copyright 2021 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module SaferNames.ResolveImplicitNames (resolveImplicitTopDecl) where
+
+import Control.Monad.Except hiding (Except)
+import Control.Monad.Reader
+import Control.Monad.Writer
+import Data.Char (isLower)
+import Data.List (nub)
+import qualified Data.Set as S
+import Data.String
+
+import LabeledItems
+import SaferNames.Name hiding (extendEnv)
+import SaferNames.Syntax
+
+resolveImplicitTopDecl :: UDecl VoidS VoidS -> UDecl VoidS VoidS
+resolveImplicitTopDecl (ULet ann (UPatAnn pat (Just ty)) expr) =
+  ULet ann (UPatAnn pat (Just ty')) expr' where
+    implicitArgs = findImplicitArgNames ty
+    ty'   = foldr addImplicitPiArg  ty   implicitArgs
+    expr' = foldr addImplicitLamArg expr implicitArgs
+resolveImplicitTopDecl (UInstance argBinders className params methods maybeName) =
+  UInstance argBinders' className params methods maybeName where
+    implicitArgs = findImplicitArgNames $ Abs argBinders (PairE className $ ListE params)
+    argBinders' = foldr Nest argBinders $ map nameAsImplicitBinder implicitArgs
+resolveImplicitTopDecl decl = decl
+
+-- === WithEnv Monad transformer ===
+
+-- The idea is to be able to monoidally accumulate (with the
+-- `extendEnv` action) some piece of state, which is made
+-- automatically available to downstream actions in their Reader
+-- environment.
+
+-- XXX: we deliberately avoid implementing the instance
+--   MonadReader env m => MonadReader env (WithEnv env m a)
+-- because we want to make lifting explicit, to avoid performance issues due
+-- to too many `WithEnv` wrappers.
+newtype WithEnv env m a = WithEnv { runWithEnv :: m (a, env) }
+
+extendEnv :: (Monad m) => env -> WithEnv env m ()
+extendEnv env = WithEnv $ return ((), env)
+
+instance (Monoid env, MonadReader env m) => Functor (WithEnv env m) where
+  fmap = liftM
+
+instance (Monoid env, MonadReader env m) => Applicative (WithEnv env m) where
+  (<*>) = ap
+  pure x = WithEnv $ pure (x, mempty)
+
+instance (Monoid env, MonadReader env m) => Monad (WithEnv env m) where
+  return = pure
+  -- TODO: Repeated bind will get expensive here. An implementation like Cat
+  -- might be more efficient
+  WithEnv m1 >>= f = WithEnv do
+    (x, env1) <- m1
+    let WithEnv m2 = f x
+    (y, env2) <- local (<> env1) m2
+    return (y, env1 <> env2)
+
+instance Monoid env => MonadTrans (WithEnv env) where
+  lift m = WithEnv $ fmap (,mempty) m
+
+instance (Monoid env, MonadError e m, MonadReader env m)
+         => MonadError e (WithEnv env m) where
+  throwError e = lift $ throwError e
+  catchError (WithEnv m) handler =
+    WithEnv $ catchError m (runWithEnv . handler)
+
+-- === Traversal to find implicit names
+
+nameAsImplicitBinder :: SourceName -> UPatAnnArrow VoidS VoidS
+nameAsImplicitBinder v = UPatAnnArrow (fromString v) ImplicitArrow
+
+addImplicitPiArg :: SourceName -> UType VoidS -> UType VoidS
+addImplicitPiArg v vTy = WithSrcE Nothing $ UPi $ UPiExpr ImplicitArrow (fromString v) Pure vTy
+
+addImplicitLamArg :: SourceName -> UExpr VoidS -> UExpr VoidS
+addImplicitLamArg v e = WithSrcE Nothing $ ULam $ ULamExpr ImplicitArrow (fromString v) e
+
+findImplicitArgNames :: HasImplicitArgNamesE e => e n -> [SourceName]
+findImplicitArgNames expr =
+  nub $ flip runReader mempty $ execWriterT $ implicitArgsE expr
+
+-- TODO: de-deuplicate with SourceRename by making a class for traversals
+--       parameterized by the base cases on UBinder and UVar.
+class HasImplicitArgNamesE (e::E) where
+  implicitArgsE :: MonadReader (S.Set SourceName) m
+                => MonadWriter [SourceName] m
+                => e n
+                -> m ()
+
+class HasImplicitArgNamesB (b::B) where
+  implicitArgsB :: MonadReader (S.Set SourceName) m
+                => MonadWriter [SourceName] m
+                => b n l
+                -> WithEnv (S.Set SourceName) m ()
+
+instance HasImplicitArgNamesE (SourceNameOr e) where
+  implicitArgsE (SourceName v) = do
+    isFree <- asks \boundNames -> not $ v `S.member` boundNames
+    when (isFree && isLower (head v)) $ tell [v]
+  implicitArgsE _ = error "Unexpected internal name"
+
+instance HasImplicitArgNamesB (UBinder (color::E)) where
+  implicitArgsB ubinder = case ubinder of
+    UBindSource b -> extendEnv (S.singleton b)
+    UBind _ -> error "Unexpected internal name"
+    UIgnore -> return ()
+
+instance HasImplicitArgNamesB UPatAnn where
+  implicitArgsB (UPatAnn b ann) = do
+    lift $ mapM_ implicitArgsE ann
+    implicitArgsB b
+
+instance HasImplicitArgNamesB UPatAnnArrow where
+  implicitArgsB (UPatAnnArrow b _) = implicitArgsB b
+
+instance HasImplicitArgNamesE UExpr' where
+  implicitArgsE expr = case expr of
+    UVar v -> implicitArgsE v
+    UPi (UPiExpr _ pat eff body) -> implicitArgsE $ Abs pat (PairE eff body)
+    -- specifically exclude vars on the lhs of an application
+    UApp _ (WithSrcE _ (UVar _)) x -> implicitArgsE x
+    UApp _ f x -> implicitArgsE f >> implicitArgsE x
+    UHole -> return ()
+    UTypeAnn v ty -> implicitArgsE v >> implicitArgsE ty
+    UIndexRange low high -> mapM_ implicitArgsE low >> mapM_ implicitArgsE high
+    UPrimExpr e -> mapM_ implicitArgsE e
+    URecord (Ext ulr _) ->  mapM_ implicitArgsE ulr  -- TODO Not scanning `rest`?
+    UVariant _ _   val -> implicitArgsE val
+    UVariantLift _ val -> implicitArgsE val
+    URecordTy  (Ext tys ext) -> mapM_ implicitArgsE tys >> mapM_ implicitArgsE ext
+    UVariantTy (Ext tys ext) -> mapM_ implicitArgsE tys >> mapM_ implicitArgsE ext
+    UIntLit   _ -> return ()
+    UFloatLit _ -> return ()
+    ULam _    -> error "Unexpected lambda in type annotation"
+    UDecl _   -> error "Unexpected let binding in type annotation"
+    UFor _ _  -> error "Unexpected for in type annotation"
+    UCase _ _ -> error "Unexpected case in type annotation"
+    UTabCon _ ->  error "Unexpected table constructor in type annotation"
+
+instance HasImplicitArgNamesB UPat' where
+  implicitArgsB pat = case pat of
+    UPatBinder b -> implicitArgsB b
+    UPatCon _ bs -> implicitArgsB bs
+    UPatPair p -> implicitArgsB p
+    UPatUnit _ -> return ()
+    UPatRecord _ ps -> implicitArgsB ps
+    UPatVariant _ _ p -> implicitArgsB p
+    UPatVariantLift _ p -> implicitArgsB p
+    UPatTable ps -> implicitArgsB ps
+
+instance HasImplicitArgNamesB b => HasImplicitArgNamesB (Nest b) where
+  implicitArgsB Empty = return ()
+  implicitArgsB (Nest b bs) = implicitArgsB b >> implicitArgsB bs
+
+instance (HasImplicitArgNamesB b1, HasImplicitArgNamesB b2)
+         => HasImplicitArgNamesB (NestPair b1 b2) where
+  implicitArgsB (NestPair b1 b2) = implicitArgsB b1 >> implicitArgsB b2
+
+instance (HasImplicitArgNamesB b, HasImplicitArgNamesE e)
+         => HasImplicitArgNamesE (Abs b e) where
+  implicitArgsE (Abs b e) = do
+    ((), vs) <- runWithEnv $ implicitArgsB b
+    local (<>vs) $ implicitArgsE e
+
+instance (HasImplicitArgNamesE e1, HasImplicitArgNamesE e2)
+         => HasImplicitArgNamesE (PairE e1 e2) where
+  implicitArgsE (PairE x y) = implicitArgsE x >> implicitArgsE y
+
+instance ((forall n. Ord (a n)), HasImplicitArgNamesE a)
+         => HasImplicitArgNamesE (EffectRowP a) where
+  implicitArgsE (EffectRow row tailVar) = do
+    mapM_ implicitArgsE $ S.toList row
+    mapM_ implicitArgsE tailVar
+
+instance HasImplicitArgNamesE a => HasImplicitArgNamesE (EffectP a) where
+  implicitArgsE (RWSEffect _ name) = implicitArgsE name
+  implicitArgsE _ = return ()
+
+instance HasImplicitArgNamesE e => HasImplicitArgNamesE (WithSrcE e) where
+  implicitArgsE (WithSrcE _ x) = implicitArgsE x
+
+instance HasImplicitArgNamesB b => HasImplicitArgNamesB (WithSrcB b) where
+  implicitArgsB (WithSrcB _ x) = implicitArgsB x
+
+instance HasImplicitArgNamesE e => HasImplicitArgNamesE (ListE e) where
+  implicitArgsE (ListE xs) = mapM_ implicitArgsE xs
+

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -1,0 +1,368 @@
+-- Copyright 2021 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module SaferNames.SourceRename (renameSourceNames) where
+
+import Prelude hiding (id, (.))
+import Control.Category
+import Control.Monad.Except hiding (Except)
+import qualified Data.Set        as S
+import qualified Data.Map.Strict as M
+
+-- import Env
+import Err
+import LabeledItems
+import SaferNames.NameCore (injectNames, singletonScope)
+import SaferNames.Name hiding (Renamer)
+import SaferNames.ResolveImplicitNames
+import SaferNames.Syntax
+
+-- renameSourceNames :: MonadErr m => Scope (n::S) -> SourceMap n -> SourceUModule -> m (UModule n)
+-- renameSourceNames scope sourceMap m =
+--   runReaderT (runReaderT (renameSourceNames' m) (scope, sourceMap)) False
+renameSourceNames = undefined
+
+type RenameEnv (n::S) = (Scope n, SourceMap n)
+
+-- We have this class because we want to read some extra context (whether
+-- shadowing is allowed) but we've already used up the MonadReader
+-- (we can't add a field because we want it to be monoidal).
+class (Monad1 m, ScopeExtender m, MonadErr1 m) => Renamer m where
+  askMayShadow :: m n Bool
+  setMayShadow :: Bool -> m n a -> m n a
+  askSourceMap :: m n (SourceMap n)
+  extendSourceMap :: (SourceMap n) -> m n a -> m n a
+
+-- Will implement Renamer directly (with a newtype)
+data RenamerData (n::S) a
+
+instance Functor (RenamerData n) where
+
+instance Applicative (RenamerData n) where
+
+instance Monad (RenamerData n) where
+
+instance ScopeReader RenamerData where
+
+instance ScopeExtender RenamerData where
+
+instance MonadError Err (RenamerData n) where
+
+instance Renamer RenamerData where
+
+-- instance MonadErr m => Renamer n (ReaderT (RenameEnv n) (ReaderT Bool m)) where
+--   askMayShadow = lift ask
+--   setMayShadow mayShadow cont = do
+--     env <- ask
+--     lift $ local (const mayShadow) (runReaderT cont env)
+
+renameSourceNames' :: Renamer m => SourceUModule -> m o (UModule o)
+renameSourceNames' (SourceUModule decl) = do
+  (RenamerContent frag sourceMap decl') <- runRenamerNameGenT $
+    sourceRenameB $ resolveImplicitTopDecl decl
+  return $ UModule frag sourceMap decl'
+
+class SourceRenamableE e where
+  sourceRenameE :: Renamer m => e i -> m o (e o)
+
+class SourceRenamableB (b :: B) where
+  sourceRenameB :: Renamer m
+                => b i i'
+                -> RenamerNameGenT m (b o) o
+
+data RenamerNameGenT (m::MonadKind1) (e::E) (n::S) =
+  RenamerNameGenT { runRenamerNameGenT :: (m n (RenamerContent e n)) }
+
+data RenamerContent e n where
+  RenamerContent
+    :: Distinct l
+    => ScopeFrag n l
+    -> SourceMap l
+    -> e l
+    -> RenamerContent e n
+
+instance (Renamer m) => NameGen (RenamerNameGenT m) where
+  returnG expr = RenamerNameGenT do
+    (Distinct _) <- getScope
+    return $ RenamerContent id mempty expr
+  bindG (RenamerNameGenT action) cont = RenamerNameGenT do
+    (RenamerContent frag sourceMap expr) <- action
+    extendScope frag $ extendSourceMap sourceMap $ do
+      (RenamerContent frag2 sourceMap2 expr2) <- runRenamerNameGenT $ cont expr
+      let sourceMap' = injectNames frag2 sourceMap <> sourceMap2
+      return $ RenamerContent (frag >>> frag2) sourceMap' expr2
+
+withSourceRenameB :: SourceRenamableB b
+                  => Renamer m
+                  => b i i'
+                  -> (forall o'. b o o' -> m o' r) -> m o r
+withSourceRenameB b cont = do
+  (RenamerContent frag sourceMap b') <- runRenamerNameGenT $ sourceRenameB b
+  extendScope frag $ extendSourceMap sourceMap $ cont b'
+
+instance SourceRenamableE (SourceNameOr UVar) where
+  sourceRenameE (SourceName sourceName) = do
+    SourceMap sourceMap <- askSourceMap
+    case M.lookup sourceName sourceMap of
+      Nothing    -> throw UnboundVarErr $ pprint sourceName
+      Just (SrcAtomName     name) -> return $ InternalName $ UAtomVar name
+      Just (SrcTyConName    name) -> return $ InternalName $ UTyConVar name
+      Just (SrcDataConName  name) -> return $ InternalName $ UDataConVar name
+      Just (SrcClassName    name) -> return $ InternalName $ UClassVar name
+      Just (SrcMethodName   name) -> return $ InternalName $ UMethodVar name
+  sourceRenameE _ = error "Shouldn't be source-renaming internal names"
+
+instance FromSourceNameDef color => SourceRenamableE (SourceNameOr (Name color)) where
+  sourceRenameE (SourceName sourceName) = do
+    SourceMap sourceMap <- askSourceMap
+    case M.lookup sourceName sourceMap of
+      Nothing    -> throw UnboundVarErr $ pprint sourceName
+      Just sourceNameDef -> case fromSourceNameDef sourceNameDef of
+        -- TODO: Do we want namespace-specific errors here?
+        Nothing -> throw TypeErr $ "Incorrect name color: " ++ pprint sourceName
+        (Just name) -> return $ InternalName name
+  sourceRenameE _ = error "Shouldn't be source-renaming internal names"
+
+instance (SourceRenamableE e, SourceRenamableB b) => SourceRenamableE (Abs b e) where
+  sourceRenameE (Abs b e) = withSourceRenameB b \b' -> Abs b' <$> sourceRenameE e
+
+instance SourceRenamableB (UBinder AtomNameDef) where
+  sourceRenameB b = sourceRenameUBinder SrcAtomName b
+
+instance SourceRenamableB UPatAnn where
+  sourceRenameB (UPatAnn b ann) = RenamerNameGenT do
+    ann' <- mapM sourceRenameE ann
+    runRenamerNameGenT $ (flip UPatAnn ann') `fmapG` sourceRenameB b
+
+instance SourceRenamableB (UAnnBinder AtomNameDef) where
+  sourceRenameB (UAnnBinder b ann) = RenamerNameGenT do
+    ann' <- sourceRenameE ann
+    runRenamerNameGenT $ (flip UAnnBinder ann') `fmapG` sourceRenameB b
+
+instance SourceRenamableB UPatAnnArrow where
+  sourceRenameB (UPatAnnArrow b arrow) =
+    (flip UPatAnnArrow arrow) `fmapG` sourceRenameB b
+
+instance SourceRenamableE UExpr' where
+  sourceRenameE expr = setMayShadow True case expr of
+    UVar v -> UVar <$> sourceRenameE v
+    ULam (ULamExpr arr pat body) ->
+      withSourceRenameB pat \pat' ->
+        ULam <$> ULamExpr arr pat' <$> sourceRenameE body
+    UPi (UPiExpr arr pat eff body) ->
+      withSourceRenameB pat \pat' ->
+        UPi <$> (UPiExpr arr pat' <$> sourceRenameE eff <*> sourceRenameE body)
+    UApp arr f x -> UApp arr <$> sourceRenameE f <*> sourceRenameE x
+    UDecl (UDeclExpr decl rest) ->
+      withSourceRenameB decl \decl' ->
+        UDecl <$> UDeclExpr decl' <$> sourceRenameE rest
+    UFor d (UForExpr pat body) ->
+      withSourceRenameB pat \pat' ->
+        UFor d <$> UForExpr pat' <$> sourceRenameE body
+    UCase scrut alts ->
+      UCase <$> sourceRenameE scrut <*> mapM sourceRenameE alts
+    UHole -> return UHole
+    UTypeAnn e ty -> UTypeAnn <$> sourceRenameE e <*> sourceRenameE ty
+    UTabCon xs -> UTabCon <$> mapM sourceRenameE xs
+    UIndexRange low high ->
+      UIndexRange <$> mapM sourceRenameE low <*> mapM sourceRenameE high
+    UPrimExpr e -> UPrimExpr <$> mapM sourceRenameE e
+    URecord (Ext tys ext) -> URecord <$>
+      (Ext <$> mapM sourceRenameE tys <*> mapM sourceRenameE ext)
+    UVariant types label val ->
+      -- Do we not need to source-rename the types?  Their type is
+      -- type :: LabeledItems ()
+      UVariant types <$> return label <*> sourceRenameE val
+    UVariantLift labels val -> UVariantLift labels <$> sourceRenameE val
+    URecordTy (Ext tys ext) -> URecordTy <$>
+      (Ext <$> mapM sourceRenameE tys <*> mapM sourceRenameE ext)
+    UVariantTy (Ext tys ext) -> UVariantTy <$>
+      (Ext <$> mapM sourceRenameE tys <*> mapM sourceRenameE ext)
+    UIntLit   x -> return $ UIntLit x
+    UFloatLit x -> return $ UFloatLit x
+
+instance SourceRenamableE UAlt where
+  sourceRenameE (UAlt pat body) =
+    withSourceRenameB pat \pat' ->
+      UAlt pat' <$> sourceRenameE body
+
+instance ((forall n. Ord (a n)), SourceRenamableE a) => SourceRenamableE (EffectRowP a) where
+  sourceRenameE (EffectRow row tailVar) =
+    EffectRow <$> row' <*> mapM sourceRenameE tailVar
+    where row' = S.fromList <$> traverse sourceRenameE (S.toList row)
+
+instance SourceRenamableE a => SourceRenamableE (EffectP a) where
+  sourceRenameE (RWSEffect rws name) = RWSEffect rws <$> sourceRenameE name
+  sourceRenameE ExceptionEffect = return ExceptionEffect
+  sourceRenameE IOEffect = return IOEffect
+
+instance SourceRenamableE a => SourceRenamableE (WithSrcE a) where
+  sourceRenameE (WithSrcE pos e) = addSrcContext pos $
+    WithSrcE pos <$> sourceRenameE e
+
+instance SourceRenamableB a => SourceRenamableB (WithSrcB a) where
+  sourceRenameB (WithSrcB pos b) = RenamerNameGenT $ addSrcContext pos $
+    runRenamerNameGenT $ (WithSrcB pos) `fmapG` sourceRenameB b
+
+instance SourceRenamableB UDecl where
+  sourceRenameB decl = RenamerNameGenT $ case decl of
+    ULet ann pat expr -> do
+      expr' <- sourceRenameE expr
+      runRenamerNameGenT $ flip (ULet ann) expr' `fmapG` sourceRenameB pat
+    UDataDefDecl dataDef tyConName dataConNames -> do
+      dataDef' <- sourceRenameE dataDef
+      runRenamerNameGenT $ sourceRenameUBinder SrcTyConName tyConName `bindG` \tyConName' ->
+        sourceRenameUBinderNest SrcDataConName dataConNames `bindG` \dataConNames' ->
+        returnG $ UDataDefDecl dataDef' tyConName' dataConNames'
+    UInterface paramBs superclasses methodTys className methodNames -> do
+      Abs paramBs' (PairE (ListE superclasses') (ListE methodTys')) <-
+        sourceRenameE $ Abs paramBs $ PairE (ListE superclasses) (ListE methodTys)
+      runRenamerNameGenT $ sourceRenameUBinder SrcClassName className `bindG` \className' ->
+        sourceRenameUBinderNest SrcMethodName methodNames `bindG` \methodNames' ->
+        returnG $ UInterface paramBs' superclasses' methodTys' className' methodNames'
+    UInstance conditions className params methodDefs instanceName -> do
+      Abs conditions' (PairE (PairE className' (ListE params')) (ListE methodDefs')) <-
+        sourceRenameE $ Abs conditions (PairE (PairE className $ ListE params) $ ListE methodDefs)
+      runRenamerNameGenT $ UInstance conditions' className' params' methodDefs' `fmapG` sourceRenameB instanceName
+
+instance SourceRenamableB b => SourceRenamableB (MaybeB b) where
+  sourceRenameB (JustB b) = JustB `fmapG` sourceRenameB b
+  sourceRenameB NothingB = returnG NothingB
+
+sourceRenameUBinderNest :: Renamer m => (forall o'. Name s o' -> SourceNameDef o')
+                        -> Nest (UBinder s) i i' -> RenamerNameGenT m (Nest (UBinder s) o) o
+sourceRenameUBinderNest _ Empty = returnG Empty
+sourceRenameUBinderNest f (Nest b bs) =
+  sourceRenameUBinder f b `bindG` \b' ->
+  sourceRenameUBinderNest f bs `bindG` \bs' ->
+  returnG $ Nest b' bs'
+
+sourceRenameUBinder :: Renamer m => (forall o'. Name s o' -> SourceNameDef o')
+                    -> UBinder s i i' -> RenamerNameGenT m (UBinder s o) o
+sourceRenameUBinder asSourceNameDef ubinder = case ubinder of
+  UBindSource b -> RenamerNameGenT do
+    SourceMap sourceMap <- askSourceMap
+    mayShadow <- askMayShadow
+    unless (mayShadow || not (M.member b sourceMap)) $
+      throw RepeatedVarErr $ pprint b
+    withFreshM b \freshName -> do
+      (Distinct _) <- getScope
+      let frag = (singletonScope freshName)
+      let sourceMap' = SourceMap (M.singleton b (asSourceNameDef $ nameBinderName freshName))
+      return $ RenamerContent frag sourceMap' $ UBind freshName
+  UBind _ -> error "Shouldn't be source-renaming internal names"
+  UIgnore -> returnG UIgnore
+
+instance SourceRenamableE UDataDef where
+  sourceRenameE (UDataDef (tyConName, paramBs) dataCons) = do
+    (RenamerContent frag sourceMap paramBs') <- runRenamerNameGenT $ sourceRenameB paramBs
+    extendScope frag $ extendSourceMap sourceMap $ do
+      dataCons' <- forM dataCons \(dataConName, argBs) -> do
+        argBs' <- sourceRenameE argBs
+        return (dataConName, argBs')
+      return $ UDataDef (tyConName, paramBs') dataCons'
+
+instance SourceRenamableE UDataDefTrail where
+  sourceRenameE (UDataDefTrail args) = withSourceRenameB args \args' ->
+    return $ UDataDefTrail args'
+
+instance (SourceRenamableE e1, SourceRenamableE e2) => SourceRenamableE (PairE e1 e2) where
+  sourceRenameE (PairE x y) = PairE <$> sourceRenameE x <*> sourceRenameE y
+
+instance SourceRenamableE e => SourceRenamableE (ListE e) where
+  sourceRenameE (ListE xs) = ListE <$> mapM sourceRenameE xs
+
+instance SourceRenamableE UMethodDef where
+  sourceRenameE (UMethodDef v expr) =
+    UMethodDef <$> sourceRenameE v <*> sourceRenameE expr
+
+instance SourceRenamableB b => SourceRenamableB (Nest b) where
+  sourceRenameB (Nest b bs) =
+    sourceRenameB b `bindG` \b' ->
+    sourceRenameB bs `bindG` \bs' ->
+    returnG $ Nest b' bs'
+  sourceRenameB Empty = returnG Empty
+
+-- -- === renaming patterns ===
+
+-- We want to ensure that pattern siblings don't shadow each other, so we carry
+-- the set of in-scope siblings' names along with the normal renaming env.
+
+type SiblingSet = S.Set SourceName
+
+-- TODO It seems this monad actually has no way for a downstream action
+-- to check for membership in the sibling set produced by an upstream action?
+-- Do we already have an ask/extend type of monad for this sort of thing?
+-- Does it need to be re-kinded?
+-- Alternately, should I just raise the error in `bindG` and be done with it?
+data PatRenamerNameGenT (m::MonadKind1) (e::E) (n::S) =
+  PatRenamerNameGenT { runPatRenamerNameGenT :: (m n (SiblingSet, RenamerContent e n)) }
+
+instance (Renamer m) => NameGen (PatRenamerNameGenT m) where
+  returnG expr = PatRenamerNameGenT $ fmap (mempty,) $ runRenamerNameGenT $ returnG expr
+  bindG (PatRenamerNameGenT action) cont = PatRenamerNameGenT do
+    (sibs, RenamerContent frag sourceMap expr) <- action
+    extendScope frag $ extendSourceMap sourceMap $ do
+      (sibs', RenamerContent frag' sourceMap' expr') <- runPatRenamerNameGenT $ cont expr
+      let sourceMap'' = injectNames frag' sourceMap <> sourceMap'
+      return (sibs <> sibs', RenamerContent (frag >>> frag') sourceMap'' expr')
+
+class SourceRenamablePat (pat::B) where
+  sourceRenamePat :: Renamer m
+                  => SiblingSet
+                  -> pat i i'
+                  -> PatRenamerNameGenT m (pat o) o
+
+instance SourceRenamablePat (UBinder AtomNameDef) where
+  sourceRenamePat siblingNames ubinder = PatRenamerNameGenT do
+    newSibs <- case ubinder of
+      UBindSource b -> do
+        when (S.member b siblingNames) $ throw RepeatedPatVarErr $ pprint b
+        return $ S.singleton b
+      UIgnore -> return mempty
+      UBind _ -> error "Shouldn't be source-renaming internal names"
+    ubinder' <- runRenamerNameGenT $ sourceRenameB ubinder
+    return $ (newSibs, ubinder')
+
+instance SourceRenamablePat UPat' where
+  sourceRenamePat siblingNames pat = case pat of
+    UPatBinder b -> UPatBinder `fmapG` sourceRenamePat siblingNames b
+    UPatCon ~(SourceName con) bs -> PatRenamerNameGenT do
+      -- TODO Deduplicate this against the code for sourceRenameE of
+      -- the SourceName case of SourceNameOr
+      SourceMap sourceMap <- askSourceMap
+      con' <- case M.lookup con sourceMap of
+        Nothing    -> throw UnboundVarErr $ pprint con
+        Just (SrcDataConName name) -> return $ InternalName name
+        Just _ -> throw TypeErr $ "Not a data constructor: " ++ pprint con
+      runPatRenamerNameGenT $ UPatCon con' `fmapG` sourceRenamePat siblingNames bs
+    UPatPair (NestPair p1 p2) ->
+      sourceRenamePat siblingNames p1 `bindG` \p1' ->
+      sourceRenamePat siblingNames p2 `bindG` \p2' ->
+      returnG $ UPatPair $ NestPair p1' p2'
+    UPatUnit UnitB -> returnG $ UPatUnit UnitB
+    UPatRecord labels ps -> UPatRecord labels `fmapG` sourceRenamePat siblingNames ps
+    UPatVariant labels label p -> UPatVariant labels label `fmapG` sourceRenamePat siblingNames p
+    UPatVariantLift labels p -> UPatVariantLift labels `fmapG` sourceRenamePat siblingNames p
+    UPatTable ps -> UPatTable `fmapG` sourceRenamePat siblingNames ps
+
+instance SourceRenamablePat p => SourceRenamablePat (WithSrcB p) where
+  sourceRenamePat sibs (WithSrcB pos pat) = PatRenamerNameGenT $ addSrcContext pos $
+    runPatRenamerNameGenT $ (WithSrcB pos) `fmapG` sourceRenamePat sibs pat
+
+instance SourceRenamablePat p => SourceRenamablePat (Nest p) where
+  sourceRenamePat sibs (Nest b bs) =
+    sourceRenamePat sibs b `bindG` \b' ->
+    sourceRenamePat sibs bs `bindG` \bs' ->
+    returnG $ Nest b' bs'
+  sourceRenamePat _ Empty = returnG Empty
+
+instance SourceRenamableB UPat' where
+  sourceRenameB pat = RenamerNameGenT $ snd <$> action where
+    action = runPatRenamerNameGenT $ sourceRenamePat mempty pat

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -122,7 +122,7 @@ data AtomBinderInfo (n::S) =
  | InferenceName
    deriving (Show, Generic)
 
--- We inlinine the definition for compatibility with the unsafe IR.
+-- We inline the definition for compatibility with the unsafe IR.
 -- TODO: remove once we don't need the bridge anymore
 type NamedDataDef n = (Name DataDef n, DataDef n)
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -288,7 +288,7 @@ data UDecl =
        (Nest UBinder)   -- method names
  | UInstance
      (Nest UPatAnnArrow)      -- dictionary args (i.e. conditions)
-       UVar [UExpr]            -- class var and params
+       UVar [UExpr]           -- class var and params
        [UMethodDef]           -- method definitions
      (Maybe UBinder)          -- optional instance name
    deriving (Show, Generic)

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -53,7 +53,7 @@ module Syntax (
     fromLeftLeaningConsListTy,
     mkBundle, mkBundleTy, BundleDesc,
     extendEffRow, getProjection, simplifyCase,
-    varType, binderType, isTabTy, LogLevel (..), IRVariant (..),
+    varType, binderType, isTabTy, BlockId, LogLevel (..), IRVariant (..),
     BaseMonoidP (..), BaseMonoid, getBaseMonoidType,
     applyIntBinOp, applyIntCmpOp, applyFloatBinOp, applyFloatUnOp,
     getIntLit, getFloatLit, sizeOf, ptrSize, vectorWidth,

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -49,6 +49,7 @@ import LLVMExec
 import PPrint()
 import Parser
 import qualified SaferNames.Parser as SP
+import qualified SaferNames.SourceRename as SSR
 import Util (highlightRegion, measureSeconds, onFst, onSnd)
 import Optimize
 import Parallelize

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -48,6 +48,7 @@ import Logging
 import LLVMExec
 import PPrint()
 import Parser
+import qualified SaferNames.Parser as SP
 import Util (highlightRegion, measureSeconds, onFst, onSnd)
 import Optimize
 import Parallelize


### PR DESCRIPTION
With apologies to Donald Knuth, beware of bugs in this code, for I have only proved it [type-]correct, not tested it.

Things that remain to be done:
- Fill in class instances GHC complains about, notably to implement SaferNames.SourceRename.Renamer
- Get the top level right in SaferNamer.SourceRename
- Port type inference to SaferNames
- Adjust Toplevel.evalUModule and friends to parse, rename, and type-check source code using both the old and new style, and check that they produce the same results on the extant corpus of Dex programs (and ideally the same errors on near misses, if there is a corpus of those available).

One particular bug this may find: there may be a `setMayShadow` call or two missing somewhere in the renamer.