### PR TITLE
Safe names version of inference pass (without implementation of the inference monad)

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -63,7 +63,7 @@ library
                        SaferNames.Syntax, SaferNames.Bridge,
                        SaferNames.PPrint, SaferNames.Parser,
                        SaferNames.ResolveImplicitNames, SaferNames.SourceRename,
-                       SaferNames.Type, SaferNames.Builder
+                       SaferNames.Type, SaferNames.Builder, SaferNames.Inference
   if flag(live)
     exposed-modules:   Actor, RenderHtml, LiveOutput
   other-modules:       Paths_dex

--- a/src/lib/LabeledItems.hs
+++ b/src/lib/LabeledItems.hs
@@ -9,7 +9,7 @@
 
 module LabeledItems
   ( Label, LabeledItems (..), labeledSingleton, reflectLabels, getLabels
-  , withLabels, lookupLabelHead, ExtLabeledItems (..), prefixExtLabeledItems
+  , withLabels, lookupLabelHead, lookupLabel, ExtLabeledItems (..), prefixExtLabeledItems
   , unzipExtLabeledItems
   , pattern NoLabeledItems, pattern NoExt, pattern InternalSingletonLabel
   , pattern Unlabeled ) where
@@ -31,7 +31,7 @@ type Label = String
 -- record objects; the order in the concrete syntax of items with different
 -- fields is discarded (so both `{b:Z & a:X & a:Y}` and `{a:X & b:Z & a:Y}` map
 -- to `M.fromList [("a", NE.fromList [X, Y]), ("b", NE.fromList [Z])]` )
-newtype LabeledItems a = LabeledItems (M.Map Label (NE.NonEmpty a))
+newtype LabeledItems a = LabeledItems { fromLabeledItems :: M.Map Label (NE.NonEmpty a) }
   deriving (Eq, Show, Generic, Functor, Foldable, Traversable)
 
 labeledSingleton :: Label -> a -> LabeledItems a
@@ -52,6 +52,11 @@ lookupLabelHead :: LabeledItems a -> Label -> Maybe a
 lookupLabelHead (LabeledItems items) l = case M.lookup l items of
   Nothing -> Nothing
   Just (x NE.:| _) -> Just x
+
+lookupLabel :: LabeledItems a -> Label -> [a]
+lookupLabel (LabeledItems items) l = case M.lookup l items of
+  Just (x NE.:| xs) -> x : xs
+  Nothing -> []
 
 instance Semigroup (LabeledItems a) where
   LabeledItems items <> LabeledItems items' =

--- a/src/lib/SaferNames/Bridge.hs
+++ b/src/lib/SaferNames/Bridge.hs
@@ -173,7 +173,7 @@ fromSafe = ()
 -- bijections, so we have to do a lot of things manually.
 nameBijectionFromDBindings
     :: MonadToSafe m => FromSafeNameMap n -> D.Bindings
-    -> (forall l. Distinct l => TopBindingsFrag n l -> ToSafeNameMap l -> FromSafeNameMap l -> m l a)
+    -> (forall l. Distinct l => BindingsFrag n l -> ToSafeNameMap l -> FromSafeNameMap l -> m l a)
     -> m n a
 nameBijectionFromDBindings fromSafeMap bindings cont = do
   withFreshSafeRec fromSafeMap (envPairs bindings) \scopeFrag fromSafeMap' -> do

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -22,7 +22,7 @@ module SaferNames.Builder (
   fromPair, getFst, getSnd, getProj, getProjRef, naryApp,
   getDataDef, getClassDef, liftBuilderNameGenT, atomAsBlock,
   Emits, buildPi, buildNonDepPi, buildLam, buildDepEffLam,
-  buildAbs, buildNaryAbs
+  buildAbs, buildNaryAbs, buildNewtype
   ) where
 
 import Prelude hiding ((.), id)
@@ -333,6 +333,13 @@ buildNaryAbs
   -> (forall l. Ext n l => [AtomName l] -> m l (e l))
   -> m n (Abs (Nest Binder) e n)
 buildNaryAbs ty body = undefined
+
+buildNewtype :: Builder m
+             => SourceName
+             -> EmptyAbs (Nest Binder) n
+             -> (forall l. Ext n l => [AtomName l] -> m l (Type l))
+             -> m n (DataDef n)
+buildNewtype _ _ _ = undefined
 
 -- === builder versions of common ops ===
 

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -44,7 +44,6 @@ import SaferNames.Syntax
 import SaferNames.Type
 import SaferNames.PPrint ()
 
-import Err
 import LabeledItems
 import Util (enumerate)
 
@@ -137,6 +136,8 @@ instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
       withFreshBinder hint ty binderInfo \b -> do
         return $ DistinctAbs (Nest (Let ann b expr') Empty) (binderName b)
 
+  emitBinding _ = undefined
+
   buildScoped cont = do
     ext1 <- idExt
     BuilderT $ liftInplace $ BuilderNameGenT do
@@ -147,6 +148,7 @@ instance (BindingsReader m, BindingsGetter m, BindingsExtender m, MonadFail1 m)
       Distinct <- getDistinct
       return $ DistinctAbs id result
 
+  buildScopedTop _ = undefined
   getAllowedEffects = undefined
   withAllowedEffects _ _ = undefined
 
@@ -209,16 +211,16 @@ class EmitsTop (n::S)
 
 instance EmitsTop UnsafeS
 
-withEmitsTopEvidence :: forall n a. EmitsTopEvidence n -> (EmitsTop n => a) -> a
-withEmitsTopEvidence _ cont = fromWrapWithEmitsTop
+_withEmitsTopEvidence :: forall n a. EmitsTopEvidence n -> (EmitsTop n => a) -> a
+_withEmitsTopEvidence _ cont = fromWrapWithEmitsTop
  ( unsafeCoerce ( WrapWithEmitsTop cont :: WrapWithEmitsTop n       a
                                       ) :: WrapWithEmitsTop UnsafeS a)
 
 newtype WrapWithEmitsTop n r =
   WrapWithEmitsTop { fromWrapWithEmitsTop :: EmitsTop n => r }
 
-fabricateEmitsTopEvidenceM :: Monad1 m => m n (EmitsTopEvidence n)
-fabricateEmitsTopEvidenceM = return FabricateEmitsTopEvidence
+_fabricateEmitsTopEvidenceM :: Monad1 m => m n (EmitsTopEvidence n)
+_fabricateEmitsTopEvidenceM = return FabricateEmitsTopEvidence
 
 -- === lambda-like things ===
 
@@ -404,6 +406,7 @@ buildNaryAbs (EmptyAbs (Nest (b:>ty) bs)) body = do
         v' <- injectM v
         body $ v' : vs
   return $ Abs (Nest b' bs') body'
+buildNaryAbs _ _ = error "impossible"
 
 buildAlt
   :: Builder m

--- a/src/lib/SaferNames/Inference.hs
+++ b/src/lib/SaferNames/Inference.hs
@@ -10,6 +10,7 @@ module SaferNames.Inference (inferModule) where
 
 import Prelude hiding ((.), id)
 import Control.Category
+import Control.Applicative
 import Control.Monad
 import Control.Monad.Except hiding (Except)
 import Data.Foldable (toList)
@@ -57,24 +58,57 @@ isTopDecl decl = case decl of
 class (MonadErr2 m, Builder2 m, EnvGetter Name m)
       => Inferer (m::MonadKind2)
 
-data InfererM (i::S) (o::S) (a:: *) = InfererM
+data InfererM (i::S) (o::S) (a:: *)
 
 runInfererM :: Bindings n
             -> (forall l. Ext n l => InfererM l l (e l))
             -> Except (e n)
 runInfererM _ _ = undefined
 
-instance Functor (InfererM i o)
-instance Applicative (InfererM i o)
-instance Monad (InfererM i o)
-instance MonadFail (InfererM i o)
-instance MonadError Err (InfererM i o)
-instance Builder (InfererM i)
-instance BindingsReader (InfererM i)
-instance ScopeReader (InfererM i)
-instance Scopable (InfererM i)
-instance (EnvReader Name) InfererM
-instance (EnvGetter Name) InfererM
+instance Functor (InfererM i o) where
+  fmap = undefined
+
+instance Applicative (InfererM i o) where
+  pure = undefined
+  liftA2 = undefined
+
+instance Monad (InfererM i o) where
+  return = undefined
+  (>>=) = undefined
+
+instance MonadFail (InfererM i o) where
+  fail = undefined
+
+instance MonadError Err (InfererM i o) where
+  throwError = undefined
+  catchError = undefined
+
+instance Builder (InfererM i) where
+  buildScoped _ = undefined
+  buildScopedTop _ = undefined
+  getAllowedEffects = undefined
+  withAllowedEffects = undefined
+  emitDecl = undefined
+  emitBinding = undefined
+
+instance BindingsReader (InfererM i) where
+  addBindings = undefined
+
+instance ScopeReader (InfererM i) where
+  getDistinctEvidenceM = undefined
+  addScope = undefined
+
+instance Scopable (InfererM i) where
+  withBindings _ _ = undefined
+
+instance (EnvReader Name) InfererM where
+  lookupEnvM = undefined
+  extendEnv  = undefined
+  dropSubst  = undefined
+
+instance (EnvGetter Name) InfererM where
+  getEnv = undefined
+
 instance Inferer InfererM
 
 constrainEq :: Inferer m => Type o -> Type o -> m i o ()

--- a/src/lib/SaferNames/Inference.hs
+++ b/src/lib/SaferNames/Inference.hs
@@ -1,0 +1,466 @@
+-- Copyright 2021 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE ViewPatterns #-}
+
+module SaferNames.Inference (inferModule) where
+
+import Prelude hiding ((.), id)
+import Control.Category
+import Control.Monad
+import Control.Monad.Reader
+import Data.Foldable (toList)
+import Data.List (elemIndex)
+import Data.Maybe (fromJust)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.Map.Strict as M
+
+import SaferNames.NameCore
+import SaferNames.Name
+import SaferNames.Builder
+import SaferNames.Syntax
+import SaferNames.Type
+import SaferNames.PPrint ()
+
+import LabeledItems
+import Err
+import Util (enumerate)
+
+inferModule :: Bindings n -> UModule n -> Except (Module n)
+inferModule = undefined
+
+-- === Inferer monad ===
+
+class (MonadErr2 m, Builder2 m, EnvGetter Name m)
+      => Inferer (m::MonadKind2)
+
+type SigmaType = Type  -- may     start with an implicit lambda
+type RhoType   = Type  -- doesn't start with an implicit lambda
+data SuggestionStrength = Suggest | Concrete  deriving Show
+data RequiredTy (e::E) (n::S) = Check SuggestionStrength (e n)
+                              | Infer
+                                deriving Show
+
+constrainEq :: Inferer m => Type o -> Type o -> m i o ()
+constrainEq = undefined
+
+freshInferenceName :: Inferer m => Kind o -> m i o (AtomName o)
+freshInferenceName = undefined
+
+zonk :: (Inferer m, SubstE Name e) => e o -> m i o (e o)
+zonk = undefined
+
+freshType :: Inferer m => Kind o -> m i o (Type o)
+freshType k = Var <$> freshInferenceName k
+
+freshEff :: Inferer m => m i o (EffectRow o)
+freshEff = EffectRow mempty . Just <$> freshInferenceName EffKind
+
+typeReduceAtom :: Inferer m => Atom o -> m i o (Atom o)
+typeReduceAtom = undefined
+
+tryGetType :: (Inferer m, HasType e) => e o -> m i o (Type o)
+tryGetType = undefined
+
+getSrcCtx :: Inferer m => m i o SrcCtx
+getSrcCtx = undefined -- lift ask
+
+addSrcContext' :: Inferer m => SrcCtx -> m i o a -> m i o a
+addSrcContext' pos m = undefined
+
+makeReqCon :: Inferer m => Type o -> m i o SuggestionStrength
+makeReqCon _ = undefined
+
+buildAndReduceScoped :: Inferer m
+                     => (forall l. (Emits l, Ext n l) => m i l (Atom l))
+                     -> m i n (Maybe (Atom n))
+buildAndReduceScoped _ = undefined
+
+-- === actual inference pass ===
+
+checkSigma :: (Emits o, Inferer m) => UExpr i
+           -> SuggestionStrength
+           -> SigmaType o -> m i o (Atom o)
+checkSigma expr reqCon sTy = case sTy of
+  Pi piTy@(PiType arrow _ _ _)
+    | arrow `elem` [ImplicitArrow, ClassArrow] -> case expr of
+        WithSrcE _ (ULam lam@(ULamExpr arrow' _ _))
+          | arrow == arrow' ->
+            -- is this even reachable? we don't have syntax for implicit/class lambda
+            checkULam lam piTy
+        -- we have to add the lambda argument corresponding to the implicit pi
+        -- type argument
+        _ -> do
+          buildPureLam arrow (piArgType piTy) \x -> do
+            piTy' <- injectM piTy
+            (Pure, bodyTy) <- instantiatePi piTy' (Var x)
+            checkSigma expr reqCon bodyTy
+  _ -> checkOrInferRho expr (Check reqCon sTy)
+
+inferSigma :: (Emits o, Inferer m) => UExpr i -> m i o (Atom o)
+inferSigma (WithSrcE pos expr) = case expr of
+  ULam lam@(ULamExpr ImplicitArrow pat body) ->
+    addSrcContext' pos $ inferULam Pure lam
+  _ -> inferRho (WithSrcE pos expr)
+
+checkRho :: (Emits o, Inferer m) => UExpr i -> RhoType o -> m i o (Atom o)
+checkRho expr ty = checkOrInferRho expr (Check Suggest ty)
+
+inferRho :: (Emits o, Inferer m) => UExpr i -> m i o (Atom o)
+inferRho expr = checkOrInferRho expr Infer
+
+instantiateSigma :: (Emits o, Inferer m) => Atom o -> m i o (Atom o)
+instantiateSigma f = do
+  ty <- tryGetType f
+  case ty of
+    Pi (PiType ImplicitArrow b _ _) -> do
+      x <- freshType $ binderType b
+      ans <- emitZonked $ App f x
+      instantiateSigma $ Var ans
+    Pi (PiType ClassArrow b _ _) -> do
+      ctx <- getSrcCtx
+      ans <- emitZonked $ App f (Con $ ClassDictHole ctx $ binderType b)
+      instantiateSigma $ Var ans
+    _ -> return f
+
+checkOrInferRho :: forall m i o.
+                   (Emits o, Inferer m)
+                => UExpr i -> RequiredTy RhoType o -> m i o (Atom o)
+checkOrInferRho (WithSrcE pos expr) reqTy = do
+ addSrcContext' pos $ case expr of
+  UVar ~(InternalName v) -> do
+    substM v >>= inferUVar >>= instantiateSigma >>= matchRequirement
+  ULam (ULamExpr ImplicitArrow (UPatAnn p ann) body) -> do
+    argTy <- checkAnn ann
+    v <- freshInferenceName argTy
+    withBindPat p v $ checkOrInferRho body reqTy
+  ULam lamExpr ->
+    case reqTy of
+      Check _ (Pi piTy) -> checkULam lamExpr piTy
+      Check _ _ -> inferULam Pure lamExpr >>= matchRequirement
+      Infer   -> inferULam Pure lamExpr
+  UFor dir (UForExpr b body) -> do
+    allowedEff <- getAllowedEffects
+    let uLamExpr = ULamExpr TabArrow b body
+    lam <- case reqTy of
+      Check _ (Pi piType) -> checkULam uLamExpr piType
+      Check _ _ -> inferULam allowedEff uLamExpr
+      Infer   -> inferULam allowedEff uLamExpr
+    result <- liftM Var $ emitZonked $ Hof $ For (RegularFor dir) lam
+    matchRequirement result
+  UApp arr f x@(WithSrcE xPos _) -> do
+    f' <- inferRho f
+    -- NB: We never infer dependent function types, but we accept them, provided they
+    --     come with annotations. So, unless we already know that the function is
+    --     dependent here (i.e. the type of the zonk comes as a dependent Pi type),
+    --     then nothing in the remainder of the program can convince us that the type
+    --     is dependent. Also, the Pi binder is never considered to be in scope for
+    --     inference variables, so they cannot get unified with it. Hence, this zonk
+    --     is safe and doesn't make the type checking depend on the program order.
+    infTy <- getType =<< zonk f'
+    piTy  <- addSrcContext' (srcPos f) $ fromPiType True arr infTy
+    considerNonDepPiType piTy >>= \case
+      Just (arr, argTy, effs, resultTy) -> do
+        x' <- checkSigma x Suggest argTy
+        addEffects effs
+        appVal <- emitZonked $ App f' x'
+        instantiateSigma (Var appVal) >>= matchRequirement
+      Nothing -> do
+        maybeX <- buildAndReduceScoped do
+          argTy' <- injectM $ piArgType piTy
+          checkSigma x Suggest argTy'
+        case maybeX of
+          Nothing -> addSrcContext' xPos $ do
+            throw TypeErr $ "Dependent functions can only be applied to fully " ++
+                            "evaluated expressions. Bind the argument to a name " ++
+                            "before you apply the function."
+          Just x' -> do
+            (effs, _) <- instantiatePi piTy x'
+            addEffects effs
+            appVal <- emitZonked $ App f' x'
+            instantiateSigma (Var appVal) >>= matchRequirement
+  UPi (UPiExpr arr (UPatAnn (WithSrcB pos' pat) ann) effs ty) -> do
+    -- TODO: make sure there's no effect if it's an implicit or table arrow
+    ann' <- checkAnn ann
+    piTy <- addSrcContext' pos' case pat of
+      UPatBinder UIgnore -> do
+        effs' <- checkUEffRow effs
+        ty' <- checkUType ty
+        buildNonDepPi ann' effs' ty'
+      -- TODO: won't type check unless we check no decls are produced
+      -- _ -> buildPi ann' \v ->
+      --   withBindPat (WithSrcB pos' pat) v do
+      --     effs' <- checkUEffRow effs
+      --     ty' <- checkUType ty
+      --     return (effs', ty')
+    matchRequirement piTy
+  UDecl (UDeclExpr decl body) -> do
+    env <- inferUDeclLocal decl
+    extendEnv env $ checkOrInferRho body reqTy
+  UCase scrut alts -> do
+    scrut' <- inferRho scrut
+    scrutTy <- getType scrut'
+    reqTy' <- case reqTy of
+      Infer -> freshType TyKind
+      Check _ req -> return req
+    alts' <- mapM (checkCaseAlt reqTy' scrutTy) alts
+    scrutTy' <- zonk scrutTy
+    scrut'' <- zonk scrut'
+    case scrutTy' of
+      TypeCon (_, def) params -> do
+        conDefs <- applyDataDefParams def params
+        altsSorted <- forM (enumerate conDefs) \(i, DataConDef _ bs) -> do
+          case lookup (ConAlt i) alts' of
+            Nothing  ->
+              buildNaryAbs bs \_ -> do
+                reqTy'' <- injectM reqTy'
+                return $ Block reqTy'' Empty $ Op $ ThrowError reqTy''
+            Just alt -> return alt
+        liftM Var $ emit $ Case scrut'' altsSorted reqTy'
+      VariantTy _ -> undefined
+      _ -> fail $ "Unexpected case expression type: " <> pprint scrutTy'
+  UTabCon xs -> inferTabCon xs reqTy >>= matchRequirement
+  UIndexRange low high -> do
+    n <- freshType TyKind
+    low'  <- mapM (flip checkRho n) low
+    high' <- mapM (flip checkRho n) high
+    matchRequirement $ TC $ IndexRange n low' high'
+  UHole -> case reqTy of
+    Infer -> throw MiscErr "Can't infer type of hole"
+    Check _ ty -> freshType ty
+  UTypeAnn val ty -> do
+    ty' <- zonk =<< checkUType ty
+    reqCon <- makeReqCon ty'
+    val' <- checkSigma val reqCon ty'
+    matchRequirement val'
+  UPrimExpr prim -> do
+    prim' <- forM prim $ inferRho >=> typeReduceAtom
+    val <- case prim' of
+      TCExpr  e -> return $ TC e
+      ConExpr e -> return $ Con e
+      OpExpr  e -> Var <$> emitZonked (Op e)
+      HofExpr e -> Var <$> emitZonked (Hof e)
+    matchRequirement val
+  URecord (Ext items Nothing) -> do
+    items' <- mapM inferRho items
+    matchRequirement $ Record items'
+  URecord (Ext items (Just ext)) -> do
+    items' <- mapM inferRho items
+    restTy <- freshInferenceName LabeledRowKind
+    ext' <- zonk =<< (checkRho ext $ RecordTy $ Ext NoLabeledItems $ Just restTy)
+    matchRequirement =<< emitOp (RecordCons items' ext')
+  UVariant labels@(LabeledItems lmap) label value -> do
+    value' <- inferRho value
+    prevTys <- mapM (const $ freshType TyKind) labels
+    rest <- freshInferenceName LabeledRowKind
+    ty <- getType value'
+    let items = prevTys <> labeledSingleton label ty
+    let extItems = Ext items $ Just rest
+    let i = case M.lookup label lmap of
+              Just prev -> length prev
+              Nothing -> 0
+    matchRequirement $ Variant extItems label i value'
+  URecordTy row -> matchRequirement =<< RecordTy <$> checkExtLabeledRow row
+  UVariantTy row -> matchRequirement =<< VariantTy <$> checkExtLabeledRow row
+  UVariantLift labels value -> do
+    row <- freshInferenceName LabeledRowKind
+    value' <- zonk =<< (checkRho value $ VariantTy $ Ext NoLabeledItems $ Just row)
+    prev <- mapM (\() -> freshType TyKind) labels
+    matchRequirement =<< emitOp (VariantLift prev value')
+  UIntLit  x  -> matchRequirement $ Con $ Lit  $ Int32Lit $ fromIntegral x
+  UFloatLit x -> matchRequirement $ Con $ Lit  $ Float32Lit $ realToFrac x
+  -- TODO: Make sure that this conversion is not lossy!
+  where
+    matchRequirement :: Atom o -> m i o (Atom o)
+    matchRequirement x = return x <*
+      case reqTy of
+        Infer -> return ()
+        Check _ req -> do
+          ty <- getType x
+          constrainEq req ty
+
+inferUVar :: Inferer m => UVar o -> m i o (Atom o)
+inferUVar = \case
+  UAtomVar v ->
+    return $ Var v
+  UTyConVar v -> do
+    -- TODO: we shouldn't need these tildes because it's the only valid case
+    ~(TyConBinding   dataDefName) <- lookupBindings v
+    ~(DataDefBinding dataDef)     <- lookupBindings dataDefName
+    return $ TypeCon (dataDefName, dataDef) []
+  UDataConVar v -> do
+   -- TODO: we shouldn't need these tildes because it's the only valid case
+    ~(DataConBinding dataDefName idx) <- lookupBindings v
+    ~(DataDefBinding dataDef)         <- lookupBindings dataDefName
+    return $ DataCon (pprint v) (dataDefName, dataDef) [] idx []
+  UClassVar v -> do
+    ~(ClassBinding (ClassDef classSoruceName _ dataDef)) <- lookupBindings v
+    return $ TypeCon dataDef []
+  UMethodVar v -> do
+    ~(MethodBinding _ _ getter) <- lookupBindings v
+    return getter
+
+inferUDeclLocal ::  (Emits o, Inferer m) => UDecl i i' -> m i o (EnvFrag Name i i' o)
+inferUDeclLocal (ULet letAnn (UPatAnn p ann) rhs) = do
+  val <- case ann of
+    Nothing -> inferSigma rhs
+    Just ty -> do
+      ty' <- zonk =<< checkUType ty
+      reqCon <- makeReqCon ty'
+      checkSigma rhs reqCon ty'
+  expr <- zonk $ Atom val
+  var <- emitDecl (getNameHint p) letAnn expr
+  bindPat p var
+inferUDeclLocal _ = error "not a local decl"
+
+inferUDeclTop ::  (Emits o, Inferer m) => UDecl i i' -> m i o (EnvFrag Name i i' o)
+inferUDeclTop (ULet letAnn p rhs) = inferUDeclLocal $ ULet letAnn p rhs
+inferUDeclTop _ = undefined
+
+inferDataDef :: Inferer m => UDataDef i -> m i o (DataDef o)
+inferDataDef = undefined
+
+inferInterfaceDataDef :: Inferer m
+                      => SourceName -> [SourceName]
+                      -> Nest (UAnnBinder AtomNameC) i i'
+                      -> [UType i'] -> [UType i']
+                      -> m i o (ClassDef o)
+inferInterfaceDataDef className methodNames paramBs superclasses methods = undefined
+
+withNestedBinders :: Inferer m
+                  => Nest (UAnnBinder AtomNameC) i i'
+                  -> (forall o'. Ext o o' => Nest Binder o o' -> m i' o' a)
+                  -> m i o a
+withNestedBinders Empty cont = cont Empty
+withNestedBinders _ _ = undefined
+
+inferULam :: Inferer m => EffectRow o -> ULamExpr i -> m i o (Atom o)
+inferULam effs (ULamExpr arrow (UPatAnn p ann) body) = do
+  argTy <- checkAnn ann
+  buildLam arrow argTy effs \v ->
+    withBindPat p v $ inferSigma body
+
+checkULam :: Inferer m => ULamExpr i -> PiType o -> m i o (Atom o)
+checkULam (ULamExpr _ (UPatAnn p ann) body) piTy = do
+  let argTy = piArgType piTy
+  checkAnn ann >>= constrainEq argTy
+  -- XXX: we're ignoring the ULam arrow here. Should we be checking that it's
+  -- consistent with the arrow supplied by the pi type?
+  buildDepEffLam (piArrow piTy) argTy
+    (\v -> do
+        piTy' <- injectM piTy
+        fst <$> instantiatePi piTy' (Var v) )
+     \v -> withBindPat p v do
+        piTy' <- injectM piTy
+        (_, resultTy) <- instantiatePi piTy' (Var v)
+        checkSigma body Suggest resultTy
+
+checkUEffRow :: Inferer m => UEffectRow i -> m i o (EffectRow o)
+checkUEffRow = undefined
+
+checkUEff :: Inferer m => UEffect i -> m i o (Effect o)
+checkUEff = undefined
+
+data CaseAltIndex = ConAlt Int
+                  | VariantAlt Label Int
+                  | VariantTailAlt (LabeledItems ())
+  deriving (Eq, Show)
+
+checkCaseAlt :: Inferer m => RhoType o -> Type o -> UAlt i -> m i o (CaseAltIndex, Alt o)
+checkCaseAlt = undefined
+
+withBindPat :: (Emits o, Inferer m) => UPat i i' -> AtomName o -> m i' o a -> m i o a
+withBindPat pat var m = do
+  env <- bindPat pat var
+  extendEnv env m
+
+bindPat :: (Emits o, Inferer m) => UPat i i' -> AtomName o -> m i o (EnvFrag Name i i' o)
+bindPat (WithSrcB pos pat) v = addSrcContext pos $ case pat of
+  UPatBinder b -> case b of
+    UBindSource _ -> error "shouldn't have source names left after the renaming pass"
+    UIgnore -> return emptyEnv
+    UBind b -> return (b @> v)
+  UPatUnit UnitB -> do
+    ty <- getType $ Var v
+    constrainEq UnitTy ty
+    return emptyEnv
+  UPatPair (PairB p1 p2) -> do
+    ty <- getType $ Var v
+    _    <- fromPairType ty
+    v' <- zonk v  -- ensure it has a pair type before unpacking
+    x1 <- emit (Atom $ ProjectElt (NE.fromList [0]) v') >>= zonk
+    env1 <- bindPat p1 x1
+    extendEnv env1 do
+      x2  <- emit (Atom $ ProjectElt (NE.fromList [1]) v') >>= zonk
+      env2 <- bindPat p2 x2
+      env1' <- injectM env1
+      return $ env1' <.> env2
+
+checkAnn :: Inferer m => Maybe (UType i) -> m i o (Type o)
+checkAnn ann = case ann of
+  Just ty -> checkUType ty
+  Nothing -> freshType TyKind
+
+checkUType :: Inferer m => UType i -> m i o (Type o)
+checkUType = undefined
+
+checkExtLabeledRow :: (Emits o, Inferer m)
+                   => ExtLabeledItems (UExpr i) (UExpr i)
+                   -> m i o (ExtLabeledItems (Type o) (AtomName o))
+checkExtLabeledRow (Ext types Nothing) = do
+  types' <- mapM checkUType types
+  return $ Ext types' Nothing
+checkExtLabeledRow (Ext types (Just ext)) = do
+  types' <- mapM checkUType types
+  -- Only variables can have kind LabeledRowKind at the moment.
+  Var ext' <- checkRho ext LabeledRowKind
+  return $ Ext types' $ Just ext'
+
+inferTabCon :: Inferer m => [UExpr i] -> RequiredTy RhoType o -> m i o (Atom o)
+inferTabCon = undefined
+
+-- Bool flag is just to tweak the reported error message
+fromPiType :: Inferer m => Bool -> Arrow -> Type o -> m i o (PiType o)
+fromPiType _ _ (Pi piTy) = return piTy -- TODO: check arrow
+fromPiType expectPi arr ty = do
+  a <- freshType TyKind
+  b <- freshType TyKind
+  piTy <- nonDepPiType arr a Pure b
+  if expectPi then  constrainEq (Pi piTy) ty
+              else  constrainEq ty (Pi piTy)
+  return piTy
+
+fromPairType :: Inferer m => Type o -> m i o (Type o, Type o)
+fromPairType (PairTy t1 t2) = return (t1, t2)
+fromPairType ty = do
+  a <- freshType TyKind
+  b <- freshType TyKind
+  constrainEq (PairTy a b) ty
+  return (a, b)
+
+emitZonked :: (Emits o, Inferer m) => Expr o -> m i o (AtomName o)
+emitZonked expr = zonk expr >>= emit
+
+addEffects :: Inferer m => EffectRow o -> m i o ()
+addEffects eff = do
+  allowed <- checkAllowedUnconditionally eff
+  unless allowed $ do
+    allowedEffects <- getAllowedEffects
+    eff' <- openEffectRow eff
+    constrainEq (Eff allowedEffects) (Eff eff')
+
+checkAllowedUnconditionally :: Inferer m => EffectRow o -> m i o Bool
+checkAllowedUnconditionally Pure = return True
+checkAllowedUnconditionally eff = do
+  eff' <- zonk eff
+  effAllowed <- getAllowedEffects >>= zonk
+  return $ case checkExtends effAllowed eff' of
+    Left _   -> False
+    Right () -> True
+
+openEffectRow :: Inferer m => EffectRow o -> m i o (EffectRow o)
+openEffectRow (EffectRow effs Nothing) = extendEffRow effs <$> freshEff
+openEffectRow effRow = return effRow

--- a/src/lib/SaferNames/Name.hs
+++ b/src/lib/SaferNames/Name.hs
@@ -49,7 +49,7 @@ module SaferNames.Name (
   GenericE (..), GenericB (..), ColorsEqual (..), ColorsNotEqual (..),
   EitherE1, EitherE2, EitherE3, EitherE4, EitherE5,
   pattern Case0, pattern Case1, pattern Case2, pattern Case3, pattern Case4,
-  splitNestAt, nestLength, binderAnn,
+  splitNestAt, nestLength, nestToList, binderAnn,
   OutReaderT (..), OutReader (..), runOutReaderT, getDistinct,
   ExtWitness (..), idExt, injectExt
   ) where
@@ -374,6 +374,8 @@ type MaybeB b = EitherB b UnitB
 pattern JustB :: b n l -> MaybeB b n l
 pattern JustB b = LeftB b
 
+-- TODO: this doesn't seem to force n==n, e.g. see where we have to explicitly
+-- write `RightB UnitB` in inference rule for instances.
 pattern NothingB :: MaybeB b n n
 pattern NothingB = RightB UnitB
 
@@ -469,6 +471,10 @@ traverseEnvFrag f frag = liftM fromEnvPairs $
 nestLength :: Nest b n l -> Int
 nestLength Empty = 0
 nestLength (Nest _ rest) = 1 + nestLength rest
+
+nestToList :: (forall n' l'. b n' l' -> a) -> Nest b n l -> [a]
+nestToList _ Empty = []
+nestToList f (Nest b rest) = f b : nestToList f rest
 
 splitNestAt :: Int -> Nest b n l -> PairB (Nest b) (Nest b) n l
 splitNestAt 0 bs = PairB Empty bs

--- a/src/lib/SaferNames/Parser.hs
+++ b/src/lib/SaferNames/Parser.hs
@@ -308,7 +308,7 @@ instanceDef isNamed = do
   let argBinders = explicitArgs
                  ++ [UPatAnnArrow (UPatAnn (nsB UPatIgnore) (Just c)) ClassArrow | c <- constraints]
   methods <- onePerLine instanceMethod
-  return $ UInstance (toNestParsed argBinders) (fromString className) params methods name
+  return $ UInstance (fromString className) (toNestParsed argBinders) params methods name
 
 instanceMethod :: Parser (UMethodDef VoidS)
 instanceMethod = do

--- a/src/lib/SaferNames/Parser.hs
+++ b/src/lib/SaferNames/Parser.hs
@@ -14,7 +14,6 @@ import Control.Monad.Reader
 import Text.Megaparsec hiding (Label, State)
 import Text.Megaparsec.Char hiding (space, eol)
 import qualified Text.Megaparsec.Char as MC
-import Data.Foldable (toList)
 import Data.Functor
 import Data.List.NonEmpty (NonEmpty (..))
 import Data.Maybe (fromMaybe)
@@ -581,7 +580,9 @@ leafPat =
                         -> UPat' VoidS VoidS
         unzipUPatRecord labeled = UPatRecord labels nest where
           (labels, items, rest) = unzipExtLabeledItems labeled
-          nest = toNestParsed $ items ++ toList rest
+          patTail = case rest of Nothing -> NothingB
+                                 Just p  -> JustB p
+          nest = PairB (toNestParsed items) patTail
 
 -- TODO: add user-defined patterns
 patOps :: [[Operator Parser (UPat VoidS VoidS)]]
@@ -664,9 +665,7 @@ uIsoSugar = withSrc (char '#' *> options) where
     UApp plain (ns "MkIso") $
       ns $ URecord $ NoExt $
         labeledSingleton "fwd" (lam
-          (nsB $ UPatRecord
-                   (Ext (labeledSingleton field ()) (Just ()))
-                   (toNest ["x", "r"]))
+            (uPatRecordLit [(field, "x")] (Just "r"))
           $ (ns "(,)") `mkApp` (ns "x") `mkApp` (ns "r")
         )
         <> labeledSingleton "bwd" (lam
@@ -697,9 +696,8 @@ uIsoSugar = withSrc (char '#' *> options) where
       ns $ URecord $ NoExt $
         labeledSingleton "fwd" (lam
           (nsB $ UPatPair $ PairB
-            (nsB $ UPatRecord (Ext NoLabeledItems $ Just $ ()) $ toNest ["l"])
-            (nsB $ (UPatRecord (Ext (labeledSingleton field ()) $ Just ())
-                               (toNest ["x", "r"]))))
+            (uPatRecordLit [] (Just "l"))
+            (uPatRecordLit [(field, "x")] (Just "r")))
           $ "(,)"
             `mkApp` (ns $ URecord $ (Ext (labeledSingleton field $ "x")
                                          $ Just $ "l"))
@@ -707,9 +705,8 @@ uIsoSugar = withSrc (char '#' *> options) where
         )
         <> labeledSingleton "bwd" (lam
           (nsB $ UPatPair $ PairB
-            (nsB $ (UPatRecord (Ext (labeledSingleton field ()) $ Just ())
-                               (toNest ["x", "l"])))
-            (nsB $ UPatRecord (Ext NoLabeledItems $ Just ()) $ toNest ["r"]))
+            (uPatRecordLit [(field, "x")] (Just "l"))
+            (uPatRecordLit [] (Just "r")))
           $ "(,)"
             `mkApp` (ns $ URecord $ Ext NoLabeledItems $ Just $ "l")
             `mkApp` (ns $ URecord $ Ext (labeledSingleton field $ "x")
@@ -748,6 +745,17 @@ uIsoSugar = withSrc (char '#' *> options) where
                     UVariantLift (labeledSingleton field ()) "l")
             ]
         )
+
+uPatRecordLit :: [(Label, UPat VoidS VoidS)] -> Maybe (UPat VoidS VoidS) -> UPat VoidS VoidS
+uPatRecordLit labelsPats ext = nsB
+  let (labels, pats) = unzip labelsPats
+  in case ext of
+       Nothing ->
+         UPatRecord (NoExt (foldMap (\s -> labeledSingleton s ()) labels))
+                    (PairB (toNestParsed $ pats) NothingB)
+       Just tailPat ->
+         UPatRecord (Ext undefined (Just ()))
+                    (PairB (toNestParsed $ pats) (JustB tailPat))
 
 parseLabeledItems
   :: String -> String -> Parser a

--- a/src/lib/SaferNames/ResolveImplicitNames.hs
+++ b/src/lib/SaferNames/ResolveImplicitNames.hs
@@ -167,6 +167,14 @@ instance (HasImplicitArgNamesB b1, HasImplicitArgNamesB b2)
          => HasImplicitArgNamesB (PairB b1 b2) where
   implicitArgsB (PairB b1 b2) = implicitArgsB b1 >> implicitArgsB b2
 
+instance HasImplicitArgNamesB UnitB where
+  implicitArgsB UnitB = return ()
+
+instance (HasImplicitArgNamesB b1, HasImplicitArgNamesB b2)
+         => HasImplicitArgNamesB (EitherB b1 b2) where
+  implicitArgsB (LeftB  b) = implicitArgsB b
+  implicitArgsB (RightB b) = implicitArgsB b
+
 instance (HasImplicitArgNamesB b, HasImplicitArgNamesE e)
          => HasImplicitArgNamesE (Abs b e) where
   implicitArgsE (Abs b e) = do

--- a/src/lib/SaferNames/ResolveImplicitNames.hs
+++ b/src/lib/SaferNames/ResolveImplicitNames.hs
@@ -27,9 +27,9 @@ resolveImplicitTopDecl (ULet ann (UPatAnn pat (Just ty)) expr) =
     implicitArgs = findImplicitArgNames ty
     ty'   = foldr addImplicitPiArg  ty   implicitArgs
     expr' = foldr addImplicitLamArg expr implicitArgs
-resolveImplicitTopDecl (UInstance argBinders className params methods maybeName) =
-  UInstance argBinders' className params methods maybeName where
-    implicitArgs = findImplicitArgNames $ Abs argBinders (PairE className $ ListE params)
+resolveImplicitTopDecl (UInstance className argBinders params methods maybeName) =
+  UInstance className argBinders' params methods maybeName where
+    implicitArgs = findImplicitArgNames $ PairE className $ Abs argBinders (ListE params)
     argBinders' = foldr Nest argBinders $ map nameAsImplicitBinder implicitArgs
 resolveImplicitTopDecl decl = decl
 

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -232,10 +232,11 @@ instance SourceRenamableB UDecl where
       runRenamerNameGenT $ sourceRenameUBinder className `bindG` \className' ->
         sourceRenameUBinderNest methodNames `bindG` \methodNames' ->
         returnG $ UInterface paramBs' superclasses' methodTys' className' methodNames'
-    UInstance conditions className params methodDefs instanceName -> do
-      Abs conditions' (PairE (PairE className' (ListE params')) (ListE methodDefs')) <-
-        sourceRenameE $ Abs conditions (PairE (PairE className $ ListE params) $ ListE methodDefs)
-      runRenamerNameGenT $ UInstance conditions' className' params' methodDefs' `fmapG` sourceRenameB instanceName
+    UInstance className conditions params methodDefs instanceName -> do
+      className' <- sourceRenameE className
+      Abs conditions' (PairE (ListE params') (ListE methodDefs')) <-
+        sourceRenameE $ Abs conditions (PairE (ListE params) $ ListE methodDefs)
+      runRenamerNameGenT $ UInstance className' conditions' params' methodDefs' `fmapG` sourceRenameB instanceName
 
 instance SourceRenamableB UnitB where
   sourceRenameB UnitB = returnG UnitB

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -367,6 +367,25 @@ instance SourceRenamablePat UPat' where
     UPatVariantLift labels p -> UPatVariantLift labels `fmapG` sourceRenamePat siblingNames p
     UPatTable ps -> UPatTable `fmapG` sourceRenamePat siblingNames ps
 
+instance SourceRenamablePat UnitB where
+  sourceRenamePat _ UnitB = returnG UnitB
+
+instance (SourceRenamablePat p1, SourceRenamablePat p2)
+         => SourceRenamablePat (PairB p1 p2) where
+  sourceRenamePat sibs (PairB p1 p2) =
+    sourceRenamePat sibs p1 `bindG` \p1' ->
+    sourceRenamePat sibs p2 `bindG` \p2' ->
+    returnG $ PairB p1' p2'
+
+instance (SourceRenamablePat p1, SourceRenamablePat p2)
+         => SourceRenamablePat (EitherB p1 p2) where
+  sourceRenamePat sibs (LeftB p) =
+    sourceRenamePat sibs p `bindG` \p' ->
+    returnG $ LeftB p'
+  sourceRenamePat sibs (RightB p) =
+    sourceRenamePat sibs p `bindG` \p' ->
+    returnG $ RightB p'
+
 instance SourceRenamablePat p => SourceRenamablePat (WithSrcB p) where
   sourceRenamePat sibs (WithSrcB pos pat) = PatRenamerNameGenT $ addSrcContext pos $
     runPatRenamerNameGenT $ (WithSrcB pos) `fmapG` sourceRenamePat sibs pat

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -64,9 +64,9 @@ class (Monad1 m, ScopeExtender m, MonadErr1 m) => Renamer m where
 
 _renameSourceNames' :: Renamer m => SourceUModule -> m o (UModule o)
 _renameSourceNames' (SourceUModule decl) = do
-  (RenamerContent frag sourceMap decl') <- runRenamerNameGenT $
+  (RenamerContent _ sourceMap decl') <- runRenamerNameGenT $
     sourceRenameB $ resolveImplicitTopDecl decl
-  return $ UModule frag sourceMap decl'
+  return $ UModule decl' sourceMap
 
 class SourceRenamableE e where
   sourceRenameE :: Renamer m => e i -> m o (e o)

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -45,7 +45,7 @@ module SaferNames.Syntax (
     SourceBlock (..), SourceBlock' (..),
     SourceUModule (..), UType,
     CmdName (..), LogLevel (..), PassName, OutFormat (..),
-    TopBindings (..), TopBindingsFrag, NamedDataDef, fromTopBindings, ScopedBindings,
+    TopBindings (..), NamedDataDef, fromTopBindings, ScopedBindings,
     BindingsReader (..), BindingsExtender (..),  Binding (..), BindingsGetter (..),
     refreshBinders, withFreshBinder, withFreshBinding,
     Bindings, BindingsFrag, lookupBindings, runBindingsReaderT,
@@ -548,10 +548,8 @@ data SourceUModule = SourceUModule (UDecl VoidS VoidS) deriving (Show)
 -- body must only contain Name version of names and binders
 data UModule (n::S) where
   UModule
-    :: Distinct l
-    => ScopeFrag n l
+    :: UDecl n l
     -> SourceMap l
-    -> UDecl n l
     -> UModule n
 
 data SourceBlock = SourceBlock
@@ -588,8 +586,6 @@ type ScopedBindings n = (Scope n, Bindings n)
 fromTopBindings :: TopBindings n -> ScopedBindings n
 fromTopBindings (TopBindings env) = (envAsScope env, emptyNameFunction <>> env)
 
-type TopBindingsFrag n l = EnvFrag Binding n l l
-
 emptyTopState :: TopState VoidS
 emptyTopState = TopState (TopBindings emptyEnv) mempty (SourceMap mempty)
 
@@ -606,7 +602,7 @@ data Module n where
 
 data EvaluatedModule (n::S) where
   EvaluatedModule
-    :: TopBindingsFrag n l  -- Evaluated bindings
+    :: BindingsFrag n l     -- Evaluated bindings
     -> SynthCandidates l    -- Values considered in scope for dictionary synthesis
     -> SourceMap l          -- Mapping of module's source names to internal names
     -> EvaluatedModule n
@@ -1461,3 +1457,6 @@ instance BindsAtMostOneName (UBinder c) c where
 
 instance BindsAtMostOneName (UAnnBinder c) c where
   UAnnBinder b _ @> x = b @> x
+
+instance InjectableE UModule where
+  injectionProofE = undefined

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -1468,4 +1468,5 @@ instance Pretty (UBinder c n l) where
   pretty UIgnore         = "_"
   pretty (UBind v)       = pretty v
 
-instance Pretty (UType n)
+instance Pretty (UType n) where
+  pretty = undefined

--- a/src/lib/SaferNames/Syntax.hs
+++ b/src/lib/SaferNames/Syntax.hs
@@ -512,10 +512,8 @@ data UPat' (n::S) (l::S) =
  | UPatCon (SourceNameOr (Name DataConNameC) n) (Nest UPat n l)
  | UPatPair (PairB UPat UPat n l)
  | UPatUnit (UnitB n l)
- -- The ExtLabeledItems and the Nest are meant to be parallel.  If the
- -- ExtLabeledItems has a Just at the end, that corresponds to the
- -- last item in the given Nest.
- | UPatRecord (ExtLabeledItems () ()) (Nest UPat n l)     -- {a=x, b=y, ...rest}
+ -- The ExtLabeledItems and the PairB are parallel, constrained by the parser.
+ | UPatRecord (ExtLabeledItems () ()) (PairB (Nest UPat) (MaybeB UPat) n l) -- {a=x, b=y, ...rest}
  | UPatVariant (LabeledItems ()) Label (UPat n l)   -- {|a|b| a=x |}
  | UPatVariantLift (LabeledItems ()) (UPat n l)     -- {|a|b| ...rest |}
  | UPatTable (Nest UPat n l)
@@ -1469,3 +1467,5 @@ instance Pretty (UBinder c n l) where
   pretty (UBindSource v) = pretty v
   pretty UIgnore         = "_"
   pretty (UBind v)       = pretty v
+
+instance Pretty (UType n)

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -14,7 +14,7 @@
 module SaferNames.Type (
   HasType (..),
   checkModule, checkTypes, getType, litType, getBaseMonoidType,
-  instantiatePi, checkExtends, applyDataDefParams, indices) where
+  instantiatePi, checkExtends, applyDataDefParams, indices, tryReduceBlock) where
 
 import Prelude hiding (id)
 import Control.Category ((>>>))
@@ -995,3 +995,8 @@ labeledRowDifference (Ext (LabeledItems items) rest)
     _ -> throw TypeErr $ "Row tail " ++ pprint subrest
       ++ " is not known to be a subset of " ++ pprint rest
   return $ Ext (LabeledItems diffitems) diffrest
+
+-- === reducing types ===
+
+tryReduceBlock :: BindingsReader m => Block n -> m n (Maybe (Atom n))
+tryReduceBlock = undefined

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -14,7 +14,8 @@
 module SaferNames.Type (
   HasType (..),
   checkModule, checkTypes, getType, litType, getBaseMonoidType,
-  instantiatePi, checkExtends, applyDataDefParams, indices, tryReduceBlock) where
+  instantiatePi, checkExtends, applyDataDefParams, indices, tryReduceBlock,
+  caseAltsBinderTys) where
 
 import Prelude hiding (id)
 import Control.Category ((>>>))
@@ -730,22 +731,25 @@ buildNaryPiType arr (Nest b rest) cont = do
       cont (param : params)
 
 checkCase :: Typer m => HasType body => Atom i -> [AltP body i] -> Type i -> m i o (Type o)
-checkCase e alts resultTy = do
+checkCase scrut alts resultTy = do
   resultTy' <- substM resultTy
-  ety <- getTypeE e
-  case ety of
-    TypeCon (defName, _) params -> do
-      DataDefBinding def <- lookupBindings defName
-      cons <- applyDataDefParams def params
-      forMZipped_ cons alts \(DataConDef _ bs') alt ->
-        checkAlt resultTy' bs' alt
-    VariantTy (NoExt types) -> do
-      bs <- mapM typeAsBinderNest $ toList types
-      forMZipped_ bs alts $ checkAlt resultTy'
-    VariantTy _ -> throw CompilerErr
-      "Can't pattern-match partially-known variants"
-    _ -> throw TypeErr $ "Case analysis only supported on ADTs and variants, not on " ++ pprint ety
+  scrutTy <- getTypeE scrut
+  altsBinderTys <- caseAltsBinderTys scrutTy
+  forMZipped_ alts altsBinderTys \alt bs ->
+    checkAlt resultTy' bs alt
   return resultTy'
+
+caseAltsBinderTys :: (MonadFail1 m, BindingsReader m)
+                  => Type n -> m n [EmptyAbs (Nest Binder) n]
+caseAltsBinderTys ty = case ty of
+  TypeCon (defName, _) params -> do
+    DataDefBinding def <- lookupBindings defName
+    cons <- applyDataDefParams def params
+    return [bs | DataConDef _ bs <- cons]
+  VariantTy (NoExt types) -> do
+    mapM typeAsBinderNest $ toList types
+  VariantTy _ -> fail "Can't pattern-match partially-known variants"
+  _ -> fail $ "Case analysis only supported on ADTs and variants, not on " ++ pprint ty
 
 checkDataConRefBindings :: Typer m
                         => EmptyAbs (Nest Binder) o

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -14,7 +14,7 @@
 module SaferNames.Type (
   HasType (..),
   checkModule, checkTypes, getType, litType, getBaseMonoidType,
-  instantiatePi, checkExtends, applyDataDefParams) where
+  instantiatePi, checkExtends, applyDataDefParams, indices) where
 
 import Prelude hiding (id)
 import Control.Category ((>>>))
@@ -913,8 +913,8 @@ _indexSetConcreteSize ty = case ty of
 
 -- === built-in index set type class ===
 
-_indices :: BindingsReader m => Type n -> m n [Atom n]
-_indices = undefined
+indices :: BindingsReader m => Type n -> m n [Atom n]
+indices = undefined
 
 -- === various helpers for querying types ===
 

--- a/src/lib/SaferNames/Type.hs
+++ b/src/lib/SaferNames/Type.hs
@@ -13,7 +13,8 @@
 
 module SaferNames.Type (
   HasType (..),
-  checkModule, checkTypes, getType, litType, getBaseMonoidType) where
+  checkModule, checkTypes, getType, litType, getBaseMonoidType,
+  instantiatePi, checkExtends, applyDataDefParams) where
 
 import Prelude hiding (id)
 import Control.Category ((>>>))
@@ -59,6 +60,11 @@ getType e = do
   Distinct <- getDistinct
   WithBindings bindings scope e' <- addBindings e
   injectM $ runIgnoreChecks $ runTyperT (scope, bindings) $ getTypeE e'
+
+instantiatePi :: ScopeReader m => PiType n -> Atom n -> m n (EffectRow n, Atom n)
+instantiatePi (PiType _ b eff body) x = do
+  PairE eff' body' <- applyAbs (Abs b (PairE eff body)) (SubstVal x)
+  return (eff', body')
 
 -- === the type checking/querying monad ===
 


### PR DESCRIPTION
This implements the inference pass assuming the existence of a monadic API with `constrainEq`, `zonk` etc. Actually implementing that API will be a separate PR. I want to consolidate the different monad classes/transformers first because they're getting out of hand.
