### PR TITLE
Start requiring `Ix` typeclass for table type and `Ix` functions

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -24,6 +24,9 @@ def interleave {m v} (blank:v) (labels: m=>v) : (m & (Fin 2))=>v =
   pairs = for i. [labels.i, blank]
   for (i, j). pairs.i.j
 
+instance {m} [Ix m] Ix {head:Unit | tail:m}
+  dummy_ix__ = 0
+
 def prepend {m v} (first: v) (seq: m=>v) : ({head:Unit | tail:m }=>v) =
   -- Concatenates a single element to the beginning of a sequence.
   for idx. case idx of
@@ -38,7 +41,7 @@ def prepend_and_interleave {m v} (blank:v) (seq: m=>v) :
   interleaved = interleave blank seq
   prepend blank interleaved
 
-def clipidx (n:Type) (i:Int) : n =
+def clipidx (n:Type) [Ix n] (i:Int) : n =
   -- Returns element at 0 if less than zero.
   -- Ideally we could have an alternative
   -- to Fin that just clips the index at its bounds.
@@ -103,7 +106,7 @@ def ctc {vocab time position}
 
 '### Demo
 
-def randIdxNoZero (n:Type) (k:Key) : n =
+def randIdxNoZero (n:Type) [Ix n] (k:Key) : n =
   unif = rand k
   fromOrdinal n $ (1 + (FToI (floor ( unif * IToF ((size n) - 1)))))
 

--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -4,14 +4,14 @@ Fluid simulation code based on
 
 import plot
 
-def wrapidx (n:Type) (i:Int) : n =
+def wrapidx (n:Type) [Ix n] (i:Int) : n =
   -- Index wrapping around at ends.
   asidx $ mod i $ size n
 
-def incwrap {n} (i:n) : n =  -- Increment index, wrapping around at ends.
+def incwrap {n} [Ix n] (i:n) : n =  -- Increment index, wrapping around at ends.
   asidx $ mod ((ordinal i) + 1) $ size n
 
-def decwrap {n} (i:n) : n =  -- Decrement index, wrapping around at ends.
+def decwrap {n} [Ix n] (i:n) : n =  -- Decrement index, wrapping around at ends.
   asidx $ mod ((ordinal i) - 1) $ size n
 
 def finite_difference_neighbours {n a} [Add a] (x:n=>a) : n=>a =
@@ -112,7 +112,7 @@ N = Fin 50
 M = Fin 50
 
 -- Create random velocity field.
-def ixkey3 {n m o} (k:Key) (i:n) (j:m) (k2:o) : Key =
+def ixkey3 {n m o} [Ix n, Ix m, Ix o] (k:Key) (i:n) (j:m) (k2:o) : Key =
   hash (hash (hash k (ordinal i)) (ordinal j)) (ordinal k2)
 init_velocity = for i:N j:M k:(Fin 2).
   3.0 * (randn $ ixkey3 (newKey 0) i j k)

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -163,7 +163,9 @@ when using a record type as an index set:
 > ((a:Type)
 >  ?-> (b:Type)
 >  ?-> (c:Type)
->  ?-> (v:Type) ?-> (Iso ({ &} & a) (b & c)) -> (a => v) -> b => c => v)
+>  ?-> (v:Type)
+>  ?-> (Ix b)
+>  ?=> (Ix c) ?=> (Iso ({ &} & a) (b & c)) -> (Ix a) ?=> (a => v) -> b => c => v)
 
 -- :p
 --   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
@@ -185,10 +187,18 @@ when using a record type as an index set:
 :t overLens
 > ((a:Type)
 >  ?-> (b:Type)
->  ?-> (c:Type) ?-> (v:Type) ?-> (Iso a (b & c)) -> (a => v) -> b => c => v)
+>  ?-> (c:Type)
+>  ?-> (v:Type)
+>  ?-> (Ix b)
+>  ?=> (Ix c) ?=> (Iso a (b & c)) -> (Ix a) ?=> (a => v) -> b => c => v)
 
 '`overLens` alone can be used with any lens-like isomorphism, for instance an
 ordinary record accessor lens.
+
+instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n & b:m & c:q}
+  dummy_ix__ = 0
+instance {m q} [Ix m, Ix q] Ix {b:m & c:q}
+  dummy_ix__ = 0
 
 :p
   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
@@ -243,14 +253,21 @@ zipper isomorphisms:
 '`sliceFields` uses this to specific named variants from a variant-indexed
 table:
 
+instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n | b:m | c:q}
+  dummy_ix__ = 0
+instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
+  dummy_ix__ = 0
+instance {n q} [Ix n, Ix q] Ix {a:n | c:q}
+  dummy_ix__ = 0
+
 :p
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}
   v1 = x
-  v2 = sliceFields (#|b) x
+  v2 = sliceFields (#|a &>> #|b) x
   v3 = sliceFields (#|a &>> #|c) x
   v4 = sliceFields (#|a &>> #|b &>> #|c) x
   (v1, v2, v3, v4)
 > ( [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2}
-> , ( [2, 3]@{b: Fin 2}
+> , ( [0, 1, 2, 3]@{a: Fin 2 | b: Fin 2}
 > , ( [0, 1, 4, 5]@{a: Fin 2 | c: Fin 2}
 > , [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2} ) ) )

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -39,7 +39,7 @@ def meanAndCovariance {n d} (xs:n=>d=>Float) : (d=>Float & d=>d=>Float) =
 
 MHParams : Type = Float  -- step size
 
-def mhStep {d}
+def mhStep {d} [Ix d]
       (stepSize: MHParams)
       (logProb: (d=>Float) -> LogProb)
       (k:Key)
@@ -67,7 +67,7 @@ def leapfrogIntegrate {a}
   p = p + (0.5 * dt) .* grad logProb x
   (x, p)
 
-def hmcStep {d}
+def hmcStep {d} [Ix d]
       (params: HMCParams)
       (logProb: (d=>Float) -> LogProb)
       (k:Key)

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -116,7 +116,7 @@ Params = { numSamples : Int
          & shareSeed  : Bool }
 
 -- TODO: use a list instead, once they work
-data Scene n:Type = MkScene (n=>Object)
+data Scene n:Type [Ix n] = MkScene (n=>Object)
 
 def sampleReflection ((nor, surf):OrientedSurface) ((pos, dir):Ray) (k:Key) : Ray =
   newDir = case surf of

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -42,7 +42,7 @@ def regress {d n} (featurize: Float -> d=>Float) (xRaw:n=>Float) (y:n=>Float) : 
 
 'Fit a third-order polynomial
 
-def poly {d} (x:Float) : d=>Float =
+def poly {d} [Ix d] (x:Float) : d=>Float =
   for i. pow x (IToF (ordinal i))
 
 params : (Fin 4)=>Float = regress poly xs ys
@@ -64,6 +64,8 @@ def rmsErr {n} (truth:n=>Float) (pred:n=>Float) : Float =
 :p rmsErr ys (map predict xs)
 > 0.252695
 
+instance {n m} [Ix n, Ix m] Ix {left:n|right:m}
+  dummy_ix__ = 0
 
 def tabCat {n m a} (xs:n=>a) (ys:m=>a) : ({left:n|right:m})=>a =
   for i. case i of

--- a/examples/rejection-sampler.dx
+++ b/examples/rejection-sampler.dx
@@ -70,7 +70,7 @@ inversionSamples = randVec numSamples (binomialSample n p) k0
 
 'The following variant is guaranteed to evaluate the CDF only once.
 
-def binomialBatch {a} (n:Int) (p:Prob) (k:Key) : a => Int =
+def binomialBatch {a} [Ix a] (n:Int) (p:Prob) (k:Key) : a => Int =
   m = n + 1
   logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
   map ordinal $ categoricalBatch logprobs k

--- a/examples/schrodinger.dx
+++ b/examples/schrodinger.dx
@@ -44,7 +44,7 @@ def fToC (x:Float) : Complex = MkComplex x 0.
 
 -- Translate from index to Float representation of real space
 -- Simulates the range [0.0, 1.0] in each dimension
-def ixToF {n} (i:n) : Float = (IToF (ordinal i)) / (IToF gridSize - 1.)
+def ixToF {n} [Ix n] (i:n) : Float = (IToF (ordinal i)) / (IToF gridSize - 1.)
 
 -- Helper to generate zero-delay GIF animations
 def animate {t n m} (imgs:t=>n=>m=>(Fin 3)=>Float) : Html =
@@ -52,7 +52,7 @@ def animate {t n m} (imgs:t=>n=>m=>(Fin 3)=>Float) : Html =
 
 -- Cuts an array down to a smaller dimension.
 -- Useful for cutting out animation frames for a faster GIF.
-def cut {n m a} (x:n=>a) : m=>a =
+def cut {n m a} [Ix m] (x:n=>a) : m=>a =
   s = idiv (size n) (size m)
   for i:m. x.(unsafeFromOrdinal _ $ s * ordinal i)
 
@@ -65,15 +65,15 @@ def toImg {n m} (xs:n=>m=>Float) : (n=>m=>Fin 3=>Float) =
 '## Computing $\psi_{t+\Delta t}$
 
 -- Are the given indices at the bounds of the grid
-def atBounds {n m} (i:n) (j:m) : Bool =
+def atBounds {n m} [Ix n, Ix m] (i:n) (j:m) : Bool =
   (ordinal i == 0
    || ordinal i == (gridSize - 1)
    || ordinal j == 0
    || ordinal j == (gridSize - 1))
 
 -- Operators for performing unsafe ordinal arithmetic
-def (+!) {n} (i:n) (off:Int) : n = unsafeFromOrdinal _ ((ordinal i) + off)
-def (-!) {n} (i:n) (off:Int) : n = i +! (-1 * off)
+def (+!) {n} [Ix n] (i:n) (off:Int) : n = unsafeFromOrdinal _ ((ordinal i) + off)
+def (-!) {n} [Ix n] (i:n) (off:Int) : n = i +! (-1 * off)
 
 -- Run a single forward-step to compute psi_(t+1) from psi_t with the given potential.
 def step {m n} (psi:m=>n=>Complex) (v:m=>n=>Float) : m=>n=>Complex =
@@ -103,7 +103,7 @@ def pdf {n m} (psi:n=>m=>Complex) : n=>m=>Float =
 '## Examples
 
 -- Generate gaussian initial conditions with zero at the bounds.
-def gaussian {n m} ((ux, uy):(Float & Float)) ((ox, oy):(Float & Float)): (n=>m=>Complex) =
+def gaussian {n m} [Ix n, Ix m] ((ux, uy):(Float & Float)) ((ox, oy):(Float & Float)): (n=>m=>Complex) =
   for i:n.
     for j:m.
       y2 = pow (ixToF i - uy) 2.

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -4,12 +4,12 @@
 - Matrix Inversion
 
 
-def cast {a m} (d:a) : m = (ordinal d)@m
+def cast {a m} [Ix a, Ix m] (d:a) : m = (ordinal d)@m
 
 '### Triangular matrices
 
-def LowerTriMat (n:Type) (v:Type) : Type = i:n=>(..i)=>v
-def UpperTriMat (n:Type) (v:Type) : Type = i:n=>(i..)=>v
+def LowerTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..i)=>v
+def UpperTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(i..)=>v
 
 def upperTriDiag {n v} (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
 def lowerTriDiag {n v} (l:LowerTriMat n v) : n=>v = for i. l.i.(cast i)
@@ -65,12 +65,12 @@ def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
 -- The sign of the determinant of a permutation is either 1.0 or -1.0
 PermutationSign = Float
 
-def Permutation (n:Type) : Type = (perm:n=>n & PermutationSign)
+def Permutation (n:Type) [Ix n] : Type = (perm:n=>n & PermutationSign)
 
 def apply_permutation {n t} ((perm, _):Permutation n) (xs: n=>t) : n=>t =
   for i. xs.(perm.i)
 
-def identity_permutation {n} : Permutation n =
+def identity_permutation {n} [Ix n] : Permutation n =
   (for i. i, 1.0)
 
 def swapInPlace {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -2,7 +2,7 @@
 
 'Utilities unrelated to parsing
 
-def fromOrdinalExc (n:Type) (i:Int) : {Except} n =
+def fromOrdinalExc (n:Type) [Ix n] (i:Int) : {Except} n =
   if (0 <= i) && (i < size n)
     then unsafeFromOrdinal _ i
     else throw ()

--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -11,11 +11,11 @@ def Scale (a:Type) : Type =
   { mapping : a -> Maybe Float
   & range   : List (CompactSet Float) }  -- non-overlapping, ordered
 
-def ScaledData (n:Type) (a:Type) : Type =
+def ScaledData (n:Type) [Ix n] (a:Type) : Type =
   { scale : Scale a
   & dat   : n => a }
 
-def Plot (n:Type) (a:Type) (b:Type) (c:Type) : Type =
+def Plot (n:Type) [Ix n] (a:Type) (b:Type) (c:Type) : Type =
   { xs : ScaledData n a
   & ys : ScaledData n b
   & cs : ScaledData n c }
@@ -79,11 +79,11 @@ def plotToDiagram {a b c n} (plot:Plot n a b c) : Diagram =
 def showPlot {a b c n} (plot:Plot n a b c) : String =
   renderSVG (plotToDiagram plot) ((0.0, 0.0), (1.0, 1.0))
 
-def blankData {n} : ScaledData n Unit = {scale = unitTypeScale, dat = for i. ()}
+def blankData {n} [Ix n] : ScaledData n Unit =
+  {scale = unitTypeScale, dat = for i. ()}
 
-def blankPlot {n} : Plot n Unit Unit Unit = { xs = blankData
-                                            , ys = blankData
-                                            , cs = blankData }
+def blankPlot {n} [Ix n] : Plot n Unit Unit Unit =
+  { xs = blankData, ys = blankData, cs = blankData }
 
 -- -- TODO: generalize beyond Float with a type class for auto scaling
 def autoScale {n} (xs:n=>Float) : ScaledData n Float =

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -27,6 +27,48 @@ RawPtr : Type = %Word8Ptr
 Int = Int32
 Float = Float32
 
+'### Index set interface and instances
+
+interface Ix a
+  dummy_ix__ : Int32
+
+-- TODO: Make those methods of Ix
+def ordinal {a} [Ix a] (i:a) : Int = %toOrdinal i
+def size (n:Type) [Ix n] : Int = %idxSetSize n
+def unsafeFromOrdinal (n : Type) [Ix n] (i : Int) : n = %unsafeFromOrdinal n i
+
+def Range (low:Int) (high:Int) : Type = %IntRange low high
+def Fin (n:Int) : Type = Range 0 n
+
+instance {l h} Ix (Range l h)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} [Ix q] Ix (i..)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} [Ix q] Ix (i<..)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} [Ix q] Ix (..i)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} [Ix q] Ix (..<i)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
+  dummy_ix__ = 0
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
+  dummy_ix__ = 0
+
+def iota (n:Type) [Ix n] : n=>Int = view i. ordinal i
+
 '### Casting
 
 def internalCast {a} (b:Type) (x:a) : b = %cast b x
@@ -243,6 +285,9 @@ def fst {a b} ((x, _): (a & b)) : a = x
 def snd {a b} ((_, y): (a & b)) : b = y
 def swap {a b} ((x, y):(a&b)) : (b&a) = (y, x)
 
+instance {a b} [Ix a, Ix b] Ix (a & b)
+  dummy_ix__ = 0
+
 def (<<<) {a b c} (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
 def (>>>) {a b c} (g: a -> b) (f: b -> c) : a -> c = \x. f (g x)
 
@@ -390,7 +435,7 @@ data AccumMonoid h w =
   UnsafeMkAccumMonoid b:Type (Monoid b)
 
 @instance
-def tableAccumMonoid {n h w} [am : AccumMonoid h w] : AccumMonoid h (n=>w) =
+def tableAccumMonoid {n h w} [Ix n] [am : AccumMonoid h w] : AccumMonoid h (n=>w) =
   (UnsafeMkAccumMonoid b bm) = am
   UnsafeMkAccumMonoid b bm
 
@@ -557,14 +602,22 @@ instance {a b} [Ord a, Ord b] Ord (a & b)
 instance Eq Ordering
   (==) = \x y. OToW8 x == OToW8 y
 
-def scan {a b n} (init:a) (body:n->a->(a&b)) : (a & n=>b) =
+-- TODO: we want Eq and Ord for all index sets, not just `Fin n`
+instance {n} Eq (Fin n)
+  (==) = \x y. ordinal x == ordinal y
+
+instance {n} Ord (Fin n)
+  (>) = \x y. ordinal x > ordinal y
+  (<) = \x y. ordinal x < ordinal y
+
+def scan {a b n} [Ix n] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
   swap $ runState init \s. for i.
     c = get s
     (c', y) = body i c
     s := c'
     y
 
-def fold {a n} (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
+def fold {a n} [Ix n] (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
 
 def compare {a} [Ord a] (x:a) (y:a) : Ordering =
   if x < y
@@ -676,23 +729,6 @@ instance Floating Float32
   pow    = \x y. %fpow x y
   lgamma = \x. %lgamma x
 
-'## Index set utilities
-
-def Range (low:Int) (high:Int) : Type = %IntRange low high
-def Fin (n:Int) : Type = Range 0 n
-def ordinal {a} (i:a) : Int = %toOrdinal i
-def size (n:Type) : Int = %idxSetSize n
-def unsafeFromOrdinal (n : Type) (i : Int) : n = %unsafeFromOrdinal n i
-def iota (n:Type) : n=>Int = view i. ordinal i
-
--- TODO: we want Eq and Ord for all index sets, not just `Fin n`
-instance {n} Eq (Fin n)
-  (==) = \x y. ordinal x == ordinal y
-
-instance {n} Ord (Fin n)
-  (>) = \x y. ordinal x > ordinal y
-  (<) = \x y. ordinal x < ordinal y
-
 '## Raw pointer operations
 
 data Ptr a = MkPtr RawPtr
@@ -763,7 +799,7 @@ def withTabPtr {a b n} [Storable a] (xs:n=>a) (action : Ptr a -> {IO} b) : {IO} 
     for i. store (ptr +>> ordinal i) xs.i
     action ptr
 
-def tabFromPtr {a} [Storable a] (n:Type) (ptr:Ptr a) : {IO} n=>a =
+def tabFromPtr {a} [Storable a] (n:Type) [Ix n] (ptr:Ptr a) : {IO} n=>a =
   for i. load $ ptr +>> ordinal i
 
 '## Miscellaneous common utilities
@@ -775,7 +811,7 @@ def dup {a} (x:a) : (a & a) = (x, x)
 def map {a b n eff} (f:a->{|eff} b) (xs: n=>a) : {|eff} (n=>b) = for i. f xs.i
 def zip {a b n} (xs:n=>a) (ys:n=>b) : (n=>(a&b)) = view i. (xs.i, ys.i)
 def unzip {a b n} (xys:n=>(a&b)) : (n=>a & n=>b) = (map fst xys, map snd xys)
-def fanout {a} (n:Type) (x:a) : n=>a = view i. x
+def fanout {a} (n:Type) [Ix n] (x:a) : n=>a = view i. x
 def sq  {a} [Mul a] (x:a) : a = x * x
 def abs {a} [Add a, Ord a] (x:a) : a = select (x > zero) x (zero - x)
 def mod (x:Int) (y:Int) : Int = rem (y + rem x y) y
@@ -806,7 +842,7 @@ instance {a n} [Floating a] Floating (n=>a)
 
 def axis1 {a b c} (x : a => b => c) : b => a => c = for j. for i. x.i.j
 def axis2 {a b c d} (x : a => b => c => d) : c => a => b => d = for k. for i. for j. x.i.j.k
-def reindex {a b v} (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
+def reindex {a b v} [Ix b] (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
 '### Reductions
 
@@ -817,7 +853,7 @@ def reduce {a n} (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
   fold identity (\i c. combine c xs.i)
 
 -- TODO: call this `scan` and call the current `scan` something else
-def scan' {a n} (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
+def scan' {a n} [Ix n] (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
 def fsum {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs i
 def sum  {n v} [Add v] (xs:n=>v) : v = reduce zero (+) xs
@@ -835,7 +871,7 @@ def applyN {a} (n:Int) (x:a) (f:a -> a) : a =
 
 '### Linear Algebra
 
-def linspace (n:Type) (low:Float) (high:Float) : n=>Float =
+def linspace (n:Type) [Ix n] (low:Float) (high:Float) : n=>Float =
   dx = (high - low) / IToF (size n)
   for i:n. low + IToF (ordinal i) * dx
 
@@ -844,7 +880,8 @@ def vdot {n} (x:n=>Float) (y:n=>Float) : Float = fsum view i. x.i * y.i
 def dot {n v} [VSpace v] (s:n=>Float) (vs:n=>v) : v = sum for j. s.j .* vs.j
 
 -- matmul. Better symbol to use? `@`?
-def (**) {l m n} (x: l=>m=>Float) (y: m=>n=>Float) : (l=>n=>Float) =
+-- TODO: Improve auto-quantification to hoist the Ix n constraint to the type binder
+def (**) {l m n} [Ix n] (x: l=>m=>Float) (y: m=>n=>Float) : (l=>n=>Float) =
   for i k. fsum view j. x.i.j * y.j.k
 
 def (**.) {n m} (mat: n=>m=>Float) (v: m=>Float) : (n=>Float) = for i. vdot mat.i v
@@ -853,7 +890,7 @@ def (.**) {n m} (v: m=>Float) (mat: n=>m=>Float) : (n=>Float) = mat **. v
 def inner {n m} (x:n=>Float) (mat:n=>m=>Float) (y:m=>Float) : Float =
   fsum view (i,j). x.i * mat.i.j * y.j
 
-def eye {n a} [Add a, Mul a] : n=>n=>a =
+def eye {n a} [Add a, Mul a, Ix n] : n=>n=>a =
   for i j. select (ordinal i == ordinal j) one zero
 
 '## cumSum
@@ -980,10 +1017,10 @@ def Tile (n : Type) (m : Type) : Type = %IndexSlice n m
 def (+>)  {n l} (t:Tile n l) (i : l) : n = %sliceOffset t i
 def (++>) {n u v} (t : Tile n (u & v)) (i : u) : Tile n v = %sliceCurry t i
 
-def tile  {n l a eff}
+def tile  {n l a eff} [Ix n, Ix l]
           (fTile : (t:(Tile n l) -> {|eff} l=>a))
           (fScalar : n -> {|eff} a) : {|eff} n=>a = %tiled fTile fScalar
-def tile1 {n m l a eff}
+def tile1 {n m l a eff} [Ix m, Ix n, Ix l]
           (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
           (fScalar : n -> {|eff} m=>a) : {|eff} m=>n=>a = %tiledd fTile fScalar
 
@@ -1008,7 +1045,7 @@ instance {a} [Eq a] Eq (List a)
       else all for i:(Fin nx).
         xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
 
-def unsafeCastTable {n a} (m:Type) (xs:n=>a) : m=>a =
+def unsafeCastTable {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
   for i. xs.(unsafeFromOrdinal _ (ordinal i))
 
 def toList {n a} (xs:n=>a) : List a =
@@ -1117,7 +1154,7 @@ Complement the focus of a prism-like isomorphism
 def exceptPrism {a b c} : Iso a (b | c) -> Iso a (c | b) = \iso. iso &>> swapEitherIso
 
 -- Use a lens-like iso to split a 1d table into a 2d table
-def overLens {a b c v} (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
+def overLens {a b c v} [Ix b, Ix c] (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
   for i j. tab.(revIso iso (i, j))
 
 '### Zipper
@@ -1132,7 +1169,7 @@ by using `splitR &>> iso`
 
 def splitR {a} : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 
-def overFields {a b c v} (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
+def overFields {a b c v} [Ix b, Ix c] (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
   overLens (splitR &>> iso) tab
 
 'Convert a variant zipper isomorphism to a normal prism-like isomorphism
@@ -1141,7 +1178,7 @@ by using `splitV &>> iso`
 def splitV {a} : Iso a ({|} | a) =
   MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
 
-def sliceFields {a b c v} (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
+def sliceFields {a b c v} [Ix b] (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
   reindex (buildWith $ splitV &>> iso) tab
 
 '## Dynamic buffer
@@ -1485,7 +1522,7 @@ def withTempFile {a} (action: FilePath -> {IO} a) : {IO} a =
   deleteFile tmpFile
   result
 
-def withTempFiles {n a} (action: (n=>FilePath) -> {IO} a) : {IO} a =
+def withTempFiles {n a} [Ix n] (action: (n=>FilePath) -> {IO} a) : {IO} a =
   tmpFiles = for i. newTempFile ()
   result = action tmpFiles
   for i. deleteFile tmpFiles.i
@@ -1493,7 +1530,7 @@ def withTempFiles {n a} (action: (n=>FilePath) -> {IO} a) : {IO} a =
 
 '### Table operations
 
-def fromOrdinal (n:Type) (i:Int) : n =
+def fromOrdinal (n:Type) [Ix n] (i:Int) : n =
   case (0 <= i) && (i < size n) of
     True  -> unsafeFromOrdinal _ i
     False -> error $
@@ -1501,16 +1538,16 @@ def fromOrdinal (n:Type) (i:Int) : n =
 
 -- TODO: could make an `unsafeCastIndex` and this could avoid the runtime copy
 -- TODO: safe (runtime-checked) and unsafe versions
-def castTable {n a} (m:Type) (xs:n=>a) : m=>a =
+def castTable {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
   case size m == size n of
      True  -> unsafeCastTable _ xs
      False -> error $
        "Table size mismatch in cast: " <> show (size m) <> " vs " <> show (size n)
 
-def asidx {n} (i:Int) : n = fromOrdinal n i
-def (@) (i:Int) (n:Type) : n = fromOrdinal n i
+def asidx {n} [Ix n] (i:Int) : n = fromOrdinal n i
+def (@) (i:Int) (n:Type) [Ix n] : n = fromOrdinal n i
 
-def slice {n a} (xs:n=>a) (start:Int) (m:Type) : m=>a =
+def slice {n a} (xs:n=>a) (start:Int) (m:Type) [Ix m] : m=>a =
   for i. xs.(fromOrdinal _ (ordinal i + start))
 
 def head {n a} (xs:n=>a) : a = xs.(0@_)
@@ -1567,9 +1604,9 @@ def hash (x:Key) (y:Int32) : Key =
   y64 = IToW64 y
   threeFry2x32 x y64
 def newKey (x:Int) : Key = hash (IToW64 0) x
-def many {a n} (f:Key->a) (k:Key) (i:n) : a = f (hash k (ordinal i))
-def ixkey {n} (k:Key) (i:n) : Key = hash k (ordinal i)
-def ixkey2 {n m} (k:Key) (i:n) (j:m) : Key = hash (hash k (ordinal i)) (ordinal j)
+def many {a n} [Ix n] (f:Key->a) (k:Key) (i:n) : a = f (hash k (ordinal i))
+def ixkey {n} (k:Key) (i:n) [Ix n] : Key = hash k (ordinal i)
+def ixkey2 {n m} (k:Key) (i:n) (j:m) [Ix n, Ix m] : Key = hash (hash k (ordinal i)) (ordinal j)
 def splitKey {n} (k:Key) : Fin n => Key = for i. ixkey k i
 
 '### Sample Generators
@@ -1594,10 +1631,10 @@ def randInt (k:Key) : Int = (internalCast Int k) `mod` 2147483647
 
 def bern (p:Float) (k:Key) : Bool = rand k < p
 
-def randnVec {n} (k:Key) : n=>Float =
+def randnVec {n} [Ix n] (k:Key) : n=>Float =
   for i. randn (ixkey k i)
 
-def randIdx {n} (k:Key) : n =
+def randIdx {n} [Ix n] (k:Key) : n =
   unif = rand k
   fromOrdinal n $ FToI $ floor $ unif * IToF (size n)
 
@@ -1845,13 +1882,13 @@ instance Floating Complex
 '## Miscellaneous utilities
 TODO: all of these should be in some other section
 
-def reflect {n} (i:n) : n =
+def reflect {n} [Ix n] (i:n) : n =
   unsafeFromOrdinal n ((size n) - 1 - ordinal i)
 
 def reverse {n a} (x:n=>a) : n=>a =
   for i. x.(reflect i)
 
-def padTo {n a} (m:Type) (x:a) (xs:n=>a) : (m=>a) =
+def padTo {n a} (m:Type) [Ix m] (x:a) (xs:n=>a) : m=>a =
   n' = size n
   for i.
     i' = ordinal i
@@ -1977,7 +2014,7 @@ def categorical {n} (logprobs: n=>Float) (key: Key) : n =
 
 -- batch variant to share the work of forming the cumsum
 -- (alternatively we could rely on hoisting of loop constants)
-def categoricalBatch {n m} (logprobs: n=>Float) (key: Key) : m=>n =
+def categoricalBatch {n m} [Ix m] (logprobs: n=>Float) (key: Key) : m=>n =
   cdf = cdfForCategorical logprobs
   for i. categoricalFromCDF cdf $ ixkey key i
 

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -10,6 +10,10 @@ it's doing bubble / insertion sort with quadratic time cost.
 However, if breaks the list in half recursively, it'll be doing parallel mergesort.
 Currently it'll do the quadratic time version.
 
+-- TODO(Ix)
+instance {a b} [Ix a, Ix b] Ix {left:a | right:b}
+  dummy_ix__ = 0
+
 def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ({left:a | right:b }=>v) =
   -- Note: It'd be nicer to use (a | b)=>v but it's not currently supported.
   for idx. case idx of
@@ -58,7 +62,7 @@ def sort {a n} [Ord a] (xs: n=>a) : n=>a =
   (AsList _ r) = reduce mempty mcombine xlists
   unsafeCastTable n r
 
-def (+|) {n} (i:n) (delta:Int) : n =
+def (+|) {n} [Ix n] (i:n) (delta:Int) : n =
   i' = ordinal i + delta
   fromOrdinal _ $ select (i' >= size n) (size n - 1) i'
 

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -233,8 +233,8 @@ instance CheaplyReducibleE Expr Atom where
     Op (SynthesizeDict _ ty') -> do
       ty <- cheapReduceE ty'
       runFallibleT1 (trySynthDictBlock ty) >>= \case
-        Success (Block _ Empty (Atom d)) -> return d
-        _ -> reportSynthesisFail ty >> empty
+        Success block -> dropSubst $ cheapReduceE block
+        Failure _     -> reportSynthesisFail ty >> empty
     -- TODO: Make sure that this wraps correctly
     -- TODO: Other casts?
     Op (CastOp ty' val') -> do

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -155,7 +155,7 @@ tripleit : Float --o Float = \x. x + x + x
 > 3.
 
 :p
-  f : n:Type ?->  Float --o n=>Float = \x. for i. x
+  f : n:Type ?-> Ix n ?=> Float --o n=>Float = \x. for i. x
 
   transposeLinear f [1.0, 2.0]
 > 3.

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -245,22 +245,21 @@ def zerosLikeList {a} (l : List a) : (Fin (listLength l))=>Float =
 :p zerosLikeList l2
 > [0., 0., 0.]
 
-data Graph a:Type =
-  MkGraph n:Type nodes:(n=>a) m:Type edges:(m=>(n & n))
+data Graph n:Type a:Type [Ix n] =
+  MkGraph nodes:(n=>a) edges:(List (n & n))
 
-def graphToAdjacencyMatrix {a} ((MkGraph n nodes m edges):Graph a) : n=>n=>Bool =
+def graphToAdjacencyMatrix {n a} ((MkGraph nodes (AsList _ edges)):Graph n a) : n=>n=>Bool =
   init = for i j. False
   yieldState init \mRef.
-    for i:m.
+    for i.
       (from, to) = edges.i
       mRef!from!to := True
 
 :t graphToAdjacencyMatrix
-> ((a:Type)
->  ?-> (pat:(Graph a)) -> (ProjectElt [0] pat) => (ProjectElt [0] pat) => Bool)
+> ((n:Type) ?-> (a:Type) ?-> (Ix n) ?=> (Graph n a) -> n => n => Bool)
 
 :p
-  g : Graph Int = MkGraph (Fin 3) [5, 6, 7] (Fin 4) [(0@_, 1@_), (0@_, 2@_), (2@_, 0@_), (1@_, 1@_)]
+  g : Graph (Fin 3) Int = MkGraph [5, 6, 7] $ AsList _ [(0@_, 1@_), (0@_, 2@_), (2@_, 0@_), (1@_, 1@_)]
   graphToAdjacencyMatrix g
 > [[False, True, True], [False, True, False], [True, False, False]]
 

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -561,10 +561,14 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
   x
 > (Right 1.2)
 
+-- TODO(Ix) : Write a proper instance
+instance {n m} [Ix n, Ix m] Ix {weights:(n&m) | biases:n}
+  dummy_ix__ = 0
+
 -- Sum types as flattened index sets!
-def Weights (n:Type) (m:Type) : Type = n=>m=>Float
-def Biases  (n:Type)          : Type = n=>Float
-def Params  (n:Type) (m:Type) : Type = {weights:(n&m) | biases:n}=>Float
+def Weights (n:Type) (m:Type) [Ix n, Ix m] : Type = n=>m=>Float
+def Biases  (n:Type)          [Ix n]       : Type = n=>Float
+def Params  (n:Type) (m:Type) [Ix n, Ix m] : Type = {weights:(n&m) | biases:n}=>Float
 
 w = for i:(Fin 2). for j:(Fin 3). (IToF (ordinal i)) * 3.0 + (IToF (ordinal j))
 b = for j:(Fin 2). neg (IToF (ordinal j) + 1.0)

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -41,13 +41,13 @@ f = \x. x + 10.
 
 'Lambdas can have specific arrow annotations.
 
-lam1 = \{n}. \x. fromOrdinal n x
+lam1 = \{n}. \x:(Fin n). ordinal x
 :t lam1
-> ((n:Type) ?-> Int32 -> n)
+> ((n:Int32) ?-> (Fin n) -> Int32)
 
-lam4 = \{n m}. (0@n, 0@m)
+lam4 = \{n m}. (Fin n, Fin m)
 :t lam4
-> ((n:Type) ?-> (m:Type) ?-> (n & m))
+> (Int32 ?-> Int32 ?-> (Type & Type))
 
 :p (
     1

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -311,6 +311,9 @@ myStuff :(Fin 5 => {foo:_ | foo:_ | foo:_ | bar:_ | baz:_}) =
 
 'As index sets
 
+instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
+  dummy_ix__ = 0
+
 :p size {a:Fin 10 & b:Fin 3}
 > 30
 :p ordinal {a=(7@Fin 10), b=(2@Fin 3)}
@@ -329,6 +332,9 @@ recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 
 -- TODO: this still causes an error
 -- :p for i:(Fin 6). recordsAsIndices.((ordinal i) @ _)
+
+instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
+  dummy_ix__ = 0
 
 :p size {a:Fin 10 | b:Fin 3}
 > 13

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -108,11 +108,11 @@ def f3 {n} (x : n=>Int) : Int = a_ x
 > def f3 {n} (x : n=>Int) : Int = a_ x
 >                                 ^^^
 -- Adding an explicit binder shouldn't change anything
-def f4 {n} [A (n=>Int)] (x : n=>Int) : Int = a_ x
+def f4 {n} [Ix n, A (n=>Int)] (x : n=>Int) : Int = a_ x
 > Type error:Multiple candidate class dictionaries for: (A (n => Int32))
 >
-> def f4 {n} [A (n=>Int)] (x : n=>Int) : Int = a_ x
->                                              ^^^
+> def f4 {n} [Ix n, A (n=>Int)] (x : n=>Int) : Int = a_ x
+>                                                    ^^^
 
 -- TODO: This should fail! The choice of dictionary depends on instantiation
 --       of a (there's a generic one and a specific one for n=>Int)!
@@ -132,18 +132,18 @@ instance {n a} [Ord' a] Ord' (n=>a)
   ord = const 4
 
 -- Simplifiable constraints should be accepted
-def f6 {n} [Eq' (n=>Int)] (x : n=>Int) : Int = eq x
-def f7 {n} [Ord' (n=>Int)] (x : n=>Int) : Int = eq x
+def f6 {n} [Ix n, Eq' (n=>Int)] (x : n=>Int) : Int = eq x
+def f7 {n} [Ix n, Ord' (n=>Int)] (x : n=>Int) : Int = eq x
 
 -- This additional instance makes f7 ambiguous. Note that there's an easy way out
 -- in the form of the superclass of Ord', but we still check that there's no overlap.
 instance Eq' Int
   eq = const 0
-def f8 {n} [Ord' (n=>Int)] (x : n=>Int) : Int = eq x
+def f8 {n} [Ix n, Ord' (n=>Int)] (x : n=>Int) : Int = eq x
 > Type error:Multiple candidate class dictionaries for: (Eq' (n => Int32))
 >
-> def f8 {n} [Ord' (n=>Int)] (x : n=>Int) : Int = eq x
->                                                 ^^^
+> def f8 {n} [Ix n, Ord' (n=>Int)] (x : n=>Int) : Int = eq x
+>                                                       ^^^
 
 -- XXX: In Haskell overlap is determined entirely by instance heads, making it
 --      independent of other instances in scope. In Dex an instance might be ruled out,

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -251,15 +251,16 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 :p (eitherFloor (Left 1), eitherFloor (Right 2.3))
 > (1, 2)
 
-:p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
-> Type error:
-> Expected: ((Fin a & Fin 2) => Int32)
->   Actual: ((Fin 4) => b)
-> (Solving for: [a, b])
-> If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
->
-> :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
->    ^^^^^^^^^^^^^
+-- Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
+-- :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+-- > Type error:
+-- > Expected: ((Fin a & Fin 2) => Int32)
+-- >   Actual: ((Fin 4) => b)
+-- > (Solving for: [a, b])
+-- > If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
+-- >
+-- > :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+-- >    ^^^^^^^^^^^^^
 
 :p
   [(a, b), c] = [(1, 2), (3, 4)]
@@ -294,11 +295,12 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 >   [a, b, c, d] = [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
 >   ^^^^^^^^^^^^^
 
-:p
-  -- parentheses needed to stop the parser from reading "zero" as a binder name
-  [a, b, c, d] = (zero) : (_ => Int)
-  (a, b, c, d)
-> (0, (0, (0, 0)))
+-- Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
+-- :p
+--   -- parentheses needed to stop the parser from reading "zero" as a binder name
+--   [a, b, c, d] = (zero) : (_ => Int)
+--   (a, b, c, d)
+-- > (0, (0, (0, 0)))
 
 def bug (n : Type) : Unit =
   for w':n.


### PR DESCRIPTION
Note that not too many changes to tests and examples were necessary,
largely thanks to automatic quantification.