### PR TITLE
Move DexCall sig_parser into a function

### DIFF
--- a/julia/src/native_function.jl
+++ b/julia/src/native_function.jl
@@ -286,26 +286,27 @@ result_type(x::Type) = x
 result_type(::ArrayBuilder{T,N}) where {T,N} = Array{T,N}
 
 # CombinedParsers.jl based parser:
-@with_names begin
-    name = map(Symbol, !re"arg\d+")
-    scalar_type = Either{Any}(Any[
-        parser("f32"=>Float32),
-        parser("f64"=>Float64),
-        parser("i32"=>Int32),
-        parser("i64"=>Int64),
-        parser("i8"=>Int8),
-    ])
-    size_ele = Numeric(Int) | name
-    sizes = join(Repeat(size_ele),",")
-    array_type = map(scalar_type * "[" * sizes * "]") do (T, _, sz, _)
-        ArrayBuilder{T}(sz)
-    end
-    type = Either{Any}(Any[array_type, scalar_type])
-    implicit = parser("?"=>true) | false
-    arg_sig = map(implicit * name * ":" * type) do (i, n, _ , t)
-        Binder(n, t, i)
-    end
-    arg_sigs = join(Repeat(arg_sig),",")
+function parse_sig(sig)
+    @with_names begin
+        name = map(Symbol, !re"arg\d+")
+        scalar_type = Either{Any}(
+            parser("f32"=>Float32),
+            parser("f64"=>Float64),
+            parser("i32"=>Int32),
+            parser("i64"=>Int64),
+            parser("i8"=>Int8),
+        )
+        size_ele = NumericParser(Int) | name
+        sizes = join(Repeat(size_ele),",")
+        array_type = map(scalar_type * "[" * sizes * "]") do (T, _, sz, _)
+            ArrayBuilder{T}(sz)
+        end
+        type = array_type | scalar_type
+        implicit = parser("?"=>true) | false
+        arg_sig = map(implicit * name * ":" * type) do (i, n, _ , t)
+            Binder(n, t, i)
+        end
+        arg_sigs = join(Repeat(arg_sig),",")
+    end    
+    return parse(arg_sigs, sig)
 end
-
-parse_sig(sig) = parse(arg_sigs, sig)


### PR DESCRIPTION
and update to remove deprecated methods

Closes one part of #630 , 
gets the precompilation time down from 30-50 seconds to something well under 5.

c.f. https://github.com/gkappler/CombinedParsers.jl/issues/32