### PR TITLE
Add Julia API to use from_CAtom

### DIFF
--- a/julia/README.md
+++ b/julia/README.md
@@ -2,7 +2,7 @@
 
 DexCall provides a mechanism for calling dex-lang code from JuliaLang.
 Three main mechanism are provided for this: `evaluate`, `DexModule` and the `dex_func` string macro.
-Two helper methods are also provided: `juliaize` and `NativeFunction`.
+Several helper methods are also provided: `dexize`, `juliaize` and `NativeFunction`.
 
 ## `evaluate`: just run a single Dex expression.
 `evaluate` takes in a Dex expression as a string and runs it, returning a `Atom` (see below).
@@ -53,20 +53,20 @@ julia> m.addTwo(m.y)
 "[44., 44., 44.]"
 ```
 
-## Atoms: `juliaize`, `NativeFunction`
+## Atoms: `dexize`, `juliaize`, `NativeFunction`
 
 `evaluate` and the contents of a `DexModule` are returned as `Atom`s.
 These can be displayed, but not much else.
 
 ```julia
 julia> typeof(m.x)
-DexCall.Atom
+Atom
 
 julia> typeof(m.addTwo)
-DexCall.Atom
+Atom
 ```
 
-To convert scalars into julia typed scalars used `juliaize`.
+To convert scalar `Atom`s into julia typed scalars used `juliaize`.
 ```julia
 julia> juliaize(m.x)
 42
@@ -75,16 +75,22 @@ julia> typeof(juliaize(m.x))
 Int32
 ```
 
-It is not presently possible to `juliaize` arrays (but you can get them as the output of functions, see below).
+It is not presently possible to `juliaize`/`dexize` arrays (but you can use them / get them as the input/output of `NativeFunction`s, see below).
 
-You can also use [`convert`](https://docs.julialang.org/en/v1/manual/conversion-and-promotion/#Conversion) to convert the atom to a Julia object.
-In which case it will make the minimal change from the Dex type to get to the type you requested
+You can also use [`convert`](https://docs.julialang.org/en/v1/manual/conversion-and-promotion/#Conversion) to convert between `Atom`sand Julia objects.
+When converting to a Julia typeit will make the minimal change from the Dex type to get to the type you requested.
 ```julia
 julia> typeof(convert(Integer, m.x))
 Int32
 
 julia> typeof(convert(Int64, m.x))
 Int64
+
+julia> convert(Atom, 1.5)
+"1.5"
+
+julia> convert(Number, convert(Atom, 1.5))
+1.5
 ```
 
 To convert function `Atom`s into something you can execute as if it was a regular julia function use `NativeFunction`.

--- a/julia/src/DexCall.jl
+++ b/julia/src/DexCall.jl
@@ -3,7 +3,8 @@ module DexCall
     using CombinedParsers
     using CombinedParsers.Regexp
 
-    export evaluate, DexError, DexModule, juliaize, NativeFunction, @dex_func_str
+    export evaluate, DexError, DexModule, NativeFunction, @dex_func_str
+    export Atom, dexize, juliaize, NativeFunction
 
     include("api_types.jl")
     include("api.jl")

--- a/julia/src/api.jl
+++ b/julia/src/api.jl
@@ -61,3 +61,4 @@ free_function_signature(s) = NO_FREE[] || @ccall libdex.dexFreeFunctionSignature
 
 
 to_CAtom(src, dest) = @ccall libdex.dexToCAtom(src::Ptr{HsAtom}, dest::Ptr{CAtom})::Int32
+from_CAtom(src) = @ccall libdex.dexFromCAtom(src::Ptr{CAtom})::Ptr{HsAtom}

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -22,8 +22,8 @@ end
 Represents a tagged union over types `A`, `B` etc.
 Must have a first field `tag::UInt64`
 and a second field `payload` which must be some isbits type that can hold the largest 
-element of the union (Probably a `NTuple{UInt8}` or similar).
-Julia doens't directly support Unions in the mappting to-from C
+element of the union, which you can (e.g.) declare as a custom `primative`.
+This is required as Julia doens't directly support Unions in the mapping to-from C
 so we store the data as arbitary bits then force it to be reinterpretted based on the tag
 """
 abstract type TaggedUnion{T<:Tuple} end
@@ -40,12 +40,13 @@ function force_reinterpret(::Type{T}, raw) where T
     return unsafe_load(Ptr{T}(Base.pointer_from_objref(Ref(raw))))
 end
 
-
+"Holds data for CLit, big enough to hold the larges of its union members, such as a Float64"
+primitive type CLitPayload 64 end
 struct CLit <: TaggedUnion{Tuple{Int64, Int32, UInt8, Float64, Float32, UInt32, UInt64}}
     tag::UInt64
-    payload::NTuple{8, UInt8}  # actually the Union, needs to be big enough to hold largest which is an Int64
+    payload::CLitPayload
 end
-CLit(x) = CLit(CLit_tag(x), force_reinterpret(NTuple{8, UInt8}, x))
+CLit(x) = CLit(CLit_tag(x), force_reinterpret(CLitPayload, x))
 
 CLit_tag(::Int64) = 0x0000_0000_0000_0000
 CLit_tag(::Int32) = 0x0000_0000_0000_0001
@@ -55,12 +56,13 @@ CLit_tag(::Float32) = 0x0000_0000_0000_0004
 CLit_tag(::UInt32) = 0x0000_0000_0000_0005
 CLit_tag(::UInt64) = 0x0000_0000_0000_0006
 
-
+"Holds data for CAtom, big enough to hold the larges of its union members, which is the CRectArray"
+primitive type CAtomPayload 3*64 end
 struct CAtom <: TaggedUnion{Tuple{CLit, CRectArray}}
     tag::UInt64
-    payload::NTuple{3, UInt64}  # actually the Union, needs to be big enough to hold largest which is the CRectArray
+    payload::CAtomPayload
 end
-CAtom(x) = CAtom(0x0000_0000_0000_0000, force_reinterpret(NTuple{3, UInt64}, CLit(x)))
+CAtom(x) = CAtom(0x0000_0000_0000_0000, force_reinterpret(CAtomPayload, CLit(x)))
 CAtom(x::AbstractArray) = throw(DomainError(typeof(x), "Arrays not yet supported"))
 function CAtom(atm::Ptr{HsAtom})
     result = Ref{CAtom}()

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -55,11 +55,3 @@ function CAtom(atm::Ptr{HsAtom})
     iszero(success) && throw_from_dex()
     return result[]
 end
-
-"""
-    juliaize(x)
-
-Get the corresponding Julia object from some output of Dex.
-"""
-juliaize(x::CAtom) = bust_union(x)
-juliaize(x::Ptr{HsAtom}) = juliaize(CAtom(x))

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -33,6 +33,7 @@ function bust_union(x::TaggedUnion{U}) where U
 end
 bust_union(x) = x  # not a union, leave it alone
 
+"Forces reinterpretting `raw` as a `T`. If sizeof(raw) <: size(T) high bits will be filled with junk."
 function force_reinterpret(::Type{T}, raw) where T
     isbits(raw) || throw(ArgumentError("Can only reinterpret from a isbits type"))
     isbitstype(T) || throw(ArgumentError("Can only reinterpret into a isbits type"))
@@ -40,15 +41,27 @@ function force_reinterpret(::Type{T}, raw) where T
 end
 
 
-struct CLit <: TaggedUnion{Tuple{Int64, Int32, Int8, Float64, Float32, UInt64, UInt32}}
+struct CLit <: TaggedUnion{Tuple{Int64, Int32, Int8, Float64, Float32, UInt32, UInt64}}
     tag::UInt64
     payload::NTuple{8, UInt8}  # actually the Union, needs to be big enough to hold largest which is an Int64
 end
+CLit(x) = CLit(CLit_tag(x), force_reinterpret(NTuple{8, UInt8}, x))
+
+CLit_tag(::Int64) = 0x0000_0000_0000_0000
+CLit_tag(::Int32) = 0x0000_0000_0000_0001
+CLit_tag(::Int8) = 0x0000_0000_0000_0002
+CLit_tag(::Float64) = 0x0000_0000_0000_0003
+CLit_tag(::Float32) = 0x0000_0000_0000_0004
+CLit_tag(::UInt32) = 0x0000_0000_0000_0005
+CLit_tag(::UInt64) = 0x0000_0000_0000_0006
+
 
 struct CAtom <: TaggedUnion{Tuple{CLit, CRectArray}}
     tag::UInt64
     payload::NTuple{3, UInt64}  # actually the Union, needs to be big enough to hold largest which is the CRectArray
 end
+CAtom(x) = CAtom(0x0000_0000_0000_0000, force_reinterpret(NTuple{3, UInt64}, CLit(x)))
+CAtom(x::AbstractArray) = throw(DomainError(typeof(x), "Arrays not yet supported"))
 function CAtom(atm::Ptr{HsAtom})
     result = Ref{CAtom}()
     success = to_CAtom(atm, result)

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -40,7 +40,7 @@ function force_reinterpret(::Type{T}, raw) where T
 end
 
 
-struct CLit <: TaggedUnion{Tuple{Int64, Int32, Int8, Float64, Float32}}
+struct CLit <: TaggedUnion{Tuple{Int64, Int32, Int8, Float64, Float32, UInt64, UInt32}}
     tag::UInt64
     payload::NTuple{8, UInt8}  # actually the Union, needs to be big enough to hold largest which is an Int64
 end

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -22,7 +22,7 @@ end
 Represents a tagged union over types `A`, `B` etc.
 Must have a first field `tag::UInt64`
 and a second field `payload` which must be some isbits type that can hold the largest 
-element of the union, which you can (e.g.) declare as a custom `primative`.
+element of the union, which you can (e.g.) declare as a custom `primitive`.
 This is required as Julia doens't directly support Unions in the mapping to-from C
 so we store the data as arbitary bits then force it to be reinterpretted based on the tag
 """

--- a/julia/src/api_types.jl
+++ b/julia/src/api_types.jl
@@ -41,7 +41,7 @@ function force_reinterpret(::Type{T}, raw) where T
 end
 
 
-struct CLit <: TaggedUnion{Tuple{Int64, Int32, Int8, Float64, Float32, UInt32, UInt64}}
+struct CLit <: TaggedUnion{Tuple{Int64, Int32, UInt8, Float64, Float32, UInt32, UInt64}}
     tag::UInt64
     payload::NTuple{8, UInt8}  # actually the Union, needs to be big enough to hold largest which is an Int64
 end
@@ -49,7 +49,7 @@ CLit(x) = CLit(CLit_tag(x), force_reinterpret(NTuple{8, UInt8}, x))
 
 CLit_tag(::Int64) = 0x0000_0000_0000_0000
 CLit_tag(::Int32) = 0x0000_0000_0000_0001
-CLit_tag(::Int8) = 0x0000_0000_0000_0002
+CLit_tag(::UInt8) = 0x0000_0000_0000_0002
 CLit_tag(::Float64) = 0x0000_0000_0000_0003
 CLit_tag(::Float32) = 0x0000_0000_0000_0004
 CLit_tag(::UInt32) = 0x0000_0000_0000_0005

--- a/julia/src/evaluate.jl
+++ b/julia/src/evaluate.jl
@@ -16,12 +16,25 @@ Base.show(io::IO, atom::Atom) = show(io, print(atom.ptr))
 """
     juliaize(x)
 
-Get the corresponding Julia object from some output of Dex.
+Get the corresponding Julia object from some Dex object.
+The inverse of [`dexize`](@ref).
 """
 juliaize(x::CAtom) = bust_union(x)
 juliaize(x::Ptr{HsAtom}) = juliaize(CAtom(x))
 juliaize(x::Atom) = juliaize(x.ptr)
 Base.convert(::Type{T}, atom::Atom) where {T<:Number} = convert(T, juliaize(atom))
+
+"""
+    dexize(x)
+
+Get the corresponding Dex object from some Julia object.
+The inverse of [`juliaize`](@ref).
+"""
+dexize(x) = Atom(from_CAtom(Ref(CAtom(x))), PRELUDE) 
+# ^ Always defined in PRELUDE as it could be defined anywhere that has all the bindings,
+# but because it has no bindings anywhere will do
+
+Base.convert(::Type{Atom}, atom::Number) = dexize(atom)
 
 
 function (self::Atom)(args...)

--- a/julia/src/evaluate.jl
+++ b/julia/src/evaluate.jl
@@ -13,6 +13,13 @@ end
 
 Base.show(io::IO, atom::Atom) = show(io, print(atom.ptr))
 
+"""
+    juliaize(x)
+
+Get the corresponding Julia object from some output of Dex.
+"""
+juliaize(x::CAtom) = bust_union(x)
+juliaize(x::Ptr{HsAtom}) = juliaize(CAtom(x))
 juliaize(x::Atom) = juliaize(x.ptr)
 Base.convert(::Type{T}, atom::Atom) where {T<:Number} = convert(T, juliaize(atom))
 

--- a/julia/test/evaluate.jl
+++ b/julia/test/evaluate.jl
@@ -17,9 +17,19 @@
     @testset "evaluate juliaize" begin
         @test juliaize(evaluate("1")) === Int32(1)
         @test juliaize(evaluate("1.5")) === 1.5f0
-
         @test juliaize(evaluate("IToW8 65")) === Int8(65)
     end
+
+    @testset "juliaize-dexize round-trip" begin
+        @test juliaize(dexize(Int64(3))) === Int64(3)
+        @test juliaize(dexize(Int32(3))) === Int32(3)
+        @test juliaize(dexize(Int8(3))) === Int8(3)
+        @test juliaize(dexize(Float64(3))) === Float64(3)
+        @test juliaize(dexize(Float32(3))) === Float32(3)
+        @test juliaize(dexize(UInt64(3))) === UInt64(3)
+        @test juliaize(dexize(UInt32(3))) === UInt32(3)
+    end
+
 
     @testset "Atom function call" begin
         m = DexModule("""
@@ -34,12 +44,12 @@
     end
 
     @testset "convert Atom" begin
-        atom = evaluate("1.0")
+        atom = convert(Atom, 1f0)
         @test convert(Number, atom) === 1f0
         @test convert(Real, atom) === 1f0
         @test convert(Float64, atom) === 1.0
 
-        atom = evaluate("2")
+        atom = convert(Atom, Int32(2))
         @test convert(Number, atom) === Int32(2)
         @test convert(Real, atom) === Int32(2)
         @test convert(Float64, atom) === 2.0

--- a/julia/test/evaluate.jl
+++ b/julia/test/evaluate.jl
@@ -17,13 +17,13 @@
     @testset "evaluate juliaize" begin
         @test juliaize(evaluate("1")) === Int32(1)
         @test juliaize(evaluate("1.5")) === 1.5f0
-        @test juliaize(evaluate("IToW8 65")) === Int8(65)
+        @test juliaize(evaluate("IToW8 65")) === UInt8(65)
     end
 
     @testset "juliaize-dexize round-trip" begin
         @test juliaize(dexize(Int64(3))) === Int64(3)
         @test juliaize(dexize(Int32(3))) === Int32(3)
-        @test juliaize(dexize(Int8(3))) === Int8(3)
+        @test juliaize(dexize(UInt8(3))) === UInt8(3)
         @test juliaize(dexize(Float64(3))) === Float64(3)
         @test juliaize(dexize(Float32(3))) === Float32(3)
         @test juliaize(dexize(UInt64(3))) === UInt64(3)


### PR DESCRIPTION
Follow up to https://github.com/google-research/dex-lang/pull/657
must be merged after that one.

Replaces the `dexize` code from #633  which will need to be rebased on top of this.