### PR TITLE
Implicitly abstract interfaces needed by binder types and interface params

### DIFF
--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -417,6 +417,10 @@ instance Fallible m => Fallible (StateT s m) where
   throwErrs errs = lift $ throwErrs errs
   addErrCtx ctx (StateT f) = StateT \s -> addErrCtx ctx $ f s
 
+instance Catchable m => Catchable (StateT s m) where
+  StateT f `catchErr` handler = StateT \s ->
+    f s `catchErr` \e -> runStateT (handler e) s
+
 instance CtxReader m => CtxReader (StateT s m) where
   getErrCtx = lift getErrCtx
 

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -156,31 +156,34 @@ def f8 {n} [Ord' (n=>Int)] (x : n=>Int) : Int = eq x
 
 -------------------- Automatic quantification --------------------
 
--- XXX: broken since safe-names refactor
 
--- interface X a
---   x_ a : Int
+interface X a
+  x_ a : Int
 
--- def MyPairOfXs (a : Type) (_ : X a) ?=> : Type = (a & a)
+def MyPairOfXs (a : Type) [X a] : Type = (a & a)
 
--- instance X Int
---   x_ = 1
+instance X Int
+  x_ = 1
 
--- -- No automatic quantification needed
--- def q0 (x : MyPairOfXs Int) : Int = fst x
--- def q1 [X a] (x : MyPairOfXs a) : a = fst x
+-- No automatic quantification needed
+def q0 (x : MyPairOfXs Int) : Int = fst x
+def q1 {a} [X a] (x : MyPairOfXs a) : a = fst x
 
--- -- Should work with implicit quantification
--- def q2 (x : MyPairOfXs a) : a = fst x
+-- Should work with implicit quantification
+def q2 {a} (x : MyPairOfXs a) : a = fst x
 
--- -- -- Should work with implicit quantification
--- -- def q3 (x : MyPairOfXs a) : Int = x_ a
+-- Should work with implicit quantification
+def q3 {a} (x : MyPairOfXs a) : Int = x_ a
 
--- -- We should also implicitly quantify over constraints of the return type
--- def f4 (x : a) : MyPairOfXs a = (x, x)
+-- We don't quantify implicitly over constraints of the return type
+def f4 {a} (x : a) : MyPairOfXs a = (x, x)
+> Type error:Couldn't synthesize a class dictionary for: (X a)
+>
+> def f4 {a} (x : a) : MyPairOfXs a = (x, x)
+>                      ^^^^^^^^^^^^^
 
--- -- Check automatic quantification for interfaces
--- interface AutoQuant a
---   dummy : Int
--- instance AutoQuant (MyPairOfXs a)
---   dummy = 1
+-- Check automatic quantification for interfaces
+interface AutoQuant a
+  dummy : Int
+instance {a} AutoQuant (MyPairOfXs a)
+  dummy = 1

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -176,10 +176,10 @@ def q2 {a} (x : MyPairOfXs a) : a = fst x
 def q3 {a} (x : MyPairOfXs a) : Int = x_ a
 
 -- We don't quantify implicitly over constraints of the return type
-def f4 {a} (x : a) : MyPairOfXs a = (x, x)
+def q4 {a} (x : a) : MyPairOfXs a = (x, x)
 > Type error:Couldn't synthesize a class dictionary for: (X a)
 >
-> def f4 {a} (x : a) : MyPairOfXs a = (x, x)
+> def q4 {a} (x : a) : MyPairOfXs a = (x, x)
 >                      ^^^^^^^^^^^^^
 
 -- Check automatic quantification for interfaces
@@ -187,3 +187,8 @@ interface AutoQuant a
   dummy : Int
 instance {a} AutoQuant (MyPairOfXs a)
   dummy = 1
+
+-- Should be able to quantify nested constraints
+def q5 {a} (x : MyPairOfXs (MyPairOfXs a)) : Int = 0
+:t q5
+> ((a:Type) ?-> (X a) ?=> (X (a & a)) ?=> ((a & a) & (a & a)) -> Int32)


### PR DESCRIPTION
This is a translation of #682 to the safer names system.