### PR TITLE
Make an IR construct for n-ary application.

### DIFF
--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -31,7 +31,7 @@ class (ScopableBuilder2 m, SubstReader Name m)
 
 traverseExprDefault :: Emits o => GenericTraverser m => Expr i -> m i o (Expr o)
 traverseExprDefault expr = liftImmut $ case expr of
-  App g x -> App  <$> tge g <*> tge x
+  App g xs -> App  <$> tge g <*> mapM tge xs
   Atom x  -> Atom <$> tge x
   Op  op  -> Op   <$> mapM tge op
   Hof hof -> Hof  <$> mapM tge hof

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -314,13 +314,13 @@ linearizeDecls (Nest (Let b (DeclBinding ann _ expr)) rest) cont = do
 
 linearizeExpr :: Emits o => Expr i -> LinM i o Atom Atom
 linearizeExpr expr = case expr of
-  App x i -> do
+  Atom x -> linearizeAtom x
+  App x idxs -> do
     substM x >>= getType >>= \case
       TabTy _ _ ->
-        zipLin (linearizeAtom x) (pureLin i) `bindLin`
-         \(PairE x' i') -> app x' i'
+        zipLin (linearizeAtom x) (pureLin $ ListE idxs) `bindLin`
+         \(PairE x' (ListE idxs')) -> naryApp x' idxs'
       _ -> error "not implemented"
-  Atom e     -> linearizeAtom e
   Op op      -> linearizeOp op
   Hof e      -> linearizeHof e
   Case e alts resultTy _ -> do

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -119,9 +119,8 @@ instance PrettyE ann => Pretty (BinderP c ann n l)
 
 instance Pretty (Expr n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (Expr n) where
-  prettyPrec (App f x) =
-    atPrec AppPrec $ pApp f <+> pArg x
   prettyPrec (Atom x ) = prettyPrec x
+  prettyPrec (App f xs) = atPrec AppPrec $ pApp f <+> spaced xs
   prettyPrec (Op  op ) = prettyPrec op
   prettyPrec (Hof (For ann (Lam lamExpr))) =
     atPrec LowestPrec $ forStr ann <+> prettyLamHelper lamExpr (PrettyFor ann)

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -59,7 +59,7 @@ getTableElements :: (MonadIO1 m, EnvReader m, Fallible1 m) => Val n -> m n [Atom
 getTableElements tab = do
   TabTy b _ <- getType tab
   idxs <- indices $ binderType b
-  forM idxs \i -> liftImmut $ liftInterpM $ evalExpr $ App tab i
+  forM idxs \i -> liftImmut $ liftInterpM $ evalExpr $ App tab [i]
 
 -- Pretty-print values, e.g. for displaying in the REPL.
 -- This doesn't handle parentheses well. TODO: treat it more like PrettyPrec

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -927,13 +927,15 @@ interface AssociatedWithTwo a c
 instance AssociatedWithTwo Int Float
   value2 = 8
 
+-- TODO: the source location for this error message is a bit off since we added
+-- n-ary applications.
 value2 Int Float
 > 8
 value2 Float Int
 > Type error:Couldn't synthesize a class dictionary for: (AssociatedWithTwo Float32 Int32)
 >
 > value2 Float Int
-> ^^^^^^^^^^^^^^^^
+> ^^^^^^^
 
 -- TODO: This is a really bad error message
 interface BadAssociatedName a


### PR DESCRIPTION
Previously, every application appeared on its own line. An innocuous expression
like `1.0 + 2.0` would be elaborated in type inference to this:

    v:((Add Float32) ?=> Float32 -> Float32 -> Float32) = (+) Float32
    v1:(Add Float32) = %OpExpr (SynthesizeDict ...)
    v2:(Float32 -> Float32 -> Float32) = v v1
    v3:(Float32 -> Float32) = v2 1.
    v4:Float32 = v3 2.

Now it's just this:

    v:(Add Float32) = %OpExpr (SynthesizeDict ...)
    v1:Float32 = (+) Float32 v 1. 2.

This speeds up prelude evaluation by 30% and it makes the IR more readable.
More importantly, it will let us work with non-inlined first-order n-ary
functions, coming soon.