### PR TITLE
Add missing CUResult checks in dex_get_cuda_architecture

### DIFF
--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -307,13 +307,13 @@ void dex_ensure_has_cuda_context() {
 
 void dex_get_cuda_architecture(int device, char* arch) {
   int majorVersion, minorVersion;
-  cuInit(0);
   CUdevice dev;
+  CHECK(cuInit, 0);
   CHECK(cuDeviceGet, &dev, device);
-  cuDeviceGetAttribute(&majorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
-  cuDeviceGetAttribute(&minorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
+  CHECK(cuDeviceGetAttribute, &majorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MAJOR, device);
+  CHECK(cuDeviceGetAttribute, &minorVersion, CU_DEVICE_ATTRIBUTE_COMPUTE_CAPABILITY_MINOR, device);
   if (majorVersion > 9 || majorVersion < 0 || minorVersion > 9 || minorVersion < 0) {
-    printf("Invalid CUDA architecture version: %d.%d", majorVersion, minorVersion);
+    printf("Unsupported CUDA architecture version: %d.%d", majorVersion, minorVersion);
     std::abort();
   }
   // Cap CUDA architecture version at 7.5, the latest supported by LLVM 9


### PR DESCRIPTION
Without them the error messages can get really confusing, as in #651.