### PR TITLE
Make integer literals polymorphic

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -3,7 +3,7 @@
 '`Iso a b` is the type of an isomorphism between `a` and `b`.
 
 :t MkIso
-> ((a:Type) ?-> (b:Type) ?-> (tmp2:{bwd: b -> a & fwd: a -> b}) -> Iso a b)
+> ((a:Type) ?-> (b:Type) ?-> (tmp8:{bwd: b -> a & fwd: a -> b}) -> Iso a b)
 
 'This is a normal ADT, and you can construct your own isomorphisms.
 

--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -124,13 +124,13 @@ mean y
   lets consider how it works. Critically, one cannot
   simply index an table with an integer.
 
-r = x.2
+r = x.(2 : Int)
 > Type error:
 > Expected: (Fin 3)
 >   Actual: Int32
 >
-> r = x.2
->       ^
+> r = x.(2 : Int)
+>          ^^
 
 ' Instead, it is necessary to cast the integer into the index type of the
   current shape. This type annotation is done with the `@` operator.

--- a/julia/test/api.jl
+++ b/julia/test/api.jl
@@ -1,9 +1,9 @@
 @testset "api.jl" begin
     @testset "basic demo of eval and check errors" begin
         DexCall.context() do ctx
-            DexCall.dex_eval(ctx, "1 + 1.0\n")
+            DexCall.dex_eval(ctx, "(1 : Int) + 1.0\n")
             error_message = DexCall.get_error_msg()
-            @test contains(error_message, r"Type error.*Expected: Int32.*Actual: Float32.*1 \+ 1.0"s)
+            @test contains(error_message, r"Type error.*Expected: Int32.*Actual: Float32.*"s)
         end
     end
 end

--- a/julia/test/evaluate.jl
+++ b/julia/test/evaluate.jl
@@ -1,6 +1,6 @@
 @testset "evaluate.jl" begin
     @testset "evaluate erroring" begin
-        @test_throws DexError evaluate("1 + 2.0")
+        @test_throws DexError evaluate("(1 : Int) + 2.0")
     end
 
     @testset "evaluate  show" begin
@@ -9,7 +9,7 @@
         @test repr(evaluate("[1, 2]")) == repr("[1, 2]")
         @test repr(evaluate("1+3")) == repr("4")
         @test repr(evaluate("for i. [1, 2].i + 1")) == repr("[2, 3]")
- 
+
         # This seems weird: why is it doubly quoted? 😕
         @test repr(evaluate("IToW8 65")) === repr(repr('A'))
     end

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1839,8 +1839,8 @@ def padTo (m:Type) (x:a) (xs:n=>a) : (m=>a) =
       False -> x
 
 def idivCeil (x:Int) (y:Int) : Int = idiv x y + BToI (rem x y /= 0)
-def intdiv2 (x:Int) : Int = %shr x 1
-def intpow2 (power:Int) : Int = %shl 1 power
+def intdiv2 (x:Int) : Int = %shr x (1 : Int)
+def intpow2 (power:Int) : Int = %shl (1 : Int) power
 def isOdd  (x:Int) : Bool = rem x 2 == 1
 def isEven (x:Int) : Bool = rem x 2 == 0
 
@@ -1861,7 +1861,7 @@ def intlog2 (x:Int) : Int =
         if x >= (get cmpRef)
           then
             ansRef := (get ansRef) + 1
-            cmpRef := %shl (get cmpRef) 1
+            cmpRef := %shl (get cmpRef) (1 : Int)
             True
           else
             False

--- a/makefile
+++ b/makefile
@@ -136,8 +136,8 @@ all-names = $(test-names:%=tests/%) $(example-names:%=examples/%)
 
 quine-test-targets = $(all-names:%=run-%)
 
-update-test-targets    = $(test-names:%=update-tests-%)
-update-example-targets = $(example-names:%=update-examples-%)
+update-test-targets    = $(test-names:%=update-tests/%)
+update-example-targets = $(example-names:%=update-examples/%)
 
 doc-example-names = $(example-names:%=doc/examples/%.html)
 
@@ -164,11 +164,11 @@ update-%: export DEX_TEST_MODE=t
 
 update-all: $(update-test-targets) $(update-example-targets)
 
-update-tests-%: tests/%.dx build
+update-tests/%: tests/%.dx build
 	$(dex) script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 
-update-examples-%: examples/%.dx build
+update-examples/%: examples/%.dx build
 	$(dex) script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -57,7 +57,8 @@ runMode evalMode preludeFile opts = do
   key <- case preludeFile of
            Nothing   -> return $ show curResourceVersion -- memoizeFileEval already checks compiler version
            Just path -> show <$> getModificationTime path
-  env <- cachedWithSnapshot "prelude" key $ execInterblockM opts initTopState $ evalPrelude preludeFile
+  env <- cachedWithSnapshot "prelude" key $
+    execInterblockM opts initTopState $ evalPrelude preludeFile
   case evalMode of
     ReplMode prompt -> do
       let filenameAndDexCompletions = completeQuotedWord (Just '\\') "\"'" listFiles dexCompletions

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -12,7 +12,7 @@
 module Err (Err (..), Errs (..), ErrType (..), Except (..), ErrCtx (..),
             SrcPosCtx, SrcTextCtx, SrcPos,
             Fallible (..), FallibleM (..), HardFailM (..),
-            runHardFail, throw, throwIf,
+            runHardFail, throw, throwErr, throwIf,
             addContext, addSrcContext, addSrcTextContext,
             catchIOExcept, liftExcept,
             assertEq, ignoreExcept, pprint, docAsStr, asCompilerErr,
@@ -170,6 +170,9 @@ instance FallibleApplicative HardFailM where
 
 throw :: Fallible m => ErrType -> String -> m a
 throw errTy s = throwErrs $ Errs [Err errTy mempty s]
+
+throwErr :: Fallible m => Err -> m a
+throwErr err = throwErrs $ Errs [err]
 
 throwIf :: Fallible m => Bool -> ErrType -> String -> m ()
 throwIf True  e s = throw e s

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1481,7 +1481,7 @@ impInstrTypes instr = case instr of
 
 checkImpBinOp :: Fallible m => BinOp -> IType -> IType -> m IType
 checkImpBinOp op x y = do
-  retTy <- checkBinOp op (BaseTy x) (BaseTy y)
+  retTy <- checkBinOp True op (BaseTy x) (BaseTy y)
   case retTy of
     BaseTy bt -> return bt
     _         -> throw CompilerErr $ "Unexpected BinOp return type: " ++ pprint retTy

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -590,6 +590,10 @@ instance Pretty AnyBinderInfo where
     ImpBound             -> "Imp name"
     TrulyUnknownBinder   -> "<unknown binder (really)>"
 
+instance Pretty a => Pretty (SubstVal a) where
+  pretty (SubstVal x) = "subst with" <+> p x
+  pretty (Rename   n) = "rename to" <+> p n
+
 instance Pretty DataDef where
   pretty (DataDef name bs cons) =
     "data" <+> p name <+> p bs <> hardline <> prettyLines cons

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -473,6 +473,8 @@ simplifyOp op = case op of
   PrimEffect ref (MExtend f) -> dropSub $ do
     ~(f', Nothing) <- simplifyLam f
     emitOp $ PrimEffect ref $ MExtend f'
+  -- TODO: Make sure that fromIntegral wraps in the same way as Dex
+  CastOp Int32Ty (Con (Lit (Int64Lit val))) -> return $ Con $ Lit $ Int32Lit $ fromIntegral val
   _ -> emitOp op
 
 simplifyHof :: Hof -> SimplifyM Atom

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -57,11 +57,13 @@ module Syntax (
     BaseMonoidP (..), BaseMonoid, getBaseMonoidType,
     applyIntBinOp, applyIntCmpOp, applyFloatBinOp, applyFloatUnOp,
     getIntLit, getFloatLit, sizeOf, ptrSize, vectorWidth,
+    ProtoludeScope (..),
     pattern MaybeTy, pattern JustAtom, pattern NothingAtom,
     pattern BoolTy, pattern FalseAtom, pattern TrueAtom,
     pattern IdxRepTy, pattern IdxRepVal, pattern IIdxRepVal, pattern IIdxRepTy,
     pattern TagRepTy, pattern TagRepVal, pattern Word8Ty,
     pattern IntLitExpr, pattern FloatLitExpr,
+    pattern Int32Ty, pattern Int64Ty,
     pattern UnitTy, pattern PairTy,
     pattern ProdTy, pattern ProdVal,
     pattern SumTy, pattern SumVal,
@@ -211,10 +213,11 @@ data EvaluatedModule =
 data TopState = TopState
   { topBindings        :: Bindings
   , topSynthCandidates :: SynthCandidates
-  , topSourceMap       :: SourceMap }
+  , topSourceMap       :: SourceMap
+  , topProtolude       :: ProtoludeScope }
   deriving (Show, Generic)
 
-emptyTopState :: TopState
+emptyTopState :: ProtoludeScope -> TopState
 emptyTopState = TopState mempty mempty mempty
 
 emptyEvaluatedModule :: EvaluatedModule
@@ -656,6 +659,15 @@ ptrSize = 8
 
 vectorWidth :: Int
 vectorWidth = 4
+
+-- === protolude ===
+
+data ProtoludeScope = ProtoludeScope
+  { protoludeFromIntegerIface  :: Name
+  , protoludeFromIntegerMethod :: Name
+  }
+  deriving (Show, Eq, Generic)
+
 
 -- === some handy monoids ===
 
@@ -1419,7 +1431,7 @@ substExtLabeledItemsTail env (Just v) = case envLookup env (v:>()) of
 getProjection :: [Int] -> Atom -> Atom
 getProjection [] a = a
 getProjection (i:is) a = case getProjection is a of
-  Var v -> ProjectElt (NE.fromList [i]) v
+  Var v               -> ProjectElt (NE.fromList [i]) v
   ProjectElt idxs' a' -> ProjectElt (NE.cons i idxs') a'
   DataCon _ _ _ xs    -> xs !! i
   Record items        -> toList items !! i
@@ -1507,7 +1519,7 @@ applyIntBinOp' f x y = case (x, y) of
   (Con (Lit (Word8Lit xv)), Con (Lit (Word8Lit yv))) -> f (Con . Lit . Word8Lit) xv yv
   (Con (Lit (Word32Lit xv)), Con (Lit (Word32Lit yv))) -> f (Con . Lit . Word32Lit) xv yv
   (Con (Lit (Word64Lit xv)), Con (Lit (Word64Lit yv))) -> f (Con . Lit . Word64Lit) xv yv
-  _ -> error "Expected integer atoms"
+  _ -> error $ "Expected integer atoms, got: " ++ show x ++ " and " ++ show y
 
 applyIntBinOp :: (forall a. (Num a, Integral a) => a -> a -> a) -> Atom -> Atom -> Atom
 applyIntBinOp f x y = applyIntBinOp' (\w -> w ... f) x y
@@ -1657,6 +1669,12 @@ pattern TabVal v b = Lam (Abs v (TabArrow, b))
 
 pattern TabValA :: Binder -> Atom -> Atom
 pattern TabValA v a = Lam (Abs v (TabArrow, (Block Empty (Atom a))))
+
+pattern Int32Ty :: Type
+pattern Int32Ty = BaseTy (Scalar Int32Type)
+
+pattern Int64Ty :: Type
+pattern Int64Ty = BaseTy (Scalar Int64Type)
 
 isTabTy :: Type -> Bool
 isTabTy (TabTy _ _) = True
@@ -1860,6 +1878,7 @@ instance Store DataConRefBinding
 instance Store SourceMap
 instance Store SynthCandidates
 instance Store SourceNameDef
+instance Store ProtoludeScope
 instance Store TopState
 
 instance IsString UVar where

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -154,9 +154,9 @@ def getTwoFoosAndABar (rest : Fields)?->
   ({b=b, a=a1, a=a2}) = {a=1, b=2}
   (a1, a2, b)
 > Type error:
-> Expected: {a: a & a: b & b: c}
->   Actual: {a: Int32 & b: Int32}
-> (Solving for: [a:Type, b:Type, c:Type])
+> Expected: {a: c & a: d & b: e}
+>   Actual: {a: a & b: b}
+> (Solving for: [a:Type, b:Type, c:Type, d:Type, e:Type])
 >
 >   ({b=b, a=a1, a=a2}) = {a=1, b=2}
 >    ^^^^^^^^^^^^^^^^^

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -99,22 +99,13 @@ xr = map IToF arr
 > ((Fin 3) => Int32)
 
 :t [1, [2]]
-> Type error:
-> Expected: Int32
->   Actual: ((Fin 1) => Int32)
-> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
->
-> :t [1, [2]]
->        ^^^
+> Type error:Couldn't synthesize a class dictionary for: (FromInteger ((Fin 1) => Int32))
 
 :t [[1, 2], [3, 4]]
 > ((Fin 2) => (Fin 2) => Int32)
 
 :t [[1, 2], [3]]
-> Type error:
-> Expected: ((Fin 2) => Int32)
->   Actual: ((Fin 1) => Int32)
-> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
+> Type error:Table literal has 1 elements, but its inferred index set (((Fin 2) => Int32)) has a size of 2
 >
 > :t [[1, 2], [3]]
 >             ^^^
@@ -218,12 +209,7 @@ g : a -> a = \x. x
 :t
    f = \x:Float. x
    f 1
-> Type error:
-> Expected: Float32
->   Actual: Int32
->
->    f 1
->      ^
+> Float32
 
 g1 : (a -> Int) -> (a -> Int) = \x. x
 
@@ -396,3 +382,29 @@ c = [1, 2]
     y
   f (1,2)
 > 2
+
+-- Tests for type inference of table literals
+
+def mkEmpty (a:Type) : (Fin 0)=>a = []
+
+:t [0.0, 1.0]
+> ((Fin 2) => Float32)
+:t [[0.0], [1.0]]
+> ((Fin 2) => (Fin 1) => Float32)
+:t [0.0, 1.0] : (Fin 2)=>Float
+> ((Fin 2) => Float32)
+:t [0.0, 1.0] : ((Fin 1) & (Fin 2))=>Float
+> ((Fin 1 & Fin 2) => Float32)
+
+:t [[0.0], [1.0, 2.0]] : i:(Fin 2)=>(..i)=>Float
+> ((i:(Fin 2)) => (..i) => Float32)
+:t [[[0.0, 1.0]], [[2.0, 3.0], [4.0, 5.0]]] : i:(Fin 2)=>(..i)=>(Fin 2)=>Float
+> ((i:(Fin 2)) => (..i) => (Fin 2) => Float32)
+
+def uncurryTable (x : ((Fin 2) & (Fin 2))=>a) : (Fin 2)=>(Fin 2)=>a =
+  for i j. x.(i, j)
+
+:t uncurryTable [0.0, 1.0, 2.0, 3.0]  -- We should be able to infer the tuple type here
+> ((Fin 2) => (Fin 2) => Float32)
+:t uncurryTable [0, 1, 2, 3]          -- Extra difficulty: need to default the integer type
+> ((Fin 2) => (Fin 2) => Int32)

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -42,28 +42,13 @@ idImplicit2 : (a:Type ?-> a -> a) = \x. x
 > 3.
 
 :p 1.0 + 1
-> Type error:
-> Expected: Float32
->   Actual: Int32
->
-> :p 1.0 + 1
->          ^
+> 2.
 
 :p 1 + (1.0 + 2.0)
-> Type error:
-> Expected: Int32
->   Actual: Float32
->
-> :p 1 + (1.0 + 2.0)
->         ^^^^^^^^^
+> 4.
 
 :p 1.0 + (2 + 3)
-> Type error:
-> Expected: Float32
->   Actual: Int32
->
-> :p 1.0 + (2 + 3)
->           ^^^^^
+> 6.
 
 :p x + x
 > Error: variable not in scope: x
@@ -153,32 +138,36 @@ myPair = (1, 2.3)
   (x,y,z)
 > (1, (2, 3))
 
-:p
-  ((x,y),z) = (1,2,3)
-  ((x,y),z)
-> Type error:
-> Expected: (a & b)
->   Actual: Int32
-> (Solving for: [a:Type, b:Type])
->
->   ((x,y),z) = (1,2,3)
->     ^^^
+-- XXX: This is an ambiguous type error with overloaded literals
+-- TODO: Reenable once we have reasonable error messages for ambiguous types
+-- :p
+--   ((x,y),z) = (1,2,3)
+--   ((x,y),z)
+-- > Type error:
+-- > Expected: (a & b)
+-- >   Actual: Int32
+-- > (Solving for: [a:Type, b:Type])
+-- >
+-- >   ((x,y),z) = (1,2,3)
+-- >     ^^^
 
 :p
   (x,(y,z)) = (1,2,3)
   (x,(y,z))
 > (1, (2, 3))
 
-:p
-  (x,y) = 1
-  (x,y)
-> Type error:
-> Expected: (a & b)
->   Actual: Int32
-> (Solving for: [a:Type, b:Type])
->
->   (x,y) = 1
->    ^^^
+-- XXX: This is an ambiguous type error with overloaded literals
+-- TODO: Reenable once we have reasonable error messages for ambiguous types
+-- :p
+--   (x,y) = 1
+--   (x,y)
+-- > Type error:
+-- > Expected: (a & b)
+-- >   Actual: Int32
+-- > (Solving for: [a:Type, b:Type])
+-- >
+-- >   (x,y) = 1
+-- >    ^^^
 
 :p
   yieldState [1,2,3] \xsRef.
@@ -263,11 +252,7 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 > (1, 2)
 
 :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
-> Type error:
-> Expected: ((Fin a & Fin 2) => Int32)
->   Actual: ((Fin 4) => Int32)
-> (Solving for: [a:Int32])
-> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
+> Type error:Failed to infer the index set of an array literal. Please try adding a type annotation.
 >
 > :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
 >    ^^^^^^^^^^^^^
@@ -280,13 +265,10 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 :p
   [a, b] = [1, 2, 3]
   (a, b)
-> Type error:
-> Expected: ((Fin 3) => Int32)
->   Actual: ((Fin 2) => a)
-> (Solving for: [a:Type])
+> Type error:Table literal has 3 elements, but its inferred index set (((Fin 2) => Int32)) has a size of 2
 >
 >   [a, b] = [1, 2, 3]
->   ^^^^^^^
+>            ^^^^^^^^^
 
 :p
   [[a, _], [_, d]] = [[1, 2], [3, 4]]


### PR DESCRIPTION
Previously, integer literals were always inferred to be of type `Int32`,
which was annoying for multiple reasons (they couldn't be used in 64-bit
computations easily, nor they could be used to represent floats). With
this change, every integer literal in the surface program is replaced by
the expression `fromInteger <literal>`, with the function being defined
in a type class:
```
interface FromInteger a where
  fromInteger : Int64 -> a
```

All this initially seemed like a simple change, but it quickly turned
out not to be the case. Below I outline some of the challenges I hit and
the solutions I arrived at.

*Protolude*

Prelude is a default, but optional part of the language (it can be even
empty when using `--prelude /dev/null`), but we need `fromInteger` to be
in scope to even be able to perform inference. So this patch also adds
_Protolude_, which is a non-optional standard library that's built into
the compiler. At the moment it's constructed in Haskell using the
builder monad and switching to a source-based specification would be
tricky, because we would need the protolude definitions to perform type
inference over protolude (there's no fully-annotated source syntax for
Dex).

*Integer literals are no longer Atoms*

This makes type inference significantly harder, because we use literals
all over the place in our types (think `Fin 5`). Because of that, I had
to add a system of "delayed unification" tasks that make it possible to
defer unification until the end of inference process.

*Integer literals cannot be fully evaluated before dictionary synthesis*

So far we had a strict phase separation between type inference and
dictionary synthesis. With this patch, some dictionary synthesis is
performed during inference (really during delayed unification).

_TODO:_ I don't think there's any good reason to keep those two separate
forever, especially now that the boundary is leaky. We should just merge
them together.

*Defaulting*

Previously expressions such as `1 == 1` were considered well typed and
it makes sense to try to keep up that behavior. The inference pass now
implements a defaulting mechanism which ensures that when the type
variables associated with integers are unconstrained, they will get
inferred as `Int32` (which really should be the same as whatever
precision the prelude-defined `Int` has).

*Type inference for table literals*

The inference rule for table literals assumed that we either have to
know the concrete type of the table (i.e. no free variables), or the
table had to have a `Fin n=>a` type for `n` matching the size of the
literal. However, with integer literals getting replaced by inference
vars (to be replaced by delayed evaluation results), we ended up only
being able to type `Fin n` tables.

This is obviously very unsatisfactory, so I worked out a completely new
inference scheme for tables. It's a bit more complicated and also uses
the delayed unification machinery. But it's also significantly stronger:
it no longer depends on the `Concrete` hack, and is able to infer rich
index sets if they're implied by the program, e.g. when they com from
function argument annotations.

_TODO:_ Remove `Concrete` from type inference. We don't use it anymore,
but I didn't want to make this patch any larger.