### PR TITLE
Make sure type reduction fails when dictionaries cannot be synthesized

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -58,7 +58,7 @@ library
                        SaferNames.Name, SaferNames.LazyMap,
                        SaferNames.Syntax, SaferNames.Bridge,
                        SaferNames.PPrint, SaferNames.Parser,
-                       SaferNames.SourceRename,
+                       SaferNames.SourceRename, SaferNames.MTL1,
                        SaferNames.Type, SaferNames.Builder, SaferNames.Inference,
                        SaferNames.CheapReduction, SaferNames.GenericTraversal
   if flag(live)

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -16,7 +16,7 @@
 module SaferNames.Builder (
   emit, emitOp,
   buildPureLam, BuilderT (..), Builder (..), Builder2,
-  runBuilderT, buildBlock, buildBlockReduced, app, add, mul, sub, neg, div',
+  runBuilderT, buildBlock, app, add, mul, sub, neg, div',
   iadd, imul, isub, idiv, ilt, ieq, irem,
   fpow, flog, fLitLike, recGetHead, buildPureNaryLam,
   emitMethodType, emitSuperclass,
@@ -257,14 +257,6 @@ inlineLastDecl (Nest decl rest) result =
   case inlineLastDecl rest result of
    Abs decls' result' ->
      Abs (Nest decl decls') result'
-
-buildBlockReduced
-  :: Builder m
-  => (forall l. (Emits l, Ext n l) => m l (Atom l))
-  -> m n (Maybe (Atom n))
-buildBlockReduced cont = do
-  Block _ decls result <- buildBlock cont
-  cheapReduceToAtom $ Abs decls result
 
 atomAsBlock :: BindingsReader m => Atom n -> m n (Block n)
 atomAsBlock x = do

--- a/src/lib/SaferNames/CheapReduction.hs
+++ b/src/lib/SaferNames/CheapReduction.hs
@@ -5,12 +5,17 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module SaferNames.CheapReduction (
   CheaplyReducibleE (..), cheapReduce, cheapReduceWithDecls, cheapReduceToAtom) where
 
+import Data.Functor.Identity
 import Control.Applicative
+import Control.Monad.Trans
+import Control.Monad.Writer.Strict
 
+import SaferNames.MTL1
 import SaferNames.Name
 import SaferNames.Syntax
 import SaferNames.PPrint ()
@@ -30,34 +35,65 @@ cheapReduce e = liftImmut do
 cheapReduceWithDecls
   :: ( BindingsReader m
      , HoistableE e, InjectableE e, SubstE AtomSubstVal e, SubstE Name e)
-  => Nest Decl n l -> e l -> m n (Maybe (e n))
-cheapReduceWithDecls decls result = fromMaybeE <$> liftImmut do
+  => Nest Decl n l -> e l -> m n (Maybe (e n), Maybe [Type n])
+cheapReduceWithDecls decls result = publicResultFromE <$> liftImmut do
   Abs decls' result' <- injectM $ Abs decls result
   DB bindings <- getDB
-  return $ toMaybeE $ runCheapReducerM idEnv bindings $
+  return $ resultToE $ runCheapReducerM idEnv bindings $
     cheapReduceWithDeclsB decls' $
       cheapReduceFromSubst result'
 
 cheapReduceToAtom :: (BindingsReader m, CheaplyReducibleE e, InjectableE e)
-                  => e n -> m n (Maybe (Atom n))
-cheapReduceToAtom e = fromMaybeE <$> liftImmut do
+                  => e n -> m n (Maybe (Atom n), Maybe [Type n])
+cheapReduceToAtom e = publicResultFromE <$> liftImmut do
   DB bindings <- getDB
   e' <- injectM e
-  return $ toMaybeE $ runCheapReducerM idEnv bindings (cheapReduceE e')
+  return $ resultToE $ runCheapReducerM idEnv bindings $ cheapReduceE e'
 
 -- === internal ===
 
-type CheapReducerM = EnvReaderT AtomSubstVal (BindingsReaderT Maybe)
+resultToE :: (Maybe (e n), FailedDictTypes n) -> (PairE (MaybeE e) (MaybeE (ListE Type))) n
+resultToE (l, FailedDictTypes r) = PairE (toMaybeE l) r
+
+publicResultFromE :: (PairE (MaybeE e) (MaybeE (ListE Type))) n -> (Maybe (e n), Maybe [Type n])
+publicResultFromE (PairE l r) = (fromMaybeE l, fromListE <$> fromMaybeE r)
+
+newtype CheapReducerM (i :: S) (o :: S) (a :: *) =
+  CheapReducerM
+    (EnvReaderT AtomSubstVal
+      (MaybeT1
+        (WriterT1 FailedDictTypes
+          (BindingsReaderT Identity))) i o a)
+  deriving ( Functor, Applicative, Monad, Alternative
+           , BindingsReader, ScopeReader, BindingsExtender
+           , EnvReader AtomSubstVal, AlwaysImmut )
+
+newtype FailedDictTypes (n::S) = FailedDictTypes ((MaybeE (ListE Type)) n)
+                                 deriving (InjectableE, HoistableE)
+
+instance Semigroup (FailedDictTypes n) where
+  FailedDictTypes (JustE l) <> FailedDictTypes (JustE r) =
+    FailedDictTypes $ JustE $ l <> r
+  _ <> _ = FailedDictTypes $ NothingE
+instance Monoid (FailedDictTypes n) where
+  mempty = FailedDictTypes $ JustE mempty
+instance FallibleMonoid1 FailedDictTypes where
+  mfail = FailedDictTypes $ NothingE
 
 class ( Alternative2 m, EnvReader AtomSubstVal m, AlwaysImmut2 m
-      , BindingsReader2 m, BindingsExtender2 m) => CheapReducer m
-instance CheapReducer CheapReducerM
+      , BindingsReader2 m, BindingsExtender2 m) => CheapReducer m where
+  reportSynthesisFail :: Type o -> m i o ()
+
+instance CheapReducer CheapReducerM where
+  reportSynthesisFail ty = CheapReducerM $ EnvReaderT $ lift $ lift11 $
+    WriterT1 $ tell $ FailedDictTypes $ JustE $ ListE [ty]
 
 runCheapReducerM :: Distinct o
                  => Env AtomSubstVal i o -> Bindings o -> CheapReducerM i o a
-                 -> Maybe a
-runCheapReducerM env bindings m =
-  runBindingsReaderT bindings $ runEnvReaderT env m
+                 -> (Maybe a, FailedDictTypes o)
+runCheapReducerM env bindings (CheapReducerM m) =
+  runIdentity $ runBindingsReaderT bindings $
+    runWriterT1 $ runMaybeT1 $ runEnvReaderT env m
 
 cheapReduceFromSubst
   :: ( EnvReader AtomSubstVal m, BindingsReader2 m
@@ -83,12 +119,12 @@ cheapReduceWithDeclsB
      , HoistableE e, InjectableE e, SubstE AtomSubstVal e, SubstE Name e)
   => Nest Decl i i'
   -> (forall o'. Ext o o' => m i' o' (e o'))
-  -> m i  o (e o)
+  -> m i o (e o)
 cheapReduceWithDeclsB decls cont = do
   Abs irreducibleDecls result <- cheapReduceWithDeclsRec decls cont
   case hoist irreducibleDecls result of
     HoistSuccess result' -> return result'
-    HoistFailure _ -> empty
+    HoistFailure _       -> empty
 
 cheapReduceWithDeclsRec
   :: ( CheapReducer m
@@ -115,8 +151,7 @@ class CheaplyReducibleE (e::E) where
   cheapReduceE :: CheapReducer m => e i -> m i o (Atom o)
 
 instance CheaplyReducibleE e => CheaplyReducibleE (Abs (Nest Decl) e) where
-  cheapReduceE (Abs decls result) =
-    cheapReduceWithDeclsB decls $ cheapReduceE result
+  cheapReduceE (Abs decls result) = cheapReduceWithDeclsB decls $ cheapReduceE result
 
 instance CheaplyReducibleE Block where
   cheapReduceE (Block _ decls result) = cheapReduceE $ Abs decls result
@@ -134,7 +169,7 @@ instance CheaplyReducibleE Expr where
     Op (SynthesizeDict _ ty) -> do
       runFallibleT1 (trySynthDictBlock ty) >>= \case
         Success (Block _ Empty (Atom d)) -> return d
-        _ -> empty
+        _ -> reportSynthesisFail ty >> empty
     -- TODO: Make sure that this wraps correctly
     -- TODO: Other casts?
     Op (CastOp (BaseTy (Scalar Int32Type)) (Con (Lit (Int64Lit v)))) ->

--- a/src/lib/SaferNames/MTL1.hs
+++ b/src/lib/SaferNames/MTL1.hs
@@ -1,0 +1,91 @@
+-- Copyright 2021 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# LANGUAGE GeneralizedNewtypeDeriving #-}
+{-# LANGUAGE UndecidableInstances #-}
+
+module SaferNames.MTL1 (
+    MonadTrans11 (..),
+    FallibleMonoid1 (..), WriterT1 (..), runWriterT1,
+    MaybeT1 (..), runMaybeT1,
+  ) where
+
+import Control.Monad.Writer.Strict
+import Control.Monad.Trans.Maybe
+import Control.Applicative
+
+import SaferNames.Name
+import SaferNames.Syntax
+
+class MonadTrans11 (t :: MonadKind1 -> MonadKind1) where
+  lift11 :: Monad1 m => m n a -> t m n a
+
+-------------------- WriterT1 --------------------
+
+-- A monoid with a special "sink" element. We expect that
+--   mfail <> _ = mfail
+-- as well as
+--   _ <> mfail = mfail.
+class Monoid1 w => FallibleMonoid1 w where
+  mfail :: w n
+
+newtype WriterT1 (w :: E) (m :: MonadKind1) (n :: S) (a :: *) =
+  WriterT1 { runWriterT1' :: (WriterT (w n) (m n) a) }
+  deriving (Functor, Applicative, Monad, MonadWriter (w n))
+
+runWriterT1 :: WriterT1 w m n a -> m n (a, w n)
+runWriterT1 = runWriterT . runWriterT1'
+
+instance (AlwaysImmut m, Monoid1 w) => AlwaysImmut (WriterT1 w m) where
+  getImmut = lift11 $ getImmut
+
+instance Monoid1 w => MonadTrans11 (WriterT1 w) where
+  lift11 = WriterT1 . lift
+
+instance (InjectableE w, Monoid1 w, BindingsReader m) => BindingsReader (WriterT1 w m) where
+  getBindings = lift11 getBindings
+
+instance (InjectableE w, Monoid1 w, ScopeReader m) => ScopeReader (WriterT1 w m) where
+  getScope = lift11 getScope
+  getDistinct = lift11 getDistinct
+  liftImmut m = WriterT1 $ WriterT $ fromPairE <$>
+    (liftImmut $ (uncurry PairE) <$> (runWriterT $ runWriterT1' m))
+
+instance (InjectableE w, HoistableE w, FallibleMonoid1 w, BindingsExtender m)
+         => BindingsExtender (WriterT1 w m) where
+  extendBindings frag m = WriterT1 $ WriterT $ do
+    (ans, update) <- extendBindings frag (runWriterT $ runWriterT1' m)
+    case hoist frag update of
+      HoistSuccess topUpdate -> return (ans, topUpdate)
+      HoistFailure _ -> return (ans, mfail)
+
+-------------------- MaybeT1 --------------------
+
+newtype MaybeT1 (m :: MonadKind1) (n :: S) (a :: *) =
+  MaybeT1 { runMaybeT1' :: (MaybeT (m n) a) }
+  deriving (Functor, Applicative, Monad, Alternative)
+
+runMaybeT1 :: MaybeT1 m n a -> m n (Maybe a)
+runMaybeT1 = runMaybeT . runMaybeT1'
+
+instance AlwaysImmut m => AlwaysImmut (MaybeT1 m) where
+  getImmut = lift11 $ getImmut
+
+instance MonadTrans11 MaybeT1 where
+  lift11 = MaybeT1 . lift
+
+instance BindingsReader m => BindingsReader (MaybeT1 m) where
+  getBindings = lift11 getBindings
+
+instance ScopeReader m => ScopeReader (MaybeT1 m) where
+  getScope = lift11 getScope
+  getDistinct = lift11 getDistinct
+  liftImmut m = MaybeT1 $ MaybeT $ fromMaybeE <$>
+    (liftImmut $ toMaybeE <$> (runMaybeT $ runMaybeT1' m))
+
+instance BindingsExtender m => BindingsExtender (MaybeT1 m) where
+  extendBindings frag m = MaybeT1 $ MaybeT $
+    extendBindings frag $ runMaybeT $ runMaybeT1' m

--- a/src/lib/SaferNames/Name.hs
+++ b/src/lib/SaferNames/Name.hs
@@ -41,7 +41,7 @@ module SaferNames.Name (
   runScopeReaderT, runScopeReaderM, runEnvReaderT, ScopeReaderT (..), EnvReaderT (..),
   lookupEnvM, dropSubst, extendEnv, fmapNames,
   MonadKind, MonadKind1, MonadKind2,
-  Monad1, Monad2, Fallible1, Fallible2, Catchable1, Catchable2,
+  Monad1, Monad2, Fallible1, Fallible2, Catchable1, Catchable2, Monoid1,
   CtxReader1, CtxReader2, MonadFail1, MonadFail2, Alternative1, Alternative2,
   Searcher1, Searcher2, ScopeReader2, ScopeExtender2,
   applyAbs, applySubst, applyNaryAbs, ZipEnvReader (..), alphaEqTraversable,
@@ -738,6 +738,8 @@ type AlwaysImmut2     (m::MonadKind2) = forall (n::S). AlwaysImmut     (m n)
 
 type Alternative1 (m::MonadKind1) = forall (n::S)        . Alternative (m n)
 type Alternative2 (m::MonadKind2) = forall (n::S) (l::S ). Alternative (m n l)
+
+type Monoid1 (m :: E) = forall (n::S). Monoid (m n)
 
 -- === subst monad ===
 


### PR DESCRIPTION
Also start stubbing out "MTL1", a 1-scope-kinded version of MTL.