### PR TITLE
Don't use Algebra for rectangular table types

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1074,50 +1074,35 @@ computeElemCount (EmptyAbs Empty) =
   -- in the case that we don't have any indices. The more general path will
   -- still compute `1`, but it might emit decls along the way.
   return $ IdxRepVal 1
-computeElemCount idxNest = do
-  idxNest' <- liftEmitBuilder $ indexStructureWithoutProjectElt idxNest
-  polySize <- liftImmut $ elemCountCPoly idxNest'
-  A.emitCPoly polySize
+computeElemCount idxNest' = do
+  let (idxList, idxNest) = indexStructureSplit idxNest'
+  listSize <- foldM imul (IdxRepVal 1) =<< traverse indexSetSize idxList
+  nestSize <- A.emitCPoly =<< liftImmut (elemCountCPoly idxNest)
+  imul listSize nestSize
 
--- we can't turn types into polynomials if they contain `ProjectElt` atoms, so
--- we traverse the index structure and emit any `ProjectElt` occurrences so we
--- just have variables instead.
--- TODO: can we just get rid of `ProjectElt`? Is causes many headaches like these.
-indexStructureWithoutProjectElt
-  :: (Emits n, ScopableBuilder m)
-  =>  IndexStructure n -> m n (IndexStructure n)
-indexStructureWithoutProjectElt (Abs Empty UnitE) = return $ EmptyAbs Empty
-indexStructureWithoutProjectElt (Abs (Nest (b:>ty) rest) UnitE) = do
-  ty' <- indexTyWithoutProjectElt ty
-  Abs decls idxNest <- liftImmut $ refreshBinders (b:>ty') \b' s -> do
-    rest' <- applySubst s $ Abs rest UnitE
-    DistinctAbs decls (Abs restNoProj UnitE) <- buildScoped $
-      indexStructureWithoutProjectElt (sink rest')
-    -- this should succeed because we shouldn't have a `ProjectElt` that depends on an index
-    PairB decls' b'' <- return $ ignoreHoistFailure $ exchangeBs $ PairB b' decls
-    return $ Abs decls' $ Abs (Nest b'' restNoProj) UnitE
-  emitDecls decls idxNest
-
-indexTyWithoutProjectElt
-  :: forall n m . (Emits n, Builder m)
-  =>  Type n -> m n (Type n)
-indexTyWithoutProjectElt ty = case ty of
-  Var v -> return $ Var v
-  ProjectElt idxs v -> liftM Var $ emit $ Atom $ ProjectElt idxs v
-  TC  con -> TC  <$> mapM rec con
-  Con con -> Con <$> mapM rec con
-  RecordTy ( NoExt types) -> RecordTy  <$> NoExt <$> mapM rec types
-  VariantTy (NoExt types) -> VariantTy <$> NoExt <$> mapM rec types
-  _ -> error $ "not implemented " ++ pprint ty
-  where
-    rec :: Type n -> m n (Type n)
-    rec = indexTyWithoutProjectElt
+-- Split the index structure into a prefix of non-dependent index types
+-- and a trailing nest of indices that can contain inter-dependencies.
+indexStructureSplit :: IndexStructure n -> ([Type n], IndexStructure n)
+indexStructureSplit (Abs Empty UnitE) = ([], EmptyAbs Empty)
+indexStructureSplit s@(Abs (Nest b rest) UnitE) =
+  case hoist b (EmptyAbs rest) of
+    HoistFailure _     -> ([], s)
+    HoistSuccess rest' -> (binderType b:ans1, ans2)
+      where (ans1, ans2) = indexStructureSplit rest'
 
 computeOffset :: forall m n. (Emits n, Builder m) => IndexStructure n -> [AtomName n] -> m n (Atom n)
-computeOffset idxNest idxs = do
-  idxNest' <- liftEmitBuilder $ indexStructureWithoutProjectElt idxNest
-  rec idxNest' idxs
+computeOffset idxNest' idxs = do
+  let (idxList , idxNest ) = indexStructureSplit idxNest'
+  let (listIdxs, nestIdxs) = splitAt (length idxList) idxs
+  nestOffset   <- rec idxNest nestIdxs
+  nestSize     <- computeElemCount idxNest
+  listOrds     <- mapM (indexToInt . Var) listIdxs
+  idxListSizes <- mapM indexSetSize idxList
+  listOffset   <- fst <$> foldM accumStrided (IdxRepVal 0, nestSize) (reverse $ zip idxListSizes listOrds)
+  iadd listOffset nestOffset
   where
+   accumStrided (total, stride) (size, i) = (,) <$> (iadd total =<< imul i stride) <*> imul stride size
+   -- Recursively process the dependent part of the nest
    rec :: IndexStructure n -> [AtomName n] -> m n (Atom n)
    rec (Abs Empty UnitE) [] = return $ IdxRepVal 0
    rec (Abs (Nest b bs) UnitE) (i:is) = do

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -174,6 +174,10 @@ evalOp expr = mapM evalAtom expr >>= \case
     Con (IntRangeVal   _ _   i) -> return i
     Con (IndexRangeVal _ _ _ i) -> return i
     _ -> evalBuilder $ indexToInt $ sink idxArg
+  Select cond t f -> case cond of
+    Con (Lit (Word8Lit 0)) -> return f
+    Con (Lit (Word8Lit 1)) -> return t
+    _ -> error $ "Invalid select condition: " ++ pprint cond
   _ -> error $ "Not implemented: " ++ pprint expr
 
 evalBuilder :: (Interp m, SinkableE e, SubstE AtomSubstVal e)

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -165,8 +165,7 @@ findReplace old new s@(x:xs) =
 scan :: Traversable t => (a -> s -> (b, s)) -> t a -> s -> (t b, s)
 scan f xs s = runState (traverse (asState . f) xs) s
 
-scanM :: (Monad m, Traversable t)
-  => (a -> s -> m (b, s)) -> t a -> s -> m (t b, s)
+scanM :: (Monad m, Traversable t) => (a -> s -> m (b, s)) -> t a -> s -> m (t b, s)
 scanM f xs s = runStateT (traverse (asStateT . f) xs) s
 
 asStateT :: Monad m => (s -> m (a, s)) -> StateT s m a


### PR DESCRIPTION
The Algebra module is neat, but it's not fully general. In the simple
case of rectangular (i.e. non-dependent) index nests the arithmetic is
simple enough that we don't need to engage it at all. In particular this
should let us the arbitrarily complex Ix implementations that users
will soon be able to throw at the compiler without crasing due to
partiality of our simplifier.