### PR TITLE
Check that the clang compiler is compatible with LLVM-9 in the makefile

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,8 +34,8 @@ development. Expect monstrous bugs and razor-sharp edges!**
     * Ubuntu/Debian: `apt-get install llvm-9-dev`
     * macOS: `brew install llvm@9`
       * Make sure `llvm@9` is on your `PATH` before building. Example: `export PATH="$(brew --prefix llvm@9)/bin:$PATH"`
-  * Install clang (may be installed together with llvm)
-    * Ubuntu/Debian: `apt-get install clang`
+  * Install clang 9 (may be installed together with llvm)
+    * Ubuntu/Debian: `apt-get install clang-9`
     * macOS: installs with llvm
   * Install libpng (often included by default in *nix platforms)
     * Ubuntu/Debian: `apt-get install libpng-dev`

--- a/makefile
+++ b/makefile
@@ -49,7 +49,7 @@ endif
 
 possible-clang-locations := clang++-9 clang++-10 clang++-11 clang++
 
-CLANG := $(shell if [[ $$DEX_LLVM_HEAD -eq 1 ]] ; \
+CLANG := $(shell if [[ "$$DEX_LLVM_HEAD" -eq 1 ]] ; \
 	then echo "clang++"; \
 	else \
 		for clangversion in $(possible-clang-locations) ; do \

--- a/makefile
+++ b/makefile
@@ -55,7 +55,7 @@ STACK_FLAGS := $(STACK_FLAGS) --flag dex:llvm-head
 STACK := $(STACK) --stack-yaml=stack-llvm-head.yaml
 endif
 
-clang_version = $(shell clang++ -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*/, "")) }')
+clang_version = $(shell clang++ -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*$$/, "")) }')
 check_clang_version:
 ifneq ($(clang_version), 1)
 	@echo "Please use clang++ version 9."

--- a/makefile
+++ b/makefile
@@ -3,7 +3,6 @@
 SHELL=/bin/bash
 
 STACK=$(shell command -v stack 2>/dev/null)
-
 ifeq (, $(STACK))
 	STACK=cabal
 

--- a/makefile
+++ b/makefile
@@ -55,6 +55,13 @@ STACK_FLAGS := $(STACK_FLAGS) --flag dex:llvm-head
 STACK := $(STACK) --stack-yaml=stack-llvm-head.yaml
 endif
 
+clang_version = $(shell clang++ -dumpversion | awk '{ print(gsub(/((9)|(10)|(11))/, "")) }')
+check_clang_version:
+ifneq ($(clang_version), 1)
+	@echo "Please use clang++ version 9."
+	false
+endif
+
 CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti
 CFLAGS := $(CFLAGS) -std=c11
 
@@ -93,7 +100,7 @@ build-nolive: dexrt-llvm
 build-safe-names: dexrt-llvm
 	$(STACK) build $(STACK_FLAGS) --flag dex:safe-names
 
-dexrt-llvm: src/lib/dexrt.bc
+dexrt-llvm: src/lib/dexrt.bc check_clang_version
 
 %.bc: %.cpp
 	clang++ $(CXXFLAGS) -DDEX_LIVE -c -emit-llvm $^ -o $@

--- a/makefile
+++ b/makefile
@@ -49,15 +49,7 @@ endif
 
 possible-clang-locations := clang++-9 clang++-10 clang++-11 clang++
 
-CLANG := $(shell if [[ "$$DEX_LLVM_HEAD" -eq 1 ]] ; \
-	then echo "clang++"; \
-	else \
-		for clangversion in $(possible-clang-locations) ; do \
-		if [[ $$(command -v "$$clangversion" 2>/dev/null) ]] ; \
-		then echo "$$clangversion" ; break ; \
-		fi ; \
-		done ; \
-	fi)
+CLANG := clang++
 
 ifeq (1,$(DEX_LLVM_HEAD))
 ifeq ($(PLATFORM),Darwin)
@@ -65,16 +57,18 @@ $(error LLVM head builds not supported on macOS!)
 endif
 STACK_FLAGS := $(STACK_FLAGS) --flag dex:llvm-head
 STACK := $(STACK) --stack-yaml=stack-llvm-head.yaml
-else \
+else
+CLANG := $(shell for clangversion in $(possible-clang-locations) ; do \
+if [[ $$(command -v "$$clangversion" 2>/dev/null) ]]; \
+then echo "$$clangversion" ; break ; fi ; done)
 ifeq (,$(CLANG))
 $(error "Please install clang++-9")
-else
+endif
 clang-version-compatible := $(shell $(CLANG) -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*$$/, "")) }')
-ifneq ($(clang-version-compatible),1)
+ifneq (1,$(clang-version-compatible))
 $(error "Please install clang++-9")
 endif
 endif
-
 
 CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti
 CFLAGS := $(CFLAGS) -std=c11

--- a/makefile
+++ b/makefile
@@ -49,13 +49,12 @@ endif
 
 possible-clang-locations := clang++-9 clang++-10 clang++-11 clang++
 
-CLANG := $(shell
-	if [[ $DEX_LLVM_HEAD -eq 1 ]] ; \
+CLANG := $(shell if [[ $$DEX_LLVM_HEAD -eq 1 ]] ; \
 	then echo "clang++"; \
 	else \
-		for clangversion in clang++-9 clang++-10 clang++-11 clang++ ; do \
-		if [[ $(command -v "$clangversion" 2>/dev/null) ]] ; \
-		then echo "$clangversion" ; break ; \
+		for clangversion in $(possible-clang-locations) ; do \
+		if [[ $$(command -v "$$clangversion" 2>/dev/null) ]] ; \
+		then echo "$$clangversion" ; break ; \
 		fi ; \
 		done ; \
 	fi)

--- a/makefile
+++ b/makefile
@@ -49,10 +49,16 @@ endif
 
 possible-clang-locations := clang++-9 clang++-10 clang++-11 clang++
 
-CLANG := $(shell for clangversion in $(possible-clang-locations) ; do \
-	if [[ $$(command -v "$$clangversion" 2>/dev/null) ]]; \
-	then echo "$$clangversion" ; break ; fi ; done)
-
+CLANG := $(shell
+	if [[ $DEX_LLVM_HEAD -eq 1 ]] ; \
+	then echo "clang++"; \
+	else \
+		for clangversion in clang++-9 clang++-10 clang++-11 clang++ ; do \
+		if [[ $(command -v "$clangversion" 2>/dev/null) ]] ; \
+		then echo "$clangversion" ; break ; \
+		fi ; \
+		done ; \
+	fi)
 
 ifeq (1,$(DEX_LLVM_HEAD))
 ifeq ($(PLATFORM),Darwin)

--- a/makefile
+++ b/makefile
@@ -59,12 +59,12 @@ CLANG = $(shell for clangversion in $(possible-clang-locations) ; do \
 	if [[ $$(command -v "$$clangversion" 2>/dev/null) ]]; \
 	then echo "$$clangversion" ; break ; fi ; done)
 possible-clang-locations = clang++-9 clang++-10 clang++-11 clang++
-clang-version-compatibile = $(shell $(CLANG) -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*$$/, "")) }')
+clang-version-compatible = $(shell $(CLANG) -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*$$/, "")) }')
 check-clang-version:
 ifeq (, $(CLANG))
 	$(error "Please install clang++-9")
 endif
-ifneq ($(clang-version-compatibile), 1)
+ifneq ($(clang-version-compatible), 1)
 	$(error "Please install clang++-9")
 endif
 

--- a/makefile
+++ b/makefile
@@ -55,11 +55,11 @@ STACK_FLAGS := $(STACK_FLAGS) --flag dex:llvm-head
 STACK := $(STACK) --stack-yaml=stack-llvm-head.yaml
 endif
 
-clang_version = $(shell clang++ -dumpversion | awk '{ print(gsub(/((9)|(10)|(11))/, "")) }')
+clang_version = $(shell clang++ -dumpversion | awk '{ print(gsub(/^((9\.)|(10\.)|(11\.)).*/, "")) }')
 check_clang_version:
 ifneq ($(clang_version), 1)
 	@echo "Please use clang++ version 9."
-	false
+	@false
 endif
 
 CXXFLAGS := $(CFLAGS) -std=c++11 -fno-exceptions -fno-rtti


### PR DESCRIPTION
This should provide an error message when there is an incompatibility between clang and llvm versions. See #638 and #585 for more discussion. 

`-dumpversion` isn't documented in `clang++ --help`, but is listed in the [reference](https://clang.llvm.org/docs/ClangCommandLineReference.html).