### PR TITLE
Change GitHub Actions cache keys

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -52,8 +52,8 @@ jobs:
           $GITHUB_WORKSPACE/examples/t10k-images-idx3-ubyte
           $GITHUB_WORKSPACE/examples/t10k-labels-idx1-ubyte
 
-        key: ${{ runner.os }}-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
-        restore-keys: ${{ runner.os }}-
+        key: ${{ runner.os }}-v2-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
+        restore-keys: ${{ runner.os }}-v2-
 
     # This step is a workaround.
     # See issue for context: https://github.com/actions/cache/issues/445

--- a/.github/workflows/julia-ci.yaml
+++ b/.github/workflows/julia-ci.yaml
@@ -27,7 +27,7 @@ jobs:
         enable-stack: true
         stack-no-global: true
         stack-version: 'latest'
-    
+
     - name: Setup Julia
       uses: julia-actions/setup-julia@ee66464cb7897ffcc5322800f4b18d449794af30  # v1.6.1
       with:
@@ -41,16 +41,16 @@ jobs:
           ~/.stack
           $GITHUB_WORKSPACE/.stack-work
           ~/.julia/artifacts
-        key: ${{ runner.os }}-julia-${{ hashFiles('**/*.cabal', 'stack*.yaml', '**/Project.toml') }}
+        key: ${{ runner.os }}-v2-julia-${{ hashFiles('**/*.cabal', 'stack*.yaml', '**/Project.toml') }}
         restore-keys: |
-          ${{ runner.os }}-julia-
-          ${{ runner.os }}-
+          ${{ runner.os }}-v2-julia-
+          ${{ runner.os }}-v2-
 
     - name: Build DexCall.jl
       uses: julia-actions/julia-buildpkg@f995fa4149fed4a8e9b95ba82f54cc107c1d832a  #v1.2.0
       with:
         project: "julia/"
-    
+
     - name: Test DexCall.jl
       uses: julia-actions/julia-runtest@eda4346d69c0d1653e483c397a83c7f32f4ef2ac  # v1.6.0
       with:

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -46,10 +46,10 @@ jobs:
           ~/.stack
           ~/.cache/pip
           $GITHUB_WORKSPACE/.stack-work
-        key: ${{ runner.os }}-python-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
+        key: ${{ runner.os }}-v2-python-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
         restore-keys: |
-          ${{ runner.os }}-python-
-          ${{ runner.os }}-
+          ${{ runner.os }}-v2-python-
+          ${{ runner.os }}-v2-
 
     - name: Build
       run: make build-ffis


### PR DESCRIPTION
Homebrew has recently updated their formula for LLVM 9 which changes the
required LDFLAGS, but the cached llvm-hs build embeds the old versions
causing our macOS CI to fail.