### PR TITLE
Print cost center call stacks along errors when in debug mode

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -38,6 +38,10 @@ flag foreign
   description:         Build the C interface to Dex
   default:             False
 
+flag debug
+  description:         Enable extra checks and stack trace printing (useful for developers)
+  default:             False
+
 library dex-resources
   if os(darwin)
     exposed-modules:   Resources
@@ -70,6 +74,8 @@ library
     build-depends:     warp, wai, blaze-html, http-types, cmark, binary
     cpp-options:       -DDEX_LIVE
     cxx-options:       -DDEX_LIVE
+  if flag(debug)
+    cpp-options:       -DDEX_DEBUG
   if !os(darwin)
     exposed-modules:   Resources
     hs-source-dirs:    src/resources

--- a/makefile
+++ b/makefile
@@ -90,7 +90,7 @@ install: dexrt-llvm
 	$(STACK) install $(STACK_BIN_PATH) --flag dex:optimized $(STACK_FLAGS)
 
 build-prof: dexrt-llvm
-	$(STACK) build $(STACK_FLAGS) $(PROF) --flag dex:-foreign
+	$(STACK) build $(STACK_FLAGS) $(PROF) --flag dex:-foreign --flag dex:debug
 
 # For some reason stack fails to detect modifications to foreign library files
 build-ffis: dexrt-llvm


### PR DESCRIPTION
This should make debugging a lot easier, since we can get pretty
reliable stack traces for any `throw` that makes it to the top-level.
Of course using this requires building with `make build-prof` and then
running Dex using the following alias:
```
alias dexprof='stack exec --trace --work-dir .stack-work-prof dex --'
```