### PR TITLE
Fix signature of dexFreeFunctionSignature in Python bindings

### DIFF
--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -74,7 +74,7 @@ compile    = dex_func('dexCompile',    HsJITPtr, HsContextPtr, HsAtomPtr, Native
 unload     = dex_func('dexUnload',     HsJITPtr, NativeFunction, None)
 
 getFunctionSignature  = dex_func('dexGetFunctionSignature', HsJITPtr, NativeFunction, NativeFunctionSignaturePtr)
-freeFunctionSignature = dex_func('dexFreeFunctionSignature', NativeFunctionSignaturePtr)
+freeFunctionSignature = dex_func('dexFreeFunctionSignature', NativeFunctionSignaturePtr, None)
 
 init()
 jit = createJIT()


### PR DESCRIPTION
Thanks to Lyndon for spotting the bug!