### PR TITLE
Make sure data and type constructors are always fully applied

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -579,9 +579,9 @@ instance Pretty AnyBinderInfo where
   pretty info = case info of
     AtomBinderInfo ty binfo -> "<atom binder>" <+> p ty <+> p binfo
     DataDefName  dataDef -> "<data def>" <+> p dataDef
-    ClassDefName classDef -> "<class def>" <+> p classDef
-    TyConName    dataDef -> "<type con name>" <+> p dataDef
-    DataConName  dataDef i -> "<data con name>" <+> parens ("idx:" <+> p i) <+> p dataDef
+    ClassDefName classDef _ -> "<class def>" <+> p classDef
+    TyConName    dataDef _ -> "<type con name>" <+> p dataDef
+    DataConName  dataDef i _ -> "<data con name>" <+> parens ("idx:" <+> p i) <+> p dataDef
     SuperclassName dataDef i getter ->
       "<superclass name>" <+> parens ("idx:" <+> p i) <+> p dataDef <+> p getter
     MethodName     dataDef i getter ->

--- a/src/lib/SaferNames/Builder.hs
+++ b/src/lib/SaferNames/Builder.hs
@@ -440,15 +440,15 @@ emitDataDef dataDef@(DataDef sourceName _ _) =
   emitBinding hint $ DataDefBinding dataDef
   where hint = getNameHint sourceName
 
-emitClassDef :: (Mut n, TopBuilder m) => ClassDef n -> m n (Name ClassNameC n)
-emitClassDef classDef@(ClassDef name _ _) =
-  emitBinding (getNameHint name) $ ClassBinding classDef
+emitClassDef :: (Mut n, TopBuilder m) => ClassDef n -> Atom n -> m n (Name ClassNameC n)
+emitClassDef classDef@(ClassDef name _ _) dictTyAtom =
+  emitBinding (getNameHint name) $ ClassBinding classDef dictTyAtom
 
-emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> m n (Name DataConNameC n)
-emitDataConName dataDefName conIdx = do
+emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> Atom n -> m n (Name DataConNameC n)
+emitDataConName dataDefName conIdx conAtom = do
   DataDef _ _ dataCons <- getDataDef dataDefName
   let (DataConDef name _) = dataCons !! conIdx
-  emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx
+  emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx conAtom
 
 emitSuperclass :: (Mut n ,TopBuilder m)
                => ClassName n -> Int -> m n (Name SuperclassNameC n)
@@ -495,9 +495,9 @@ makeMethodGetter classDefName explicit methodIdx = liftBuilder do
     buildPureLam "dict" ClassArrow (TypeCon (defName', def') (map Var params)) \dict ->
       return $ getProjection [methodIdx] $ getProjection [1, 0] $ Var dict
 
-emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> m n (Name TyConNameC n)
-emitTyConName dataDefName =
-  emitBinding (getNameHint dataDefName) $ TyConBinding dataDefName
+emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> Atom n -> m n (Name TyConNameC n)
+emitTyConName dataDefName tyConAtom = do
+  emitBinding (getNameHint dataDefName) $ TyConBinding dataDefName tyConAtom
 
 getDataDef :: BindingsReader m => DataDefName n -> m n (DataDef n)
 getDataDef v = do
@@ -506,12 +506,12 @@ getDataDef v = do
 
 getDataCon :: BindingsReader m => Name DataConNameC n -> m n (DataDefName n, Int)
 getDataCon v = do
-  ~(DataConBinding defName idx) <- lookupBindings v
+  ~(DataConBinding defName idx _) <- lookupBindings v
   return (defName, idx)
 
 getClassDef :: BindingsReader m => Name ClassNameC n -> m n (ClassDef n)
 getClassDef classDefName = do
-  ~(ClassBinding classDef) <- lookupBindings classDefName
+  ~(ClassBinding classDef _) <- lookupBindings classDefName
   return classDef
 
 -- === builder versions of common local ops ===

--- a/src/lib/SaferNames/PPrint.hs
+++ b/src/lib/SaferNames/PPrint.hs
@@ -277,11 +277,11 @@ instance Pretty (Binding s n) where
   pretty b = case b of
     AtomNameBinding   info -> "Atom name:" <+> pretty info
     DataDefBinding    dataDef -> pretty dataDef
-    TyConBinding      dataDefName -> "Type constructor:" <+> pretty dataDefName
-    DataConBinding    dataDefName idx ->
+    TyConBinding      dataDefName e -> "Type constructor:" <+> pretty dataDefName <+> (parens $ "atom:" <+> p e)
+    DataConBinding    dataDefName idx e ->
       "Data constructor:" <+> pretty dataDefName <+>
-      "Constructor index:" <+> pretty idx
-    ClassBinding      classDef -> pretty classDef
+      "Constructor index:" <+> pretty idx <+> (parens $ "atom:" <+> p e)
+    ClassBinding      classDef e -> pretty classDef <+> (parens $ "atom:" <+> p e)
     SuperclassBinding className idx _ ->
       "Superclass" <+> pretty idx <+> "of" <+> pretty className
     MethodBinding     className idx _ ->

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -316,9 +316,6 @@ simplifyExpr expr = case expr of
     case f' of
       Lam (Abs b (_, body)) ->
         dropSub $ extendR (b@> SubstVal x') $ simplifyBlock body
-      DataCon def params con xs -> return $ DataCon def params' con xs'
-         where (_, DataDef _ paramBs _) = def
-               (params', xs') = splitAt (length paramBs) $ params ++ xs ++ [x']
       ACase e alts ~(Pi ab) -> do
         let rty' = snd $ applyAbs ab $ getType x'
         case all isCurriedFun alts of
@@ -332,8 +329,6 @@ simplifyExpr expr = case expr of
             _ -> False
           appAlt ~(Abs bs (LamVal b (Block Empty (Atom r)))) =
             Abs bs $ subst (b @> SubstVal  x', mempty) r
-      TypeCon def params -> return $ TypeCon def params'
-         where params' = params ++ [x']
       _ -> emit $ App f' x'
   Op  op  -> mapM simplifyAtom op >>= simplifyOp
   Hof hof -> simplifyHof hof

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -1179,14 +1179,9 @@ nameToAtom :: Scope -> Name -> Maybe Atom
 nameToAtom scope v = do
   case scope ! v of
     AtomBinderInfo ty _ -> return $ Var $ v :> ty
-    ClassDefName (ClassDef dataDef _) ->
-      return $ TypeCon dataDef []
-    TyConName dataDefName -> do
-      let DataDefName dataDef = scope ! dataDefName
-      return $ TypeCon (dataDefName, dataDef) []
-    DataConName dataDefName conIdx -> do
-      let DataDefName dataDef = scope ! dataDefName
-      return $ DataCon (dataDefName, dataDef) [] conIdx []
+    ClassDefName _ e -> return e
+    TyConName _ e -> return e
+    DataConName _ _ e -> return e
     MethodName _ _ methodGetter -> return methodGetter
     binderInfo -> error $ "Not an atom name: " ++ pprint binderInfo
 

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -255,7 +255,7 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 > 1
 
 :p NewPair
-> NewPair
+> \a:Type b:Type. NewPair a b
 
 -- TODO: these are broken since switching from newtype mechanism to ADTs
 


### PR DESCRIPTION
Previously we allowed them to be partially applied, in which case they
would have function types. This approach is a little surprising and
makes the implementation of interface dependencies for data definitions
more difficult, so this patch makes it so that data and type
constructors are always elaborated as nested lambda expressions that
contain fully applied `DataCon`s or `TypeCon`s in their bodies.

Note that this doesn't really change anything important. It's only a
setup for follow-up work.