### PR TITLE
Fix source renamer to properly handle interfaces

### DIFF
--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -48,3 +48,12 @@ instance InterfaceTest4 Float
   foo = 1
   bar = \_. 1
 
+outer = 1.0
+-- Should be able to shadow a variable with the parameter
+interface InterfaceTest5 outer
+  value outer : Int
+
+-- Shouldn't be able to bind a parameter variable twice
+interface InterfaceTest6 a a
+  f : a -> Int
+> Error: variable already defined within pattern: a


### PR DESCRIPTION
Previously interface parameters were not allowed to shadow variables
from the outer scope, which doesn't really make much sense.