### PR TITLE
Require a nonempty arg list for n-ary application and n-ary pi types.

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -59,6 +59,7 @@ import Control.Monad.Writer.Strict hiding (Alt)
 import qualified Data.Map.Strict as M
 import Data.Functor ((<&>))
 import Data.Foldable (toList)
+import Data.List.NonEmpty (nonEmpty)
 import Data.List (elemIndex)
 import Data.Maybe (fromJust)
 import Data.Graph (graphFromEdges, topSort)
@@ -74,7 +75,7 @@ import CheapReduction
 import MTL1
 
 import LabeledItems
-import Util (enumerate, scanM, restructure, transitiveClosureM, bindM2)
+import Util (enumerate, scanM, restructure, transitiveClosureM, bindM2, unsnoc)
 import Err
 
 -- === Ordinary (local) builder class ===
@@ -956,11 +957,13 @@ emitUnpacked tup = do
   forM xs \x -> emit $ Atom x
 
 app :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
-app x i = Var <$> emit (App x [i])
+app x i = Var <$> emit (App x [] i)
 
 naryApp :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
-naryApp f [] = return f
-naryApp f xs = Var <$> emit (App f xs)
+naryApp f xs = case nonEmpty xs of
+  Nothing -> return f
+  Just xs' -> Var <$> emit (App f args finalArg)
+    where (args, finalArg) = unsnoc xs'
 
 indexRef :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 indexRef ref i = emitOp $ IndexRef ref i

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -159,9 +159,10 @@ instance CheaplyReducibleE Block where
 instance CheaplyReducibleE Expr where
   cheapReduceE expr = cheapReduceFromSubst expr >>= \case
     Atom atom -> return atom
-    App f xs -> case fromNaryLam (length xs) f of
-      Just (NaryLamExpr bs Pure body) -> do
-        dropSubst $ extendSubst (bs@@>map SubstVal xs) $ cheapReduceE body
+    App f xs x -> case fromNaryLam (length xs) f of
+      Just (NaryLamExpr bs b Pure body) -> do
+        let subst = bs @@> map SubstVal xs <.> b @> SubstVal x
+        dropSubst $ extendSubst subst $ cheapReduceE body
       _ -> empty
     Op (SynthesizeDict _ ty) -> do
       runFallibleT1 (trySynthDictBlock ty) >>= \case

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -31,7 +31,7 @@ class (ScopableBuilder2 m, SubstReader Name m)
 
 traverseExprDefault :: Emits o => GenericTraverser m => Expr i -> m i o (Expr o)
 traverseExprDefault expr = liftImmut $ case expr of
-  App g xs -> App  <$> tge g <*> mapM tge xs
+  App g xs x -> App  <$> tge g <*> mapM tge xs <*> tge x
   Atom x  -> Atom <$> tge x
   Op  op  -> Op   <$> mapM tge op
   Hof hof -> Hof  <$> mapM tge hof

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -171,18 +171,20 @@ translateDecl (Let b (DeclBinding _ _ expr)) cont = do
 translateExpr :: (Imper m, Emits o) => MaybeDest o -> Expr i -> m i o (Atom o)
 translateExpr maybeDest expr = case expr of
   Hof hof -> toImpHof maybeDest hof
-  Atom x -> substM x >>= returnVal
-  App f' xs' -> do
+  App f' xs' x' -> do
     f <- substM f'
     xs <- mapM substM xs'
+    x  <- substM x'
     getType f >>= \case
       TabTy _ _ -> do
         case fromNaryLam (length xs) f of
-          Just (NaryLamExpr bs _ body) -> do
-            body' <- applyNaryAbs (Abs bs body) (map SubstVal xs)
+          Just (NaryLamExpr bs b _ body) -> do
+            let subst = bs @@> map SubstVal xs <.> b @> SubstVal x
+            body' <- applySubst subst body
             dropSubst $ translateBlock maybeDest body'
           _ -> error $ "Invalid Imp atom: " ++ pprint f
       _ -> error $ "unexpected expression: " ++ pprint expr
+  Atom x -> substM x >>= returnVal
   Op op -> mapM substM op >>= toImpOp maybeDest
   Case e alts ty _ -> do
     e' <- substM e
@@ -832,7 +834,7 @@ zipTabDestAtom f dest src = do
   emitLoop "i" Fwd n \i -> do
     idx <- intToIndexImp (sink idxTy) i
     destIndexed <- destGet (sink dest) idx
-    srcIndexed  <- runSubstReaderT idSubst $ translateExpr Nothing (App (sink src) [idx])
+    srcIndexed  <- runSubstReaderT idSubst $ translateExpr Nothing (App (sink src) [] idx)
     f destIndexed srcIndexed
 
 zipWithRefConM :: Monad m => (Dest n -> Atom n -> m ()) -> Con n -> Con n -> m ()

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -315,10 +315,10 @@ linearizeDecls (Nest (Let b (DeclBinding ann _ expr)) rest) cont = do
 linearizeExpr :: Emits o => Expr i -> LinM i o Atom Atom
 linearizeExpr expr = case expr of
   Atom x -> linearizeAtom x
-  App x idxs -> do
+  App x idxs idx -> do
     substM x >>= getType >>= \case
       TabTy _ _ ->
-        zipLin (linearizeAtom x) (pureLin $ ListE idxs) `bindLin`
+        zipLin (linearizeAtom x) (pureLin $ ListE $ idxs ++ [idx]) `bindLin`
          \(PairE x' (ListE idxs')) -> naryApp x' idxs'
       _ -> error "not implemented"
   Op op      -> linearizeOp op

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -120,7 +120,7 @@ instance PrettyE ann => Pretty (BinderP c ann n l)
 instance Pretty (Expr n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (Expr n) where
   prettyPrec (Atom x ) = prettyPrec x
-  prettyPrec (App f xs) = atPrec AppPrec $ pApp f <+> spaced xs
+  prettyPrec (App f xs x) = atPrec AppPrec $ pApp f <+> spaced (xs ++ [x])
   prettyPrec (Op  op ) = prettyPrec op
   prettyPrec (Hof (For ann (Lam lamExpr))) =
     atPrec LowestPrec $ forStr ann <+> prettyLamHelper lamExpr (PrettyFor ann)

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -59,7 +59,7 @@ getTableElements :: (MonadIO1 m, EnvReader m, Fallible1 m) => Val n -> m n [Atom
 getTableElements tab = do
   TabTy b _ <- getType tab
   idxs <- indices $ binderType b
-  forM idxs \i -> liftImmut $ liftInterpM $ evalExpr $ App tab [i]
+  forM idxs \i -> liftImmut $ liftInterpM $ evalExpr $ App tab [] i
 
 -- Pretty-print values, e.g. for displaying in the REPL.
 -- This doesn't handle parentheses well. TODO: treat it more like PrettyPrec

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -121,11 +121,12 @@ _simplifyStandalone block =
 
 simplifyExpr :: (Emits o, Simplifier m) => Expr i -> m i o (Atom o)
 simplifyExpr expr = case expr of
-  Atom x -> simplifyAtom x
-  App f xs -> do
+  App f xs x -> do
     xs' <- mapM simplifyAtom xs
+    x' <- simplifyAtom x
     f' <- simplifyAtom f
-    simplifyApp f' xs'
+    simplifyApp f' xs' x'
+  Atom x -> simplifyAtom x
   Op  op  -> mapM simplifyAtom op >>= simplifyOp
   Hof hof -> simplifyHof hof
   Case e alts resultTy eff -> do
@@ -203,22 +204,23 @@ defuncCase scrut alts resultTy = do
                             (Atom (PairVal resultData newResult))
           return $ PairE (Abs bs' block) (LamRecon reconAbs)
 
-simplifyApp :: (Emits o, Simplifier m) => Atom o -> [Atom o] -> m i o (Atom o)
-simplifyApp f [] = return f
-simplifyApp f xs@(x:rest) = case f of
+simplifyApp :: (Emits o, Simplifier m) => Atom o -> [Atom o] -> Atom o -> m i o (Atom o)
+simplifyApp f xs xEnd = case f of
   Lam (LamExpr b body) -> do
-    ans <- dropSubst $ extendSubst (b@>SubstVal x) $ simplifyBlock body
-    simplifyApp ans rest
+    case xs of
+      [] -> dropSubst $ extendSubst (b@>SubstVal xEnd) $ simplifyBlock body
+      x:rest -> do
+       ans <- dropSubst $ extendSubst (b@>SubstVal x) $ simplifyBlock body
+       simplifyApp ans rest xEnd
   ACase e alts ty -> do
-    Just (NaryPiType piBinders _ resultTy) <- return $ fromNaryPiType (length xs) ty
-    resultTy' <- applySubst (piBinders @@> map SubstVal xs) resultTy
+    resultTy <- getAppType ty xs xEnd
     alts' <- forM alts \(Abs bs a) -> do
       buildAlt (EmptyAbs bs) \vs -> do
         a' <- applySubst (bs@@>vs) a
-        naryApp a' (map sink xs)
+        naryApp a' (map sink (xs ++ [xEnd]))
     eff <- getAllowedEffects -- TODO: more precise effects
-    dropSubst $ simplifyExpr $ Case e alts' resultTy' eff
-  _ -> naryApp f xs
+    dropSubst $ simplifyExpr $ Case e alts' resultTy eff
+  _ -> naryApp f (xs ++ [xEnd])
 
 simplifyAtom :: Simplifier m => Atom i -> m i o (Atom o)
 simplifyAtom atom = case atom of

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -132,10 +132,10 @@ transposeExpr expr ct = case expr of
   Atom atom     -> transposeAtom atom ct
   -- TODO: Instead, should we handle table application like nonlinear
   -- expressions, where we just project the reference?
-  App x is -> do
+  App x is i -> do
     -- TODO: we should check that it's a table type here, but it's awkward to do
     -- because we need something in the o-space to do that.
-    is' <- mapM substNonlin is
+    is' <- mapM substNonlin (is ++ [i])
     case x of
       Var v -> do
         lookupSubstM v >>= \case

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -67,10 +67,10 @@ getType e = liftImmut do
   DB bindings <- getDB
   return $ runHardFail $ runTyperT bindings $ getTypeE e
 
-getAppType :: EnvReader m => Type n -> [Atom n] -> m n (Type n)
-getAppType f xs = liftImmut do
+getAppType :: EnvReader m => Type n -> [Atom n] -> Atom n -> m n (Type n)
+getAppType f xs x = liftImmut do
   DB bindings <- getDB
-  return $ runHardFail $ runTyperT bindings $ checkApp f xs
+  return $ runHardFail $ runTyperT bindings $ checkApp f xs x
 
 getTypeSubst :: (SubstReader Name m, EnvReader2 m, HasType e)
              => e i -> m i o (Type o)
@@ -129,13 +129,14 @@ getReferentTy (Abs (PairB hB refB) UnitE) = do
 exprEffects :: (MonadFail1 m, EnvReader m) => Expr n -> m n (EffectRow n)
 exprEffects expr = case expr of
   Atom _  -> return $ Pure
-  App f xs -> do
+  App f xs x -> do
     fTy <- getType f
-    case fromNaryPiType (length xs)fTy of
-      Just (NaryPiType bs effs _) ->
-        applySubst (bs @@> map SubstVal xs) effs
+    case fromNaryPiType (length xs) fTy of
+      Just (NaryPiType bs b effs _) -> do
+        let subst = bs @@> map SubstVal xs <.> b @> SubstVal x
+        applySubst subst effs
       Nothing -> error $
-        "Not a " ++ show (length xs) ++ "-argument pi type: " ++ pprint fTy
+        "Not a " ++ show (length xs + 1) ++ "-argument pi type: " ++ pprint fTy
   Op op   -> case op of
     PrimEffect ref m -> do
       RefTy (Var h) _ <- getType ref
@@ -450,9 +451,10 @@ instance (NameColor c, ToBinding ann c, CheckableE ann)
 
 instance HasType Expr where
   getTypeE expr = case expr of
-    App f xs -> do
+    App f xs x -> do
       fTy <- getTypeE f
-      checkApp fTy xs
+      checkApp fTy xs x
+    Atom x   -> getTypeE x
     Op   op  -> typeCheckPrimOp op
     Hof  hof -> typeCheckPrimHof hof
     Case e alts resultTy effs -> checkCase e alts resultTy effs
@@ -935,25 +937,31 @@ checkAlt resultTyReq reqBs (Abs bs body) = do
     resultTyReq' <- sinkM resultTyReq
     body |: resultTyReq'
 
-checkApp :: Typer m => Type o -> [Atom i] -> m i o (Type o)
-checkApp fTy xs = case fromNaryPiType (length xs) fTy of
-  Just (NaryPiType bs effs resultTy) -> do
+checkApp :: Typer m => Type o -> [Atom i] -> Atom i -> m i o (Type o)
+checkApp fTy xs x = case fromNaryPiType (length xs) fTy of
+  Just (NaryPiType bs b effs resultTy) -> do
     xs' <- mapM substM xs
-    checkArgTys (EmptyAbs bs) xs'
-    PairE effs' resultTy' <- applySubst (bs @@> map SubstVal xs') (PairE effs resultTy)
+    x' <- substM x
+    checkArgTys bs b xs' x'
+    let subst = bs @@> map SubstVal xs' <.> b @> SubstVal x'
+    PairE effs' resultTy' <- applySubst subst $ PairE effs resultTy
     declareEffs effs'
     return resultTy'
   Nothing -> throw TypeErr $
-    "Not a " ++ show (length xs) ++ "-argument pi type: " ++ pprint fTy
+    "Not a " ++ show (length xs + 1) ++ "-argument pi type: " ++ pprint fTy
       ++ " (tried to apply it to: " ++ pprint xs ++ ")"
 
-checkArgTys :: Typer m => EmptyAbs (Nest PiBinder) o -> [Atom o] ->  m i o ()
-checkArgTys (Abs Empty UnitE) [] = return ()
-checkArgTys (Abs (Nest b bs) UnitE) (x:xs) = do
+checkArgTys
+  :: Typer m
+  => Nest PiBinder o o' -> PiBinder o' o''
+  -> [Atom o] -> Atom o
+  -> m i o ()
+checkArgTys Empty b [] x = dropSubst $ x |: binderType b
+checkArgTys (Nest b bs) bEnd (x:xs) xEnd = do
   dropSubst $ x |: binderType b
-  bs' <- applySubst (b@>SubstVal x) (EmptyAbs bs)
-  checkArgTys bs' xs
-checkArgTys _ _ = throw TypeErr $ "wrong number of args"
+  Abs (PairB bs' bEnd') UnitE <- applySubst (b@>SubstVal x) (EmptyAbs $ PairB bs bEnd)
+  checkArgTys bs' bEnd' xs xEnd
+checkArgTys _ _ _ _ = throw TypeErr $ "wrong number of args"
 
 typeCheckRef :: Typer m => HasType e => e i -> m i o (Type o)
 typeCheckRef x = do

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -16,12 +16,13 @@ module Util (IsBool (..), group, ungroup, pad, padLeft, delIdx, replaceIdx,
              measureSeconds,
              bindM2, foldMapM, lookupWithIdx, (...), zipWithT, for,
              Zippable (..), zipWithZ_, zipErr, forMZipped, forMZipped_,
-             iota, whenM) where
+             iota, whenM, unsnoc) where
 
 import Data.Functor.Identity (Identity(..))
 import Data.List (sort)
 import qualified Data.List.NonEmpty as NE
 import Data.Foldable
+import Data.List.NonEmpty (NonEmpty (..))
 import Prelude
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as M
@@ -46,6 +47,11 @@ onFst f (x, y) = (f x, y)
 
 onSnd :: (a -> b) -> (c, a) -> (c, b)
 onSnd f (x, y) = (x, f y)
+
+unsnoc :: NonEmpty a -> ([a], a)
+unsnoc (x:|xs) = case reverse (x:xs) of
+  (y:ys) -> (reverse ys, y)
+  _ -> error "impossible"
 
 enumerate :: Traversable f => f a -> f (Int, a)
 enumerate xs = evalState (traverse addCount xs) 0


### PR DESCRIPTION
This means we don't have the degenerate case of `App f []`, which is equivalent to `Atom f`.