### PR TITLE
'/usr/bin/env bash' works on systems without /bin/bash.

### DIFF
--- a/makefile
+++ b/makefile
@@ -1,6 +1,6 @@
 # Set shell to bash to resolve symbolic links when looking up
 # executables, to support user-account installation of stack.
-SHELL=/bin/bash
+SHELL=/usr/bin/env bash
 
 STACK=$(shell command -v stack 2>/dev/null)
 ifeq (, $(STACK))


### PR DESCRIPTION
Still works on systems with `/bin/bash`, too.