### PR TITLE
Fix MNIST loading in tutorial

### DIFF
--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -317,7 +317,7 @@ Full = Fin ((size Batch) * (size IHeight) * (size IWidth))
 def pixel (x:Char) : Float32 =
      r = W8ToI x
      IToF case r < 0 of
-             True -> (abs r) + 128
+             True -> 256 + r
              False -> r
 
 def getIm : Batch => Image =
@@ -603,16 +603,11 @@ def bincount (inp : a => b) : b => Int =
 ' Plot how many times each pixel value occurs in an image:
 
 hist = bincount $ for (i,j). (FToI (ims.(0 @ _).i.j) @Pixels)
-> Ordinal index out of range:256 >= 256
-> Runtime error
 :t hist
-> Error: variable not in scope: hist
+> ((Fin 256) => Int32)
 
 :html showPlot $ yPlot (for i. (IToF hist.i))
-> Error: variable not in scope: hist
->
-> :html showPlot $ yPlot (for i. (IToF hist.i))
->                                      ^^^^
+> <html output>
 
 ' Find nearest images in the dataset:
 


### PR DESCRIPTION
Each pixel value in the Fashion MNIST dataset is stored as unsigned
byte.  Previously the loading code of the tutorial would map values
equal and above 128 (which are interpreted as negative numbers by the
signed datatypes) to the wrong integer value (e.g., '\128' -> 256,
should be 128, '\129' -> 255, should be 129).

Testing: Compared the rendering of the first shoe image displayed in the
browser with a Python reference implementation.