### PR TITLE
Allow local type aliases in both surface language and core

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -321,7 +321,7 @@ buildBlock
 buildBlock cont = liftImmut do
   DistinctAbs decls results <- buildScoped do
     result <- cont
-    ty <- getType result
+    ty <- cheapNormalize =<< getType result
     return $ result `PairE` ty
   let (result `PairE` ty) = results
   ty' <- liftHoistExcept $ hoist decls ty
@@ -330,7 +330,7 @@ buildBlock cont = liftImmut do
 
 makeBlock :: EnvReader m => Nest Decl n l -> Expr l -> m l (Block n)
 makeBlock decls expr = do
-  ty <- getType expr
+  ty <- cheapNormalize =<< getType expr
   let ty' = ignoreHoistFailure $ hoist decls ty
   return $ Block (BlockAnn ty') decls expr
 
@@ -945,7 +945,7 @@ getProjRef i r = emitOp $ ProjRef i r
 -- equivalent types spelled differently).
 getUnpacked :: (Fallible1 m, EnvReader m) => Atom n -> m n [Atom n]
 getUnpacked atom = do
-  atom' <- cheapReduce atom
+  atom' <- cheapNormalize atom
   ty <- getType atom'
   len <- projectLength ty
   return $ map (\i -> getProjection [i] atom') [0..(len-1)]

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -5,15 +5,20 @@
 -- https://developers.google.com/open-source/licenses/bsd
 
 {-# LANGUAGE FlexibleInstances #-}
+{-# LANGUAGE InstanceSigs #-}
+{-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module CheapReduction (
-  CheaplyReducibleE (..), cheapReduce, cheapReduceWithDecls, cheapReduceToAtom) where
+  CheaplyReducibleE (..), cheapReduce, cheapReduceWithDecls, cheapNormalize) where
 
+import qualified Data.Map.Strict as M
+import Data.Maybe
 import Data.Functor.Identity
 import Control.Applicative
 import Control.Monad.Trans
 import Control.Monad.Writer.Strict
+import Control.Monad.State.Strict
 
 import MTL1
 import Name
@@ -24,31 +29,32 @@ import Err
 
 -- === api ===
 
-cheapReduce :: (EnvReader m, SubstE AtomSubstVal e, SinkableE e)
-            => e n -> m n (e n)
-cheapReduce e = liftImmut do
+type NiceE e = (HoistableE e, SinkableE e, SubstE AtomSubstVal e, SubstE Name e)
+
+cheapReduce :: forall e' e m n
+             . (EnvReader m, CheaplyReducibleE e e', NiceE e, NiceE e')
+            => e n -> m n (Maybe (e' n), Maybe [Type n])
+cheapReduce e = publicResultFromE <$> liftImmut do
   DB bindings <- getDB
   e' <- sinkM e
-  return $ runEnvReaderM bindings $
-    runSubstReaderT idSubst $ cheapReduceFromSubst e'
+  return $ resultToE $ runCheapReducerM idSubst bindings $ cheapReduceE e'
 
+-- Second argument contains a list of dictionary types that failed to synthesize
+-- during traversal of the supplied decls.
 cheapReduceWithDecls
-  :: ( EnvReader m
-     , HoistableE e, SinkableE e, SubstE AtomSubstVal e, SubstE Name e)
-  => Nest Decl n l -> e l -> m n (Maybe (e n), Maybe [Type n])
+  :: forall e' e m n l
+   . ( CheaplyReducibleE e e', NiceE e', NiceE e, EnvReader m )
+  => Nest Decl n l -> e l -> m n (Maybe (e' n), Maybe [Type n])
 cheapReduceWithDecls decls result = publicResultFromE <$> liftImmut do
   Abs decls' result' <- sinkM $ Abs decls result
   DB bindings <- getDB
   return $ resultToE $ runCheapReducerM idSubst bindings $
     cheapReduceWithDeclsB decls' $
-      cheapReduceFromSubst result'
+      cheapReduceE result'
 
-cheapReduceToAtom :: (EnvReader m, CheaplyReducibleE e, SinkableE e)
-                  => e n -> m n (Maybe (Atom n), Maybe [Type n])
-cheapReduceToAtom e = publicResultFromE <$> liftImmut do
-  DB bindings <- getDB
-  e' <- sinkM e
-  return $ resultToE $ runCheapReducerM idSubst bindings $ cheapReduceE e'
+-- Reduction of atoms always succeeds (though it might get stuck immediately).
+cheapNormalize :: EnvReader m => Atom n -> m n (Atom n)
+cheapNormalize a = fromJust . fst <$> cheapReduce a
 
 -- === internal ===
 
@@ -63,7 +69,8 @@ newtype CheapReducerM (i :: S) (o :: S) (a :: *) =
     (SubstReaderT AtomSubstVal
       (MaybeT1
         (WriterT1 FailedDictTypes
-          (EnvReaderT Identity))) i o a)
+          (ScopedT1 (MapE AtomName (MaybeE Atom))
+            (EnvReaderT Identity)))) i o a)
   deriving ( Functor, Applicative, Monad, Alternative
            , EnvReader, ScopeReader, EnvExtender
            , SubstReader AtomSubstVal, AlwaysImmut )
@@ -83,36 +90,41 @@ instance FallibleMonoid1 FailedDictTypes where
 class ( Alternative2 m, SubstReader AtomSubstVal m, AlwaysImmut2 m
       , EnvReader2 m, EnvExtender2 m) => CheapReducer m where
   reportSynthesisFail :: Type o -> m i o ()
+  updateCache :: AtomName o -> Maybe (Atom o) -> m i o ()
+  lookupCache :: AtomName o -> m i o (Maybe (Maybe (Atom o)))
 
 instance CheapReducer CheapReducerM where
   reportSynthesisFail ty = CheapReducerM $ SubstReaderT $ lift $ lift11 $
     WriterT1 $ tell $ FailedDictTypes $ JustE $ ListE [ty]
+  updateCache v u = CheapReducerM $ SubstReaderT $ lift $ lift11 $ lift11 $
+    modify (MapE . M.insert v (toMaybeE u) . fromMapE)
+  lookupCache v = CheapReducerM $ SubstReaderT $ lift $ lift11 $ lift11 $
+    fmap fromMaybeE <$> gets (M.lookup v . fromMapE)
 
 runCheapReducerM :: Distinct o
                  => Subst AtomSubstVal i o -> Env o -> CheapReducerM i o a
                  -> (Maybe a, FailedDictTypes o)
 runCheapReducerM env bindings (CheapReducerM m) =
-  runIdentity $ runEnvReaderT bindings $
-    runWriterT1 $ runMaybeT1 $ runSubstReaderT env m
+  runIdentity $ runEnvReaderT bindings $ fmap fst $ runScopedT1
+    (runWriterT1 $ runMaybeT1 $ runSubstReaderT env m) mempty
 
 cheapReduceFromSubst
-  :: ( SubstReader AtomSubstVal m, EnvReader2 m
-     , AlwaysImmut2 m, SinkableE e, SubstE AtomSubstVal e)
+  :: ( SubstReader AtomSubstVal m, EnvReader2 m, AlwaysImmut2 m
+     , SinkableE e, SubstE AtomSubstVal e )
   => e i -> m i o (e o)
 cheapReduceFromSubst e = do
   e' <- substM e
   Immut <- getImmut
   DB bindings <- getDB
-  return $ fmapNames (toScope bindings) (cheapReduceName bindings) e'
-
-cheapReduceName :: Distinct n
-                => Env n -> Name c n -> AtomSubstVal c n
-cheapReduceName bindings v =
-  runEnvReaderM bindings $ withNameColorRep (getNameColor v) do
-    lookupEnv v >>= \case
+  return $ fmapNames (toScope bindings) (cheapSubstName bindings) e'
+  where
+    cheapSubstName :: Distinct n
+                    => Env n -> Name c n -> AtomSubstVal c n
+    cheapSubstName bindings v = case lookupEnvPure bindings v of
       AtomNameBinding (LetBound (DeclBinding _ _ (Atom x))) ->
-        SubstVal <$> cheapReduce x
-      _ -> return $ Rename v
+        SubstVal $ runEnvReaderM bindings $
+          runSubstReaderT idSubst $ cheapReduceFromSubst x
+      _ -> Rename v
 
 cheapReduceWithDeclsB
   :: ( CheapReducer m
@@ -139,7 +151,8 @@ cheapReduceWithDeclsRec decls cont = case decls of
       Nothing -> do
         binding' <- substM binding
         Immut <- getImmut
-        withFreshBinder (getNameHint b) binding' \b' ->
+        withFreshBinder (getNameHint b) binding' \b' -> do
+          updateCache (binderName b') Nothing
           extendSubst (b@>Rename (binderName b')) do
             Abs decls' result <- cheapReduceWithDeclsRec rest cont
             return $ Abs (Nest (Let b' binding') decls') result
@@ -147,29 +160,97 @@ cheapReduceWithDeclsRec decls cont = case decls of
         extendSubst (b@>SubstVal x) $
           cheapReduceWithDeclsRec rest cont
 
-class CheaplyReducibleE (e::E) where
-  cheapReduceE :: CheapReducer m => e i -> m i o (Atom o)
+cheapReduceName :: CheapReducer m => Name c o -> m i o (AtomSubstVal c o)
+cheapReduceName v =
+  withNameColorRep (getNameColor v)
+    lookupEnv v >>= \case
+      AtomNameBinding (LetBound (DeclBinding _ _ e)) -> case e of
+        -- We avoid synthesizing the dictionaries during the traversal
+        -- and only do that when cheap reduction is performed on the expr directly.
+        Op (SynthesizeDict _ _) -> stuck
+        _ -> do
+          cachedVal <- lookupCache v >>= \case
+            Nothing -> do
+              result <- optional (dropSubst $ cheapReduceE e)
+              updateCache v result
+              return result
+            Just result -> return result
+          case cachedVal of
+            Nothing  -> stuck
+            Just ans -> return $ SubstVal ans
+      _ -> stuck
+  where stuck = return $ Rename v
 
-instance CheaplyReducibleE e => CheaplyReducibleE (Abs (Nest Decl) e) where
+class CheaplyReducibleE (e::E) (e'::E) where
+  cheapReduceE :: CheapReducer m => e i -> m i o (e' o)
+
+instance CheaplyReducibleE Atom Atom where
+  cheapReduceE :: forall m i o. CheapReducer m => Atom i -> m i o (Atom o)
+  cheapReduceE a = case a of
+    -- Don't try to eagerly reduce lambda bodies. We might get stuck long before
+    -- we have a chance to apply tham. Also, recursive traversal of those bodies
+    -- means that we will follow the full call chain, so it's really expensive!
+    Lam _   -> substM a
+    -- We traverse the Atom constructors that might contain lambda expressions
+    -- explicitly, to make sure that we can skip normalizing free vars inside those.
+    Con con -> Con <$> mapM cheapReduceE con
+    DataCon sourceName dataDefName params con args ->
+      DataCon sourceName <$> substM dataDefName <*> mapM cheapReduceE params <*> pure con <*> mapM cheapReduceE args
+    Record items -> Record <$> mapM cheapReduceE items
+    Variant ty l c p -> do
+      ExtLabeledItemsE ty' <- substM $ ExtLabeledItemsE ty
+      Variant ty' <$> pure l <*> pure c <*> cheapReduceE p
+    -- Do recursive reduction via substitution
+    _ -> liftImmut do
+      a' <- substM a
+      substMap <- fmap M.fromList $ dropSubst $
+        forM (freeVarsList AtomNameRep a') \v -> (v,) <$> cheapReduceName v
+      let subst :: Subst AtomSubstVal o o =
+            newSubst \v -> case getNameColor v of
+              AtomNameRep -> substMap M.! v
+              _ -> Rename v
+      DB bindings <- getDB
+      return $ substE (toScope bindings, subst) a'
+
+instance (CheaplyReducibleE e e', NiceE e') => CheaplyReducibleE (Abs (Nest Decl) e) e' where
   cheapReduceE (Abs decls result) = cheapReduceWithDeclsB decls $ cheapReduceE result
 
-instance CheaplyReducibleE Block where
+instance (CheaplyReducibleE Expr e', NiceE e') => CheaplyReducibleE Block e' where
   cheapReduceE (Block _ decls result) = cheapReduceE $ Abs decls result
 
-instance CheaplyReducibleE Expr where
-  cheapReduceE expr = cheapReduceFromSubst expr >>= \case
-    Atom atom -> return atom
-    App f xs x -> case fromNaryLam (length xs) f of
-      Just (NaryLamExpr bs b Pure body) -> do
-        let subst = bs @@> map SubstVal xs <.> b @> SubstVal x
-        dropSubst $ extendSubst subst $ cheapReduceE body
-      _ -> empty
-    Op (SynthesizeDict _ ty) -> do
+instance CheaplyReducibleE Expr Atom where
+  cheapReduceE = \case
+    Atom atom -> cheapReduceE atom
+    App f' xs' x' -> do
+      f <- cheapReduceE f'
+      case fromNaryLam (length xs') f of
+        Just (NaryLamExpr bs b _ body) -> do
+          xs <- mapM cheapReduceE xs'
+          x <- cheapReduceE x'
+          let subst = bs @@> map SubstVal xs <.> b @> SubstVal x
+          dropSubst $ extendSubst subst $ cheapReduceE body
+        _ -> empty
+    Op (SynthesizeDict _ ty') -> do
+      ty <- cheapReduceE ty'
       runFallibleT1 (trySynthDictBlock ty) >>= \case
         Success (Block _ Empty (Atom d)) -> return d
         _ -> reportSynthesisFail ty >> empty
     -- TODO: Make sure that this wraps correctly
     -- TODO: Other casts?
-    Op (CastOp (BaseTy (Scalar Int32Type)) (Con (Lit (Int64Lit v)))) ->
-      return $ Con $ Lit $ Int32Lit $ fromIntegral v
+    Op (CastOp ty' val') -> do
+      ty <- cheapReduceE ty'
+      case ty of
+        BaseTy (Scalar Int32Type) -> do
+          val <- cheapReduceE val'
+          case val of
+            Con (Lit (Int64Lit v)) -> return $ Con $ Lit $ Int32Lit $ fromIntegral v
+            _ -> empty
+        _ -> empty
     _ -> empty
+
+instance (CheaplyReducibleE e1 e1', CheaplyReducibleE e2 e2')
+  => CheaplyReducibleE (PairE e1 e2) (PairE e1' e2') where
+    cheapReduceE (PairE e1 e2) = PairE <$> cheapReduceE e1 <*> cheapReduceE e2
+
+instance CheaplyReducibleE EffectRow EffectRow where
+  cheapReduceE row = cheapReduceFromSubst row

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -40,6 +40,7 @@ import LabeledItems
 import Err
 import Util (forMZipped, forMZipped_, iota, scan, restructure)
 
+import CheapReduction
 import Syntax
 import Name
 import PPrint ()
@@ -230,7 +231,14 @@ class (SinkableE e, SubstE Name e, PrettyE e) => HasType (e::E) where
   checkTypeE :: Typer m => Type o -> e i -> m i o (e o)
   checkTypeE reqTy e = do
     (e', ty) <- getTypeAndSubstE e
-    checkAlphaEq reqTy ty
+    -- TODO: Write an alphaEq variant that works modulo an equivalence
+    -- relation on names.
+    alphaEq reqTy ty >>= \case
+      True  -> return ()
+      False -> do
+        reqTy' <- cheapNormalize reqTy
+        ty'    <- cheapNormalize ty
+        checkAlphaEq reqTy' ty'
     return e'
 
 class (SinkableE e, SubstE Name e) => CheckableE (e::E) where

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -411,3 +411,25 @@ def uncurryTable {a} (x : ((Fin 2) & (Fin 2))=>a) : (Fin 2)=>(Fin 2)=>a =
 > ((Fin 2) => (Fin 2) => Float32)
 :t uncurryTable [0, 1, 2, 3]          -- Extra difficulty: need to default the integer type
 > ((Fin 2) => (Fin 2) => Int32)
+
+
+-- Make sure that the local type alias is unifiable with Int
+def GetInt (n : Int) : Type = Int
+def the (t : Type) (x : t) : t = x
+def f (n : Int) : Int =
+  i = GetInt n
+  the i 2
+
+f 0
+> 2
+
+-- The two local aliases for Fin n should be unifiable with each other and Fin n
+def q (n : Int) : (Fin n)=>Int =
+  ix1 = Fin n
+  x1 = for i:ix1. ordinal i
+  ix2 = Fin n
+  x2 = for i:ix2. ordinal i
+  for i. x1.i + x2.i
+
+q 5
+> [0, 2, 4, 6, 8]


### PR DESCRIPTION
Turns out that at some point we might have lost (or perhaps never
acquired?) the ability to have local type aliases due to limitations
of our type equality relation and cheap reduction. We still treat alpha
equivalence as the first check, but in case it fails we do fall back to
cheap normalization before we conclude the check as unsuccessful.