### PR TITLE
Safe-names telescope-based defunctionalization

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -641,6 +641,7 @@ makeDestRec idxs idxBinders ty = case ty of
           Nothing -> error "Dependent data constructors only allowed for single-constructor types"
           Just tys -> mapM (makeDestRec idxs idxBinders') tys
         return $ Con $ ConRef $ SumAsProd ty' tag contents
+  DepPairTy _ -> error "not implemented"
   TC con -> case con of
     BaseType b -> do
       ptr <- makeBaseTypePtr idxs idxBinders b

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -378,6 +378,12 @@ toImpHof maybeDest hof = do
             void $ extendSubst (b @> SubstVal idx) $
               translateBlock (Just ithDest) body
           destToAtom dest
+    While (Lam (LamExpr b body)) -> do
+      body' <- buildBlockImp $ extendSubst (b@>SubstVal UnitVal) do
+        ans <- fromScalarAtom =<< translateBlock Nothing body
+        return [ans]
+      emitStatement $ IWhile body'
+      return UnitVal
     RunReader r (Lam (BinaryLamExpr h ref body)) -> do
       r' <- substM r
       rDest <- alloc =<< getType r'

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -635,7 +635,7 @@ makeDestRec idxs idxBinders ty = case ty of
     Abs idxBinders' (ListE dcs) <- liftImmut do
       refreshAbsM (sink $ Abs idxBinders ty) \idxBinders' (TypeCon _ defName params) -> do
         def <- lookupDataDef defName
-        dcs <- applyDataDefParams def params
+        dcs <- instantiateDataDef def params
         return $ Abs idxBinders' $ ListE dcs
     case dcs of
       [] -> error "Void type not allowed"

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -70,6 +70,8 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   Var v -> doWithName v
   Lam _ -> substM atom
   Pi  _ -> substM atom
+  DepPair l r ty -> DepPair <$> rec l <*> rec r <*> substM ty
+  DepPairTy _ -> substM atom
   Con con -> Con <$> mapM rec con
   TC  tc  -> TC  <$> mapM rec tc
   Eff _ -> substM atom
@@ -83,6 +85,7 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   Record items -> Record <$> mapM rec items
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _ _ _   -> error "Should only occur in Imp lowering"
+  DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> rec (Var v)
   _ -> error "not implemented"
   where rec x = traverseSurfaceAtomNames x doWithName

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -83,11 +83,18 @@ traverseSurfaceAtomNames atom doWithName = case atom of
     DataCon printName defName' <$> mapM rec params
                                <*> pure con <*> mapM rec args
   Record items -> Record <$> mapM rec items
+  RecordTy _ -> substM atom
+  Variant ty l con payload ->
+    Variant
+       <$> (fromExtLabeledItemsE <$> substM (ExtLabeledItemsE ty))
+       <*> return l <*> return con <*> rec payload
+  VariantTy _      -> substM atom
+  LabeledRow _     -> substM atom
+  ACase _ _ _ -> error "not implemented"
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _ _ _   -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> rec (Var v)
-  _ -> error "not implemented"
   where rec x = traverseSurfaceAtomNames x doWithName
 
 evalAtom :: Interp m => Atom i -> m i o (Atom o)

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -92,7 +92,7 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   LabeledRow _     -> substM atom
   ACase _ _ _ -> error "not implemented"
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
-  BoxedRef _ _ _   -> error "Should only occur in Imp lowering"
+  BoxedRef _ _     -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> rec (Var v)
   where rec x = traverseSurfaceAtomNames x doWithName

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -40,7 +40,8 @@ module Name (
   MaybeE, fromMaybeE, toMaybeE, pattern JustE, pattern NothingE, MaybeB,
   pattern JustB, pattern NothingB,
   toConstAbs, PrettyE, PrettyB, ShowE, ShowB,
-  runScopeReaderT, runScopeReaderM, runSubstReaderT, ScopeReaderT (..), SubstReaderT (..),
+  runScopeReaderT, runScopeReaderM, runSubstReaderT, idNameSubst,
+  ScopeReaderT (..), SubstReaderT (..),
   lookupSubstM, dropSubst, extendSubst, fmapNames,
   MonadKind, MonadKind1, MonadKind2,
   Monad1, Monad2, Fallible1, Fallible2, Catchable1, Catchable2, Monoid1,
@@ -69,7 +70,8 @@ module Name (
   toSubstPairs, fromSubstPairs, SubstPair (..), refreshRecSubstFrag,
   substAbsDistinct, refreshAbs,
   hoist, hoistToTop, sinkFromTop, fromConstAbs, exchangeBs, HoistableE (..),
-  HoistExcept (..), liftHoistExcept, abstractFreeVars, abstractFreeVarsNoAnn,
+  HoistExcept (..), liftHoistExcept, abstractFreeVars, abstractFreeVar,
+  abstractFreeVarsNoAnn,
   WithRenamer (..), ignoreHoistFailure,
   HoistableB (..), HoistableV,
   WrapE (..), WithColor (..), fromWithColor,
@@ -102,6 +104,7 @@ import Data.Function ((&))
 import Data.List (nubBy)
 import Data.Text.Prettyprint.Doc  hiding (nest)
 import qualified Data.Text as T
+import GHC.Stack
 import GHC.Exts (Constraint)
 import GHC.Generics (Generic (..), Rep)
 import Data.Store (Store)
@@ -126,6 +129,10 @@ envFromFrag frag = Subst absurdNameFunction frag
 
 idSubst :: FromName v => Subst v n n
 idSubst = newSubst fromName
+
+-- common instantiation (useful where `v` would be ambiguous)
+idNameSubst :: Subst Name n n
+idNameSubst = idSubst
 
 idSubstFrag :: (BindsNames b, FromName v) => b n l -> SubstFrag v n l l
 idSubstFrag b =
@@ -625,7 +632,7 @@ instance BindsOneName (BinderP c ann) c where
 
 infixr 7 @@>
 class BindsNameList (b::B) (c::C) | b -> c where
-  (@@>) :: b i i' -> [v c o] -> SubstFrag v i i' o
+  (@@>) :: HasCallStack => b i i' -> [v c o] -> SubstFrag v i i' o
 
 instance BindsAtMostOneName b c => BindsNameList (Nest b) c where
   (@@>) Empty [] = emptyInFrag
@@ -2255,7 +2262,7 @@ liftHoistExcept :: Fallible m => HoistExcept a -> m a
 liftHoistExcept (HoistSuccess x) = return x
 liftHoistExcept (HoistFailure vs) = throw EscapedNameErr (pprint vs)
 
-ignoreHoistFailure :: HoistExcept a -> a
+ignoreHoistFailure :: HasCallStack => HoistExcept a -> a
 ignoreHoistFailure (HoistSuccess x) = x
 ignoreHoistFailure (HoistFailure _) = error "hoist failure"
 
@@ -2307,6 +2314,12 @@ hoistNameSet :: BindsNames b => b n l -> NameSet l -> NameSet n
 hoistNameSet b nameSet = unsafeCoerceNameSet $ nameSet `M.difference` frag
   where UnsafeMakeScopeFrag frag = toScopeFrag b
 
+abstractFreeVar :: Name c n -> e n -> Abs (NameBinder c) e n
+abstractFreeVar v e =
+  case abstractFreeVarsNoAnn [v] e of
+    Abs (Nest b Empty) e' -> Abs b e'
+    _ -> error "impossible"
+
 abstractFreeVars :: [(Name c n, ann n)]
                  -> e n -> Abs (Nest (BinderP c ann)) e n
 abstractFreeVars vs e = Abs bs e
@@ -2319,17 +2332,6 @@ abstractFreeVarsNoAnn vs e =
   case abstractFreeVars (zip vs (repeat UnitE)) e of
     Abs bs e' -> Abs bs' e'
       where bs' = fmapNest (\(b:>UnitE) -> b) bs
-
--- captureClosure decls result = do
---   let vs = capturedVars decls result
---   case abstractFreeVars (zip vs (repeat UnitE)) result of
---     Abs bs e -> do
---       let bs' = fmapNest (\(b:>UnitE) -> b) bs
---       case hoist decls $ Abs bs' e of
---         HoistSuccess abHoisted -> (vs, abHoisted)
---         HoistFailure _ ->
---           error "shouldn't happen"  -- but it will if we have types that reference
---                                     -- local vars. We really need a telescope.
 
 instance HoistableB (NameBinder c) where
   freeVarsB _ = mempty

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -632,7 +632,7 @@ instance BindsOneName (BinderP c ann) c where
 
 infixr 7 @@>
 class BindsNameList (b::B) (c::C) | b -> c where
-  (@@>) :: HasCallStack => b i i' -> [v c o] -> SubstFrag v i i' o
+  (@@>) :: b i i' -> [v c o] -> SubstFrag v i i' o
 
 instance BindsAtMostOneName b c => BindsNameList (Nest b) c where
   (@@>) Empty [] = emptyInFrag

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -207,8 +207,8 @@ instance PrettyPrec (Atom n) where
     ACase e alts _ -> prettyPrecCase "acase" e alts
     DataConRef _ params args -> atPrec AppPrec $
       "DataConRef" <+> p params <+> p args
-    BoxedRef ptr size (Abs b body) -> atPrec AppPrec $
-      "Box" <+> p b <+> "<-" <+> p ptr <+> "[" <> p size <> "]" <+> hardline <> "in" <+> p body
+    BoxedRef ptrsSizes (Abs b body) -> atPrec AppPrec $
+      "Box" <+> p b <+> "<-" <+> p ptrsSizes <+> hardline <> "in" <+> p body
     ProjectElt idxs v ->
       atPrec AppPrec $ "ProjectElt" <+> p idxs <+> p v
     DepPairRef l (Abs b r) _ -> atPrec LowestPrec $

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -168,12 +168,20 @@ instance PrettyPrec (LamExpr n) where
       atPrec LowestPrec $ "\\"
       <> prettyLamHelper lamExpr (PrettyLam arr)
 
+instance Pretty (DepPairType n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (DepPairType n) where
+  prettyPrec (DepPairType b rhs) =
+    atPrec ArgPrec $ align $ group $ parens $ p b <+> "&>" <+> p rhs
+
 instance Pretty (Atom n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (Atom n) where
   prettyPrec atom = case atom of
     Var v -> atPrec ArgPrec $ p v
     Lam lamExpr -> prettyPrec lamExpr
     Pi piType -> atPrec LowestPrec $ align $ p piType
+    DepPairTy ty -> prettyPrec ty
+    DepPair x y _ -> atPrec ArgPrec $ align $ group $
+        parens $ p x <> ",>" <+> p y
     TC  e -> prettyPrec e
     Con e -> prettyPrec e
     Eff e -> atPrec ArgPrec $ p e
@@ -203,6 +211,8 @@ instance PrettyPrec (Atom n) where
       "Box" <+> p b <+> "<-" <+> p ptr <+> "[" <> p size <> "]" <+> hardline <> "in" <+> p body
     ProjectElt idxs v ->
       atPrec AppPrec $ "ProjectElt" <+> p idxs <+> p v
+    DepPairRef l (Abs b r) _ -> atPrec LowestPrec $
+      "DepPairRef" <+> p l <+> "as" <+> p b <+> "in" <+> p r
 
 instance Pretty (DataConRefBinding n l) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (DataConRefBinding n l) where

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -216,6 +216,9 @@ simplifyHof hof = case hof of
     case recon of
       IdentityRecon -> return ans
       LamRecon _ -> undefined
+  While body -> do
+    (lam', IdentityRecon) <- simplifyLam body
+    liftM Var $ emit $ Hof $ While lam'
   RunReader r lam -> do
     r' <- simplifyAtom r
     (lam', recon) <- simplifyBinaryLam lam

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -54,7 +54,7 @@ module Syntax (
     withFreshPiBinder, piBinderToLamBinder, catEnvFrags,
     EnvFrag (..), lookupEnv, lookupDataDef, lookupAtomName,
     lookupEnvPure, lookupSourceMap,
-    getSourceMapM, updateEnv, runEnvReaderT, liftEnvReaderM,
+    getSourceMapM, updateEnv, runEnvReaderT, liftEnvReaderM, liftSubstEnvReaderM,
     EnvReaderM, runEnvReaderM,
     EnvReaderT (..), EnvReader2, EnvExtender2,
     getDB, DistinctEnv (..),
@@ -412,6 +412,12 @@ liftEnvReaderM :: (EnvReader m, Immut n) => EnvReaderM n a -> m n a
 liftEnvReaderM cont = do
   DB env <- getDB
   return $ runEnvReaderM env cont
+
+liftSubstEnvReaderM
+  :: (EnvReader m, Immut n)
+  => SubstReaderT Name EnvReaderM n n a
+  -> m n a
+liftSubstEnvReaderM cont = liftEnvReaderM $ runSubstReaderT idNameSubst $ cont
 
 instance Monad m => EnvReader (EnvReaderT m) where
   getEnv = EnvReaderT $ asks snd

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -1650,7 +1650,8 @@ deriving instance Show (DataConRefBinding n l)
 deriving instance Generic (DataConRefBinding n l)
 
 newtype ExtLabeledItemsE (e1::E) (e2::E) (n::S) =
-  ExtLabeledItemsE (ExtLabeledItems (e1 n) (e2 n))
+  ExtLabeledItemsE
+   { fromExtLabeledItemsE :: ExtLabeledItems (e1 n) (e2 n) }
 
 instance GenericE Atom where
   type RepE Atom =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -1581,6 +1581,8 @@ getProjection (i:is) a = case getProjection is a of
   DataCon _ _ _ _ xs -> xs !! i
   Record items -> toList items !! i
   Con (ProdCon xs) -> xs !! i
+  DepPair l _ _ | i == 0 -> l
+  DepPair _ r _ | i == 1 -> r
   a' -> error $ "Not a valid projection: " ++ show i ++ " of " ++ show a'
 
 bundleFold :: a -> (a -> a -> a) -> [a] -> (a, BundleDesc)

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -1292,10 +1292,3 @@ checkDataLikeBinderNest (Abs Empty UnitE) = return ()
 checkDataLikeBinderNest (Abs (Nest b rest) UnitE) = do
   checkDataLike "data con binder" $ binderType b
   refreshBinders b \_ -> checkDataLikeBinderNest $ Abs rest UnitE
-
--- checkDataLikeDataCon :: ( EnvReader2 m, EnvExtender2 m
---                         , SubstReader Name m, Fallible2 m, Immut o)
---                      => DataConDef n -> m n ()
--- checkDataLikeDataCon (DataConDef _ bs) = do
---   refreshBinders bs \_ -> do
---     mapM_ (checkDataLike "data con binder" . binderAnn) bs

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -9,7 +9,8 @@
 
 module Util (IsBool (..), group, ungroup, pad, padLeft, delIdx, replaceIdx,
              insertIdx, mvIdx, mapFst, mapSnd, splitOn, scan,
-             scanM, composeN, mapMaybe, uncons, repeated, transitiveClosure,
+             scanM, composeN, mapMaybe, uncons, repeated,
+             transitiveClosure, transitiveClosureM,
              showErr, listDiff, splitMap, enumerate, restructure,
              onSnd, onFst, findReplace, swapAt, uncurry3,
              measureSeconds,
@@ -208,6 +209,17 @@ transitiveClosure getParents seeds =
       unless (x `Set.member` visited) $ do
         extend $ Set.singleton x
         mapM_ go $ getParents x
+
+transitiveClosureM :: forall m a. (Monad m, Ord a) => (a -> m [a]) -> [a] -> m [a]
+transitiveClosureM getParents seeds =
+  toList <$> execStateT (mapM_ go seeds) mempty
+  where
+    go :: a -> StateT (Set.Set a) m ()
+    go x = do
+      visited <- get
+      unless (x `Set.member` visited) $ do
+        modify (<> Set.singleton x)
+        lift (getParents x) >>= mapM_ go
 
 measureSeconds :: MonadIO m => m a -> m (a, Double)
 measureSeconds m = do


### PR DESCRIPTION
This goes a bit further than just safely reimplementing what we had before. Since we needed the telescope for `splitSimpModule` anyway, I used the same machinery in the other places we needed defunctionalization. Seems to work pretty well.