### PR TITLE
Exclude fft from CI

### DIFF
--- a/makefile
+++ b/makefile
@@ -119,10 +119,10 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator mcmc ctc raytrace particle-filter \
                 isomorphisms ode-integrator fluidsim \
-                sgd psd fft chol tutorial kernelregression \
+                sgd psd tutorial kernelregression \
                 quaternions manifold-gradients schrodinger
 # TODO: re-enable
-# vega-plotting
+# fft vega-plotting
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              shadow-tests monad-tests io-tests exception-tests sort-tests \


### PR DESCRIPTION
It seems to be uncovering a pretty nasty bug that should get fixed by
the safer names effort.