### PR TITLE
Add dexFromCAtom to the C API

### DIFF
--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -17,11 +17,22 @@ def tagged_union(name: str, members: List[type]):
   payload = type(name + "Payload", (ctypes.Union,), {"_fields_": named_members})
   union = type(name, (ctypes.Structure,), {
     "_fields_": [("tag", ctypes.c_uint64), ("payload", payload)],
-    "value": property(lambda self: getattr(self.payload, f"t{self.tag}")),
+    "value": property(
+        fget=lambda self: getattr(self.payload, f"t{self.tag}"),
+        fset=lambda self, value: setattr(self.payload, f"t{self.tag}", value)),
+    "Payload": payload,
   })
   return union
 
-CLit = tagged_union("Lit", [ctypes.c_int64, ctypes.c_int32, ctypes.c_int8, ctypes.c_double, ctypes.c_float])
+CLit = tagged_union("Lit", [
+  ctypes.c_int64,
+  ctypes.c_int32,
+  ctypes.c_uint8,
+  ctypes.c_double,
+  ctypes.c_float,
+  ctypes.c_uint32,
+  ctypes.c_uint64
+])
 class CRectArray(ctypes.Structure):
   _fields_ = [("data", ctypes.c_void_p),
               ("shape_ptr", ctypes.POINTER(ctypes.c_int64)),
@@ -65,8 +76,9 @@ insert   = dex_func('dexInsert',   HsContextPtr, ctypes.c_char_p, HsAtomPtr, HsC
 evalExpr = dex_func('dexEvalExpr', HsContextPtr, ctypes.c_char_p,            HsAtomPtr)
 lookup   = dex_func('dexLookup',   HsContextPtr, ctypes.c_char_p,            HsAtomPtr)
 
-print   = dex_func('dexPrint',   HsAtomPtr,           ctypes.c_char_p)
-toCAtom = dex_func('dexToCAtom', HsAtomPtr, CAtomPtr, ctypes.c_int)
+print     = dex_func('dexPrint',     HsAtomPtr,           ctypes.c_char_p)
+toCAtom   = dex_func('dexToCAtom',   HsAtomPtr, CAtomPtr, ctypes.c_int)
+fromCAtom = dex_func('dexFromCAtom', CAtomPtr,            HsAtomPtr)
 
 createJIT  = dex_func('dexCreateJIT',  HsJITPtr)
 destroyJIT = dex_func('dexDestroyJIT', HsJITPtr, None)

--- a/python/tests/api_test.py
+++ b/python/tests/api_test.py
@@ -39,6 +39,8 @@ class APITest(unittest.TestCase):
   def test_scalar_conversions(self):
     assert float(dex.eval("5.0")) == 5.0
     assert int(dex.eval("5")) == 5
+    assert str(dex.Atom(5)) == "5"
+    assert str(dex.Atom(5.0)) == "5."
 
 
 if __name__ == "__main__":

--- a/python/tests/jax_test.py
+++ b/python/tests/jax_test.py
@@ -52,12 +52,12 @@ class JAXTest(unittest.TestCase):
 
   def test_vmap(self):
     add_two = primitive(dex.eval(r'\x:((Fin 2)=>Float). for i. x.i + 2.0'))
-    x = jnp.linspace([0, 3], [5, 8], num=4, dtype=jnp.float32)
+    x = jnp.linspace(jnp.array([0, 3]), jnp.array([5, 8]), num=4, dtype=jnp.float32)
     np.testing.assert_allclose(jax.vmap(add_two)(x), x + 2.0)
 
   def test_vmap_nonzero_index(self):
     add_two = primitive(dex.eval(r'\x:((Fin 4)=>Float). for i. x.i + 2.0'))
-    x = jnp.linspace([0, 3], [5, 8], num=4, dtype=jnp.float32)
+    x = jnp.linspace(jnp.array([0, 3]), jnp.array([5, 8]), num=4, dtype=jnp.float32)
     np.testing.assert_allclose(
         jax.vmap(add_two, in_axes=1, out_axes=1)(x), x + 2.0)
 
@@ -72,12 +72,12 @@ class JAXTest(unittest.TestCase):
 
   def test_vmap_jit(self):
     add_two = primitive(dex.eval(r'\x:((Fin 2)=>Float). for i. x.i + 2.0'))
-    x = jnp.linspace([0, 3], [5, 8], num=4, dtype=jnp.float32)
+    x = jnp.linspace(jnp.array([0, 3]), jnp.array([5, 8]), num=4, dtype=jnp.float32)
     np.testing.assert_allclose(jax.jit(jax.vmap(add_two))(x), x + 2.0)
 
   def test_vmap_jit_nonzero_index(self):
     add_two = primitive(dex.eval(r'\x:((Fin 4)=>Float). for i. x.i + 2.0'))
-    x = jnp.linspace([0, 3], [5, 8], num=4, dtype=jnp.float32)
+    x = jnp.linspace(jnp.array([0, 3]), jnp.array([5, 8]), num=4, dtype=jnp.float32)
     np.testing.assert_allclose(
         jax.jit(jax.vmap(add_two, in_axes=1, out_axes=1))(x), x + 2.0)
 

--- a/src/Dex/Foreign/API.hs
+++ b/src/Dex/Foreign/API.hs
@@ -31,8 +31,9 @@ foreign export ccall "dexEvalExpr" dexEvalExpr :: Ptr Context -> CString   -> IO
 foreign export ccall "dexLookup"   dexLookup   :: Ptr Context -> CString   -> IO (Ptr Atom)
 
 -- Serialization
-foreign export ccall "dexPrint"    dexPrint    :: Ptr Atom                 -> IO CString
-foreign export ccall "dexToCAtom"  dexToCAtom  :: Ptr Atom    -> Ptr CAtom -> IO CInt
+foreign export ccall "dexPrint"     dexPrint      :: Ptr Atom                      -> IO CString
+foreign export ccall "dexToCAtom"   dexToCAtom    :: Ptr Atom    -> Ptr CAtom      -> IO CInt
+foreign export ccall "dexFromCAtom" dexFromCAtom  :: Ptr CAtom                     -> IO (Ptr Atom)
 
 -- JIT
 foreign export ccall "dexCreateJIT"  dexCreateJIT  :: IO (Ptr JIT)

--- a/src/Dex/Foreign/Serialize.hs
+++ b/src/Dex/Foreign/Serialize.hs
@@ -6,7 +6,7 @@
 
 module Dex.Foreign.Serialize (
   CAtom,
-  dexPrint, dexToCAtom
+  dexPrint, dexToCAtom, dexFromCAtom
   ) where
 
 import Data.Word
@@ -79,3 +79,12 @@ dexToCAtom atomPtr resultPtr = do
     _ -> notSerializable
   where
     notSerializable = setError "Unserializable atom" $> 0
+
+dexFromCAtom :: Ptr CAtom -> IO (Ptr Atom)
+dexFromCAtom catomPtr = do
+  catom <- peek catomPtr
+  case catom of
+    CLit lit         -> toStablePtr $ Con $ Lit lit
+    CRectArray _ _ _ -> unsupported
+  where
+    unsupported = setError "Unsupported CAtom" $> nullPtr


### PR DESCRIPTION
This makes it possible to use `CAtom` as a common language for getting
values both into and out of Dex.

cc @oxinabox 