### PR TITLE
Fix CUDA backend

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -132,6 +132,8 @@ executable dex
   hs-source-dirs:      src
   default-extensions:  CPP, LambdaCase, BlockArguments
   ghc-options:         -threaded -optP-Wno-nonportable-include-path
+  if flag(cuda)
+    cpp-options:       -DDEX_CUDA
   if flag(live)
     cpp-options:       -DDEX_LIVE
   if flag(optimized)

--- a/makefile
+++ b/makefile
@@ -90,7 +90,7 @@ install: dexrt-llvm
 	$(STACK) install $(STACK_BIN_PATH) --flag dex:optimized $(STACK_FLAGS)
 
 build-prof: dexrt-llvm
-	$(STACK) build $(PROF) --flag dex:-foreign
+	$(STACK) build $(STACK_FLAGS) $(PROF) --flag dex:-foreign
 
 # For some reason stack fails to detect modifications to foreign library files
 build-ffis: dexrt-llvm

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -225,9 +225,6 @@ void dex_check(const char* fname, driver_func<Args1...> f, Args2... args) {
 
 extern "C" {
 
-void load_cuda_array(void* host_ptr, void* device_ptr, int64_t bytes) {
-  CHECK(cuMemcpyDtoH, host_ptr, reinterpret_cast<CUdeviceptr>(device_ptr), bytes);
-}
 
 void dex_cuMemcpyDtoH(int64_t bytes, char* device_ptr, char* host_ptr) {
   CHECK(cuMemcpyDtoH, host_ptr, reinterpret_cast<CUdeviceptr>(device_ptr), bytes);


### PR DESCRIPTION
Now that we run Dex with the threaded runtime, the CUDA context
initialization performed by the thread that evaluates the computation
might no longer carry over to the top-level thread, leading to errors
when it tries to perform device-to-host transfers.