### PR TITLE
Safe names builder

### DIFF
--- a/src/lib/SaferNames/Bridge.hs
+++ b/src/lib/SaferNames/Bridge.hs
@@ -178,7 +178,8 @@ nameBijectionFromDBindings
 nameBijectionFromDBindings fromSafeMap bindings cont = do
   withFreshSafeRec fromSafeMap (envPairs bindings) \scopeFrag fromSafeMap' -> do
     toSafeMap' <- getToSafeNameMap
-    Distinct scope <- getScope
+    Distinct <- getDistinct
+    scope <- getScope
     let bindingsFrag = makeBindingsFrag scope bindings toSafeMap' fromSafeMap' scopeFrag
     cont bindingsFrag toSafeMap' fromSafeMap'
 
@@ -206,7 +207,7 @@ withFreshSafeRec :: MonadToSafe m
                  -> (forall l. Distinct l => ConstEnv n l -> FromSafeNameMap l -> m l a)
                  -> m n a
 withFreshSafeRec fromSafeMap [] cont = do
-  Distinct _ <- getScope
+  Distinct <- getDistinct
   cont emptyEnv fromSafeMap
 withFreshSafeRec (FromSafeNameMap fromSafeMap) ((vD,info):rest) cont = do
   withFreshBijectionD vD info \b valD -> do
@@ -788,7 +789,10 @@ instance HasPtrs TopStateEx where
   traversePtrs _ s = pure s
 
 instance ScopeReader ToSafeM where
-  getScope = ToSafeM $ ReaderT \_ -> getScope
+  addScope e = ToSafeM $ lift $ addScope e
+
+instance ScopeGetter ToSafeM where
+  getScope = ToSafeM $ lift $ getScope
 
 instance ScopeExtender ToSafeM where
   extendScope frag m  =

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -274,16 +274,15 @@ buildPureNaryLam :: LocalBuilder m
                  -> m n (Atom n)
 buildPureNaryLam _ (EmptyAbs Empty) cont = cont []
 buildPureNaryLam arr (EmptyAbs (Nest (b:>ty) rest)) cont = do
-  p1 <- getScopeProxy
+  ext1 <- idExt
   buildPureLam arr ty \x -> do
-    p2 <- getScopeProxy
+    ext2 <- injectExt ext1
     restAbs <- injectM $ Abs b $ EmptyAbs rest
     rest' <- applyAbs restAbs x
     atomAsBlock =<< buildPureNaryLam arr rest' \xs -> do
-      p3 <- getScopeProxy
+      ExtW <- injectExt ext2
       x' <- injectM x
-      withComposeExts p1 p2 p3 $
-        cont (x':xs)
+      cont (x':xs)
 buildPureNaryLam _ _ _ = error "impossible"
 
 -- === builder versions of common ops ===

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -13,17 +13,14 @@
 
 module SaferNames.Builder (
   emit, emitOp, buildLamGeneral,
-  buildPureLam, BuilderT, Builder (..), Builder2, EffectsReader2,
-  runBuilderT, buildBlock,
-  EffectsReader (..), EffectsReaderT (..),
-  runEffectsReaderT, liftEffectsReaderT,
-  liftBuilder, app, add, mul, sub, neg, div',
+  buildPureLam, BuilderT, Builder (..), Builder2,
+  runBuilderT, buildBlock, app, add, mul, sub, neg, div',
   iadd, imul, isub, idiv, ilt, ieq, irem,
   fpow, flog, fLitLike, recGetHead, buildPureNaryLam,
   makeSuperclassGetter, makeMethodGetter,
   select, getUnpacked,
   fromPair, getFst, getSnd, getProj, getProjRef, naryApp,
-  getClassDef, liftBuilderNameGenT,
+  getClassDef, liftBuilderNameGenT, atomAsBlock,
   ) where
 
 import Prelude hiding ((.), id)
@@ -35,6 +32,8 @@ import Data.Foldable (toList)
 import Data.List (elemIndex)
 import Data.Maybe (fromJust)
 
+import Unsafe.Coerce
+
 import SaferNames.NameCore
 import SaferNames.Name
 import SaferNames.Syntax
@@ -43,19 +42,21 @@ import SaferNames.PPrint ()
 
 import LabeledItems
 
-class BindingsReader m => Builder (m::MonadKind1) where
-  emitDecl :: NameHint -> LetAnn -> Expr n -> m n (AtomName n)
-
--- Everything but the decls
-type LocalBuilder m = (BindingsReader m, EffectsReader m, Scopable m)
+class (BindingsReader m, Scopable m, MonadFail1 m)
+      => Builder (m::MonadKind1) where
+  emitDecl :: Emits n => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
+  buildScoped :: (InjectableE e, HasNamesE e)
+              => (forall l. (Emits l, Ext n l) => m l (e l))
+              -> m n (Abs (Nest Decl) e n)
+  getAllowedEffects :: m n (EffectRow n)
+  withAllowedEffects :: EffectRow n -> m n a -> m n a
 
 type Builder2       (m :: MonadKind2) = forall i. Builder (m i)
-type EffectsReader2 (m :: MonadKind2) = forall i. EffectsReader (m i)
 
-emit :: Builder m => Expr n -> m n (AtomName n)
+emit :: (Builder m, Emits n) => Expr n -> m n (AtomName n)
 emit expr = emitDecl NoHint PlainLet expr
 
-emitOp :: Builder m => Op n -> m n (Atom n)
+emitOp :: (Builder m, Emits n) => Op n -> m n (Atom n)
 emitOp op = Var <$> emit (Op op)
 
 -- === BuilderNameGenT ===
@@ -84,129 +85,116 @@ liftBuilderNameGenT m = BuilderNameGenT do
 
 -- === BuilderT ===
 
-newtype BuilderT (m::MonadKind1) (n::S) (l::S) (a:: *) =
-  BuilderT { runBuilderT' :: Inplace (BuilderNameGenT Decl m) n l a }
+newtype BuilderT (m::MonadKind1) (n::S) (a:: *) =
+  BuilderT { runBuilderT' :: Inplace (BuilderNameGenT Decl m) n a }
   deriving (Functor, Applicative, Monad)
 
-runBuilderT :: (BindingsReader m, BindingsExtender m, InjectableE e)
-            => (forall l. (Distinct l, Ext n l) => BuilderT m n l (e l))
-            -> m n (DistinctAbs (Nest Decl) e n)
-runBuilderT cont = runBuilderNameGenT $ runInplace $ runBuilderT' cont
+runBuilderT
+  :: ( BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m
+     , InjectableE e, HasNamesE e)
+  => (forall l. (Distinct l, Ext n l) => BuilderT m l (e l))
+  -> m n (e n)
+runBuilderT cont = do
+  (DistinctAbs decls result) <- runBuilderNameGenT $ runInplace $ runBuilderT' cont
+  -- this should always succeed because we don't supply the `Emits` predicate to
+  -- the continuation
+  fromConstAbs $ Abs decls result
+
+runBuilderTWithEmits
+  :: ( BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m
+     , InjectableE e, HasNamesE e)
+  => (forall l. (Emits l, Distinct l, Ext n l) => BuilderT m l (e l))
+  -> m n (Abs (Nest Decl) e n)
+runBuilderTWithEmits _ = undefined
 
 -- TODO: should be able to get away with `Scopable m` instead of `BindingsExtender m`
-instance (BindingsReader m, BindingsGetter m, BindingsExtender m)
-         => Builder (BuilderT m n) where
+instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
+         => Builder (BuilderT m) where
   emitDecl hint ann expr = BuilderT $
-    liftInplace expr \expr' -> BuilderNameGenT do
+    liftInplace $ BuilderNameGenT do
+      expr' <- injectM expr
       ty <- getType expr'
       let binderInfo = LetBound ann expr'
       withFreshBinder hint ty binderInfo \b -> do
         return $ DistinctAbs (Nest (Let ann b expr') Empty) (binderName b)
 
-instance (BindingsReader m, BindingsGetter m, BindingsExtender m)
-         => ScopeReader (BuilderT m n) where
-  getDistinctEvidenceM = BuilderT $
-    liftInplace UnitE \UnitE ->
-      liftBuilderNameGenT getDistinctEvidenceM
-  addScope e = BuilderT $
-    liftInplace e \e' ->
-      liftBuilderNameGenT $ addScope e'
-
-instance (BindingsReader m, BindingsGetter m, BindingsExtender m)
-         => BindingsReader (BuilderT m n) where
-  addBindings e = BuilderT $
-    liftInplace e \e' ->
-      liftBuilderNameGenT $ addBindings e'
-
-apBuilder :: ( Monad1 m, BindingsReader m, BindingsExtender m
-             , InjectableE e, InjectableE e')
-          => (forall l'. e l' -> m l' (e' l'))
-          -> e l
-          -> BuilderT m n l (e' l)
-apBuilder cont x = liftBuilder x cont
-
-liftBuilder :: ( Monad1 m, BindingsReader m, BindingsExtender m
-               , InjectableE e, InjectableE e')
-            => e l
-            -> (forall l'. e l' -> m l' (e' l'))
-            -> BuilderT m n l (e' l)
-liftBuilder x cont = BuilderT $
-  liftInplace x \x' ->
-    BuilderNameGenT do
+  buildScoped cont = do
+    ext1 <- idExt
+    BuilderT $ liftInplace $ BuilderNameGenT do
+      ext2 <- injectExt ext1
+      result <- runBuilderTWithEmits do
+                  ExtW <- injectExt ext2
+                  cont
       Distinct <- getDistinct
-      DistinctAbs Empty <$> cont x'
+      return $ DistinctAbs id result
 
-liftLocalBuilder
-  :: (EffectsReader m, BindingsReader m, InjectableE e, InjectableE e')
-  => e n
-  -> (forall l. e l -> EffectsReaderT (BindingsReaderT Identity) l (e' l))
-  -> m n (e' n)
-liftLocalBuilder x cont = do
-  effs <- getAllowedEffects
-  WithBindings bindings scope (PairE x' effs') <- addBindings (PairE x effs)
-  injectM $ runIdentity $ runBindingsReaderT (scope, bindings) $
-    runEffectsReaderT effs' (cont x')
+fabricateEmitsEvidenceM :: Monad1 m => m n (EmitsEvidence n)
+fabricateEmitsEvidenceM = return FabricateEmitsEvidence
 
--- === effects monad ===
+instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
+         => MonadFail (BuilderT m n) where
 
-class Monad1 m => EffectsReader m where
-  getAllowedEffects :: m n (EffectRow n)
-  withAllowedEffects :: EffectRow n -> m n a -> m n a
+instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
+         => ScopeReader (BuilderT m) where
+  getDistinctEvidenceM = BuilderT $
+    liftInplace $ liftBuilderNameGenT getDistinctEvidenceM
+  addScope e = BuilderT $
+    liftInplace $
+      liftBuilderNameGenT do
+        e' <- injectM e
+        addScope e'
 
-newtype EffectsReaderT (m::MonadKind1) (n::S) (a:: *) =
-  EffectsReaderT { runEffectsReaderT' :: ReaderT (EffectRow n) (m n) a }
-  deriving (Functor, Applicative, Monad)
+instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
+         => BindingsReader (BuilderT m) where
+  addBindings e = BuilderT $
+    liftInplace $
+      liftBuilderNameGenT do
+        e' <- injectM e
+        addBindings e'
 
-instance ScopeGetter m => (ScopeGetter (EffectsReaderT m)) where
-  getScope = EffectsReaderT $ lift $ getScope
+instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
+         => Scopable (BuilderT m) where
+  withBindings (Abs b e) cont = undefined
 
-instance ScopeReader m => (ScopeReader (EffectsReaderT m)) where
-  addScope e = EffectsReaderT $ lift $ addScope e
-  getDistinctEvidenceM = EffectsReaderT $ lift getDistinctEvidenceM
+-- === Emits predicate ===
 
-instance BindingsReader m => (BindingsReader (EffectsReaderT m)) where
-  addBindings e = EffectsReaderT $ lift $ addBindings e
+-- We use the `Emits` predicate on scope parameters to indicate that we may emit
+-- decls. This lets us ensure that a computation *doesn't* emit decls, by
+-- supplying a fresh name without supplying the `Emits` predicate.
 
-instance Scopable m => (Scopable (EffectsReaderT m)) where
-  withBindings ab cont = EffectsReaderT $ ReaderT \effs ->
-    withBindings ab \e -> do
-      effs' <- injectM effs
-      runReaderT (runEffectsReaderT' $ cont e) effs'
+data EmitsEvidence (n::S) = FabricateEmitsEvidence
 
-instance BindingsGetter m => (BindingsGetter (EffectsReaderT m)) where
-  getBindings = EffectsReaderT $ lift $ getBindings
+class Emits (n::S)
 
-instance BindingsExtender m => (BindingsExtender (EffectsReaderT m)) where
-  extendBindings frag cont =
-    EffectsReaderT $ ReaderT \effs ->
-      extendBindings frag do
-        effs' <- injectM effs
-        runReaderT (runEffectsReaderT' cont) effs'
+instance Emits UnsafeS
 
-instance Monad1 m => EffectsReader (EffectsReaderT m) where
-  getAllowedEffects = EffectsReaderT ask
-  withAllowedEffects effs (EffectsReaderT cont) =
-    EffectsReaderT $ local (const effs) cont
+withEmitsEvidence :: forall n a. EmitsEvidence n -> (Emits n => a) -> a
+withEmitsEvidence _ cont = fromWrapWithEmits
+ ( unsafeCoerce ( WrapWithEmits cont :: WrapWithEmits n       a
+                                   ) :: WrapWithEmits UnsafeS a)
 
-runEffectsReaderT :: EffectRow n -> EffectsReaderT m n a -> m n a
-runEffectsReaderT effs cont = runReaderT (runEffectsReaderT' cont) effs
-
-liftEffectsReaderT :: m n a -> EffectsReaderT m n a
-liftEffectsReaderT cont = EffectsReaderT $ ReaderT $ const cont
+newtype WrapWithEmits n r =
+  WrapWithEmits { fromWrapWithEmits :: Emits n => r }
 
 -- === lambda-like things ===
 
-
-buildBlock :: (BindingsReader m, BindingsExtender m, MonadFail1 m)
-            => (forall l. (Distinct l, Ext n l) => BuilderT m n l (Atom l))
-            -> m n (Block n)
-buildBlock cont = do
-  DistinctAbs decls (PairE result ty) <- runBuilderT do
-    result <- cont
-    ty <- getType `apBuilder` result
-    return $ PairE result ty
+buildBlockAux :: Builder m
+           => (forall l. (Emits l, Ext n l) => m l (Atom l, a))
+           -> m n (Block n, a)
+buildBlockAux cont = do
+  Abs decls (result `PairE` ty `PairE` LiftE aux) <- buildScoped do
+    (result, aux) <- cont
+    ty <- getType result
+    return $ result `PairE` ty `PairE` LiftE aux
   ty' <- fromConstAbs $ Abs decls ty
-  return $ Block ty' decls $ Atom result
+  return (Block ty' decls $ Atom result, aux)
+
+buildBlock :: Builder m
+           => (forall l. (Emits l, Ext n l) => m l (Atom l))
+           -> m n (Block n)
+buildBlock cont = fst <$> buildBlockAux do
+  result <- cont
+  return (result, ())
 
 atomAsBlock :: BindingsReader m => Atom n -> m n (Block n)
 atomAsBlock x = do
@@ -241,25 +229,30 @@ withFreshAtomBinder hint ty info cont = do
   return $ Abs b' body
 
 buildLamGeneral
-  :: LocalBuilder m
+  :: Builder m
   => Arrow
   -> Type n
-  -> (forall l. Ext n l => AtomName l -> m l (EffectRow l))
-  -> (forall l. Ext n l => AtomName l -> m l (Block l, a))
+  -> (forall l. (         Ext n l) => AtomName l -> m l (EffectRow l))
+  -> (forall l. (Emits l, Ext n l) => AtomName l -> m l (Atom l, a))
   -> m n (Atom n, a)
 buildLamGeneral arr ty fEff fBody = do
+  ext1 <- idExt
   ab <- withFreshAtomBinder NoHint ty (LamBound arr) \v -> do
+    ext2 <- injectExt ext1
     effs <- fEff v
     withAllowedEffects effs do
-      (body, aux) <- fBody v
+      (body, aux) <- buildBlockAux do
+        ExtW <- injectExt ext2
+        v' <- injectM v
+        fBody v'
       return $ effs `PairE` body `PairE` LiftE aux
   Abs b (effs `PairE` body `PairE` LiftE aux) <- return ab
   return (Lam $ LamExpr arr b effs body, aux)
 
-buildPureLam :: LocalBuilder m
+buildPureLam :: Builder m
              => Arrow
              -> Type n
-             -> (forall l. Ext n l => AtomName l -> m l (Block l))
+             -> (forall l. (Emits l, Ext n l) => AtomName l -> m l (Atom l))
              -> m n (Atom n)
 buildPureLam arr ty body =
   fst <$> buildLamGeneral arr ty (const $ return Pure) \x ->
@@ -267,7 +260,9 @@ buildPureLam arr ty body =
       result <- body x
       return (result, ())
 
-buildPureNaryLam :: LocalBuilder m
+-- Body must be an Atom because otherwise the nullary case would require
+-- emitting decls into the enclosing scope.
+buildPureNaryLam :: Builder m
                  => Arrow
                  -> EmptyAbs (Nest Binder) n
                  -> (forall l. Ext n l => [AtomName l] -> m l (Atom l))
@@ -279,7 +274,7 @@ buildPureNaryLam arr (EmptyAbs (Nest (b:>ty) rest)) cont = do
     ext2 <- injectExt ext1
     restAbs <- injectM $ Abs b $ EmptyAbs rest
     rest' <- applyAbs restAbs x
-    atomAsBlock =<< buildPureNaryLam arr rest' \xs -> do
+    buildPureNaryLam arr rest' \xs -> do
       ExtW <- injectExt ext2
       x' <- injectM x
       cont (x':xs)
@@ -292,25 +287,23 @@ getClassDef classDefName = do
   ~(ClassBinding classDef) <- lookupBindings classDefName
   return classDef
 
-makeMethodGetter :: BindingsReader m => Name ClassNameC n -> Int -> m n (Atom n)
-makeMethodGetter classDefName methodIdx = runEffectsReaderT Pure do
-  liftLocalBuilder classDefName \classDefName' -> do
-    ClassDef _ _ (defName, def@(DataDef _ paramBs _)) <- getClassDef classDefName'
-    buildPureNaryLam ImplicitArrow (EmptyAbs paramBs) \params -> do
-      defName' <- injectM defName
-      def'     <- injectM def
-      buildPureLam ClassArrow (TypeCon (defName', def') (map Var params)) \dict ->
-        atomAsBlock $ getProjection [methodIdx] $ getProjection [1, 0] $ Var dict
+makeMethodGetter :: Builder m => Name ClassNameC n -> Int -> m n (Atom n)
+makeMethodGetter classDefName methodIdx = do
+  ClassDef _ _ (defName, def@(DataDef _ paramBs _)) <- getClassDef classDefName
+  buildPureNaryLam ImplicitArrow (EmptyAbs paramBs) \params -> do
+    defName' <- injectM defName
+    def'     <- injectM def
+    buildPureLam ClassArrow (TypeCon (defName', def') (map Var params)) \dict ->
+      return $ getProjection [methodIdx] $ getProjection [1, 0] $ Var dict
 
-makeSuperclassGetter :: BindingsReader m => Name ClassNameC n -> Int -> m n (Atom n)
-makeSuperclassGetter classDefName methodIdx = runEffectsReaderT Pure do
-  liftLocalBuilder classDefName \classDefName' -> do
-    ClassDef _ _ (defName, def@(DataDef _ paramBs _)) <- getClassDef classDefName'
-    buildPureNaryLam ImplicitArrow (EmptyAbs paramBs) \params -> do
-      defName' <- injectM defName
-      def'     <- injectM def
-      buildPureLam PlainArrow (TypeCon (defName', def') (map Var params)) \dict ->
-        atomAsBlock $ getProjection [methodIdx] $ getProjection [0, 0] $ Var dict
+makeSuperclassGetter :: Builder m => Name ClassNameC n -> Int -> m n (Atom n)
+makeSuperclassGetter classDefName methodIdx = do
+  ClassDef _ _ (defName, def@(DataDef _ paramBs _)) <- getClassDef classDefName
+  buildPureNaryLam ImplicitArrow (EmptyAbs paramBs) \params -> do
+    defName' <- injectM defName
+    def'     <- injectM def
+    buildPureLam PlainArrow (TypeCon (defName', def') (map Var params)) \dict ->
+      return $ getProjection [methodIdx] $ getProjection [0, 0] $ Var dict
 
 recGetHead :: BindingsReader m => Label -> Atom n -> m n (Atom n)
 recGetHead l x = do
@@ -318,7 +311,7 @@ recGetHead l x = do
   let i = fromJust $ elemIndex l $ map fst $ toList $ reflectLabels r
   return $ getProjection [i] x
 
-fLitLike :: Builder m => Double -> Atom n -> m n (Atom n)
+fLitLike :: (Builder m, Emits n) => Double -> Atom n -> m n (Atom n)
 fLitLike x t = do
   ty <- getType t
   case ty of
@@ -326,88 +319,88 @@ fLitLike x t = do
     BaseTy (Scalar Float32Type) -> return $ Con $ Lit $ Float32Lit $ realToFrac x
     _ -> error "Expected a floating point scalar"
 
-neg :: Builder m => Atom n -> m n (Atom n)
+neg :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 neg x = emitOp $ ScalarUnOp FNeg x
 
-add :: Builder m => Atom n -> Atom n -> m n (Atom n)
+add :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 add x y = emitOp $ ScalarBinOp FAdd x y
 
 -- TODO: Implement constant folding for fixed-width integer types as well!
-iadd :: Builder m => Atom n -> Atom n -> m n (Atom n)
+iadd :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 iadd (Con (Lit l)) y | getIntLit l == 0 = return y
 iadd x (Con (Lit l)) | getIntLit l == 0 = return x
 iadd x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (+) x y
 iadd x y = emitOp $ ScalarBinOp IAdd x y
 
-mul :: Builder m => Atom n -> Atom n -> m n (Atom n)
+mul :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 mul x y = emitOp $ ScalarBinOp FMul x y
 
-imul :: Builder m => Atom n -> Atom n -> m n (Atom n)
+imul :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 imul   (Con (Lit l)) y               | getIntLit l == 1 = return y
 imul x                 (Con (Lit l)) | getIntLit l == 1 = return x
 imul x@(Con (Lit _)) y@(Con (Lit _))                    = return $ applyIntBinOp (*) x y
 imul x y = emitOp $ ScalarBinOp IMul x y
 
-sub :: Builder m => Atom n -> Atom n -> m n (Atom n)
+sub :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 sub x y = emitOp $ ScalarBinOp FSub x y
 
-isub :: Builder m => Atom n -> Atom n -> m n (Atom n)
+isub :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 isub x (Con (Lit l)) | getIntLit l == 0 = return x
 isub x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (-) x y
 isub x y = emitOp $ ScalarBinOp ISub x y
 
-select :: Builder m => Atom n -> Atom n -> Atom n -> m n (Atom n)
+select :: (Builder m, Emits n) => Atom n -> Atom n -> Atom n -> m n (Atom n)
 select (Con (Lit (Word8Lit p))) x y = return $ if p /= 0 then x else y
 select p x y = emitOp $ Select p x y
 
-div' :: Builder m => Atom n -> Atom n -> m n (Atom n)
+div' :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 div' x y = emitOp $ ScalarBinOp FDiv x y
 
-idiv :: Builder m => Atom n -> Atom n -> m n (Atom n)
+idiv :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 idiv x (Con (Lit l)) | getIntLit l == 1 = return x
 idiv x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp div x y
 idiv x y = emitOp $ ScalarBinOp IDiv x y
 
-irem :: Builder m => Atom n -> Atom n -> m n (Atom n)
+irem :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 irem x y = emitOp $ ScalarBinOp IRem x y
 
-fpow :: Builder m => Atom n -> Atom n -> m n (Atom n)
+fpow :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 fpow x y = emitOp $ ScalarBinOp FPow x y
 
-flog :: Builder m => Atom n -> m n (Atom n)
+flog :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 flog x = emitOp $ ScalarUnOp Log x
 
-ilt :: Builder m => Atom n -> Atom n -> m n (Atom n)
+ilt :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 ilt x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (<) x y
 ilt x y = emitOp $ ScalarBinOp (ICmp Less) x y
 
-ieq :: Builder m => Atom n -> Atom n -> m n (Atom n)
+ieq :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 ieq x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (==) x y
 ieq x y = emitOp $ ScalarBinOp (ICmp Equal) x y
 
-fromPair :: Builder m => Atom n -> m n (Atom n, Atom n)
+fromPair :: (Builder m, Emits n) => Atom n -> m n (Atom n, Atom n)
 fromPair pair = do
   ~[x, y] <- getUnpacked pair
   return (x, y)
 
-getProj :: Builder m => Int -> Atom n -> m n (Atom n)
+getProj :: (Builder m, Emits n) => Int -> Atom n -> m n (Atom n)
 getProj i x = do
   xs <- getUnpacked x
   return $ xs !! i
 
-getFst :: Builder m => Atom n -> m n (Atom n)
+getFst :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 getFst p = fst <$> fromPair p
 
-getSnd :: Builder m => Atom n -> m n (Atom n)
+getSnd :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 getSnd p = snd <$> fromPair p
 
-getProjRef :: Builder m => Int -> Atom n -> m n (Atom n)
+getProjRef :: (Builder m, Emits n) => Int -> Atom n -> m n (Atom n)
 getProjRef i r = emitOp $ ProjRef i r
 
 -- XXX: getUnpacked must reduce its argument to enforce the invariant that
 -- ProjectElt atoms are always fully reduced (to avoid type errors between two
 -- equivalent types spelled differently).
-getUnpacked :: Builder m => Atom n -> m n [Atom n]
+getUnpacked :: (Builder m, Emits n) => Atom n -> m n [Atom n]
 getUnpacked = undefined
 -- getUnpacked (ProdVal xs) = return xs
 -- getUnpacked atom = do
@@ -417,8 +410,8 @@ getUnpacked = undefined
 --       res = map (\i -> getProjection [i] atom') [0..(len-1)]
 --   return res
 
-app :: Builder m => Atom n -> Atom n -> m n (Atom n)
+app :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 app x i = Var <$> emit (App x i)
 
-naryApp :: Builder m => Atom n -> [Atom n] -> m n (Atom n)
+naryApp :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
 naryApp f xs = foldM app f xs

--- a/src/lib/SaferNames/Name.hs
+++ b/src/lib/SaferNames/Name.hs
@@ -15,11 +15,12 @@
 
 module SaferNames.Name (
   Name (..), RawName, S (..), C (..), Env, (<.>), EnvFrag (..), NameBinder (..),
-  EnvReader (..), EnvGetter (..), FromName (..), Distinct, WithDistinct (..),
+  EnvReader (..), EnvGetter (..), FromName (..), Distinct, DistinctWitness (..),
   Ext, ExtEvidence, ProvesExt (..), withExtEvidence, getExtEvidence, getScopeProxy, withComposeExts,
   NameFunction (..), emptyNameFunction, idNameFunction, newNameFunction,
-  DistinctAbs (..), WithScopeSubstFrag (..), extendRenamer,
-  ScopeReader (..), ScopeExtender (..),
+  DistinctAbs (..), WithScope (..),
+  WithScopeSubstFrag (..), extendRenamer,
+  ScopeReader (..), ScopeExtender (..), ScopeGetter (..), ScopeReader (..),
   Scope, ScopeFrag (..), SubstE (..), SubstB (..),
   Inplace, liftInplace, runInplace,
   E, B, V, HasNamesE, HasNamesB, BindsNames (..), RecEnvFrag (..),
@@ -42,13 +43,13 @@ module SaferNames.Name (
   EmptyAbs, pattern EmptyAbs, SubstVal (..), lookupEnv,
   NameGen (..), fmapG, NameGenT (..), SubstGen (..), SubstGenT (..), withSubstB,
   liftSG, traverseEnvFrag, forEachNestItem, forEachNestItemSG,
-  substM, ScopedEnvReader, liftScopedEnvReader,
+  substM, ScopedEnvReader, runScopedEnvReader,
   HasNameHint (..), HasNameColor (..), NameHint (..), NameColor (..),
   GenericE (..), GenericB (..), ColorsEqual (..), ColorsNotEqual (..),
   EitherE1, EitherE2, EitherE3, EitherE4, EitherE5,
   pattern Case0, pattern Case1, pattern Case2, pattern Case3, pattern Case4,
   splitNestAt, nestLength, binderAnn,
-  OutReaderT (..), OutReader (..), runOutReaderT
+  OutReaderT (..), OutReader (..), runOutReaderT, getDistinct
   ) where
 
 import Prelude hiding (id, (.))
@@ -87,13 +88,19 @@ idNameFunction = newNameFunction fromName
 
 -- === monadic type classes for reading and extending envs and scopes ===
 
-data WithDistinct e n where
-  Distinct :: Distinct n => e n -> WithDistinct e n
+data WithScope (e::E) (n::S) where
+  WithScope :: (Distinct l, Ext l n) => Scope l -> e l -> WithScope e n
 
+-- Similar functionality to ScopeGetter, but suitable for InPlace
 class Monad1 m => ScopeReader (m::MonadKind1) where
-  getScope :: m n (WithDistinct Scope n)
+  getDistinctEvidenceM :: m n (DistinctEvidence n)
+  addScope :: InjectableE e => e n -> m n (WithScope e n)
 
-class ScopeReader m => ScopeExtender (m::MonadKind1) where
+-- Unrestricted scope access
+class ScopeReader m => ScopeGetter (m::MonadKind1) where
+  getScope :: m n (Scope n)
+
+class ScopeGetter m => ScopeExtender (m::MonadKind1) where
   extendScope :: Distinct l => ScopeFrag n l -> (Ext n l => m l r) -> m n r
 
 class (InjectableV v, Monad2 m) => EnvReader (v::V) (m::MonadKind2) | m -> v where
@@ -170,7 +177,7 @@ withExtEvidence b cont = withExtEvidence' (toExtEvidence b) cont
 -- like inject, but uses the ScopeReader monad for its `Distinct` proof
 injectM :: (ScopeReader m, Ext n l, InjectableE e) => e n -> m l (e l)
 injectM e = do
-  Distinct _ <- getScope
+  Distinct <- getDistinct
   return $ inject e
 
 -- Uses `proxy n2` to provide the type `n2` to use as the intermediate scope.
@@ -203,11 +210,12 @@ traverseNames scope f e =
 
 -- This may become expensive. It traverses the body of the Abs to check for
 -- leaked variables.
-fromConstAbs :: (ScopeReader m, MonadFail1 m, BindsNames b, HasNamesE e)
+fromConstAbs :: ( ScopeReader m, MonadFail1 m, BindsNames b, HasNamesE e
+                , InjectableB b, InjectableE e)
              => Abs b e n -> m n (e n)
-fromConstAbs (Abs b e) = do
-  Distinct scope <- getScope
-  traverseNames scope (tryProjectName $ toScopeFrag b) e
+fromConstAbs ab = do
+  WithScope scope (Abs b e) <- addScope ab
+  injectM =<< traverseNames scope (tryProjectName $ toScopeFrag b) e
 
 tryProjectName :: MonadFail m => ScopeFrag n l -> Name c l -> m (Name c n)
 tryProjectName names name =
@@ -218,9 +226,9 @@ tryProjectName names name =
 toConstAbs :: (InjectableE e, ScopeReader m)
            => NameColorRep c -> e n -> m n (Abs (NameBinder c) e n)
 toConstAbs rep body = do
-  Distinct scope <- getScope
+  WithScope scope body <- addScope body
   withFresh "ignore" rep scope \b -> do
-    return $ Abs b $ inject body
+    injectM $ Abs b $ inject body
 
 -- === type classes for traversing names ===
 
@@ -253,16 +261,20 @@ instance SubstE Name (Name c) where
 
 instance SubstB v (NameBinder c) where
   substB b = SubstGenT do
-    Distinct names <- getScope
+    Distinct <- getDistinct
+    names <- getScope
     let rep = getNameColorRep $ nameBinderName b
     withFresh (getNameHint b) rep names \b' -> do
       let frag = singletonScope b'
       return $ WithScopeSubstFrag frag (b @> binderName b') b'
 
 -- Like SubstE, but with fewer requirements for the monad
-substM :: (EnvGetter v m, ScopeReader2 m, SubstE v e, FromName v)
+substM :: (EnvGetter v m, ScopeReader2 m, SubstE v e, FromName v, InjectableE e)
        => e i -> m i o (e o)
-substM e = liftScopedEnvReader $ substE e
+substM e = do
+  env <- getEnv
+  WithScope scope env' <- addScope env
+  injectM $ runScopedEnvReader scope env' $ substE e
 
 withSubstB :: (SubstB v b, ScopeReader2 m, ScopeExtender2 m , EnvReader v m, FromName v)
            => b i i'
@@ -374,20 +386,19 @@ instance BindsOneName b c => BindsNameList (Nest b) c where
   (@@>) (Nest b rest) (x:xs) = b@>x <.> rest@@>xs
   (@@>) _ _ = error "length mismatch"
 
-applySubst :: (ScopeReader m, SubstE v e, InjectableV v, FromName v)
+applySubst :: (ScopeReader m, SubstE v e, InjectableE e, InjectableV v, FromName v)
            => EnvFrag v o i o -> e i -> m o (e o)
 applySubst substFrag x = do
-  Distinct scope <- getScope
-  return $ runIdentity $ runScopeReaderT scope $
-    runEnvReaderT (emptyNameFunction) $
-      dropSubst $ extendEnv substFrag $ substE x
+  let fullSubst = idNameFunction <>> substFrag
+  WithScope scope fullSubst' <- addScope fullSubst
+  injectM $ runScopedEnvReader scope fullSubst' $ substE x
 
-applyAbs :: (InjectableV v, FromName v, ScopeReader m, BindsOneName b c, SubstE v e)
+applyAbs :: (InjectableV v, FromName v, InjectableE e, ScopeReader m, BindsOneName b c, SubstE v e)
          => Abs b e n -> v c n -> m n (e n)
 applyAbs (Abs b body) x = applySubst (b@>x) body
 
 applyNaryAbs :: ( InjectableV v, FromName v, ScopeReader m, BindsNameList b c, SubstE v e
-                , SubstB v b)
+                , SubstB v b, InjectableE e)
              => Abs b e n -> [v c n] -> m n (e n)
 applyNaryAbs (Abs bs body) xs = applySubst (bs @@> xs) body
 
@@ -438,6 +449,15 @@ splitNestAt n (Nest b rest) =
 binderAnn :: BinderP b ann n l -> ann n
 binderAnn (_:>ann) = ann
 
+
+data DistinctWitness (n::S) where
+  Distinct :: Distinct n => DistinctWitness n
+
+getDistinct :: ScopeReader m => m n (DistinctWitness n)
+getDistinct = do
+  d <- getDistinctEvidenceM
+  return $ withDistinctEvidence d Distinct
+
 -- === versions of monad constraints with scope params ===
 
 type MonadKind  =           * -> *
@@ -465,20 +485,21 @@ data SubstVal (cMatch::C) (atom::E) (c::C) (n::S) where
   SubstVal :: atom n   -> SubstVal c      atom c n
   Rename   :: Name c n -> SubstVal cMatch atom c n
 
-withFreshM :: (ScopeReader m, ScopeExtender m)
+withFreshM :: (ScopeGetter m, ScopeExtender m)
            => NameHint
            -> NameColorRep c
            -> (forall o'. (Distinct o', Ext o o')
                           => NameBinder c o o' -> m o' a)
            -> m o a
 withFreshM hint rep cont = do
-  Distinct m <- getScope
+  Distinct <- getDistinct
+  m <- getScope
   withFresh hint rep m \b' -> do
     extendScope (singletonScope b') $
       cont b'
 
 withFreshLike
-  :: (ScopeReader m, ScopeExtender m, HasNameHint hint, HasNameColor hint c)
+  :: (ScopeGetter m, ScopeExtender m, HasNameHint hint, HasNameColor hint c)
   => hint
   -> (forall o'. NameBinder c o o' -> m o' a)
   -> m o a
@@ -511,7 +532,7 @@ type AlphaEq e = AlphaEqE e  :: Constraint
 class ( forall i1 i2 o. Monad (m i1 i2 o)
       , forall i1 i2 o. MonadErr (m i1 i2 o)
       , forall i1 i2 o. MonadFail (m i1 i2 o)
-      , forall i1 i2.   ScopeReader (m i1 i2)
+      , forall i1 i2.   ScopeGetter (m i1 i2)
       , forall i1 i2.   ScopeExtender (m i1 i2))
       => ZipEnvReader (m :: S -> S -> S -> * -> *) where
   lookupZipEnvFst :: Name c i1 -> m i1 i2 o (Name c o)
@@ -522,14 +543,14 @@ class ( forall i1 i2 o. Monad (m i1 i2 o)
 
   withEmptyZipEnv :: m o o o a -> m i1 i2 o a
 
-class AlphaEqE (e::E) where
+class InjectableE e => AlphaEqE (e::E) where
   alphaEqE :: ZipEnvReader m => e i1 -> e i2 -> m i1 i2 o ()
 
   default alphaEqE :: (GenericE e, AlphaEqE (RepE e), ZipEnvReader m)
                    => e i1 -> e i2 -> m i1 i2 o ()
   alphaEqE e1 e2 = fromE e1 `alphaEqE` fromE e2
 
-class AlphaEqB (b::B) where
+class InjectableB b => AlphaEqB (b::B) where
   withAlphaEqB :: ZipEnvReader m => b i1 i1' -> b i2 i2'
                -> (forall o'. m i1' i2' o' a)
                ->             m i1  i2  o  a
@@ -543,11 +564,11 @@ class AlphaEqB (b::B) where
 checkAlphaEq :: (AlphaEqE e, MonadErr1 m, ScopeReader m)
              => e n -> e n -> m n ()
 checkAlphaEq e1 e2 = do
-  Distinct scope <- getScope
+  WithScope scope (PairE e1' e2') <- addScope $ PairE e1 e2
   liftEither $
     runScopeReaderT scope $
       flip runReaderT (emptyNameFunction, emptyNameFunction) $ runZipEnvReaderT $
-        withEmptyZipEnv $ alphaEqE e1 e2
+        withEmptyZipEnv $ alphaEqE e1' e2'
 
 instance AlphaEqE (Name c) where
   alphaEqE v1 v2 = do
@@ -605,18 +626,27 @@ instance (AlphaEqE e1, AlphaEqE e2) => AlphaEqE (EitherE e1 e2) where
 -- === ScopeReaderT transformer ===
 
 newtype ScopeReaderT (m::MonadKind) (n::S) (a:: *) =
-  ScopeReaderT {runScopeReaderT' :: ReaderT (WithDistinct Scope n) m a}
+  ScopeReaderT {runScopeReaderT' :: ReaderT (DistinctEvidence n, Scope n) m a}
   deriving (Functor, Applicative, Monad, MonadError err, MonadFail)
 
 runScopeReaderT :: Distinct n => Scope n -> ScopeReaderT m n a -> m a
-runScopeReaderT scope m = flip runReaderT (Distinct scope) $ runScopeReaderT' m
+runScopeReaderT scope m =
+  flip runReaderT (getDistinctEvidence, scope) $ runScopeReaderT' m
 
 instance Monad m => ScopeReader (ScopeReaderT m) where
-  getScope = ScopeReaderT ask
+  getDistinctEvidenceM = ScopeReaderT $ asks fst
+  addScope e = ScopeReaderT do
+    (d, scope) <- ask
+    withDistinctEvidence d $
+      return $ WithScope scope e
+
+
+instance Monad m => ScopeGetter (ScopeReaderT m) where
+  getScope = ScopeReaderT $ asks snd
 
 instance Monad m => ScopeExtender (ScopeReaderT m) where
   extendScope frag m = ScopeReaderT $ withReaderT
-    (\(Distinct scope) -> Distinct (scope >>> frag)) $
+    (\(d, scope) -> (getDistinctEvidence, scope >>> frag)) $
         withExtEvidence (toExtEvidence frag) $
           runScopeReaderT' m
 
@@ -628,18 +658,10 @@ newtype EnvReaderT (v::V) (m::MonadKind1) (i::S) (o::S) (a:: *) =
 
 type ScopedEnvReader (v::V) = EnvReaderT v (ScopeReaderT Identity) :: MonadKind2
 
--- lets you call SubstE etc from a monad that lets you read the scope but not
--- extend it (or at least, not extend it without more information, like
--- bindings).
-liftScopedEnvReader :: (EnvGetter v m, ScopeReader2 m)
-                    => ScopedEnvReader (v::V) i o a
-                    -> m i o a
-liftScopedEnvReader m = do
-  env <- getEnv
-  Distinct scope <- getScope
-  return $
-    runIdentity $ runScopeReaderT scope $
-      runEnvReaderT env m
+runScopedEnvReader :: Distinct o => Scope o -> NameFunction v i o
+                   -> ScopedEnvReader v i o a -> a
+runScopedEnvReader scope env m =
+  runIdentity $ runScopeReaderT scope $ runEnvReaderT env m
 
 runEnvReaderT :: NameFunction v i o -> EnvReaderT v m i o a -> m o a
 runEnvReaderT env m = runReaderT (runEnvReaderT' m) env
@@ -657,6 +679,9 @@ instance (InjectableV v, Monad1 m) => EnvGetter v (EnvReaderT v m) where
   getEnv = EnvReaderT ask
 
 instance ScopeReader m => ScopeReader (EnvReaderT v m i) where
+  addScope e = EnvReaderT $ lift $ addScope e
+
+instance ScopeGetter m => ScopeGetter (EnvReaderT v m i) where
   getScope = EnvReaderT $ lift getScope
 
 -- The rest are boilerplate but this one is a bit interesting. When we extend
@@ -685,6 +710,10 @@ runOutReaderT env m = flip runReaderT env $ runOutReaderT' m
 
 instance (InjectableE e, ScopeReader m)
          => ScopeReader (OutReaderT e m) where
+  addScope e = OutReaderT $ lift $ addScope e
+
+instance (InjectableE e, ScopeGetter m)
+         => ScopeGetter (OutReaderT e m) where
   getScope = OutReaderT $ lift getScope
 
 instance (InjectableE e, ScopeExtender m)
@@ -713,6 +742,9 @@ newtype ZipEnvReaderT (m::MonadKind1) (i1::S) (i2::S) (o::S) (a:: *) =
 type ZipEnv i1 i2 o = (NameFunction Name i1 o, NameFunction Name i2 o)
 
 instance ScopeReader m => ScopeReader (ZipEnvReaderT m i1 i2) where
+  addScope e = ZipEnvReaderT $ lift $ addScope e
+
+instance ScopeGetter m => ScopeGetter (ZipEnvReaderT m i1 i2) where
   getScope = ZipEnvReaderT $ lift getScope
 
 instance (ScopeReader m, ScopeExtender m)
@@ -765,7 +797,12 @@ instance InjectableE (NameTraverserEnv m i) where
   injectionProofE _ _ = undefined
 
 instance Monad m => ScopeReader (NameTraverserT m i) where
+  getDistinctEvidenceM = NameTraverserT $ lift $ getDistinctEvidenceM
+  addScope e = NameTraverserT $ lift $ addScope e
+
+instance Monad m => ScopeGetter (NameTraverserT m i) where
   getScope = NameTraverserT $ lift $ getScope
+
 
 instance Monad m => ScopeExtender (NameTraverserT m i) where
   extendScope frag m = NameTraverserT $ ReaderT \env ->
@@ -809,14 +846,14 @@ newtype NameGenT (m::MonadKind1) (e::E) (n::S) =
 
 instance (ScopeReader m, ScopeExtender m, Monad1 m) => NameGen (NameGenT m) where
   returnG e = NameGenT $ do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return (DistinctAbs id e)
   bindG (NameGenT m) f = NameGenT do
     DistinctAbs s  e  <- m
     DistinctAbs s' e' <- extendScope s $ runNameGenT $ f e
     return $ DistinctAbs (s >>> s') e'
   getDistinctEvidenceG = NameGenT do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return $ DistinctAbs id getDistinctEvidence
 
 -- === in-place scope updating monad ===
@@ -907,7 +944,7 @@ instance (ScopeReader2 m, ScopeExtender2 m, EnvReader v m, FromName v, Monad2 m)
 instance (ScopeReader2 m, ScopeExtender2 m, EnvReader v m, FromName v, Monad2 m)
          => SubstGen (SubstGenT m) where
   returnSG e = SubstGenT $ do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return (WithScopeSubstFrag id emptyEnv e)
   bindSG (SubstGenT m) f = SubstGenT do
     WithScopeSubstFrag s env e <- m
@@ -916,7 +953,7 @@ instance (ScopeReader2 m, ScopeExtender2 m, EnvReader v m, FromName v, Monad2 m)
       envInj <- extendScope s' $ injectM env
       return $ WithScopeSubstFrag (s >>> s') (envInj <.> env')  e'
   getDistinctEvidenceSG = SubstGenT do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return $ WithScopeSubstFrag id emptyEnv getDistinctEvidence
 
 liftSG :: ScopeReader2 m => m i o a -> (a -> SubstGenT m i i' e o) -> SubstGenT m i i' e o

--- a/src/lib/SaferNames/NameCore.hs
+++ b/src/lib/SaferNames/NameCore.hs
@@ -303,6 +303,12 @@ instance InjectableB (NameBinder s) where
   injectionProofB  _ (UnsafeMakeBinder b) cont =
     cont (InjectionCoercion unsafeCoerceE) (UnsafeMakeBinder b)
 
+instance InjectableE DistinctEvidence where
+  injectionProofE _ _ = FabricateDistinctEvidence
+
+instance InjectableE (ExtEvidence n) where
+  injectionProofE _ _ = FabricateExtEvidence
+
 -- === environments ===
 
 -- The `Env` type is purely an optimization. We could do everything using

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -89,7 +89,7 @@ data RenamerContent e n where
 
 instance (Renamer m) => NameGen (RenamerNameGenT m) where
   returnG expr = RenamerNameGenT do
-    (Distinct _) <- getScope
+    Distinct <- getDistinct
     return $ RenamerContent id mempty expr
   bindG (RenamerNameGenT action) cont = RenamerNameGenT do
     (RenamerContent frag sourceMap expr) <- action
@@ -99,7 +99,7 @@ instance (Renamer m) => NameGen (RenamerNameGenT m) where
         let sourceMap' = inject sourceMap <> sourceMap2
         return $ RenamerContent (frag >>> frag2) sourceMap' expr2
   getDistinctEvidenceG = RenamerNameGenT do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return $ RenamerContent id mempty getDistinctEvidence
 
 withSourceRenameB :: SourceRenamableB b
@@ -262,7 +262,7 @@ sourceRenameUBinder ubinder = case ubinder of
     unless (mayShadow || not (M.member b sourceMap)) $
       throw RepeatedVarErr $ pprint b
     withFreshM (getNameHint b) nameColorRep \freshName -> do
-      (Distinct _) <- getScope
+      Distinct <- getDistinct
       let frag = (singletonScope freshName)
       let sourceMap' = SourceMap (M.singleton b (EnvVal nameColorRep $ nameBinderName freshName))
       return $ RenamerContent frag sourceMap' $ UBind freshName
@@ -324,7 +324,7 @@ instance (Renamer m) => NameGen (PatRenamerNameGenT m) where
         let sourceMap'' = inject sourceMap <> sourceMap'
         return (sibs <> sibs', RenamerContent (frag >>> frag') sourceMap'' expr')
   getDistinctEvidenceG = PatRenamerNameGenT do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     return (mempty, RenamerContent id mempty getDistinctEvidence)
 
 class SourceRenamablePat (pat::B) where

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -27,7 +27,7 @@ module SaferNames.Syntax (
     BinOp (..), UnOp (..), CmpOp (..), SourceMap (..),
     ForAnn (..), Val, Op, Con, Hof, TC, Module (..), UModule (..),
     ClassDef (..), EvaluatedModule (..), SynthCandidates (..), TopState (..),
-    emptyTopState, BindsBindings (..),
+    emptyTopState, BindsBindings (..), WithBindings (..),
     DataConRefBinding (..), AltP, Alt, AtomBinderInfo (..),
     SubstE (..), SubstB (..), Ptr, PtrType,
     AddressSpace (..), Device (..), showPrimName, strToPrimName, primNameToStr,
@@ -46,13 +46,14 @@ module SaferNames.Syntax (
     SourceUModule (..), UType,
     CmdName (..), LogLevel (..), PassName, OutFormat (..),
     TopBindings (..), TopBindingsFrag, NamedDataDef, fromTopBindings, ScopedBindings,
-    BindingsReader (..), BindingsExtender (..),  Binding (..),
+    BindingsReader (..), BindingsExtender (..),  Binding (..), BindingsGetter (..),
     refreshBinders, withFreshBinder, withFreshBinding,
     Bindings, BindingsFrag, lookupBindings, runBindingsReaderT,
-    BindingsReaderT (..), BindingsReader2, BindingsExtender2,
+    BindingsReaderT (..), BindingsReader2, BindingsExtender2, BindingsGetter2,
     naryNonDepPiType, nonDepPiType, fromNonDepPiType, fromNaryNonDepPiType,
     fromNonDepTabTy, binderType, getProjection,
     applyIntBinOp, applyIntCmpOp, applyFloatBinOp, applyFloatUnOp,
+    SrcCtx,
     pattern IdxRepTy, pattern IdxRepVal, pattern TagRepTy,
     pattern TagRepVal, pattern Word8Ty,
     pattern UnitTy, pattern PairTy,
@@ -225,20 +226,31 @@ deriving instance Show (Binding c n)
 type Bindings n = NameFunction Binding n n
 type BindingsFrag n l = EnvFrag Binding n l l
 
+data WithBindings (e::E) (n::S) where
+  WithBindings :: (Distinct l, Ext l n) => Bindings l -> Scope l -> e l -> WithBindings e n
+
 class ScopeReader m => BindingsReader (m::MonadKind1) where
+  addBindings :: InjectableE e => e n -> m n (WithBindings e n)
+
+class (BindingsReader m, ScopeGetter m) => BindingsGetter (m::MonadKind1) where
   getBindings :: m n (Bindings n)
 
-class ScopeReader m => BindingsExtender (m::MonadKind1) where
+class ScopeGetter m => BindingsExtender (m::MonadKind1) where
   extendBindings :: Distinct l => BindingsFrag n l -> (Ext n l => m l r) -> m n r
 
 type BindingsReader2   (m::MonadKind2) = forall (n::S). BindingsReader   (m n)
 type BindingsExtender2 (m::MonadKind2) = forall (n::S). BindingsExtender (m n)
+type BindingsGetter2   (m::MonadKind2) = forall (n::S). BindingsGetter   (m n)
 
 instance Monad m => BindingsExtender (ScopeReaderT m) where
   extendBindings frag = extendScope (envAsScope frag)
 
 instance (InjectableE e, BindingsReader m)
          => BindingsReader (OutReaderT e m) where
+  addBindings e = OutReaderT $ lift $ addBindings e
+
+instance (InjectableE e, BindingsGetter m)
+         => BindingsGetter (OutReaderT e m) where
   getBindings = OutReaderT $ lift getBindings
 
 instance (InjectableE e, ScopeReader m, BindingsExtender m)
@@ -258,6 +270,13 @@ runBindingsReaderT (scope, bindings) cont =
   runScopeReaderT scope $ runReaderT (runBindingsReaderT' cont) bindings
 
 instance Monad m => BindingsReader (BindingsReaderT m) where
+  addBindings e = BindingsReaderT do
+    bindings <- ask
+    scope <- lift $ getScope
+    Distinct <- lift $ getDistinct
+    return $ WithBindings bindings scope e
+
+instance Monad m => BindingsGetter (BindingsReaderT m) where
   getBindings = BindingsReaderT ask
 
 instance Monad m => BindingsExtender (BindingsReaderT m) where
@@ -270,12 +289,19 @@ instance Monad m => BindingsExtender (BindingsReaderT m) where
          f (bindings' <>> frag)
 
 instance Monad m => ScopeReader (BindingsReaderT m) where
+  addScope e = BindingsReaderT $ lift $ addScope e
+  getDistinctEvidenceM = BindingsReaderT $ lift $ getDistinctEvidenceM
+
+instance Monad m => ScopeGetter (BindingsReaderT m) where
   getScope = BindingsReaderT $ lift $ getScope
 
 instance BindingsReader m => BindingsReader (EnvReaderT v m i) where
+  addBindings e = EnvReaderT $ lift $ addBindings e
+
+instance BindingsGetter m => BindingsGetter (EnvReaderT v m i) where
   getBindings = EnvReaderT $ lift getBindings
 
-instance (InjectableV v, ScopeReader m, BindingsExtender m)
+instance (InjectableV v, ScopeGetter m, BindingsExtender m)
          => BindingsExtender (EnvReaderT v m i) where
   extendBindings frag m = EnvReaderT $ ReaderT \env ->
     extendBindings frag do
@@ -288,8 +314,10 @@ instance (InjectableV v, ScopeReader m, BindingsExtender m)
 class BindsNames b => BindsBindings (b::B) where
   boundBindings :: Distinct l => b n l -> BindingsFrag n l
 
-lookupBindings :: BindingsReader m => Name c o -> m o (Binding c o)
-lookupBindings v = (!v) <$> getBindings
+lookupBindings :: (NameColor c, BindingsReader m) => Name c o -> m o (Binding c o)
+lookupBindings v = do
+  WithBindings bindings _ v' <- addBindings v
+  injectM $ bindings ! v'
 
 withFreshBinding
   :: (NameColor c, BindingsReader m, BindingsExtender m)
@@ -298,14 +326,15 @@ withFreshBinding
   -> (forall o'. (Distinct o', Ext o o') => NameBinder c o o' -> m o' a)
   -> m o a
 withFreshBinding hint binding cont = do
-  Distinct scope <- getScope
+  scope <- getScope
+  Distinct <- getDistinct
   withFresh hint nameColorRep scope \b' -> do
     let binding' = inject binding
     extendBindings (b' @> binding') $
       cont b'
 
 withFreshBinder
-  :: (BindingsReader m, BindingsExtender m)
+  :: (BindingsGetter m, BindingsExtender m)
   => NameHint
   -> Type o
   -> AtomBinderInfo o
@@ -313,7 +342,7 @@ withFreshBinder
   -> m o a
 withFreshBinder hint ty info cont =
   withFreshBinding hint (AtomNameBinding ty info) \b -> do
-    Distinct _ <- getScope
+    Distinct <- getDistinct
     cont $ b :> ty
 
 refreshBinders
@@ -323,10 +352,14 @@ refreshBinders
   -> (forall o'. Ext o o' => b o o' -> m i' o' r)
   -> m i o r
 refreshBinders b cont = do
-  WithScopeSubstFrag _ env b' <- liftScopedEnvReader $ runSubstGenT $ substB b
-  extendBindings (boundBindings b') do
-    extendRenamer env $
-      cont b'
+  scope <- getScope
+  Distinct <- getDistinct
+  env <- getEnv
+  case runScopedEnvReader scope env $ runSubstGenT $ substB b of
+    WithScopeSubstFrag _ env' b' ->
+      extendBindings (boundBindings b') do
+        extendRenamer env' $
+          cont b'
 
 -- === front-end language AST ===
 
@@ -1358,3 +1391,12 @@ instance BindsBindings b => (BindsBindings (Nest b)) where
 
 instance BindsBindings (RecEnvFrag Binding) where
   boundBindings (RecEnvFrag frag) = frag
+
+-- TODO: name subst instances for the rest of UExpr
+instance SubstE Name UVar where
+  substE = \case
+    UAtomVar    v -> UAtomVar    <$> substE v
+    UTyConVar   v -> UTyConVar   <$> substE v
+    UDataConVar v -> UDataConVar <$> substE v
+    UClassVar   v -> UClassVar   <$> substE v
+    UMethodVar  v -> UMethodVar  <$> substE v

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -715,13 +715,13 @@ buildNaryPiType :: Typer m
                 -> m i o (Type o)
 buildNaryPiType _ Empty cont = cont []
 buildNaryPiType arr (Nest b rest) cont = do
-  p1 <- getScopeProxy
+  ext1 <- idExt
   refreshBinders b \b' -> do
-    p2 <- getScopeProxy
+    ext2 <- injectExt ext1
     Pi <$> PiType arr b' Pure <$> buildNaryPiType arr rest \params -> do
-      p3 <- getScopeProxy
+      ExtW <- injectExt ext2
       param <- Var <$> injectM (binderName b')
-      withComposeExts p1 p2 p3 $ cont (param : params)
+      cont (param : params)
 
 checkCase :: Typer m => HasType body => Atom i -> [AltP body i] -> Type i -> m i o (Type o)
 checkCase e alts resultTy = do

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -12,6 +12,7 @@
 {-# LANGUAGE StandaloneDeriving #-}
 
 module SaferNames.Type (
+  HasType (..),
   checkModule, checkTypes, getType, litType, getBaseMonoidType) where
 
 import Prelude hiding (id)
@@ -45,19 +46,19 @@ checkModule env m =
     runBindingsReaderT (fromTopBindings env) $
       checkTypes m
 
-checkTypes :: (BindingsReader m, MonadErr1 m, CheckableE e)
+checkTypes :: (BindingsReader m, MonadErr1 m, InjectableE e, CheckableE e)
            => e n -> m n ()
 checkTypes e = do
-  Distinct scope <- getScope
-  bindings <- getBindings
-  liftEither $ runTyperT (scope, bindings) $ void $ checkE e
+  Distinct <- getDistinct
+  WithBindings bindings scope e' <- addBindings e
+  liftEither $ runTyperT (scope, bindings) $ void $ checkE e'
 
 getType :: (BindingsReader m, HasType e)
            => e n -> m n (Type n)
 getType e = do
-  Distinct scope <- getScope
-  bindings <- getBindings
-  return $ runIgnoreChecks $ runTyperT (scope, bindings) $ getTypeE e
+  Distinct <- getDistinct
+  WithBindings bindings scope e' <- addBindings e
+  injectM $ runIgnoreChecks $ runTyperT (scope, bindings) $ getTypeE e'
 
 -- === the type checking/querying monad ===
 
@@ -65,7 +66,7 @@ getType e = do
 -- already be a superclass, transitively, through both MonadErr2 and
 -- MonadAtomSubst.
 class ( MonadFail2 m, Monad2 m, MonadErr2 m, EnvGetter Name m
-      , BindingsReader2 m, BindingsExtender2 m)
+      , BindingsGetter2 m, BindingsExtender2 m)
      => Typer (m::MonadKind2) where
   declareEffs :: EffectRow o -> m i o ()
   extendAllowedEffect :: Effect o -> m i o () -> m i o ()
@@ -93,7 +94,8 @@ newtype TyperT (m::MonadKind) (i::S) (o::S) (a :: *) =
         (BindingsReaderT m)) i o a }
   deriving ( Functor, Applicative, Monad, MonadFail
            , EnvGetter Name, EnvReader Name
-           , ScopeReader, BindingsReader, BindingsExtender)
+           , ScopeReader, ScopeGetter, BindingsReader
+           , BindingsGetter, BindingsExtender)
 
 deriving instance MonadError e m => MonadError e (TyperT m i o)
 
@@ -120,7 +122,7 @@ instance (MonadFail m, MonadErr m) => Typer (TyperT m) where
 -- Minimal complete definition: getTypeE | getTypeAndSubstE
 -- (Usually we just implement `getTypeE` but for big things like blocks it can
 -- be worth implementing the specialized versions too, as optimizations.)
-class SubstE Name e => HasType (e::E) where
+class (InjectableE e, SubstE Name e) => HasType (e::E) where
   getTypeE   :: Typer m => e i -> m i o (Type o)
   getTypeE e = snd <$> getTypeAndSubstE e
 
@@ -185,8 +187,11 @@ instance CheckableE SynthCandidates where
 
 instance CheckableB (RecEnvFrag Binding) where
   checkB recEnv cont = do
-    WithScopeSubstFrag _ envFrag recEnv' <-
-      liftScopedEnvReader $ runSubstGenT $ substB recEnv
+    WithScopeSubstFrag _ envFrag recEnv' <- do
+      Distinct <- getDistinct
+      env <- getEnv
+      scope <- getScope
+      return $ runScopedEnvReader scope env $ runSubstGenT $ substB recEnv
     void $ extendBindings (boundBindings recEnv') $ dropSubst $
       traverseEnvFrag checkE (fromRecEnvFrag recEnv')
     extendBindings (boundBindings recEnv') $


### PR DESCRIPTION
Safe-names version of builder monad. We handle continuation-accepting functions like `buildLam` using a new predicate, `Emits`, which gives permission to emit decls into a mutable name space. For example, the following type gives has `Emits` constraint on `l` but not on `n`, which means that the body of the lambda may produce decls, but building the lambda itself doesn't.

```
buildLam
  :: Builder m
  => Type n                                                        -- argument type
  -> (forall l. (Emits l, Ext n l) => AtomName l -> m l (Atom l))  -- lambda body builder
  -> m n (Atom n)                                                  -- result, a lambda term

```