### PR TITLE
Automatically abstract interfaces required by annotated lambda binders

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -156,7 +156,7 @@ buildPi b fArr fTy = do
   case typeReduceBlock scope block of
     Right piTy -> return piTy
     Left _ -> throw CompilerErr $
-      "Unexpected irreducible decls in pi type: " ++ pprint decls
+      "Unexpected irreducible decls in pi type: " ++ pprint block
 
 buildAbsAux :: (MonadBuilder m, HasVars a) => Binder -> (Atom -> m (a, b)) -> m (Abs Binder (Nest Decl, a), b)
 buildAbsAux b f = do

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -152,3 +152,32 @@ def f8 [Ord' (n=>Int)] (x : n=>Int) : Int = eq x
 -------------------- Multi-parameter interfaces --------------------
 
 -- TODO!
+
+-------------------- Automatic quantification --------------------
+
+interface X a
+  x_ a : Int
+
+def MyPairOfXs (a : Type) (_ : X a) ?=> : Type = (a & a)
+
+instance X Int
+  x_ = 1
+
+-- No automatic quantification needed
+def q0 (x : MyPairOfXs Int) : Int = fst x
+def q1 [X a] (x : MyPairOfXs a) : a = fst x
+
+-- Should work with implicit quantification
+def q2 (x : MyPairOfXs a) : a = fst x
+
+-- Should work with implicit quantification
+def q3 (x : MyPairOfXs a) : Int = x_ a
+
+-- We should also implicitly quantify over constraints of the return type
+def f4 (x : a) : MyPairOfXs a = (x, x)
+
+-- Check automatic quantification for interfaces
+interface AutoQuant a
+  dummy : Int
+instance AutoQuant (MyPairOfXs a)
+  dummy = 1


### PR DESCRIPTION
With this change, we automatically elaborate a type such as
```
(n : Type) ?-> (a : Type) ?-> Table n a -> a
```
into
```
(n : Type) ?-> (a : Type) ?-> Ix n ?=> Table n a -> a
```
(assuming `def Table (n : Type) (_ : Ix n) ?=> (a : Type) : Type = n=>a`)

In the near future this should let us start enforcing the index set
constraints in a backwards-compatible and non-verbose way, since any
type appearing to the left of `=>` will get constrained automatically.

This will be convenient for associated types too, because e.g. mentioning
`TangentSpace a` in a type will automatically add a constraint `Manifold a`
to the type signature.