### PR TITLE
Use CUDA driver APIs to avoid scheduling too large blocks

### DIFF
--- a/makefile
+++ b/makefile
@@ -172,8 +172,9 @@ update-examples/%: examples/%.dx build
 	$(dex) script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 
-run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
-run-gpu-tests: tests/gpu-tests.dx build
+gpu-tests: run-gpu-tests/gpu-tests
+
+run-gpu-tests/%: tests/%.dx build
 	misc/check-quine $< $(dex) --backend llvm-cuda script --allow-errors
 
 update-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0


### PR DESCRIPTION
We sometimes emit kernels that require lots of registers and cannot be
scheduled in 1024-sized blocks. This uses a CUDA driver API to query for
a good block size. In the future we might want to cache this number to
avoid any driver-related overheads.