### PR TITLE
Reuse builder's implementation of index set size for Algebra

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1114,7 +1114,12 @@ indexSetSize ty = case ty of
       InclusiveLim x -> indexToInt x >>= iadd (IdxRepVal 1)
       ExclusiveLim x -> indexToInt x
       Unlimited      -> indexSetSize n
-    clampPositive =<< high' `isub` low'
+    -- The clamp is only necessary when both sides are not unlimited.
+    let maybeClamp = case (low, high) of
+          (Unlimited, _) -> return
+          (_, Unlimited) -> return
+          _              -> clampPositive
+    maybeClamp =<< high' `isub` low'
   TC (ProdType types) -> do
     sizes <- traverse indexSetSize types
     foldM imul (IdxRepVal 1) sizes

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE GeneralizedNewtypeDeriving #-}
 
 module Interpreter (
-  evalBlock, evalExpr, indices, indexSetSize,
+  evalBlock, evalExpr, indices,
   runInterpM, liftInterpM, InterpM, Interp,
   traverseSurfaceAtomNames) where
 


### PR DESCRIPTION
There was no good reason to keep those method duplicated, and
in fact making them separate should make it possible to do algebraic
simplification on user-defined instances!