### PR TITLE
Add support for interface constraints on `data` types

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -518,8 +518,8 @@ instance Pretty (UAlt n) where
 instance Pretty (UDecl n l) where
   pretty (ULet ann b rhs) =
     align $ p ann <+> p b <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
-  pretty (UDataDefDecl (UDataDef bParams dataCons) bTyCon bDataCons) =
-    "data" <+> p bTyCon <+> p bParams
+  pretty (UDataDefDecl (UDataDef bParams bIfaces dataCons) bTyCon bDataCons) =
+    "data" <+> p bTyCon <+> p bParams <+> (brackets $ p bIfaces)
        <+> "where" <> nest 2
        (hardline <> prettyLines (zip (toList $ fromNest bDataCons) dataCons))
   pretty (UInterface params superclasses methodTys interfaceName methodNames) =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -843,9 +843,8 @@ type UConDef (n::S) (l::S) = (SourceName, Nest (UAnnBinder AtomNameC) n l)
 -- than being scoped names of the proper color of their own?
 data UDataDef (n::S) where
   UDataDef
-    :: (SourceName, Nest (UAnnBinder AtomNameC) n l)    -- param binders
-    -- Trailing l' is the last scope for the chain of potentially
-    -- dependent constructor argument types.
+    :: (SourceName, Nest (UAnnBinder AtomNameC) n l')    -- param binders
+    -> Nest (UAnnBinder AtomNameC) l' l  -- typeclass binders
     -> [(SourceName, UDataDefTrail l)] -- data constructor types
     -> UDataDef n
 

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -192,3 +192,13 @@ instance {a} AutoQuant (MyPairOfXs a)
 def q5 {a} (x : MyPairOfXs (MyPairOfXs a)) : Int = 0
 :t q5
 > ((a:Type) ?-> (X a) ?=> (X (a & a)) ?=> ((a & a) & (a & a)) -> Int32)
+
+-------------------- Data interface constraints --------------------
+
+data MyData a       = MkMyData (MyPairOfXs a)
+> Type error:Couldn't synthesize a class dictionary for: (X a)
+>
+> data MyData a       = MkMyData (MyPairOfXs a)
+>                                 ^^^^^^^^^^^^
+
+data MyData a [X a] = MkMyData (MyPairOfXs a)


### PR DESCRIPTION
This should be the last blocker for rolling out the `Ix` constraint in
surface language. Without this syntax it would be impossible to define
a type such as:
```
data MyData n a = MkMyData (n=>a)
```
because there would be no `Ix n` constraint to satisfy the left hand
side of `=>`. Instead, this type should be defined as:
```
data MyData n a [Ix n] = MkMyData (n=>a)
```