### PR TITLE
Make `Fallible`, a class for throwing errors but not catching them.

### DIFF
--- a/src/dex.hs
+++ b/src/dex.hs
@@ -71,7 +71,7 @@ runMode evalMode preludeFile opts = do
       let errors = foldMap (\case (Result _ (Left err)) -> [err]; _ -> []) results
       putStr $ foldMap (nonEmptyNewline . pprint) errors
       let exportedFuns = foldMap (\case (ExportedFun name f) -> [(name, f)]; _ -> []) outputs
-      unless (backendName opts == LLVM) $ liftEitherIO $
+      unless (backendName opts == LLVM) $
         throw CompilerErr "Export only supported with the LLVM CPU backend"
       TopStateEx env' <- return env
       exportFunctions objPath exportedFuns $ topBindings $ topStateD env'

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -64,7 +64,7 @@ import PPrint ()
 import Util (bindM2, scanM, restructure)
 
 newtype BuilderT m a = BuilderT (ReaderT BuilderEnvR (CatT BuilderEnvC m) a)
-  deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Alternative)
+  deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Fallible, Alternative)
 
 type Builder = BuilderT Identity
 type BuilderEnv = (BuilderEnvR, BuilderEnvC)
@@ -140,7 +140,7 @@ freshNestedBindersRec substEnv (Nest b bs) = do
   vs <- freshNestedBindersRec (substEnv <> b @> SubstVal (Var v)) bs
   return $ Nest v vs
 
-buildPi :: (MonadError Err m, MonadBuilder m)
+buildPi :: (Fallible m, MonadBuilder m)
         => Binder -> (Atom -> m (Arrow, Type)) -> m Atom
 buildPi b f = do
   scope <- getScope
@@ -675,16 +675,6 @@ instance (Monoid env, MonadCat env m) => MonadCat env (BuilderT m) where
     ((ans, env'), scopeEnv) <- lift $ lift $ scoped $ runCatT (runReaderT m name) env
     extend env'
     return (ans, scopeEnv)
-
-instance MonadError e m => MonadError e (BuilderT m) where
-  throwError = lift . throwError
-  catchError m catch = do
-    envC <- builderLook
-    envR <- builderAsk
-    (ans, envC') <- lift $ runBuilderT' m (envR, envC)
-                     `catchError` (\e -> runBuilderT' (catch e) (envR, envC))
-    builderExtend envC'
-    return ans
 
 instance MonadReader r m => MonadReader r (BuilderT m) where
   ask = lift ask

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -4,18 +4,26 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE FlexibleContexts #-}
 {-# LANGUAGE ConstraintKinds #-}
 
-module Err (Err (..), ErrType (..), Except, SrcPos, SrcCtx,
-            throw, throwIf, modifyErr, MonadErr,
-            addContext, addSrcContext, catchIOExcept, liftEitherIO,
-            assertEq, ignoreExcept, pprint, docAsStr, asCompilerErr) where
+module Err (Err (..), Errs (..), ErrType (..), Except, ErrCtx (..),
+            SrcPosCtx, SrcTextCtx, SrcPos,
+            Fallible (..), FallibleM (..), HardFailM (..),
+            runHardFail, throw, throwIf,
+            addContext, addSrcContext, addSrcTextContext,
+            catchIOExcept, liftExcept,
+            assertEq, ignoreExcept, pprint, docAsStr, asCompilerErr,
+            SeqFallibleApplicative, traverseMergingErrs) where
 
 import Control.Exception hiding (throw)
+import Control.Applicative
 import Control.Monad
-import Control.Monad.Except hiding (Except)
+import Control.Monad.Identity
+import Control.Monad.State.Strict
+import Control.Monad.Reader
 import Data.Text (unpack)
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
@@ -23,7 +31,11 @@ import GHC.Stack
 import System.Environment
 import System.IO.Unsafe
 
-data Err = Err ErrType SrcCtx String  deriving (Show, Eq)
+-- === core API ===
+
+data Err = Err ErrType ErrCtx String  deriving (Show, Eq)
+newtype Errs = Errs [Err]  deriving (Show, Eq, Semigroup, Monoid)
+
 data ErrType = NoErr
              | ParseErr
              | TypeErr
@@ -42,60 +54,141 @@ data ErrType = NoErr
              | ZipErr
              | EscapedNameErr
              | ModuleImportErr
+             | MonadFailErr
                deriving (Show, Eq)
 
-type Except = Either Err
+type SrcPosCtx  = Maybe SrcPos
+type SrcTextCtx = Maybe (Int, String) -- Int is the offset in the source file
+data ErrCtx = ErrCtx
+  { srcTextCtx :: SrcTextCtx
+  , srcPosCtx  :: SrcPosCtx
+  , messageCtx :: [String] }
+    deriving (Show, Eq)
+
+type Except = Either Errs
 
 type SrcPos = (Int, Int)
-type SrcCtx = Maybe SrcPos
 
-type MonadErr = MonadError Err
+class MonadFail m => Fallible m where
+  throwErrs :: Errs -> m a
+  addErrCtx :: ErrCtx -> m a -> m a
 
-throw :: MonadErr m => ErrType -> String -> m a
-throw e s = throwError $ Err e Nothing s
+-- We have this in its own class because IO and `Either Err` can't implement it
+class Fallible m => CtxReader m where
+  getErrCtx :: m ErrCtx
 
-throwIf :: MonadErr m => Bool -> ErrType -> String -> m ()
+-- We have this in its own class because StateT can't implement it
+class Fallible m => FallibleApplicative m where
+  mergeErrs :: m a -> m b -> m (a, b)
+
+newtype FallibleM a =
+  FallibleM { fromFallibleM :: ReaderT ErrCtx (Either Errs) a }
+  deriving (Functor, Applicative, Monad)
+
+instance Fallible FallibleM where
+  throwErrs errs = FallibleM $ lift $ throwErrs errs
+  addErrCtx ctx (FallibleM m) = FallibleM $ local (<> ctx) m
+
+instance FallibleApplicative FallibleM where
+  mergeErrs (FallibleM (ReaderT f1)) (FallibleM (ReaderT f2)) =
+    FallibleM $ ReaderT \ctx -> mergeErrs (f1 ctx) (f2 ctx)
+
+instance CtxReader FallibleM where
+  getErrCtx = FallibleM ask
+
+instance Fallible IO where
+  throwErrs errs = throwIO errs
+  addErrCtx ctx m = do
+    result <- catchIOExcept m
+    liftExcept $ addErrCtx ctx result
+
+instance FallibleApplicative IO where
+  mergeErrs m1 m2 = do
+    result1 <- catchIOExcept m1
+    result2 <- catchIOExcept m2
+    liftExcept $ mergeErrs result1 result2
+
+-- === SeqFallibleApplicative ===
+
+-- Wraps a Fallible monad, presenting an applicative interface that sequences
+-- actions using the error-concatenating `mergeErrs` instead of the default
+-- abort-on-failure sequencing.
+
+newtype SeqFallibleApplicative m a =
+  SeqFallibleApplicative { fromSeqFallibleApplicative :: m a }
+  deriving (Functor)
+
+instance FallibleApplicative m => Applicative (SeqFallibleApplicative m) where
+  pure x = SeqFallibleApplicative $ pure x
+  liftA2 f (SeqFallibleApplicative m1) (SeqFallibleApplicative m2) =
+    SeqFallibleApplicative $ fmap (uncurry f) (mergeErrs m1 m2)
+
+-- === HardFail ===
+
+-- Implements Fallible by crashing. Used in type querying when we want to avoid
+-- work by trusting decl annotations and skipping the checks.
+newtype HardFailM a =
+  HardFailM { runHardFail' :: Identity a }
+  deriving (Functor, Applicative, Monad)
+
+runHardFail :: HardFailM a -> a
+runHardFail m = runIdentity $ runHardFail' m
+
+instance MonadFail HardFailM where
+  fail s = error s
+
+instance Fallible HardFailM where
+  throwErrs errs = error $ pprint errs
+  addErrCtx _ cont = cont
+
+instance FallibleApplicative HardFailM where
+  mergeErrs cont1 cont2 = (,) <$> cont1 <*> cont2
+
+-- === convenience layer ===
+
+throw :: Fallible m => ErrType -> String -> m a
+throw errTy s = throwErrs $ Errs [Err errTy mempty s]
+
+throwIf :: Fallible m => Bool -> ErrType -> String -> m ()
 throwIf True  e s = throw e s
 throwIf False _ _ = return ()
 
-modifyErr :: MonadError e m => m a -> (e -> e) -> m a
-modifyErr m f = catchError m \e -> throwError (f e)
+addContext :: Fallible m => String -> m a -> m a
+addContext s m = addErrCtx (mempty {messageCtx = [s]}) m
 
-asCompilerErr :: MonadErr m => m a -> m a
-asCompilerErr m =
-  modifyErr m (\(Err _ c msg) -> Err CompilerErr c msg)
+addSrcContext :: Fallible m => SrcPosCtx -> m a -> m a
+addSrcContext ctx m = addErrCtx (mempty {srcPosCtx = ctx}) m
 
-addContext :: MonadErr m => String -> m a -> m a
-addContext s m = modifyErr m \(Err e p s') -> Err e p (s' ++ "\n" ++ s)
+addSrcTextContext :: Fallible m => Int -> String -> m a -> m a
+addSrcTextContext offset text m =
+  addErrCtx (mempty {srcTextCtx = Just (offset, text)}) m
 
-addSrcContext :: MonadErr m => SrcCtx -> m a -> m a
-addSrcContext ctx m = modifyErr m updateErr
-  where
-    updateErr :: Err -> Err
-    updateErr (Err e ctx' s) = case ctx' of Nothing -> Err e ctx  s
-                                            Just _  -> Err e ctx' s
-
-catchIOExcept :: (MonadIO m , MonadErr m) => IO a -> m a
-catchIOExcept m = (liftIO >=> liftEither) $ (liftM Right m) `catches`
-  [ Handler \(e::Err)           -> return $ Left e
-  , Handler \(e::IOError)       -> return $ Left $ Err DataIOErr   Nothing $ show e
-  , Handler \(e::SomeException) -> return $ Left $ Err CompilerErr Nothing $ show e
+catchIOExcept :: MonadIO m => IO a -> m (Except a)
+catchIOExcept m = liftIO $ (liftM Right m) `catches`
+  [ Handler \(e::Errs)          -> return $ Left e
+  , Handler \(e::IOError)       -> return $ Left $ Errs [Err DataIOErr   mempty $ show e]
+  , Handler \(e::SomeException) -> return $ Left $ Errs [Err CompilerErr mempty $ show e]
   ]
 
-liftEitherIO :: (Exception e, MonadIO m) => Either e a -> m a
-liftEitherIO (Left err) = liftIO $ throwIO err
-liftEitherIO (Right x ) = return x
+liftExcept :: Fallible m => Except a -> m a
+liftExcept (Left errs) = throwErrs errs
+liftExcept (Right ans) = return ans
 
 ignoreExcept :: HasCallStack => Except a -> a
 ignoreExcept (Left e) = error $ pprint e
 ignoreExcept (Right x) = x
 
-assertEq :: (HasCallStack, MonadErr m, Show a, Pretty a, Eq a) => a -> a -> String -> m ()
+assertEq :: (HasCallStack, Fallible m, Show a, Pretty a, Eq a) => a -> a -> String -> m ()
 assertEq x y s = if x == y then return ()
                            else throw CompilerErr msg
   where msg = "assertion failure (" ++ s ++ "):\n"
               ++ pprint x ++ " != " ++ pprint y ++ "\n\n"
               ++ prettyCallStack callStack ++ "\n"
+
+-- TODO: think about the best way to handle these. This is just a
+-- backwards-compatibility shim.
+asCompilerErr :: Fallible m => m a -> m a
+asCompilerErr cont = addContext "(This is a compiler error!)" cont
 
 -- === small pretty-printing utils ===
 -- These are here instead of in PPrint.hs for import cycle reasons
@@ -110,15 +203,53 @@ layout :: LayoutOptions
 layout = if unbounded then LayoutOptions Unbounded else defaultLayoutOptions
   where unbounded = unsafePerformIO $ (Just "1"==) <$> lookupEnv "DEX_PPRINT_UNBOUNDED"
 
+traverseMergingErrs :: (Traversable f, FallibleApplicative m)
+                    => (a -> m b) -> f a -> m (f b)
+traverseMergingErrs f xs =
+  fromSeqFallibleApplicative $ traverse (\x -> SeqFallibleApplicative $ f x) xs
+
 -- === instances ===
 
-instance MonadFail (Either Err) where
-  fail s = Left $ Err CompilerErr Nothing s
+instance MonadFail FallibleM where
+  fail s = throw MonadFailErr s
 
-instance Exception Err
+instance Fallible (Either Errs) where
+  throwErrs errs = Left errs
+
+  addErrCtx _ (Right ans) = Right ans
+  addErrCtx ctx (Left (Errs errs)) =
+    Left $ Errs [Err errTy (ctx <> ctx') s | Err errTy ctx' s <- errs]
+
+instance FallibleApplicative (Either Errs) where
+  mergeErrs (Right x) (Right y) = Right (x, y)
+  mergeErrs x y = Left (getErrs x <> getErrs y)
+    where getErrs :: Except a -> Errs
+          getErrs = \case Left e  -> e
+                          Right _ -> mempty
+
+instance MonadFail (Either Errs) where
+  fail s = Left $ Errs [Err CompilerErr mempty s]
+
+instance Exception Errs
 
 instance Pretty Err where
-  pretty (Err e _ s) = pretty e <> pretty s
+  pretty (Err e ctx s) = pretty e <> pretty s <> prettyCtx
+    -- TODO: figure out a more uniform way to newlines
+    where prettyCtx = case ctx of
+            ErrCtx _ Nothing [] -> mempty
+            _ -> hardline <> pretty ctx
+
+instance Pretty ErrCtx where
+  pretty (ErrCtx maybeTextCtx maybePosCtx messages) =
+    -- The order of messages is outer-scope-to-inner-scope, but we want to print
+    -- them starting the other way around (Not for a good reason. It's just what
+    -- we've always done.)
+    prettyLines (reverse messages) <> highlightedSource
+    where
+      highlightedSource = case (maybeTextCtx, maybePosCtx) of
+        (Just (offset, text), Just (start, stop)) ->
+           hardline <> pretty (highlightRegion (start - offset, stop - offset) text)
+        _ -> mempty
 
 instance Pretty ErrType where
   pretty e = case e of
@@ -144,3 +275,80 @@ instance Pretty ErrType where
     ZipErr            -> "Zipping error"
     EscapedNameErr    -> "Escaped name"
     ModuleImportErr   -> "Module import error"
+    MonadFailErr      -> "MonadFail error (internal error)"
+
+instance Fallible m => Fallible (ReaderT r m) where
+  throwErrs errs = lift $ throwErrs errs
+  addErrCtx ctx (ReaderT f) = ReaderT \r -> addErrCtx ctx $ f r
+
+instance FallibleApplicative m => FallibleApplicative (ReaderT r m) where
+  mergeErrs (ReaderT f1) (ReaderT f2) =
+    ReaderT \r -> mergeErrs (f1 r) (f2 r)
+
+instance CtxReader m => CtxReader (ReaderT r m) where
+  getErrCtx = lift getErrCtx
+
+instance Pretty Errs where
+  pretty (Errs [err]) = pretty err
+  pretty (Errs errs) = prettyLines errs
+
+instance Fallible m => Fallible (StateT s m) where
+  throwErrs errs = lift $ throwErrs errs
+  addErrCtx ctx (StateT f) = StateT \s -> addErrCtx ctx $ f s
+
+instance CtxReader m => CtxReader (StateT s m) where
+  getErrCtx = lift getErrCtx
+
+instance Semigroup ErrCtx where
+  ErrCtx text pos ctxStrs <> ErrCtx text' pos' ctxStrs' =
+    ErrCtx (leftmostJust  text text')
+           (rightmostJust pos  pos' )
+           (ctxStrs <> ctxStrs')
+instance Monoid ErrCtx where
+  mempty = ErrCtx Nothing Nothing []
+
+-- === misc util stuff ===
+
+leftmostJust :: Maybe a -> Maybe a -> Maybe a
+leftmostJust (Just x) _ = Just x
+leftmostJust Nothing y  = y
+
+rightmostJust :: Maybe a -> Maybe a -> Maybe a
+rightmostJust _ (Just y) = Just y
+rightmostJust x Nothing  = x
+
+prettyLines :: (Foldable f, Pretty a) => f a -> Doc ann
+prettyLines xs = foldMap (\d -> pretty d <> hardline) xs
+
+highlightRegion :: (Int, Int) -> String -> String
+highlightRegion pos@(low, high) s
+  | low > high || high > length s = error $ "Bad region: \n"
+                                              ++ show pos ++ "\n" ++ s
+  | otherwise =
+    -- TODO: flag to control line numbers
+    -- (disabling for now because it makes quine tests tricky)
+    -- "Line " ++ show (1 + lineNum) ++ "\n"
+
+    allLines !! lineNum ++ "\n"
+    ++ take start (repeat ' ') ++ take (stop - start) (repeat '^') ++ "\n"
+  where
+    allLines = lines s
+    (lineNum, start, stop) = getPosTriple pos allLines
+
+getPosTriple :: (Int, Int) -> [String] -> (Int, Int, Int)
+getPosTriple (start, stop) lines_ = (lineNum, start - offset, stop')
+  where
+    lineLengths = map ((+1) . length) lines_
+    lineOffsets = cumsum lineLengths
+    lineNum = maxLT lineOffsets start
+    offset = lineOffsets  !! lineNum
+    stop' = min (stop - offset) (lineLengths !! lineNum)
+
+cumsum :: [Int] -> [Int]
+cumsum xs = scanl (+) 0 xs
+
+maxLT :: Ord a => [a] -> a -> Int
+maxLT [] _ = 0
+maxLT (x:xs) n = if n < x then -1
+                          else 1 + maxLT xs n
+

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -37,7 +37,7 @@ import Optimize
 exportFunctions :: FilePath -> [(String, Atom)] -> Bindings -> IO ()
 exportFunctions objPath funcs env = do
   let names = fmap fst funcs
-  unless (length (nub names) == length names) $ liftEitherIO $
+  unless (length (nub names) == length names) $
     throw CompilerErr "Duplicate export names"
   modules <- forM funcs $ \(name, funcAtom) -> do
     let (impModule, _) = prepareFunctionForExport env name funcAtom

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1290,7 +1290,7 @@ withDevice device = local (\opts -> opts {curDevice = device })
 -- "shouldn't launch a kernel from device/thread code"
 
 -- State keeps track of _all_ names used in the program, Reader keeps the type env.
-type ImpCheckM a = StateT (Env ()) (ReaderT (Env IType, Device) (Either Err)) a
+type ImpCheckM a = StateT (Env ()) (ReaderT (Env IType, Device) (Either Errs)) a
 
 instance Checkable ImpModule where
   -- TODO: check main function defined
@@ -1479,14 +1479,14 @@ impInstrTypes instr = case instr of
   IQueryParallelism _ _ -> [IIdxRepTy, IIdxRepTy]
   ICall (_:>IFunType _ _ resultTys) _ -> resultTys
 
-checkImpBinOp :: MonadError Err m => BinOp -> IType -> IType -> m IType
+checkImpBinOp :: Fallible m => BinOp -> IType -> IType -> m IType
 checkImpBinOp op x y = do
   retTy <- checkBinOp op (BaseTy x) (BaseTy y)
   case retTy of
     BaseTy bt -> return bt
     _         -> throw CompilerErr $ "Unexpected BinOp return type: " ++ pprint retTy
 
-checkImpUnOp :: MonadError Err m => UnOp -> IType -> m IType
+checkImpUnOp :: Fallible m => UnOp -> IType -> m IType
 checkImpUnOp op x = do
   retTy <- checkUnOp op (BaseTy x)
   case retTy of

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -13,7 +13,6 @@ module Inference (inferModule, synthModule) where
 import Control.Applicative
 import Control.Monad
 import Control.Monad.Reader
-import Control.Monad.Except hiding (Except)
 import Data.Maybe (fromJust)
 import Data.Foldable (fold, toList)
 import Data.Functor
@@ -33,8 +32,9 @@ import Type
 import PPrint
 import Cat
 import Util
+import Err
 
-type UInferM = ReaderT SubstEnv (ReaderT SrcCtx ((BuilderT (SolverT (Either Err)))))
+type UInferM = ReaderT SubstEnv (ReaderT SrcPosCtx ((BuilderT (SolverT (Either Errs)))))
 
 type SigmaType = Type  -- may     start with an implicit lambda
 type RhoType   = Type  -- doesn't start with an implicit lambda
@@ -731,7 +731,7 @@ checkAllowedUnconditionally Pure = return True
 checkAllowedUnconditionally eff = do
   eff' <- zonk eff
   effAllowed <- getAllowedEffects >>= zonk
-  return $ case checkExtends effAllowed eff' of
+  return $ case checkExtends effAllowed eff' :: Except () of
     Left _   -> False
     Right () -> True
 
@@ -739,20 +739,20 @@ openEffectRow :: EffectRow -> UInferM EffectRow
 openEffectRow (EffectRow effs Nothing) = extendEffRow effs <$> freshEff
 openEffectRow effRow = return effRow
 
-addSrcContext' :: SrcCtx -> UInferM a -> UInferM a
+addSrcContext' :: SrcPosCtx -> UInferM a -> UInferM a
 addSrcContext' pos m = do
   env <- ask
   addSrcContext pos $ lift $
     local (const pos) $ runReaderT m env
 
-getSrcCtx :: UInferM SrcCtx
+getSrcCtx :: UInferM SrcPosCtx
 getSrcCtx = lift ask
 
 -- === typeclass dictionary synthesizer ===
 
 -- We have two variants here because at the top level we want error messages and
 -- internally we want to consider all alternatives.
-type SynthPassM = SubstBuilderT (Either Err)
+type SynthPassM = SubstBuilderT (Either Errs)
 type SynthDictM = SubstBuilderT []
 
 synthModule :: Scope -> SynthCandidates -> Module -> Except Module
@@ -765,7 +765,7 @@ synthModule scope scs (Module Typed decls result) = do
   return $ Module Core decls' result'
 synthModule _ _ _ = error $ "Unexpected IR variant"
 
-synthDictTop :: SrcCtx -> Type -> SynthPassM Atom
+synthDictTop :: SrcPosCtx -> Type -> SynthPassM Atom
 synthDictTop ctx ty = do
   scope <- getScope
   scs <- getSynthCandidates
@@ -777,7 +777,7 @@ synthDictTop ctx ty = do
            ++ "\n" ++ pprint solutions
 
 traverseHoles :: (MonadReader SubstEnv m, MonadBuilder m)
-              => (SrcCtx -> Type -> m Atom) -> TraversalDef m
+              => (SrcPosCtx -> Type -> m Atom) -> TraversalDef m
 traverseHoles fillHole = (traverseDecl recur, traverseExpr recur, synthPassAtom)
   where
     synthPassAtom atom = case atom of
@@ -846,7 +846,7 @@ data SolverEnv = SolverEnv { solverVars :: Env Kind
                            , solverSub  :: Env (SubstVal Type) }
 type SolverT m = CatT SolverEnv m
 
-runSolverT :: (MonadError Err m, HasVars a, Subst a, Pretty a)
+runSolverT :: (Fallible m, HasVars a, Subst a, Pretty a)
            => CatT SolverEnv m a -> m a
 runSolverT m = liftM fst $ flip runCatT mempty $ do
    ans <- m >>= zonk
@@ -893,21 +893,21 @@ checkLeaks tvs m = do
 unsolved :: SolverEnv -> Env Kind
 unsolved (SolverEnv vs sub) = vs `envDiff` sub
 
-freshInferenceName :: (MonadError Err m, MonadCat SolverEnv m) => Kind -> m Name
+freshInferenceName :: (Fallible m, MonadCat SolverEnv m) => Kind -> m Name
 freshInferenceName k = do
   env <- look
   let v = genFresh (rawName InferenceName "?") $ solverVars env
   extend $ SolverEnv (v@>k) mempty
   return v
 
-freshType ::  (MonadError Err m, MonadCat SolverEnv m) => Kind -> m Type
+freshType ::  (Fallible m, MonadCat SolverEnv m) => Kind -> m Type
 freshType EffKind = Eff <$> freshEff
 freshType k = Var . (:>k) <$> freshInferenceName k
 
-freshEff :: (MonadError Err m, MonadCat SolverEnv m) => m EffectRow
+freshEff :: (Fallible m, MonadCat SolverEnv m) => m EffectRow
 freshEff = EffectRow mempty . Just <$> freshInferenceName EffKind
 
-constrainEq :: (MonadCat SolverEnv m, MonadError Err m)
+constrainEq :: (MonadCat SolverEnv m, Fallible m)
              => Type -> Type -> m ()
 constrainEq t1 t2 = do
   t1' <- zonk t1
@@ -924,7 +924,7 @@ zonk x = do
   s <- looks solverSub
   return $ scopelessSubst s x
 
-unify :: (MonadCat SolverEnv m, MonadError Err m)
+unify :: (MonadCat SolverEnv m, Fallible m)
        => Type -> Type -> m ()
 unify t1 t2 = do
   t1' <- zonk t1
@@ -954,7 +954,7 @@ unify t1 t2 = do
     (Eff eff, Eff eff') -> unifyEff eff eff'
     _ -> throw TypeErr ""
 
-unifyExtLabeledItems :: (MonadCat SolverEnv m, MonadError Err m)
+unifyExtLabeledItems :: (MonadCat SolverEnv m, Fallible m)
   => ExtLabeledItems Type Name -> ExtLabeledItems Type Name -> m ()
 unifyExtLabeledItems r1 r2 = do
   r1' <- zonk r1
@@ -980,8 +980,7 @@ unifyExtLabeledItems r1 r2 = do
       unifyExtLabeledItems (Ext NoLabeledItems t2)
                            (Ext (LabeledItems extras1) (Just newTail))
 
-unifyEff :: (MonadCat SolverEnv m, MonadError Err m)
-         => EffectRow -> EffectRow -> m ()
+unifyEff :: (MonadCat SolverEnv m, Fallible m) => EffectRow -> EffectRow -> m ()
 unifyEff r1 r2 = do
   r1' <- zonk r1
   r2' <- zonk r2
@@ -998,7 +997,7 @@ unifyEff r1 r2 = do
       unifyEff (extendEffRow extras1 newRow) (EffectRow mempty t2)
     _ -> throw TypeErr ""
 
-bindQ :: (MonadCat SolverEnv m, MonadError Err m) => Var -> Type -> m ()
+bindQ :: (MonadCat SolverEnv m, Fallible m) => Var -> Type -> m ()
 bindQ v t | v `occursIn` t = throw TypeErr $ "Occurs check failure: " ++ pprint (v, t)
           | hasSkolems t = throw TypeErr "Can't unify with skolem vars"
           | otherwise = extend $ mempty { solverSub = v@>SubstVal t }

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -97,7 +97,7 @@ compileAndBench shouldSyncCUDA logger ast fname args resultTypes = do
             let run = do
                   let (CInt fd') = fdFD fd
                   exitCode <- callFunPtr fPtr fd' argsPtr resultPtr
-                  unless (exitCode == 0) $ throwIO $ Err RuntimeErr Nothing ""
+                  unless (exitCode == 0) $ throw RuntimeErr ""
                   freeLitVals resultPtr resultTypes
             let sync = when shouldSyncCUDA $ synchronizeCUDA
             exampleDuration <- snd <$> measureSeconds (run >> sync)
@@ -127,7 +127,7 @@ checkedCallFunPtr fd argsPtr resultPtr fPtr = do
   (exitCode, duration) <- measureSeconds $ do
     exitCode <- callFunPtr fPtr fd' argsPtr resultPtr
     return exitCode
-  unless (exitCode == 0) $ throwIO $ Err RuntimeErr Nothing ""
+  unless (exitCode == 0) $ throw RuntimeErr ""
   return duration
 
 compileOneOff :: Logger [Output] -> L.Module -> String -> (DexExecutable -> IO a) -> IO a

--- a/src/lib/Logging.hs
+++ b/src/lib/Logging.hs
@@ -20,6 +20,7 @@ import Prelude hiding (log)
 import System.IO
 
 import PPrint
+import Err
 
 data Logger l = Logger (MVar l) (Maybe Handle)
 
@@ -47,7 +48,8 @@ readLog (Logger log _) = liftIO $ readMVar log
 -- === monadic interface ===
 
 newtype LoggerT l m a = LoggerT (ReaderT (Logger l) m a)
-                        deriving (Functor, Applicative, Monad, MonadTrans, MonadIO)
+                        deriving (Functor, Applicative, Monad, MonadTrans,
+                                  MonadIO, MonadFail, Fallible)
 
 class (Pretty l, Monoid l, Monad m) => MonadLogger l m | m -> l where
   getLogger :: m (Logger l)
@@ -62,4 +64,3 @@ logIO val = do
 
 runLoggerT :: Monoid l => Logger l -> LoggerT l m a -> m a
 runLoggerT l (LoggerT m) = runReaderT m l
-

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -25,6 +25,7 @@ import qualified Text.Megaparsec.Debug
 import LabeledItems
 import Syntax
 import PPrint
+import Err
 
 -- canPair is used for the ops (,) (|) (&) which should only appear inside
 -- parentheses (to avoid conflicts with records and other syntax)

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -350,7 +350,7 @@ buildPureNaryLam arr (EmptyAbs (Nest (b:>ty) rest)) cont = do
       cont (x':xs)
 buildPureNaryLam _ _ _ = error "impossible"
 
-buildPi :: (MonadErr1 m, Builder m)
+buildPi :: (Fallible1 m, Builder m)
         => Arrow -> Type n
         -> (forall l. Ext n l => AtomName l -> m l (EffectRow l, Type l))
         -> m n (Type n)
@@ -362,7 +362,7 @@ buildPi arr ty body = do
   Abs b (PairE effs resultTy) <- return ab
   return $ Pi $ PiType arr b effs resultTy
 
-buildNonDepPi :: (MonadErr1 m, Builder m)
+buildNonDepPi :: (Fallible1 m, Builder m)
               => Arrow -> Type n -> EffectRow n -> Type n -> m n (Type n)
 buildNonDepPi arr argTy effs resultTy = buildPi arr argTy \_ -> do
   resultTy' <- injectM resultTy

--- a/src/lib/SaferNames/SourceRename.hs
+++ b/src/lib/SaferNames/SourceRename.hs
@@ -23,7 +23,7 @@ import SaferNames.Name
 import SaferNames.ResolveImplicitNames
 import SaferNames.Syntax
 
-renameSourceNames :: MonadErr m => Scope (n::S) -> SourceMap n -> SourceUModule -> m (UModule n)
+renameSourceNames :: Fallible m => Scope (n::S) -> SourceMap n -> SourceUModule -> m (UModule n)
 -- renameSourceNames scope sourceMap m =
 --   runReaderT (runReaderT (renameSourceNames' m) (scope, sourceMap)) False
 renameSourceNames = undefined
@@ -33,7 +33,7 @@ renameSourceNames = undefined
 -- We have this class because we want to read some extra context (whether
 -- shadowing is allowed) but we've already used up the MonadReader
 -- (we can't add a field because we want it to be monoidal).
-class (Monad1 m, ScopeExtender m, MonadErr1 m) => Renamer m where
+class (Monad1 m, ScopeExtender m, Fallible1 m) => Renamer m where
   askMayShadow :: m n Bool
   setMayShadow :: Bool -> m n a -> m n a
   askSourceMap :: m n (SourceMap n)
@@ -52,11 +52,11 @@ class (Monad1 m, ScopeExtender m, MonadErr1 m) => Renamer m where
 
 -- instance ScopeExtender RenamerData where
 
--- instance MonadError Err (RenamerData n) where
+-- instance Fallibleor Err (RenamerData n) where
 
 -- instance Renamer RenamerData where
 
--- instance MonadErr m => Renamer n (ReaderT (RenameEnv n) (ReaderT Bool m)) where
+-- instance Fallible m => Renamer n (ReaderT (RenameEnv n) (ReaderT Bool m)) where
 --   askMayShadow = lift ask
 --   setMayShadow mayShadow cont = do
 --     env <- ask

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -50,7 +50,7 @@ import Logging
 import LLVMExec
 import PPrint()
 import Parser
-import Util (highlightRegion, measureSeconds, onFst, onSnd)
+import Util (measureSeconds, onFst, onSnd)
 import Optimize
 import Parallelize
 
@@ -102,7 +102,7 @@ execInterblockM opts env m = snd <$> runInterblockM opts env m
 
 -- === monad for wiring together the passes within each source block ===
 
-class ( forall n. MonadErr (m n)
+class ( forall n. Fallible (m n)
       , forall n. MonadLogger [Output] (m n)
       , forall n. ConfigReader (m n)
       , forall n. MonadIO (m n) )
@@ -113,17 +113,18 @@ class ( forall n. MonadErr (m n)
 newtype PassesM (n::S.S) a = PassesM
   { runPassesM' :: ReaderT (Bool, EvalConfig, (S.DistinctWitness n, JointTopState n))
                      (LoggerT [Output] IO) a }
-    deriving (Functor, Applicative, Monad, MonadIO)
+    deriving (Functor, Applicative, Monad, MonadIO, MonadFail, Fallible)
 
 type ModulesImported = M.Map ModuleName ModuleImportStatus
 
 data ModuleImportStatus = CurrentlyImporting | FullyImported  deriving Generic
 
 runPassesM :: S.Distinct n => Bool -> EvalConfig -> JointTopState n -> PassesM n a -> IO (Except a, [Output])
-runPassesM bench opts env (PassesM m) = do
+runPassesM bench opts env m = do
   let maybeLogFile = logFile opts
   runLogger maybeLogFile \l ->
-    runExceptT $ catchIOExcept $ runLoggerT l $ runReaderT m $ (bench, opts, (S.Distinct, env))
+    catchIOExcept $ runLoggerT l $ runReaderT (runPassesM' m) $
+      (bench, opts, (S.Distinct, env))
 
 -- ======
 
@@ -297,7 +298,7 @@ evalUModuleVal v m = do
      AtomBinderInfo _ (LetBound _ (Atom atom)) -> return atom
      _ -> throw TypeErr $ "Not an atom name: " ++ pprint v
 
-lookupSourceName :: MonadErr m => TopStateEx -> SourceName -> m AnyBinderInfo
+lookupSourceName :: Fallible m => TopStateEx -> SourceName -> m AnyBinderInfo
 lookupSourceName (TopStateEx topState) v =
   let D.TopState bindings _ (SourceMap sourceMap) = topStateD topState
   in case M.lookup v sourceMap of
@@ -317,13 +318,13 @@ evalUModule sourceModule = do
   logPass Parse sourceModule
   renamed <- renameSourceNames bindings sourceMap sourceModule
   logPass RenamePass renamed
-  typed <- liftEither $ inferModule bindings renamed
+  typed <- liftExcept $ inferModule bindings renamed
   -- This is a (hopefully) no-op pass. It's here as a sanity check to test the
   -- safer names system while we're staging it in.
   checkPass TypePass typed
   typed' <- roundtripSaferNamesPass typed
   checkPass TypePass typed'
-  synthed <- liftEither $ synthModule bindings synthCandidates typed'
+  synthed <- liftExcept $ synthModule bindings synthCandidates typed'
   -- TODO: check that the type of module exports doesn't change from here on
   checkPass SynthPass synthed
   let defunctionalized = simplifyModule bindings synthed
@@ -428,24 +429,15 @@ checkPass name x = do
   (S.Distinct, topState) <- getTopState
   let scope = topBindings $ topStateD topState
   logPass name x
-  liftEither $ checkValid scope x
+  liftExcept $ checkValid scope x
   logTop $ MiscLog $ pprint name ++ " checks passed"
 
 logPass :: (MonadPasses m, Pretty a) => PassName -> a -> m n ()
 logPass passName x = logTop $ PassInfo passName $ pprint x
 
 addResultCtx :: SourceBlock -> Result -> Result
-addResultCtx block (Result outs maybeErr) = case maybeErr of
-  Left err -> Result outs $ Left $ addCtx block err
-  Right () -> Result outs $ Right ()
-
-addCtx :: SourceBlock -> Err -> Err
-addCtx block err@(Err e src s) = case src of
-  Nothing -> err
-  Just (start, stop) ->
-    Err e Nothing $ s ++ "\n\n" ++ ctx
-    where n = sbOffset block
-          ctx = highlightRegion (start - n, stop - n) (sbText block)
+addResultCtx block (Result outs errs) =
+  Result outs (addSrcTextContext (sbOffset block) (sbText block) errs)
 
 logTop :: MonadPasses m => Output -> m n ()
 logTop x = logIO [x]
@@ -503,16 +495,6 @@ instance ConfigReader (PassesM n) where
 instance MonadPasses PassesM where
   requireBenchmark = PassesM $ asks \(bench, _, _) -> bench
   getTopState      = PassesM $ asks \(_    , _, s) -> s
-
-instance MonadError Err (PassesM n) where
-  throwError err = liftEitherIO $ throwError err
-  catchError (PassesM m) f = PassesM do
-    env <- ask
-    l <- runPassesM' getLogger
-    result <- runExceptT $ catchIOExcept $ runLoggerT l $ runReaderT m env
-    case result of
-      Left e -> runPassesM' $ f e
-      Right x -> return x
 
 instance MonadLogger [Output] (PassesM n) where
   getLogger = PassesM $ lift $ getLogger

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -20,7 +20,6 @@ module Type (
 
 import Prelude hiding (pi)
 import Control.Monad
-import Control.Monad.Except hiding (Except)
 import Control.Monad.Reader
 import Data.Foldable (toList, traverse_)
 import Data.Functor
@@ -53,8 +52,8 @@ getType :: (HasCallStack, HasType a) => a -> Type
 getType x = ignoreExcept $ ctx $ runTypeCheck SkipChecks $ typeCheck x
   where ctx = addContext $ "Querying:\n" ++ pprint x
 
-tryGetType :: (MonadErr m, HasCallStack, HasType a) => a -> m Type
-tryGetType x = liftEither $ ctx $ runTypeCheck SkipChecks $ typeCheck x
+tryGetType :: (Fallible m, HasCallStack, HasType a) => a -> m Type
+tryGetType x = liftExcept $ ctx $ runTypeCheck SkipChecks $ typeCheck x
   where ctx = addContext $ "Querying:\n" ++ pprint x
 
 checkType :: HasType a => TypeEnv -> EffectRow -> a -> Except ()
@@ -488,10 +487,8 @@ goneBy ir = do
   curIR <- ask
   when (curIR >= ir) $ throw IRVariantErr $ "shouldn't appear after " ++ show ir
 
-addExpr :: (Pretty e, MonadError Err m) => e -> m a -> m a
-addExpr x m = modifyErr m \e -> case e of
-  Err IRVariantErr ctx s -> Err CompilerErr ctx (s ++ ": " ++ pprint x)
-  _ -> e
+addExpr :: (Pretty e, Fallible m) => e -> m a -> m a
+addExpr x m = addContext (pprint x) m
 
 -- === effects ===
 
@@ -514,7 +511,7 @@ declareEffs :: EffectRow -> TypeM ()
 declareEffs effs = checkWithEnv \(_, allowedEffects) ->
   checkExtends allowedEffects effs
 
-checkExtends :: MonadError Err m => EffectRow -> EffectRow -> m ()
+checkExtends :: Fallible m => EffectRow -> EffectRow -> m ()
 checkExtends allowed (EffectRow effs effTail) = do
   let (EffectRow allowedEffs allowedEffTail) = allowed
   case effTail of
@@ -647,7 +644,7 @@ typeCheckRef x = do
   TC (RefType _ a) <- typeCheck x
   return a
 
-checkIntBaseType :: MonadError Err m => Bool -> Type -> m ()
+checkIntBaseType :: Fallible m => Bool -> Type -> m ()
 checkIntBaseType allowVector t = case t of
   BaseTy (Scalar sbt)               -> checkSBT sbt
   BaseTy (Vector sbt) | allowVector -> checkSBT sbt
@@ -663,7 +660,7 @@ checkIntBaseType allowVector t = case t of
     notInt = throw TypeErr $ "Expected a fixed-width " ++ (if allowVector then "" else "scalar ") ++
                              "integer type, but found: " ++ pprint t
 
-checkFloatBaseType :: MonadError Err m => Bool -> Type -> m ()
+checkFloatBaseType :: Fallible m => Bool -> Type -> m ()
 checkFloatBaseType allowVector t = case t of
   BaseTy (Scalar sbt)               -> checkSBT sbt
   BaseTy (Vector sbt) | allowVector -> checkSBT sbt
@@ -967,14 +964,14 @@ litType v = case v of
 data ArgumentType = SomeFloatArg | SomeIntArg | SomeUIntArg
 data ReturnType   = SameReturn | Word8Return
 
-checkOpArgType :: MonadError Err m => ArgumentType -> Type -> m ()
+checkOpArgType :: Fallible m => ArgumentType -> Type -> m ()
 checkOpArgType argTy x =
   case argTy of
     SomeIntArg   -> checkIntBaseType   True x
     SomeUIntArg  -> assertEq x Word8Ty ""
     SomeFloatArg -> checkFloatBaseType True x
 
-checkBinOp :: MonadError Err m => BinOp -> Type -> Type -> m Type
+checkBinOp :: Fallible m => BinOp -> Type -> Type -> m Type
 checkBinOp op x y = do
   checkOpArgType argTy x
   assertEq x y ""
@@ -998,7 +995,7 @@ checkBinOp op x y = do
         ia = SomeIntArg; fa = SomeFloatArg
         br = Word8Return; sr = SameReturn
 
-checkUnOp :: MonadError Err m => UnOp -> Type -> m Type
+checkUnOp :: Fallible m => UnOp -> Type -> m Type
 checkUnOp op x = do
   checkOpArgType argTy x
   return $ case retTy of
@@ -1030,7 +1027,7 @@ indexSetConcreteSize ty = case ty of
   FixedIntRange low high -> Just $ fromIntegral $ high - low
   _                      -> Nothing
 
-checkDataLike :: MonadError Err m => String -> Type -> m ()
+checkDataLike :: Fallible m => String -> Type -> m ()
 checkDataLike msg ty = case ty of
   Var _ -> error "Not implemented"
   TabTy _ b -> recur b
@@ -1049,16 +1046,16 @@ checkDataLike msg ty = case ty of
   _   -> throw TypeErr $ pprint ty ++ msg
   where recur x = checkDataLike msg x
 
-checkDataLikeDataCon :: MonadError Err m => DataConDef -> m ()
+checkDataLikeDataCon :: Fallible m => DataConDef -> m ()
 checkDataLikeDataCon (DataConDef _ bs) =
   mapM_ (checkDataLike "data con binder" . binderAnn) bs
 
-checkData :: MonadError Err m => Type -> m ()
+checkData :: Fallible m => Type -> m ()
 checkData = checkDataLike " is not serializable"
 
 --TODO: Make this work even if the type has type variables!
 isData :: Type -> Bool
-isData ty = case checkData ty of
+isData ty = case checkData ty :: Except () of
   Left  _ -> False
   Right _ -> True
 

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -11,7 +11,7 @@ module Util (IsBool (..), group, ungroup, pad, padLeft, delIdx, replaceIdx,
              insertIdx, mvIdx, mapFst, mapSnd, splitOn, scan,
              scanM, composeN, mapMaybe, uncons, repeated, transitiveClosure,
              showErr, listDiff, splitMap, enumerate, restructure,
-             onSnd, onFst, highlightRegion, findReplace, swapAt, uncurry3,
+             onSnd, onFst, findReplace, swapAt, uncurry3,
              measureSeconds,
              bindM2, foldMapM, lookupWithIdx, (...), zipWithT, for,
              Zippable (..), zipWithZ_, zipErr, forMZipped, forMZipped_,
@@ -144,38 +144,6 @@ restructure xs structure = evalState (traverse procLeaf structure) xs
         procLeaf _ = do ~(x:rest) <- get
                         put rest
                         return x
-
-highlightRegion :: (Int, Int) -> String -> String
-highlightRegion pos@(low, high) s
-  | low > high || high > length s = error $ "Bad region: \n"
-                                              ++ show pos ++ "\n" ++ s
-  | otherwise =
-    -- TODO: flag to control line numbers
-    -- (disabling for now because it makes quine tests tricky)
-    -- "Line " ++ show (1 + lineNum) ++ "\n"
-
-    allLines !! lineNum ++ "\n"
-    ++ take start (repeat ' ') ++ take (stop - start) (repeat '^') ++ "\n"
-  where
-    allLines = lines s
-    (lineNum, start, stop) = getPosTriple pos allLines
-
-getPosTriple :: (Int, Int) -> [String] -> (Int, Int, Int)
-getPosTriple (start, stop) lines_ = (lineNum, start - offset, stop')
-  where
-    lineLengths = map ((+1) . length) lines_
-    lineOffsets = cumsum lineLengths
-    lineNum = maxLT lineOffsets start
-    offset = lineOffsets  !! lineNum
-    stop' = min (stop - offset) (lineLengths !! lineNum)
-
-cumsum :: [Int] -> [Int]
-cumsum xs = scanl (+) 0 xs
-
-maxLT :: Ord a => [a] -> a -> Int
-maxLT [] _ = 0
-maxLT (x:xs) n = if n < x then -1
-                          else 1 + maxLT xs n
 
 -- TODO: find a more efficient implementation
 findReplace :: Eq a => [a] -> [a] -> [a] -> [a]


### PR DESCRIPTION
Our go-to error-handling class had been `MonadError Err` which gives you both
`throwError` and `catchError`. But we never actually use `catchError` to recover
from errors. We just use it to add more error context and then re-raise.
Meanwhile, `catchError` in its full generality can't be implemented by some of
the monads we care about. In particular, it doesn't play well with our
name-scoping system because the value you throw might contain names that don't
make any sense in the handler's context.

In this change, we add the `Fallible` class to model this restricted error
handling. It just has methods for throwing and adding context.

There's a second potential use for `catchError` that we don't currently exploit:
continuing after an error long enough to collect further error information. Adam
had the insight that this looks like an applicative-but-not-monadic pattern: if
you want to sequence two computations where the second computation doesn't
depend on the result of the first, you can run the first and then run the second
even if the first failed. You get to collect all the errors from both
computations before you finally crash. For example, if we're doing type
inference on a decl with a user-annotated type, we'll check that the decl's rhs
matches the type supplied, but even if doesn't (or it's otherwise broken), we
can continue to check the rest of the program with the variable assumed to have
the user-supplied type.

I put this pattern in another class, `SeqFallibleApplicative`. I initially tried
making it part of `Fallible`, but `IO` and `Either Err` can't implement it. It
doesn't have any customers yet but we have the API and implementation if we want
to use it.