### PR TITLE
Add support for user-defined index sets

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -24,17 +24,13 @@ def interleave {m v} (blank:v) (labels: m=>v) : (m & (Fin 2))=>v =
   pairs = for i. [labels.i, blank]
   for (i, j). pairs.i.j
 
-instance {m} [Ix m] Ix {head:Unit | tail:m}
-  dummy_ix__ = 0
-
-def prepend {m v} (first: v) (seq: m=>v) : ({head:Unit | tail:m }=>v) =
+def prepend {m v} (first: v) (seq: m=>v) : ((Unit|m)=>v) =
   -- Concatenates a single element to the beginning of a sequence.
   for idx. case idx of
-    {| head = () |} -> first
-    {| tail = i  |} -> seq.i
+    Left () -> first
+    Right i -> seq.i
 
-def prepend_and_interleave {m v} (blank:v) (seq: m=>v) :
-  ({head:Unit | tail:(m & (Fin 2))}=>v) =
+def prepend_and_interleave {m v} (blank:v) (seq: m=>v) : ((Unit|(m & (Fin 2)))=>v) =
   -- Turns "text" into " t e x t".
   -- The output of this function has a slightly complicated output type, which
   -- has size 1 + 2 * (size m).

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -45,26 +45,22 @@ that produce isos. We will start with the first two:
 %passes parse
 :t #b : Iso {a:Int & b:Float & c:Unit} _
 > (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
-> === parse ===
->  _ans_ =
->   MkIso {bwd = \(x, r). {b = x, ...r}, fwd = \{b = (), ...()}. (,) x r}
->   : Iso {a: Int & b: Float & c: Unit} _
+> (MkIso {bwd = \(x, r). {b = x, ...r}, fwd = \{b = (), ...()}. (,) x r}
+>  : Iso {a: Int & b: Float & c: Unit} _)
 
 %passes parse
 :t #?b : Iso {a:Int | b:Float | c:Unit} _
 > (Iso {a: Int32 | b: Float32 | c: Unit} (Float32 | {a: Int32 | c: Unit}))
-> === parse ===
->  _ans_ =
->   MkIso
->     { bwd = \v. case v
->                 ((Left x)) -> {| b = x |}
->                 ((Right r)) -> {|b| ...r |}
->                 
->     , fwd = \v. case v
->                 {| b = x |} -> (Left x)
->                 {|b| ...r |} -> (Right r)
->                 }
->   : Iso {a: Int | b: Float | c: Unit} _
+> (MkIso
+>    { bwd = \v. case v
+>                ((Left x)) -> {| b = x |}
+>                ((Right r)) -> {|b| ...r |}
+>                
+>    , fwd = \v. case v
+>                {| b = x |} -> (Left x)
+>                {|b| ...r |} -> (Right r)
+>                }
+>  : Iso {a: Int | b: Float | c: Unit} _)
 
 'There are also two "zipper" forms, described later on this page:
 - `#&x` produces a "record-zipper" isomorphism
@@ -141,12 +137,10 @@ another. For instance:
 > (Iso
 >    ({ &} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
-> === parse ===
->  _ans_ =
->   MkIso
->     { bwd = \({a = (), ...()}, {, ...()}). (,) {, ...l} {a = x, ...r}
->     , fwd = \({, ...()}, {a = (), ...()}). (,) {a = x, ...l} {, ...r}}
->   : Iso ((&) { &} {a: Int & b: Float & c: Unit}) _
+> (MkIso
+>    { bwd = \({a = (), ...()}, {, ...()}). (,) {, ...l} {a = x, ...r}
+>    , fwd = \({, ...()}, {a = (), ...()}). (,) {a = x, ...l} {, ...r}}
+>  : Iso ((&) { &} {a: Int & b: Float & c: Unit}) _)
 
 :t (#&a &>> #&b) : Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
@@ -200,7 +194,7 @@ def abcToTuple {a b c} : Iso {a:a & b:b & c:c} (c&b&a) =
   bwd = \(c, b, a). {a, b, c}
   MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n & b:m & c:q}
-  size = size n * size m * size q
+  getSize = \(). size n * size m * size q
   ordinal = ordinal <<< appIso abcToTuple
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToTuple
 
@@ -209,7 +203,7 @@ def bcToPair {b c} : Iso {b:b & c:c} (c&b) =
   bwd = \(c, b). {b, c}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {b:n & c:m}
-  size = size n * size m
+  getSize = \(). size n * size m
   ordinal = ordinal <<< appIso bcToPair
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso bcToPair
 
@@ -234,24 +228,22 @@ zipper isomorphisms:
 > (Iso
 >    ({ |} | {a: Int32 | b: Float32 | c: Unit})
 >    ({a: Int32} | {b: Float32 | c: Unit}))
-> === parse ===
->  _ans_ =
->   MkIso
->     { bwd = \v. case v
->                 ((Left w)) -> (case w
->                                  {| a = x |} -> (Right {| a = x |})
->                                  {|a| ...r |} -> (Left r)
+> (MkIso
+>    { bwd = \v. case v
+>                ((Left w)) -> (case w
+>                                 {| a = x |} -> (Right {| a = x |})
+>                                 {|a| ...r |} -> (Left r)
+>                                 )
+>                ((Right l)) -> (Right {|a| ...l |})
+>                
+>    , fwd = \v. case v
+>                ((Left l)) -> (Left {|a| ...l |})
+>                ((Right w)) -> (case w
+>                                  {| a = x |} -> (Left {| a = x |})
+>                                  {|a| ...r |} -> (Right r)
 >                                  )
->                 ((Right l)) -> (Right {|a| ...l |})
->                 
->     , fwd = \v. case v
->                 ((Left l)) -> (Left {|a| ...l |})
->                 ((Right w)) -> (case w
->                                   {| a = x |} -> (Left {| a = x |})
->                                   {|a| ...r |} -> (Right r)
->                                   )
->                 }
->   : Iso ((|) { |} {a: Int | b: Float | c: Unit}) _
+>                }
+>  : Iso ((|) { |} {a: Int | b: Float | c: Unit}) _)
 
 '`splitV` makes a prism zipper into an ordinary prism isomorphism:
 
@@ -278,7 +270,7 @@ def abcToEither {a b c} : Iso {a:a | b:b | c:c} (a|(b|c)) =
       Right y -> {|c=y|}
   MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n | b:m | c:q}
-  size = size n + size m + size q
+  getSize = \(). size n + size m + size q
   ordinal = ordinal <<< appIso abcToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToEither
 
@@ -291,7 +283,7 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  size = size n + size m
+  getSize = \(). size n + size m
   ordinal = ordinal <<< appIso abToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
 
@@ -304,7 +296,7 @@ def acToEither {a c} : Iso {a:a | c:c} (a|c) =
     Right x -> {|c=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | c:m}
-  size = size n + size m
+  getSize = \(). size n + size m
   ordinal = ordinal <<< appIso acToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso acToEither
 

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -195,10 +195,23 @@ when using a record type as an index set:
 '`overLens` alone can be used with any lens-like isomorphism, for instance an
 ordinary record accessor lens.
 
+def abcToTuple {a b c} : Iso {a:a & b:b & c:c} (c&b&a) =
+  fwd = \{a, b, c}. (c, b, a)
+  bwd = \(c, b, a). {a, b, c}
+  MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n & b:m & c:q}
-  dummy_ix__ = 0
-instance {m q} [Ix m, Ix q] Ix {b:m & c:q}
-  dummy_ix__ = 0
+  size = size n * size m * size q
+  ordinal = ordinal <<< appIso abcToTuple
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToTuple
+
+def bcToPair {b c} : Iso {b:b & c:c} (c&b) =
+  fwd = \{b, c}. (c, b)
+  bwd = \(c, b). {b, c}
+  MkIso {fwd, bwd}
+instance {n m} [Ix n, Ix m] Ix {b:n & c:m}
+  size = size n * size m
+  ordinal = ordinal <<< appIso bcToPair
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso bcToPair
 
 :p
   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
@@ -253,12 +266,47 @@ zipper isomorphisms:
 '`sliceFields` uses this to specific named variants from a variant-indexed
 table:
 
+def abcToEither {a b c} : Iso {a:a | b:b | c:c} (a|(b|c)) =
+  fwd = \v.  case v of
+    {|a=x|} -> Left x
+    {|b=x|} -> Right (Left x)
+    {|c=x|} -> Right (Right x)
+  bwd = \v. case v of
+    Left  x -> {|a=x|}
+    Right x -> case x of
+      Left  y -> {|b=y|}
+      Right y -> {|c=y|}
+  MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n | b:m | c:q}
-  dummy_ix__ = 0
+  size = size n + size m + size q
+  ordinal = ordinal <<< appIso abcToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToEither
+
+def abToEither {a b} : Iso {a:a | b:b} (a|b) =
+  fwd = \v.  case v of
+    {|a=x|} -> Left x
+    {|b=x|} -> Right x
+  bwd = \v. case v of
+    Left x  -> {|a=x|}
+    Right x -> {|b=x|}
+  MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  dummy_ix__ = 0
-instance {n q} [Ix n, Ix q] Ix {a:n | c:q}
-  dummy_ix__ = 0
+  size = size n + size m
+  ordinal = ordinal <<< appIso abToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
+
+def acToEither {a c} : Iso {a:a | c:c} (a|c) =
+  fwd = \v.  case v of
+    {|a=x|} -> Left x
+    {|c=x|} -> Right x
+  bwd = \v. case v of
+    Left x  -> {|a=x|}
+    Right x -> {|c=x|}
+  MkIso {fwd, bwd}
+instance {n m} [Ix n, Ix m] Ix {a:n | c:m}
+  size = size n + size m
+  ordinal = ordinal <<< appIso acToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso acToEither
 
 :p
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -73,7 +73,7 @@ def lrToEither {a b} : Iso {left:a | right:b} (a|b) =
     Right x -> {|right=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {left:n | right:m}
-  size = size n + size m
+  getSize = \(). size n + size m
   ordinal = ordinal <<< appIso lrToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso lrToEither
 

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -64,8 +64,18 @@ def rmsErr {n} (truth:n=>Float) (pred:n=>Float) : Float =
 :p rmsErr ys (map predict xs)
 > 0.252695
 
-instance {n m} [Ix n, Ix m] Ix {left:n|right:m}
-  dummy_ix__ = 0
+def lrToEither {a b} : Iso {left:a | right:b} (a|b) =
+  fwd = \v.  case v of
+    {|left=x|}  -> Left x
+    {|right=x|} -> Right x
+  bwd = \v. case v of
+    Left x  -> {|left=x|}
+    Right x -> {|right=x|}
+  MkIso {fwd, bwd}
+instance {n m} [Ix n, Ix m] Ix {left:n | right:m}
+  size = size n + size m
+  ordinal = ordinal <<< appIso lrToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso lrToEither
 
 def tabCat {n m a} (xs:n=>a) (ys:m=>a) : ({left:n|right:m})=>a =
   for i. case i of

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -27,48 +27,6 @@ RawPtr : Type = %Word8Ptr
 Int = Int32
 Float = Float32
 
-'### Index set interface and instances
-
-interface Ix a
-  dummy_ix__ : Int32
-
--- TODO: Make those methods of Ix
-def ordinal {a} [Ix a] (i:a) : Int = %toOrdinal i
-def size (n:Type) [Ix n] : Int = %idxSetSize n
-def unsafeFromOrdinal (n : Type) [Ix n] (i : Int) : n = %unsafeFromOrdinal n i
-
-def Range (low:Int) (high:Int) : Type = %IntRange low high
-def Fin (n:Int) : Type = Range 0 n
-
-instance {l h} Ix (Range l h)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} [Ix q] Ix (i..)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} [Ix q] Ix (i<..)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} [Ix q] Ix (..i)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} [Ix q] Ix (..<i)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
-  dummy_ix__ = 0
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
-  dummy_ix__ = 0
-
-def iota (n:Type) [Ix n] : n=>Int = view i. ordinal i
-
 '### Casting
 
 def internalCast {a} (b:Type) (x:a) : b = %cast b x
@@ -192,21 +150,6 @@ instance Add Unit
   sub = \x y. ()
   zero = ()
 
-instance {a n} [Add a] Add (n=>a)
-  add = \xs ys. for i. xs.i + ys.i
-  sub = \xs ys. for i. xs.i - ys.i
-  zero = for _. zero
-
-instance {a n} [Add a] Add (i:n => (i..) => a)  -- Upper triangular tables
-  add = \xs ys. for i. xs.i + ys.i
-  sub = \xs ys. for i. xs.i - ys.i
-  zero = for _. zero
-
-instance {a n} [Add a] Add (i:n => (..i) => a)  -- Lower triangular tables
-  add = \xs ys. for i. xs.i + ys.i
-  sub = \xs ys. for i. xs.i - ys.i
-  zero = for _. zero
-
 '#### Mul
 Things that can be multiplied.
 This defines the `Mul` [Monoid](https://en.wikipedia.org/wiki/Monoid), and its operator.
@@ -241,10 +184,6 @@ instance Mul Unit
   mul = \x y. ()
   one = ()
 
-instance {a n} [Mul a] Mul (n=>a)
-  mul = \xs ys. for i. xs.i * ys.i
-  one = for _. one
-
 '#### Integral
 Integer-like things.
 
@@ -277,6 +216,96 @@ instance Fractional Float64
 instance Fractional Float32
   divide = \x y. %fdiv x y
 
+'## Index set interface and instances
+
+interface Ix n
+  size n : Int
+  ordinal : n -> Int
+  unsafeFromOrdinal n : Int -> n
+
+def Range (low:Int) (high:Int) : Type = %IntRange low high
+def Fin (n:Int) : Type = Range 0 n
+
+-- A max(a, 0) that is friendly to our algebraic simplifier
+def clampNonnegPrim (a: Int) : Int =
+  z : Int = 0
+  isNeg = %ilt a z
+  %select isNeg z a
+
+-- TODO: Define Range in surface syntax
+instance {l h} Ix (Range l h)
+  size = clampNonnegPrim $ h - l
+  ordinal = \i. %cast Int i
+  unsafeFromOrdinal = \i. %cast (Range l h) i
+
+instance {q:Type} {i:q} [Ix q] Ix (i..)
+  size = size q - ordinal i
+  ordinal = \j. %cast Int j
+  unsafeFromOrdinal = \j. %cast (i..) j
+
+instance {q:Type} {i:q} [Ix q] Ix (i<..)
+  size = size q - ordinal i - 1
+  ordinal = \j. %cast Int j
+  unsafeFromOrdinal = \j. %cast (i<..) j
+
+instance {q:Type} {i:q} [Ix q] Ix (..i)
+  size = ordinal i + 1
+  ordinal = \j. %cast Int j
+  unsafeFromOrdinal = \j. %cast (..i) j
+
+instance {q:Type} {i:q} [Ix q] Ix (..<i)
+  size = ordinal i
+  ordinal = \j. %cast Int j
+  unsafeFromOrdinal = \j. %cast (..<i) j
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
+  size = clampNonnegPrim $ ordinal i - ordinal j + 1
+  ordinal = \k. %cast Int k
+  unsafeFromOrdinal = \k. %cast (j..i) k
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
+  size = clampNonnegPrim $ ordinal i - ordinal j
+  ordinal = \k. %cast Int k
+  unsafeFromOrdinal = \k. %cast (j..<i) k
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
+  size = clampNonnegPrim $ ordinal i - ordinal j
+  ordinal = \k. %cast Int k
+  unsafeFromOrdinal = \k. %cast (j<..i) k
+
+instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
+  size = clampNonnegPrim $ ordinal i - ordinal j - 1
+  ordinal = \k. %cast Int k
+  unsafeFromOrdinal = \k. %cast (j<..<i) k
+
+instance Ix Unit
+  size = 1
+  ordinal = \_. 0
+  unsafeFromOrdinal = \_. ()
+
+def iota (n:Type) [Ix n] : n=>Int = view i. ordinal i
+
+'## Arithmetic instances for table types
+
+instance {a n} [Add a] Add (n=>a)
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [Add a] Add (i:n => (i..) => a)  -- Upper triangular tables
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [Add a] Add (i:n => (..i) => a)  -- Lower triangular tables
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [Mul a] Mul (n=>a)
+  mul = \xs ys. for i. xs.i * ys.i
+  one = for _. one
+
 '## Basic polymorphic functions and types
 
 def (&) (a:Type) (b:Type) : Type = %PairType a b
@@ -286,7 +315,11 @@ def snd {a b} ((_, y): (a & b)) : b = y
 def swap {a b} ((x, y):(a&b)) : (b&a) = (y, x)
 
 instance {a b} [Ix a, Ix b] Ix (a & b)
-  dummy_ix__ = 0
+  size = size a * size b
+  ordinal = \(i, j). (ordinal i * size b) + ordinal j
+  unsafeFromOrdinal = \o.
+    bs = size b
+    (unsafeFromOrdinal a (idiv o bs), unsafeFromOrdinal b (rem o bs))
 
 def (<<<) {a b c} (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
 def (>>>) {a b c} (g: a -> b) (f: b -> c) : a -> c = \x. f (g x)
@@ -338,6 +371,26 @@ def not  (x:Bool) : Bool =
   x' = BToW8 x
   W8ToB $ %not x'
 
+'## More Boolean operations
+TODO: move these with the others?
+
+def select {a} (p:Bool) (x:a) (y:a) : a = case p of
+  True  -> x
+  False -> y
+
+def BToI (x:Bool) : Int  = W8ToI $ BToW8 x
+def BToF (x:Bool) : Float = IToF (BToI x)
+
+'## Ordering
+TODO: move this down to with `Ord`?
+
+data Ordering =
+  LT
+  EQ
+  GT
+
+def OToW8 (x : Ordering) : Word8 = %dataConTag x
+
 '## Sum types
 A [sum type, or tagged union](https://en.wikipedia.org/wiki/Tagged_union) can hold values from a fixed set of types, distinguished by tags.
 For those familiar with the C language, they can be though of as a combination of an `enum` with a `union`.
@@ -362,25 +415,17 @@ data (|) a b =
   Left  a
   Right b
 
-'## More Boolean operations
-TODO: move these with the others?
-
-def select {a} (p:Bool) (x:a) (y:a) : a = case p of
-  True  -> x
-  False -> y
-
-def BToI (x:Bool) : Int  = W8ToI $ BToW8 x
-def BToF (x:Bool) : Float = IToF (BToI x)
-
-'## Ordering
-TODO: move this down to with `Ord`?
-
-data Ordering =
-  LT
-  EQ
-  GT
-
-def OToW8 (x : Ordering) : Word8 = %dataConTag x
+instance {a b} [Ix a, Ix b] Ix (a | b)
+  size = size a + size b
+  ordinal = \i. case i of
+    Left ai  -> ordinal ai
+    Right bi -> ordinal bi + size a
+  unsafeFromOrdinal = \o.
+    as = size a
+    -- TODO: Reshuffle the prelude to be able to use (<) here
+    case W8ToB $ %ilt o as of
+      True  -> Left $ unsafeFromOrdinal a o
+      False -> Right $ unsafeFromOrdinal b (o - as)
 
 '### Monoid
 A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -219,9 +219,11 @@ instance Fractional Float32
 '## Index set interface and instances
 
 interface Ix n
-  size n : Int
+  getSize n : Unit -> Int
   ordinal : n -> Int
   unsafeFromOrdinal n : Int -> n
+
+def size (n : Type) [Ix n] : Int = getSize n ()
 
 def Range (low:Int) (high:Int) : Type = %IntRange low high
 def Fin (n:Int) : Type = Range 0 n
@@ -234,52 +236,52 @@ def clampNonnegPrim (a: Int) : Int =
 
 -- TODO: Define Range in surface syntax
 instance {l h} Ix (Range l h)
-  size = clampNonnegPrim $ h - l
+  getSize = \(). clampNonnegPrim $ h - l
   ordinal = \i. %cast Int i
   unsafeFromOrdinal = \i. %cast (Range l h) i
 
 instance {q:Type} {i:q} [Ix q] Ix (i..)
-  size = size q - ordinal i
+  getSize = \(). size q - ordinal i
   ordinal = \j. %cast Int j
   unsafeFromOrdinal = \j. %cast (i..) j
 
 instance {q:Type} {i:q} [Ix q] Ix (i<..)
-  size = size q - ordinal i - 1
+  getSize = \(). size q - ordinal i - 1
   ordinal = \j. %cast Int j
   unsafeFromOrdinal = \j. %cast (i<..) j
 
 instance {q:Type} {i:q} [Ix q] Ix (..i)
-  size = ordinal i + 1
+  getSize = \(). ordinal i + 1
   ordinal = \j. %cast Int j
   unsafeFromOrdinal = \j. %cast (..i) j
 
 instance {q:Type} {i:q} [Ix q] Ix (..<i)
-  size = ordinal i
+  getSize = \(). ordinal i
   ordinal = \j. %cast Int j
   unsafeFromOrdinal = \j. %cast (..<i) j
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
-  size = clampNonnegPrim $ ordinal i - ordinal j + 1
+  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j + 1
   ordinal = \k. %cast Int k
   unsafeFromOrdinal = \k. %cast (j..i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
-  size = clampNonnegPrim $ ordinal i - ordinal j
+  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j
   ordinal = \k. %cast Int k
   unsafeFromOrdinal = \k. %cast (j..<i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
-  size = clampNonnegPrim $ ordinal i - ordinal j
+  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j
   ordinal = \k. %cast Int k
   unsafeFromOrdinal = \k. %cast (j<..i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
-  size = clampNonnegPrim $ ordinal i - ordinal j - 1
+  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j - 1
   ordinal = \k. %cast Int k
   unsafeFromOrdinal = \k. %cast (j<..<i) k
 
 instance Ix Unit
-  size = 1
+  getSize = \(). 1
   ordinal = \_. 0
   unsafeFromOrdinal = \_. ()
 
@@ -315,7 +317,7 @@ def snd {a b} ((_, y): (a & b)) : b = y
 def swap {a b} ((x, y):(a&b)) : (b&a) = (y, x)
 
 instance {a b} [Ix a, Ix b] Ix (a & b)
-  size = size a * size b
+  getSize = \(). size a * size b
   ordinal = \(i, j). (ordinal i * size b) + ordinal j
   unsafeFromOrdinal = \o.
     bs = size b
@@ -416,7 +418,7 @@ data (|) a b =
   Right b
 
 instance {a b} [Ix a, Ix b] Ix (a | b)
-  size = size a + size b
+  getSize = \(). size a + size b
   ordinal = \i. case i of
     Left ai  -> ordinal ai
     Right bi -> ordinal bi + size a

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -10,17 +10,13 @@ it's doing bubble / insertion sort with quadratic time cost.
 However, if breaks the list in half recursively, it'll be doing parallel mergesort.
 Currently it'll do the quadratic time version.
 
--- TODO(Ix)
-instance {a b} [Ix a, Ix b] Ix {left:a | right:b}
-  dummy_ix__ = 0
-
-def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ({left:a | right:b }=>v) =
+def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ((a|b)=>v) =
   -- Note: It'd be nicer to use (a | b)=>v but it's not currently supported.
   for idx. case idx of
-    {| left = i  |} -> leftin.i
-    {| right = i |} -> rightin.i
+    Left i  -> leftin.i
+    Right i -> rightin.i
 
-def mergeSortedTables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ({left:m | right:n }=>a) =
+def mergeSortedTables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ((m|n)=>a) =
   -- Possible improvements:
   --  1) Using a SortedTable type.
   --  2) Avoid initializing the return array.

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -24,7 +24,7 @@ import Data.List (intersperse)
 import Data.Tuple (swap)
 import Data.Coerce
 
-import Builder hiding (sub, add, indexSetSize)
+import Builder hiding (sub, add)
 import Syntax
 import Type
 import Name
@@ -217,6 +217,10 @@ blockAsCPoly (Block _ decls' result') = fromMaybeE <$> liftImmut do
       Op (ScalarBinOp IAdd x y) -> add  <$> intAsCPoly x <*> intAsCPoly y
       Op (ScalarBinOp ISub x y) -> sub  <$> intAsCPoly x <*> intAsCPoly y
       Op (ScalarBinOp IMul x y) -> mulC <$> intAsCPoly x <*> intAsCPoly y
+      -- TODO: Remove once IntRange and IndexRange are defined in the surface language
+      Op (CastOp IdxRepTy v)    -> getType v >>= \case
+        IdxRepTy -> intAsCPoly v
+        _        -> indexAsCPoly v
       -- This looks for `select c 0 n` such that `c` is defined as `n < 0`.
       Op (Select (Var c) t f) -> do
         lookupAtomName c >>= \case

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -11,6 +11,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE RecordWildCards #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Builder (
@@ -72,10 +73,11 @@ import Syntax
 import Type
 import PPrint ()
 import CheapReduction
+import {-# SOURCE #-} Inference
 import MTL1
 
 import LabeledItems
-import Util (enumerate, scanM, restructure, transitiveClosureM, bindM2)
+import Util (enumerate, restructure, transitiveClosureM, bindM2)
 import Err
 
 -- === Ordinary (local) builder class ===
@@ -957,7 +959,6 @@ getUnpacked atom = do
   len <- projectLength ty
   return $ map (\i -> getProjection [i] atom') [0..(len-1)]
 
--- TODO: should we just make all of these return names instead of atoms?
 emitUnpacked :: (Builder m, Emits n) => Atom n -> m n [AtomName n]
 emitUnpacked tup = do
   xs <- getUnpacked tup
@@ -976,9 +977,6 @@ indexRef ref i = emitOp $ IndexRef ref i
 
 naryIndexRef :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
 naryIndexRef ref is = foldM indexRef ref is
-
-indexAsInt :: (Builder m, Emits n) => Atom n -> m n (Atom n)
-indexAsInt idx = emitOp $ ToOrdinal idx
 
 ptrOffset :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 ptrOffset x (IdxRepVal 0) = return x
@@ -1035,112 +1033,24 @@ clampPositive x = do
   select isNegative (IdxRepVal 0) x
 
 intToIndex :: forall m n. (Builder m, Emits n) => Type n -> Atom n -> m n (Atom n)
-intToIndex ty i = case ty of
-  TC (IntRange        low high) -> return $ Con $ IntRangeVal        low high i
-  TC (IndexRange from low high) -> return $ Con $ IndexRangeVal from low high i
-  -- Strategically placed reverses make intToProd major-to-minor
-  TC (ProdType types) -> (ProdVal . reverse) <$> intToProd (reverse types)
-  RecordTy  (NoExt types) -> Record <$> intToProd types
-  SumTy types             -> intToSum types [0..] $ SumVal ty
-  VariantTy (NoExt types) -> intToSum types (reflectLabels types) $ uncurry $ Variant (NoExt types)
-  _ -> error "not an (implemented) index set"
-  where
-    -- XXX: Expects that the types are in a minor-to-major order
-    intToProd :: Traversable t => t (Type n) -> m n (t (Atom n))
-    intToProd types = do
-      sizes <- traverse indexSetSize types
-      (strides, _) <- scanM
-        (\sz prev -> do {v <- imul sz prev; return ((prev, v), v)}) sizes (IdxRepVal 1)
-      offsets <- flip mapM (zip (toList types) (toList strides)) $
-        \(ety, (s1, s2)) -> do
-          x <- irem i s2
-          y <- idiv x s1
-          intToIndex ety y
-      return $ restructure offsets types
-
-    intToSum :: Traversable t => t (Type n) -> t l -> (l -> Atom n -> Atom n) -> m n (Atom n)
-    intToSum types labels mkSum = do
-      sizes <- traverse indexSetSize types
-      (offsets, _) <- scanM (\sz prev -> (prev,) <$> iadd sz prev) sizes (IdxRepVal 0)
-      let
-        -- Find the right index by looping through the possible offsets
-        go prev (label, cty, offset) = do
-          shifted <- isub i offset
-          -- TODO: This might run intToIndex on negative indices. Fix this!
-          index   <- intToIndex cty shifted
-          beforeThis <- ilt i offset
-          select beforeThis prev $ mkSum label index
-        (l, ty0, _):zs = zip3 (toList labels) (toList types) (toList offsets)
-      start <- mkSum l <$> intToIndex ty0 i
-      foldM go start zs
-
-data IterOrder = MinorToMajor | MajorToMinor
+intToIndex ty i = do
+  f <- unsafeFromOrdinal <$> getIxImpl ty
+  app f i
 
 indexToInt :: forall m n. (Builder m, Emits n) => Atom n -> m n (Atom n)
-indexToInt (Con (IntRangeVal _ _ i))     = return i
-indexToInt (Con (IndexRangeVal _ _ _ i)) = return i
-indexToInt idx = getType idx >>= \case
-  TC (IntRange _ _)     -> indexAsInt idx
-  TC (IndexRange _ _ _) -> indexAsInt idx
-  ProdTy           types  -> prodToInt MajorToMinor types
-  RecordTy  (NoExt types) -> prodToInt MinorToMajor types
-  SumTy            types  -> sumToInt types
-  VariantTy (NoExt types) -> sumToInt types
-  TC (ParIndexRange _ _ _) -> error "Int casts unsupported on ParIndexRange"
-  ty -> error $ "Unexpected type " ++ pprint ty
-  where
-    prodToInt :: Traversable t => IterOrder -> t (Type n) -> m n (Atom n)
-    prodToInt order types = do
-      sizes <- toList <$> traverse indexSetSize types
-      let rev = case order of MinorToMajor -> id; MajorToMinor -> reverse
-      strides <- rev . fst <$> scanM (\sz prev -> (prev,) <$> imul sz prev) (rev sizes) (IdxRepVal 1)
-      -- Unpack and sum the strided contributions
-      subindices <- getUnpacked idx
-      subints <- traverse indexToInt subindices
-      scaled <- mapM (uncurry imul) $ zip strides subints
-      foldM iadd (IdxRepVal 0) scaled
-
-    sumToInt :: Traversable t => t (Type n) -> m n (Atom n)
-    sumToInt types = do
-      sizes <- traverse indexSetSize types
-      (offsets, _) <- scanM (\sz prev -> (prev,) <$> iadd sz prev) sizes (IdxRepVal 0)
-      alts <- flip mapM (zip (toList offsets) (toList types)) $
-        \(offset, subty) -> liftEmitBuilder $ buildUnaryAlt subty \subix -> do
-          i <- indexToInt $ Var subix
-          iadd (sink offset) i
-      liftM Var $ emit $ Case idx alts IdxRepTy Pure
+indexToInt idx = do
+  f <- toOrdinal <$> (getIxImpl =<< getType idx)
+  app f idx
 
 indexSetSize :: (Builder m, Emits n) => Type n -> m n (Atom n)
-indexSetSize ty = case ty of
-  TC (IntRange low high) -> clampPositive =<< high `isub` low
-  TC (IndexRange n low high) -> do
-    low' <- case low of
-      InclusiveLim x -> indexToInt x
-      ExclusiveLim x -> indexToInt x >>= iadd (IdxRepVal 1)
-      Unlimited      -> return $ IdxRepVal 0
-    high' <- case high of
-      InclusiveLim x -> indexToInt x >>= iadd (IdxRepVal 1)
-      ExclusiveLim x -> indexToInt x
-      Unlimited      -> indexSetSize n
-    -- The clamp is only necessary when both sides are not unlimited.
-    let maybeClamp = case (low, high) of
-          (Unlimited, _) -> return
-          (_, Unlimited) -> return
-          _              -> clampPositive
-    maybeClamp =<< high' `isub` low'
-  TC (ProdType types) -> do
-    sizes <- traverse indexSetSize types
-    foldM imul (IdxRepVal 1) sizes
-  RecordTy (NoExt types) -> do
-    sizes <- traverse indexSetSize types
-    foldM imul (IdxRepVal 1) sizes
-  TC (SumType types) -> do
-    sizes <- traverse indexSetSize types
-    foldM iadd (IdxRepVal 0) sizes
-  VariantTy (NoExt types) -> do
-    sizes <- traverse indexSetSize types
-    foldM iadd (IdxRepVal 0) sizes
-  _ -> error $ "Not an (implemented) index set " ++ pprint ty
+indexSetSize ty = size <$> getIxImpl ty
+
+data IxImpl n = IxImpl { size :: Atom n, toOrdinal :: Atom n, unsafeFromOrdinal :: Atom n }
+
+getIxImpl :: (Builder m, Emits n) => Type n -> m n (IxImpl n)
+getIxImpl ty = do
+  [size, toOrdinal, unsafeFromOrdinal] <- getUnpacked =<< getProj 1 =<< getProj 0 =<< emitBlock =<< synthIx ty
+  return $ IxImpl{..}
 
 -- === pseudo-prelude ===
 

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -105,7 +105,7 @@ runCheapReducerM :: Distinct o
                  => Subst AtomSubstVal i o -> Env o -> CheapReducerM i o a
                  -> (Maybe a, FailedDictTypes o)
 runCheapReducerM env bindings (CheapReducerM m) =
-  runIdentity $ runEnvReaderT bindings $ fmap fst $ runScopedT1
+  runIdentity $ runEnvReaderT bindings $ runScopedT1
     (runWriterT1 $ runMaybeT1 $ runSubstReaderT env m) mempty
 
 cheapReduceFromSubst

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -12,7 +12,7 @@
 
 module Inference
   ( inferTopUDecl, inferTopUExpr, applyUDeclAbs, trySynthDict, trySynthDictBlock
-  , synthTopBlock, UDeclInferenceResult (..)) where
+  , synthTopBlock, UDeclInferenceResult (..), synthIx ) where
 
 import Prelude hiding ((.), id)
 import Control.Category
@@ -1580,6 +1580,14 @@ checkIx ctx ty = do
     Just ixInterfaceName -> do
       ClassBinding (ClassDef _ _ dictDataDefName) _ <- lookupEnv ixInterfaceName
       void $ emitOp $ SynthesizeDict ctx $ TypeCon "Ix" dictDataDefName [ty]
+
+synthIx :: (Fallible1 m, EnvReader m) => Type n -> m n (Block n)
+synthIx ty = do
+  lookupSourceMap ClassNameRep "Ix" >>= \case
+    Nothing -> throw CompilerErr $ "Ix interface needed but not defined!"
+    Just ixInterfaceName -> do
+      ClassBinding (ClassDef _ _ dictDataDefName) _ <- lookupEnv ixInterfaceName
+      trySynthDictBlock $ TypeCon "Ix" dictDataDefName [ty]
 
 -- === Solver ===
 

--- a/src/lib/Inference.hs-boot
+++ b/src/lib/Inference.hs-boot
@@ -4,9 +4,10 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Inference (trySynthDictBlock) where
+module Inference (trySynthDictBlock, synthIx) where
 
 import Name
 import Syntax
 
 trySynthDictBlock :: (Fallible1 m, EnvReader m) => Type n -> m n (Block n)
+synthIx :: (Fallible1 m, EnvReader m) => Type n -> m n (Block n)

--- a/src/lib/Interpreter.hs-boot
+++ b/src/lib/Interpreter.hs-boot
@@ -1,0 +1,11 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Interpreter (indices) where
+
+import Syntax
+
+indices :: EnvReader m => Type n -> m n [Atom n]

--- a/src/lib/MTL1.hs
+++ b/src/lib/MTL1.hs
@@ -159,8 +159,8 @@ newtype ScopedT1 (s :: E) (m :: MonadKind1) (n :: S) (a :: *) =
 pattern ScopedT1 :: ((s n) -> m n (a, s n)) -> ScopedT1 s m n a
 pattern ScopedT1 f = WrapScopedT1 (StateT1 f)
 
-runScopedT1 :: ScopedT1 s m n a -> s n -> m n (a, s n)
-runScopedT1 = runStateT1 . runScopedT1'
+runScopedT1 :: Monad1 m => ScopedT1 s m n a -> s n -> m n a
+runScopedT1 m s = fst <$> runStateT1 (runScopedT1' m) s
 
 deriving instance (Monad1 m, Fallible1 m) => Fallible (ScopedT1 s m n)
 deriving instance (Monad1 m, Catchable1 m) => Catchable (ScopedT1 s m n)
@@ -168,7 +168,7 @@ deriving instance (Monad1 m, CtxReader1 m) => CtxReader (ScopedT1 s m n)
 
 instance (SinkableE s, EnvExtender m) => EnvExtender (ScopedT1 s m) where
   extendEnv frag m = ScopedT1 \s -> do
-    (ans, _) <- extendEnv frag $ runScopedT1 m (sink s)
+    ans <- extendEnv frag $ runScopedT1 m (sink s)
     return (ans, s)
 
 -------------------- MaybeT1 --------------------

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1955,6 +1955,9 @@ instance (SinkableE k, SinkableE v, OrdE k) => SinkableE (MapE k v) where
 instance SinkableE e => SinkableE (ListE e) where
   sinkingProofE fresh (ListE xs) = ListE $ map (sinkingProofE fresh) xs
 
+instance SinkableE e => SinkableE (NonEmptyListE e) where
+  sinkingProofE fresh (NonEmptyListE xs) = NonEmptyListE $ fmap (sinkingProofE fresh) xs
+
 instance AlphaEqE e => AlphaEqE (ListE e) where
   alphaEqE (ListE xs) (ListE ys)
     | length xs == length ys = mapM_ (uncurry alphaEqE) (zip xs ys)
@@ -1980,6 +1983,9 @@ instance Eq a => AlphaEqE (LiftE a) where
 
 instance SubstE v e => SubstE v (ListE e) where
   substE env (ListE xs) = ListE $ map (substE env) xs
+
+instance SubstE v e => SubstE v (NonEmptyListE e) where
+  substE env (NonEmptyListE xs) = NonEmptyListE $ fmap (substE env) xs
 
 instance (PrettyB b, PrettyE e) => Pretty (Abs b e n) where
   pretty (Abs b body) = "(Abs " <> pretty b <> " " <> pretty body <> ")"

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -562,7 +562,7 @@ newtype MapE (k::E) (v::E) (n::S) = MapE { fromMapE :: M.Map (k n) (v n) }
 
 newtype HashMapE (k::E) (v::E) (n::S) =
   HashMapE { fromHashMapE :: HM.HashMap (k n) (v n) }
-  deriving (Semigroup, Monoid)
+  deriving (Semigroup, Monoid, Show)
 
 newtype NonEmptyListE (e::E) (n::S) = NonEmptyListE { fromNonEmptyListE :: NonEmpty (e n)}
         deriving (Show, Eq, Generic)
@@ -1142,6 +1142,7 @@ instance AlphaHashableE VoidE where
 -- === wrapper for E-kinded things suitable for use as keys ===
 
 newtype EKey (e::E) (n::S) = EKey { fromEKey :: e n }
+                           deriving (Show)
 
 instance GenericE (EKey e) where
   type RepE (EKey e) = e

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -204,12 +204,12 @@ instance PrettyPrec (Atom n) where
     RecordTy items -> prettyExtLabeledItems items (line <> "&") ":"
     VariantTy items -> prettyExtLabeledItems items (line <> "|") ":"
     ACase e alts _ -> prettyPrecCase "acase" e alts
-    DataConRef _ params args -> atPrec AppPrec $
+    DataConRef _ params args -> atPrec LowestPrec $
       "DataConRef" <+> p params <+> p args
-    BoxedRef ptrsSizes (Abs b body) -> atPrec AppPrec $
+    BoxedRef ptrsSizes (Abs b body) -> atPrec LowestPrec $
       "Box" <+> p b <+> "<-" <+> p ptrsSizes <+> hardline <> "in" <+> p body
     ProjectElt idxs v ->
-      atPrec AppPrec $ "ProjectElt" <+> p idxs <+> p v
+      atPrec LowestPrec $ "ProjectElt" <+> p idxs <+> p v
     DepPairRef l (Abs b r) _ -> atPrec LowestPrec $
       "DepPairRef" <+> p l <+> "as" <+> p b <+> "in" <+> p r
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -9,7 +9,7 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Simplify ( simplifyTopBlock, SimplifiedBlock (..)
-                , simplifyBlock, liftSimplifyM) where
+                , simplifyBlock, liftSimplifyM, buildBlockSimplified ) where
 
 import Control.Category ((>>>))
 import Control.Monad
@@ -56,6 +56,15 @@ liftSimplifyM
 liftSimplifyM cont = liftImmut do
   DB env <- getDB
   return $ runSimplifyM env $ cont
+
+buildBlockSimplified
+  :: (Builder m)
+  => (forall l. (Emits l, DExt n l) => BuilderM l (Atom l))
+  -> m n (Block n)
+buildBlockSimplified m =
+  liftSimplifyM do
+    block <- liftBuilder $ buildBlock m
+    buildBlock $ simplifyBlock block
 
 instance Simplifier SimplifyM
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -9,7 +9,8 @@
 {-# LANGUAGE TypeFamilies #-}
 
 module Simplify ( simplifyTopBlock, SimplifiedBlock (..)
-                , simplifyBlock, liftSimplifyM, buildBlockSimplified ) where
+                , simplifyBlock, liftSimplifyM, buildBlockSimplified
+                , simplifyLam, simplifyDecls, simplifyExpr ) where
 
 import Control.Category ((>>>))
 import Control.Monad

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -10,20 +10,24 @@
 
 module Simplify ( simplifyTopBlock, SimplifiedBlock (..)
                 , simplifyBlock, liftSimplifyM, buildBlockSimplified
-                , simplifyLam, simplifyDecls, simplifyExpr ) where
+                , IxCache, MonadIxCache1, SimpleIxInstance (..)
+                , simplifiedIxInstance, appSimplifiedIxMethod ) where
 
 import Control.Category ((>>>))
 import Control.Monad
 import Control.Monad.Reader
+import Control.Monad.State.Class
 import Data.Foldable (toList)
 import Data.Text.Prettyprint.Doc (Pretty (..), hardline)
 import qualified Data.Map.Strict as M
+import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 
 import Err
 
 import Name
+import MTL1
 import Builder
 import Syntax
 import Type
@@ -561,3 +565,77 @@ hasExceptions expr = do
   case t of
     Nothing -> return $ ExceptionEffect `S.member` effs
     Just _  -> error "Shouldn't have tail left"
+
+-- === Ix simplification ===
+
+data SimpleIxInstance (n::S) =
+  SimpleIxInstance
+    { simpleIxSize            :: (Abs (Nest Decl) LamExpr n)
+    , simpleToOrdinal         :: (Abs (Nest Decl) LamExpr n)
+    , simpleUnsafeFromOrdinal :: (Abs (Nest Decl) LamExpr n)
+    }
+
+instance GenericE SimpleIxInstance where
+  type RepE SimpleIxInstance = (PairE (Abs (Nest Decl) LamExpr)
+                                 (PairE (Abs (Nest Decl) LamExpr)
+                                        (Abs (Nest Decl) LamExpr)))
+  fromE (SimpleIxInstance a b c) = PairE a (PairE b c)
+  toE (PairE a (PairE b c)) = SimpleIxInstance a b c
+
+instance SinkableE SimpleIxInstance
+instance HoistableE SimpleIxInstance
+
+type IxCache = HashMapE (EKey Type) SimpleIxInstance
+
+type MonadIxCache1 (m::MonadKind1) = forall n. MonadState (IxCache n) (m n)
+
+instance Monad1 m => HoistableState IxCache m where
+  -- TODO: I think we can do hoisting only based on the free vars in keys.
+  -- Instances should only be added at the top-level so it's not like they
+  -- can refer to any local vars that could prevent the values from being hoistable.
+  hoistState s b s' = case hoist b s' of
+    HoistSuccess s'' -> return s''
+    HoistFailure _   -> return s
+
+simplifiedIxInstance
+  :: (EnvReader m, MonadIxCache1 m)
+  => Type n -> m n (SimpleIxInstance n)
+simplifiedIxInstance ty = do
+  let key = EKey ty
+  gets (HM.lookup key . fromHashMapE) >>= \case
+    Just a -> return a
+    Nothing -> do
+      a <- simplifyInstance
+      modify (<> (HashMapE $ HM.singleton key a))
+      return a
+  where
+    simplifyInstance = liftSimplifyM do
+      Block _ decls expr <- liftBuilder $ buildBlock $ do
+        impl <- getIxImpl $ sink ty
+        return $ ProdVal [ixSize impl, toOrdinal impl, unsafeFromOrdinal impl]
+      simpBlock <- buildBlock $ simplifyDecls decls $
+        simplifyExpr expr >>= \case
+          ProdVal [size, toOrd, fromOrd] -> dropSubst do
+            (size'   , IdentityRecon) <- simplifyLam size
+            (toOrd'  , IdentityRecon) <- simplifyLam toOrd
+            (fromOrd', IdentityRecon) <- simplifyLam fromOrd
+            return $ ProdVal [size', toOrd', fromOrd']
+          _ -> error "Failed to simplify Ix methods"
+      case simpBlock of
+        Block _ simpDecls (Atom (ProdVal [Lam size, Lam toOrd, Lam fromOrd])) -> do
+          return $ SimpleIxInstance (Abs simpDecls size) (Abs simpDecls toOrd) (Abs simpDecls fromOrd)
+        _ -> error "Failed to simplify Ix methods"
+
+appSimplifiedIxMethod
+  :: (Emits n, Builder m, MonadIxCache1 m)
+  => Type n -> (SimpleIxInstance n -> Abs (Nest Decl) LamExpr n)
+  -> Atom n -> m n (Atom n)
+appSimplifiedIxMethod ty method x = do
+  Abs decls f <- method <$> simplifiedIxInstance ty
+  f' <- emitDecls decls f
+  Distinct <- getDistinct
+  case f' of
+    LamExpr fx' fb' -> do
+      emitBlock =<< liftImmut do
+        scope <- getScope
+        return $ substE (scope, idSubst <>> fx' @> SubstVal x) fb'

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -571,7 +571,7 @@ def wbToEither {a b} : Iso {weights:a | biases:b} (a|b) =
   MkIso {fwd, bwd}
 
 instance {n m} [Ix n, Ix m] Ix {weights:n | biases:m}
-  size = size n + size m
+  getSize = \(). size n + size m
   ordinal = ordinal <<< appIso wbToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso wbToEither
 

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -561,9 +561,19 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
   x
 > (Right 1.2)
 
--- TODO(Ix) : Write a proper instance
-instance {n m} [Ix n, Ix m] Ix {weights:(n&m) | biases:n}
-  dummy_ix__ = 0
+def wbToEither {a b} : Iso {weights:a | biases:b} (a|b) =
+  fwd = \v.  case v of
+    {|weights=x|} -> Left x
+    {|biases=x|}  -> Right x
+  bwd = \v. case v of
+    Left x  -> {|weights=x|}
+    Right x -> {|biases=x|}
+  MkIso {fwd, bwd}
+
+instance {n m} [Ix n, Ix m] Ix {weights:n | biases:m}
+  size = size n + size m
+  ordinal = ordinal <<< appIso wbToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso wbToEither
 
 -- Sum types as flattened index sets!
 def Weights (n:Type) (m:Type) [Ix n, Ix m] : Type = n=>m=>Float

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -317,7 +317,7 @@ def abToPair {a b} : Iso {a:a & b:b} (b&a) =
   bwd = \(b, a). {a, b}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
-  size = size n * size m
+  getSize = \(). size n * size m
   ordinal = ordinal <<< appIso abToPair
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToPair
 
@@ -349,7 +349,7 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  size = size n + size m
+  getSize = \(). size n + size m
   ordinal = ordinal <<< appIso abToEither
   unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
 

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -311,8 +311,15 @@ myStuff :(Fin 5 => {foo:_ | foo:_ | foo:_ | bar:_ | baz:_}) =
 
 'As index sets
 
+-- Use a non-standard iteration order by putting b before a!
+def abToPair {a b} : Iso {a:a & b:b} (b&a) =
+  fwd = \{a, b}. (b, a)
+  bwd = \(b, a). {a, b}
+  MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
-  dummy_ix__ = 0
+  size = size n * size m
+  ordinal = ordinal <<< appIso abToPair
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToPair
 
 :p size {a:Fin 10 & b:Fin 3}
 > 30
@@ -333,8 +340,18 @@ recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 -- TODO: this still causes an error
 -- :p for i:(Fin 6). recordsAsIndices.((ordinal i) @ _)
 
+def abToEither {a b} : Iso {a:a | b:b} (a|b) =
+  fwd = \v.  case v of
+    {|a=x|} -> Left x
+    {|b=x|} -> Right x
+  bwd = \v. case v of
+    Left x  -> {|a=x|}
+    Right x -> {|b=x|}
+  MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  dummy_ix__ = 0
+  size = size n + size m
+  ordinal = ordinal <<< appIso abToEither
+  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
 
 :p size {a:Fin 10 | b:Fin 3}
 > 13


### PR DESCRIPTION
... and make all existing index sets defined in user code. No methods
are implemented inside the compiler anymore! This is great in that it
opens up lots of possibilities (a very simple one is that the `(|)` type
from prelude can finally be an index set), but it does come with a
pretty significant slowdown in the compiler (likely due to lack of
caching).