### PR TITLE
Sets and index sets for sets.

### DIFF
--- a/examples/setixset.dx
+++ b/examples/setixset.dx
@@ -40,14 +40,6 @@ def removeDuplicatesFromSorted {n a} [Eq a] (xs:n=>a) : List a =
   xlists = for i:n. (AsList 1 [xs.i])
   reduce (AsList 0 []) mergeUniqueSortedLists xlists
 
-:p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
-
--- Compiler can't handle the associated type yet.
--- interface AssocIx n  -- index sets where indices have data associated with them
---   IxValueType : Type
---   ixValue  : n -> IxValueType n
---   lookupIx : IxValueType n -> n
-
 
 '#### Misc instances
 
@@ -106,12 +98,30 @@ instance {a} [Eq a] Eq (Set a)
       else all for i:(Fin nx).
         xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
 
+def setUnion {a}
+  ((UnsafeAsSet nx xs):Set a)
+  ((UnsafeAsSet ny ys):Set a) : Set a =
+    combined = mergeSortedTables xs ys
+    newsize = nx + ny
+    concatted = unsafeCastTable (Fin newsize) combined
+    (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted concatted
+    UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_unique_xs
+
+def setIntersect {a}
+  ((UnsafeAsSet nx xs):Set a)
+  ((UnsafeAsSet ny ys):Set a) : Set a =
+    -- Todo: this could be done in linear time instead of nlogn.
+    isInYs = \x. case searchSorted ys x of
+      Just x -> True
+      Nothing -> False
+    (AsList n' r) = filter isInYs xs
+    UnsafeAsSet _ $ unsafeCastTable (Fin n') r
 
 
 '### Index set for sets of strings
 
---data SetIx a l:(Set a) [Ord a] =
--- need a bugfix before we can be polymorphic in type
+-- Todo: Make polymorphic in type.  Waiting on a bugfix.
+-- data SetIx a l:(Set a) [Ord a] =
 
 data StringSetIx l:(Set String) =
   MkSetIx Int
@@ -127,6 +137,12 @@ def lookUpSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
   case maybeIx of
     Nothing -> Nothing
     Just i -> Just $ MkSetIx (ordinal i)
+
+-- Compiler can't handle the associated type yet.
+-- interface AssocIx n  -- index sets where indices have data associated with them
+--   IxValueType : Type
+--   ixValue  : n -> IxValueType n
+--   lookupIx : IxValueType n -> n
 
 
 '# Table types
@@ -220,9 +236,8 @@ setix2 : StringSetIx names2 = fromJust $ lookUpSetIx "Charlie"
 
 :p for i:(StringSetIx names2). i
 
+
 rowsAndColsTable : (StringSetIx names2)=>(StringSetIx names2)=>Int =
   for i j. (ordinal i + ordinal j)
 
 :p rowsAndColsTable
-
-:p for i:(StringSetIx rowsAndColsTable). i

--- a/examples/setixset.dx
+++ b/examples/setixset.dx
@@ -92,30 +92,27 @@ def toSet {n a} [Ord a] (xs:n=>a) : Set a =
 def setSize {a} ((UnsafeAsSet n _):Set a) : Int = n
 
 instance {a} [Eq a] Eq (Set a)
-  (==) = \(UnsafeAsSet nx xs) (UnsafeAsSet ny ys).
-    if nx /= ny
-      then False
-      else all for i:(Fin nx).
-        xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
+  (==) = \(UnsafeAsSet _ xs) (UnsafeAsSet _ ys).
+    (AsList _ xs) == (AsList _ ys)
 
 def setUnion {a}
   ((UnsafeAsSet nx xs):Set a)
   ((UnsafeAsSet ny ys):Set a) : Set a =
     combined = mergeSortedTables xs ys
-    newsize = nx + ny
-    concatted = unsafeCastTable (Fin newsize) combined
+    combinedsize = nx + ny
+    concatted = unsafeCastTable (Fin combinedsize) combined
     (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted concatted
     UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_unique_xs
 
 def setIntersect {a}
   ((UnsafeAsSet nx xs):Set a)
   ((UnsafeAsSet ny ys):Set a) : Set a =
-    -- Todo: this could be done in linear time instead of nlogn.
+    -- This could be done in O(nx + ny) instead of O(nx log ny).
     isInYs = \x. case searchSorted ys x of
       Just x -> True
       Nothing -> False
-    (AsList n' r) = filter isInYs xs
-    UnsafeAsSet _ $ unsafeCastTable (Fin n') r
+    (AsList n' intersection) = filter isInYs xs
+    UnsafeAsSet _ $ unsafeCastTable (Fin n') intersection
 
 
 '### Index set for sets of strings
@@ -131,113 +128,16 @@ instance {set} Ix (StringSetIx set)
   ordinal = \(MkSetIx i). i
   unsafeFromOrdinal = \k. MkSetIx k
 
-def lookUpSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
-  (UnsafeAsSet n elements) = set
-  maybeIx = searchSorted elements s
-  case maybeIx of
-    Nothing -> Nothing
-    Just i -> Just $ MkSetIx (ordinal i)
-
+-- Todo: Add an interface for converting to and from integer indices.
 -- Compiler can't handle the associated type yet.
 -- interface AssocIx n  -- index sets where indices have data associated with them
 --   IxValueType : Type
 --   ixValue  : n -> IxValueType n
 --   lookupIx : IxValueType n -> n
 
-
-'# Table types
-These match the definitions from
-section 3.1 of [Types for Tables: A Language Design Benchmark](https://arxiv.org/pdf/2111.10412.pdf)
-
-ColumnName = String
-Header = StringSetIx
-Sort = Type
-
--- Also just a record, or product type with names?
-data Schema a:(Set ColumnName) =
-  MkSchema ((StringSetIx a)=>Type)
-
---data Table a:(Set ColumnName) b : Type =
---  MkTable (b=>(StringSetIx a)=>)
-
-Cell = Maybe
-
-
-
-'### Example Tables
-
--- Original from https://github.com/brownplt/B2T2/blob/v1.0/ExampleTables.md
-
---| name    | age | favorite color |
---| ------- | --- | -------------- |
---| "Bob"   | 12  | "blue"         |
---| "Alice" | 17  | "green"        |
---| "Eve"   | 13  | "red"          |
-
--- Records version
-students1 = [{name = "Bob",   age = 12, color = "blue"},
-             {name = "Alice", age = 17, color = "green"},
-             {name = "Eve",   age = 13, color = "red"}]
-:t students1
-
--- Schema version
-studentColNames = toSet ["name", "age", "favorite color"]
-studentColTypes = [String, Int, String]
---studentSchema = 
---  MkSchema ((StringSetIx a)=>Type)
-students2 = [("Bob",   12, "blue"),
-             ("Alice", 17, "green"),
-             ("Eve",   13, "red")]
-:t students2
-
-'# Table API
-From https://github.com/brownplt/B2T2/blob/v1.0/TableAPI.md
-
---emptyTable : Table = []
--- Test: schema(t) is equal to []
--- Test: nrows(t) is equal to 0
-
---def addRows (t1:Table) (rs:Seq<Row>) : Table =
-  -- Enforce: for all r in rs, schema(r) is equal to schema(t1)
-  -- Test: schema(output) is equal to schema(t1)
-  -- Test: nrows(output) is equal to nrows(t1) + length(rs)
---  todo
-
---addColumn :: t1:Table * c:ColName * vs:Seq<Value> -> t2:Table
---Constraints
---Requires:
---c is not in header(t1)
---length(vs) is equal to nrows(t1)
---Ensures:
---header(t2) is equal to concat(header(t1), [c])
---for all c' in header(t1), schema(t2)[c'] is equal to schema(t1)[c']
---schema(t2)[c] is the sort of elements of vs
---nrows(t2) is equal to nrows(t1)
-
--- Dougal: Histogram, average age within each dept,
--- grouped histogram
--- table of depts
--- table of employees (age, salary, dept)
-
-'#### More experiments with Set index sets.
-
-names2 = toSet ["Bob", "Alice", "Charlie", "Alice"]
-enumerateNames2 : (StringSetIx names2)=>Int =
-  for i. ordinal i
-
-:p enumerateNames2
-:p size (StringSetIx names2)
-
-setix : StringSetIx names2 = fromJust $ lookUpSetIx "Bob"
-:p setix
-
-setix2 : StringSetIx names2 = fromJust $ lookUpSetIx "Charlie"
-:p setix2
-
-:p for i:(StringSetIx names2). i
-
-
-rowsAndColsTable : (StringSetIx names2)=>(StringSetIx names2)=>Int =
-  for i j. (ordinal i + ordinal j)
-
-:p rowsAndColsTable
+def lookUpSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
+  (UnsafeAsSet n elements) = set
+  maybeIx = searchSorted elements s
+  case maybeIx of
+    Nothing -> Nothing
+    Just i -> Just $ MkSetIx (ordinal i)

--- a/examples/setixset.dx
+++ b/examples/setixset.dx
@@ -1,5 +1,54 @@
 import sort
 
+
+'### Monoidal enforcement of uniqueness in sorted lists
+
+def last {n a} (xs:n=>a) : Maybe a =
+  s = size n
+  case s == 0 of
+    True -> Nothing
+    False -> Just xs.(unsafeFromOrdinal n (s - 1))
+
+def first {n a} (xs:n=>a) : Maybe a =
+  s = size n
+  case s == 0 of
+    True -> Nothing
+    False -> Just xs.(unsafeFromOrdinal n 0)
+
+def allExceptLast {n a} (xs:n=>a) : List a =
+  shortSize = Fin (max 0 ((size n) - 1))
+  allButLast = view i:shortSize. xs.(unsafeFromOrdinal _ (ordinal i))
+  (AsList _ allButLast)
+
+def mergeUniqueSortedLists {a} [Eq a] (xlist:List a) (ylist:List a) : List a =
+    -- This function is associative, for use in a monoidal reduction.
+    -- Assumes all xs are <= all ys.
+    -- The element at the end of xs might equal the
+    -- element at the beginning of ys.  If so, this
+    -- function removes the duplicate when concatenating the lists.
+    (AsList nx xs) = xlist
+    (AsList _  ys) = ylist
+    case last xs of
+      Nothing -> ylist
+      Just last_x -> case first ys of
+        Nothing -> xlist
+        Just first_y -> case last_x == first_y of
+          False -> concat [xlist,            ylist]
+          True ->  concat [allExceptLast xs, ylist]
+
+def removeDuplicatesFromSorted {n a} [Eq a] (xs:n=>a) : List a =
+  xlists = for i:n. (AsList 1 [xs.i])
+  reduce (AsList 0 []) mergeUniqueSortedLists xlists
+
+:p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
+
+-- Compiler can't handle the associated type yet.
+-- interface AssocIx n  -- index sets where indices have data associated with them
+--   IxValueType : Type
+--   ixValue  : n -> IxValueType n
+--   lookupIx : IxValueType n -> n
+
+
 '#### Misc instances
 
 instance {n} [Ix n] Eq n
@@ -9,8 +58,9 @@ def lexicalOrder {n} [Ord n]
   (compareElements:n->n->Bool)
   (compareLengths:Int->Int->Bool)
   ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
-    -- Orders Lists (e.g. words) according to the order of their
-    -- elements (e.g. letters).
+    -- Orders Lists according to the order of their elements,
+    -- in the same way a dictionary does.
+    -- For example, this lets us sort Strings.
     --
     -- This function operates serially and short-circuits
     -- at the first difference.  One could also write this
@@ -32,119 +82,22 @@ instance {n} [Ord n] Ord (List n)
   (>) = lexicalOrder (>) (>)
   (<) = lexicalOrder (<) (<)
 
-:p "aaa" < "bbb"
-> True
-
-:p "aa" < "bbb"
-> True
-
-:p "a" < "aa"
-> True
-
-:p "aaa" > "bbb"
-> False
-
-:p "aa" > "bbb"
-> False
-
-:p "a" > "aa"
-> False
-
-:p "a" < "aa"
-> True
-
-:p ("": List Word8) > ("": List Word8)
-> False
-
-:p ("": List Word8) < ("": List Word8)
-> False
-
-:p "a" > "a"
-> False
-
-:p "a" < "a"
-> False
-
-:p "Thomas" < "Thompson"
-> True
-
-:p "Thomas" > "Thompson"
-> False
 
 
-
-:p sort [1]
-
-:p sort [3, 2, 1]
-
-:p sort ["A"]
-
-:p sort ["A", "B", "C"]
-
-:p sort ["Alice", "Bob", "Charlie"]
-
-:p sort ["Charlie", "Alice", "Bob", "Aaron"]
-
-----------------------
-
-
-'#### Misc Ix Set instances
-
-
-instance Ix Bool
-  getSize = \(). 2
-  ordinal = \b. case b of
-    False -> 0
-    True -> 1
-  unsafeFromOrdinal = \k. k == 1
-
-:p for i:Bool.
-  i
-
------------------
-
-
-'### An index set for List
-
-data ListIx a l:(List a) =
-  MkListIx Int 
-
-instance {a list} Ix (ListIx a list)
-  getSize = \(). listLength list
-  ordinal = \(MkListIx i). i
-  unsafeFromOrdinal = \k. MkListIx k
-
-names = AsList _ ["Alice", "Bob", "Charlie"]
-enumerateNames : (ListIx _ names)=>Int =
-  for i. ordinal i  -- expensive round trip!?
-
-:p enumerateNames
-:p size (ListIx _ names)
-
-:p for i:(ListIx _ names). i
-
-
-
-
-
-
-
-'### An index set for Sets
-
-'#### Sets
+'### Sets
 
 data Set a [Ord a] =
-  -- Guaranteed to be in sorted order,
+  -- Guaranteed to be in sorted order with unique elements,
   -- as long as no one else uses this constructor.
   -- Instead use the "toSet" function below.
   UnsafeAsSet n:Int elements:(Fin n => a)
 
 def toSet {n a} [Ord a] (xs:n=>a) : Set a =
-  n' = size n
   sorted_xs = sort xs
-  UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_xs
+  (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted sorted_xs
+  UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_unique_xs
 
-def setLength {a} ((UnsafeAsSet n _):Set a) : Int = n
+def setSize {a} ((UnsafeAsSet n _):Set a) : Int = n
 
 instance {a} [Eq a] Eq (Set a)
   (==) = \(UnsafeAsSet nx xs) (UnsafeAsSet ny ys).
@@ -154,13 +107,8 @@ instance {a} [Eq a] Eq (Set a)
         xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
 
 
-'##### Tests
 
--- check order invariance.
-:p (toSet ["Bob", "Alice", "Charlie"]) == (toSet ["Charlie", "Bob", "Alice"])
-
-
-'#### Index set for sets of strings
+'### Index set for sets of strings
 
 --data SetIx a l:(Set a) [Ord a] =
 -- need a bugfix before we can be polymorphic in type
@@ -169,16 +117,106 @@ data StringSetIx l:(Set String) =
   MkSetIx Int
 
 instance {set} Ix (StringSetIx set)
-  getSize = \(). setLength set
+  getSize = \(). setSize set
   ordinal = \(MkSetIx i). i
   unsafeFromOrdinal = \k. MkSetIx k
 
-names2 = toSet ["Bob", "Alice", "Charlie"]
+def lookUpSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
+  (UnsafeAsSet n elements) = set
+  maybeIx = searchSorted elements s
+  case maybeIx of
+    Nothing -> Nothing
+    Just i -> Just $ MkSetIx (ordinal i)
+
+
+'# Table types
+These match the definitions from
+section 3.1 of [Types for Tables: A Language Design Benchmark](https://arxiv.org/pdf/2111.10412.pdf)
+
+ColumnName = String
+Header = StringSetIx
+Sort = Type
+
+-- Also just a record, or product type with names?
+data Schema a:(Set ColumnName) =
+  MkSchema ((StringSetIx a)=>Type)
+
+--data Table a:(Set ColumnName) b : Type =
+--  MkTable (b=>(StringSetIx a)=>)
+
+Cell = Maybe
+
+
+
+'### Example Tables
+
+-- Original from https://github.com/brownplt/B2T2/blob/v1.0/ExampleTables.md
+
+--| name    | age | favorite color |
+--| ------- | --- | -------------- |
+--| "Bob"   | 12  | "blue"         |
+--| "Alice" | 17  | "green"        |
+--| "Eve"   | 13  | "red"          |
+
+-- Records version
+students1 = [{name = "Bob",   age = 12, color = "blue"},
+             {name = "Alice", age = 17, color = "green"},
+             {name = "Eve",   age = 13, color = "red"}]
+:t students1
+
+-- Schema version
+studentColNames = toSet ["name", "age", "favorite color"]
+studentColTypes = [String, Int, String]
+--studentSchema = 
+--  MkSchema ((StringSetIx a)=>Type)
+students2 = [("Bob",   12, "blue"),
+             ("Alice", 17, "green"),
+             ("Eve",   13, "red")]
+:t students2
+
+'# Table API
+From https://github.com/brownplt/B2T2/blob/v1.0/TableAPI.md
+
+--emptyTable : Table = []
+-- Test: schema(t) is equal to []
+-- Test: nrows(t) is equal to 0
+
+--def addRows (t1:Table) (rs:Seq<Row>) : Table =
+  -- Enforce: for all r in rs, schema(r) is equal to schema(t1)
+  -- Test: schema(output) is equal to schema(t1)
+  -- Test: nrows(output) is equal to nrows(t1) + length(rs)
+--  todo
+
+--addColumn :: t1:Table * c:ColName * vs:Seq<Value> -> t2:Table
+--Constraints
+--Requires:
+--c is not in header(t1)
+--length(vs) is equal to nrows(t1)
+--Ensures:
+--header(t2) is equal to concat(header(t1), [c])
+--for all c' in header(t1), schema(t2)[c'] is equal to schema(t1)[c']
+--schema(t2)[c] is the sort of elements of vs
+--nrows(t2) is equal to nrows(t1)
+
+-- Dougal: Histogram, average age within each dept,
+-- grouped histogram
+-- table of depts
+-- table of employees (age, salary, dept)
+
+'#### More experiments with Set index sets.
+
+names2 = toSet ["Bob", "Alice", "Charlie", "Alice"]
 enumerateNames2 : (StringSetIx names2)=>Int =
   for i. ordinal i
 
 :p enumerateNames2
 :p size (StringSetIx names2)
+
+setix : StringSetIx names2 = fromJust $ lookUpSetIx "Bob"
+:p setix
+
+setix2 : StringSetIx names2 = fromJust $ lookUpSetIx "Charlie"
+:p setix2
 
 :p for i:(StringSetIx names2). i
 

--- a/examples/setixset.dx
+++ b/examples/setixset.dx
@@ -1,0 +1,190 @@
+import sort
+
+'#### Misc instances
+
+instance {n} [Ix n] Eq n
+  (==) = \x y. ordinal x == ordinal y
+
+def lexicalOrder {n} [Ord n]
+  (compareElements:n->n->Bool)
+  (compareLengths:Int->Int->Bool)
+  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
+    -- Orders Lists (e.g. words) according to the order of their
+    -- elements (e.g. letters).
+    --
+    -- This function operates serially and short-circuits
+    -- at the first difference.  One could also write this
+    -- functon to operate in parallel, but it would be
+    -- wasteful in the case where there is an early difference.
+    iter \i.
+      case i == min nx ny of
+        True -> Done $ compareLengths nx ny
+        False ->
+          xi = xs.(unsafeFromOrdinal _ i)
+          yi = ys.(unsafeFromOrdinal _ i)
+          case compareElements xi yi of
+            True -> Done True
+            False -> case xi == yi of
+              True -> Continue
+              False -> Done False
+
+instance {n} [Ord n] Ord (List n)
+  (>) = lexicalOrder (>) (>)
+  (<) = lexicalOrder (<) (<)
+
+:p "aaa" < "bbb"
+> True
+
+:p "aa" < "bbb"
+> True
+
+:p "a" < "aa"
+> True
+
+:p "aaa" > "bbb"
+> False
+
+:p "aa" > "bbb"
+> False
+
+:p "a" > "aa"
+> False
+
+:p "a" < "aa"
+> True
+
+:p ("": List Word8) > ("": List Word8)
+> False
+
+:p ("": List Word8) < ("": List Word8)
+> False
+
+:p "a" > "a"
+> False
+
+:p "a" < "a"
+> False
+
+:p "Thomas" < "Thompson"
+> True
+
+:p "Thomas" > "Thompson"
+> False
+
+
+
+:p sort [1]
+
+:p sort [3, 2, 1]
+
+:p sort ["A"]
+
+:p sort ["A", "B", "C"]
+
+:p sort ["Alice", "Bob", "Charlie"]
+
+:p sort ["Charlie", "Alice", "Bob", "Aaron"]
+
+----------------------
+
+
+'#### Misc Ix Set instances
+
+
+instance Ix Bool
+  getSize = \(). 2
+  ordinal = \b. case b of
+    False -> 0
+    True -> 1
+  unsafeFromOrdinal = \k. k == 1
+
+:p for i:Bool.
+  i
+
+-----------------
+
+
+'### An index set for List
+
+data ListIx a l:(List a) =
+  MkListIx Int 
+
+instance {a list} Ix (ListIx a list)
+  getSize = \(). listLength list
+  ordinal = \(MkListIx i). i
+  unsafeFromOrdinal = \k. MkListIx k
+
+names = AsList _ ["Alice", "Bob", "Charlie"]
+enumerateNames : (ListIx _ names)=>Int =
+  for i. ordinal i  -- expensive round trip!?
+
+:p enumerateNames
+:p size (ListIx _ names)
+
+:p for i:(ListIx _ names). i
+
+
+
+
+
+
+
+'### An index set for Sets
+
+'#### Sets
+
+data Set a [Ord a] =
+  -- Guaranteed to be in sorted order,
+  -- as long as no one else uses this constructor.
+  -- Instead use the "toSet" function below.
+  UnsafeAsSet n:Int elements:(Fin n => a)
+
+def toSet {n a} [Ord a] (xs:n=>a) : Set a =
+  n' = size n
+  sorted_xs = sort xs
+  UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_xs
+
+def setLength {a} ((UnsafeAsSet n _):Set a) : Int = n
+
+instance {a} [Eq a] Eq (Set a)
+  (==) = \(UnsafeAsSet nx xs) (UnsafeAsSet ny ys).
+    if nx /= ny
+      then False
+      else all for i:(Fin nx).
+        xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
+
+
+'##### Tests
+
+-- check order invariance.
+:p (toSet ["Bob", "Alice", "Charlie"]) == (toSet ["Charlie", "Bob", "Alice"])
+
+
+'#### Index set for sets of strings
+
+--data SetIx a l:(Set a) [Ord a] =
+-- need a bugfix before we can be polymorphic in type
+
+data StringSetIx l:(Set String) =
+  MkSetIx Int
+
+instance {set} Ix (StringSetIx set)
+  getSize = \(). setLength set
+  ordinal = \(MkSetIx i). i
+  unsafeFromOrdinal = \k. MkSetIx k
+
+names2 = toSet ["Bob", "Alice", "Charlie"]
+enumerateNames2 : (StringSetIx names2)=>Int =
+  for i. ordinal i
+
+:p enumerateNames2
+:p size (StringSetIx names2)
+
+:p for i:(StringSetIx names2). i
+
+rowsAndColsTable : (StringSetIx names2)=>(StringSetIx names2)=>Int =
+  for i j. (ordinal i + ordinal j)
+
+:p rowsAndColsTable
+
+:p for i:(StringSetIx rowsAndColsTable). i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -579,9 +579,6 @@ interface Eq a
 
 def (/=) {a} [Eq a] (x:a) (y:a) : Bool = not $ x == y
 
-instance {n} [Ix n] Eq n
-  (==) = \x y. ordinal x == ordinal y
-
 '#### Ord
 Orderable / Comparable.
 Things that can be place in a total order.
@@ -1140,38 +1137,6 @@ def argFilter {a n} (condition:a->Bool) (xs:n=>a) : List n =
     for i.
       if condition xs.i
         then append list i
-
-def lexicalOrder {n} [Ord n]
-  (compareElements:n->n->Bool)
-  (compareLengths:Int->Int->Bool)
-  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
-    -- Orders Lists according to the order of their elements,
-    -- in the same way a dictionary does.
-    -- For example, this lets us sort Strings.
-    --
-    -- More precisely, it returns True iff compareElements xs.i ys.i is true
-    -- at the first location they differ.
-    --
-    -- This function operates serially and short-circuits
-    -- at the first difference.  One could also write this
-    -- function as a parallel reduction, but it would be
-    -- wasteful in the case where there is an early difference,
-    -- because we can't short circuit.
-    iter \i.
-      case i == min nx ny of
-        True -> Done $ compareLengths nx ny
-        False ->
-          xi = xs.(unsafeFromOrdinal _ i)
-          yi = ys.(unsafeFromOrdinal _ i)
-          case compareElements xi yi of
-            True -> Done True
-            False -> case xi == yi of
-              True -> Continue
-              False -> Done False
-
-instance {n} [Ord n] Ord (List n)
-  (>) = lexicalOrder (>) (>)
-  (<) = lexicalOrder (<) (<)
 
 '## Isomorphisms
 
@@ -1817,6 +1782,38 @@ def argscan {n o} (comp:o->o->Bool) (xs:n=>o) : n =
 
 def argmin {n o} [Ord o] (xs:n=>o) : n = argscan (<) xs
 def argmax {n o} [Ord o] (xs:n=>o) : n = argscan (>) xs
+
+def lexicalOrder {n} [Ord n]
+  (compareElements:n->n->Bool)
+  (compareLengths:Int->Int->Bool)
+  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
+    -- Orders Lists according to the order of their elements,
+    -- in the same way a dictionary does.
+    -- For example, this lets us sort Strings.
+    --
+    -- More precisely, it returns True iff compareElements xs.i ys.i is true
+    -- at the first location they differ.
+    --
+    -- This function operates serially and short-circuits
+    -- at the first difference.  One could also write this
+    -- function as a parallel reduction, but it would be
+    -- wasteful in the case where there is an early difference,
+    -- because we can't short circuit.
+    iter \i.
+      case i == min nx ny of
+        True -> Done $ compareLengths nx ny
+        False ->
+          xi = xs.(unsafeFromOrdinal _ i)
+          yi = ys.(unsafeFromOrdinal _ i)
+          case compareElements xi yi of
+            True -> Done True
+            False -> case xi == yi of
+              True -> Continue
+              False -> Done False
+
+instance {n} [Ord n] Ord (List n)
+  (>) = lexicalOrder (>) (>)
+  (<) = lexicalOrder (<) (<)
 
 '### clip
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -579,6 +579,9 @@ interface Eq a
 
 def (/=) {a} [Eq a] (x:a) (y:a) : Bool = not $ x == y
 
+instance {n} [Ix n] Eq n
+  (==) = \x y. ordinal x == ordinal y
+
 '#### Ord
 Orderable / Comparable.
 Things that can be place in a total order.
@@ -1138,6 +1141,37 @@ def argFilter {a n} (condition:a->Bool) (xs:n=>a) : List n =
       if condition xs.i
         then append list i
 
+def lexicalOrder {n} [Ord n]
+  (compareElements:n->n->Bool)
+  (compareLengths:Int->Int->Bool)
+  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
+    -- Orders Lists according to the order of their elements,
+    -- in the same way a dictionary does.
+    -- For example, this lets us sort Strings.
+    --
+    -- More precisely, it returns True iff compareElements xs.i ys.i is true
+    -- at the first location they differ.
+    --
+    -- This function operates serially and short-circuits
+    -- at the first difference.  One could also write this
+    -- function as a parallel reduction, but it would be
+    -- wasteful in the case where there is an early difference,
+    -- because we can't short circuit.
+    iter \i.
+      case i == min nx ny of
+        True -> Done $ compareLengths nx ny
+        False ->
+          xi = xs.(unsafeFromOrdinal _ i)
+          yi = ys.(unsafeFromOrdinal _ i)
+          case compareElements xi yi of
+            True -> Done True
+            False -> case xi == yi of
+              True -> Continue
+              False -> Done False
+
+instance {n} [Ord n] Ord (List n)
+  (>) = lexicalOrder (>) (>)
+  (<) = lexicalOrder (<) (<)
 
 '## Isomorphisms
 

--- a/lib/set.dx
+++ b/lib/set.dx
@@ -64,10 +64,8 @@ def setUnion {a}
   ((UnsafeAsSet nx xs):Set a)
   ((UnsafeAsSet ny ys):Set a) : Set a =
     combined = mergeSortedTables xs ys
-    combinedsize = nx + ny
-    concatted = unsafeCastTable (Fin combinedsize) combined
-    (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted concatted
-    UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_unique_xs
+    (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted combined
+    UnsafeAsSet _ sorted_unique_xs
 
 def setIntersect {a}
   ((UnsafeAsSet nx xs):Set a)
@@ -77,7 +75,7 @@ def setIntersect {a}
       Just x -> True
       Nothing -> False
     (AsList n' intersection) = filter isInYs xs
-    UnsafeAsSet _ $ unsafeCastTable (Fin n') intersection
+    UnsafeAsSet _ intersection
 
 
 '### Index set for sets of strings
@@ -86,7 +84,7 @@ def setIntersect {a}
 -- data SetIx a l:(Set a) [Ord a] =
 
 data StringSetIx l:(Set String) =
-  MkSetIx Int
+  MkSetIx Int   -- TODO: Use (Fin (setSize l)) instead.
 
 instance {set} Ix (StringSetIx set)
   getSize = \(). setSize set

--- a/lib/set.dx
+++ b/lib/set.dx
@@ -41,41 +41,6 @@ def removeDuplicatesFromSorted {n a} [Eq a] (xs:n=>a) : List a =
   reduce (AsList 0 []) mergeUniqueSortedLists xlists
 
 
-'#### Misc instances
-
-instance {n} [Ix n] Eq n
-  (==) = \x y. ordinal x == ordinal y
-
-def lexicalOrder {n} [Ord n]
-  (compareElements:n->n->Bool)
-  (compareLengths:Int->Int->Bool)
-  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
-    -- Orders Lists according to the order of their elements,
-    -- in the same way a dictionary does.
-    -- For example, this lets us sort Strings.
-    --
-    -- This function operates serially and short-circuits
-    -- at the first difference.  One could also write this
-    -- functon to operate in parallel, but it would be
-    -- wasteful in the case where there is an early difference.
-    iter \i.
-      case i == min nx ny of
-        True -> Done $ compareLengths nx ny
-        False ->
-          xi = xs.(unsafeFromOrdinal _ i)
-          yi = ys.(unsafeFromOrdinal _ i)
-          case compareElements xi yi of
-            True -> Done True
-            False -> case xi == yi of
-              True -> Continue
-              False -> Done False
-
-instance {n} [Ord n] Ord (List n)
-  (>) = lexicalOrder (>) (>)
-  (<) = lexicalOrder (<) (<)
-
-
-
 '### Sets
 
 data Set a [Ord a] =
@@ -87,7 +52,7 @@ data Set a [Ord a] =
 def toSet {n a} [Ord a] (xs:n=>a) : Set a =
   sorted_xs = sort xs
   (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted sorted_xs
-  UnsafeAsSet _ $ unsafeCastTable (Fin n') sorted_unique_xs
+  UnsafeAsSet n' sorted_unique_xs
 
 def setSize {a} ((UnsafeAsSet n _):Set a) : Int = n
 
@@ -128,6 +93,9 @@ instance {set} Ix (StringSetIx set)
   ordinal = \(MkSetIx i). i
   unsafeFromOrdinal = \k. MkSetIx k
 
+instance {set} Eq (StringSetIx set)
+  (==) = \ix1 ix2. ordinal ix1 == ordinal ix2
+
 -- Todo: Add an interface for converting to and from integer indices.
 -- Compiler can't handle the associated type yet.
 -- interface AssocIx n  -- index sets where indices have data associated with them
@@ -135,9 +103,14 @@ instance {set} Ix (StringSetIx set)
 --   ixValue  : n -> IxValueType n
 --   lookupIx : IxValueType n -> n
 
-def lookUpSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
+def stringToSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
   (UnsafeAsSet n elements) = set
   maybeIx = searchSorted elements s
   case maybeIx of
     Nothing -> Nothing
     Just i -> Just $ MkSetIx (ordinal i)
+
+def setIxToString {set:Set String} (ix:StringSetIx set) : String =
+  (UnsafeAsSet n elements) = set
+  elements.(unsafeFromOrdinal _ (ordinal ix))
+

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -18,24 +18,26 @@ def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ((a|b)=>v) =
 def mergeSortedTables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ((m|n)=>a) =
   -- Possible improvements:
   --  1) Using a SortedTable type.
-  --  2) Avoid initializing the return array.
-  init = concatTable xs ys
+  --  2) Avoid pontlessly initializing the return array.
+  init = concatTable xs ys  -- Initialize array of correct size.
   yieldState init \buf.
     withState (0, 0) \countrefs.
-      for i.
+      for i:(m|n).
         (cur_x, cur_y) = get countrefs
-        noYsLeft = cur_y >= size n
-        stillXsLeft = cur_x < size m
-        cur_x_at_n = (unsafeFromOrdinal _ cur_x)
-        cur_y_at_n = (unsafeFromOrdinal _ cur_y)
-        xIsLess = xs.cur_x_at_n < ys.cur_y_at_n
-        if noYsLeft || (stillXsLeft && xIsLess)
+        if cur_y >= size n  -- no ys left
           then
             countrefs := (cur_x + 1, cur_y)
-            buf!i := xs.cur_x_at_n
+            buf!i := xs.(unsafeFromOrdinal _ cur_x)
           else
-            countrefs := (cur_x, cur_y + 1)
-            buf!i := ys.cur_y_at_n
+            if cur_x < size m -- still xs left
+              then 
+                if xs.(unsafeFromOrdinal _ cur_x) <= ys.(unsafeFromOrdinal _ cur_y)
+                  then
+                    countrefs := (cur_x + 1, cur_y)
+                    buf!i := xs.(unsafeFromOrdinal _ cur_x)
+                  else
+                    countrefs := (cur_x, cur_y + 1)
+                    buf!i := ys.(unsafeFromOrdinal _ cur_y)
 
 def mergeSortedLists {a} [Ord a] (AsList nx xs: List a) (AsList ny ys: List a) : List a =
   -- Need this wrapper because Dex can't automatically weaken

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -18,7 +18,7 @@ def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ((a|b)=>v) =
 def mergeSortedTables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ((m|n)=>a) =
   -- Possible improvements:
   --  1) Using a SortedTable type.
-  --  2) Avoid pontlessly initializing the return array.
+  --  2) Avoid needlessly initializing the return array.
   init = concatTable xs ys  -- Initialize array of correct size.
   yieldState init \buf.
     withState (0, 0) \countrefs.

--- a/makefile
+++ b/makefile
@@ -125,7 +125,7 @@ test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
              shadow-tests monad-tests io-tests exception-tests sort-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests \
-             linalg-tests
+             linalg-tests set-tests
 
 lib-names = diagram plot png
 

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -5,3 +5,19 @@
 -- check uniqueness.
 :p (toSet ["Bob", "Alice", "Alice", "Charlie"]) == (toSet ["Charlie", "Charlie", "Bob", "Alice"])
 > True
+
+
+set1 = toSet ["Xeno", "Alice", "Bob"]
+set2 = toSet ["Bob", "Xeno", "Charlie"]
+
+:p setUnion set1 set2
+> (UnsafeAsSet 4 [ (AsList 5 "Alice")
+>                , (AsList 3 "Bob")
+>                , (AsList 7 "Charlie")
+>                , (AsList 4 "Xeno") ])
+
+:p setIntersect set1 set2
+> (UnsafeAsSet 2 [(AsList 3 "Bob"), (AsList 4 "Xeno")])
+
+:p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
+> (AsList 3 [(AsList 5 "Alice"), (AsList 3 "Bob"), (AsList 7 "Charlie")])

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -1,3 +1,5 @@
+import set
+
 -- check order invariance.
 :p (toSet ["Bob", "Alice", "Charlie"]) == (toSet ["Charlie", "Bob", "Alice"])
 > True
@@ -6,9 +8,11 @@
 :p (toSet ["Bob", "Alice", "Alice", "Charlie"]) == (toSet ["Charlie", "Charlie", "Bob", "Alice"])
 > True
 
-
 set1 = toSet ["Xeno", "Alice", "Bob"]
 set2 = toSet ["Bob", "Xeno", "Charlie"]
+
+:p set1 == set2
+> False
 
 :p setUnion set1 set2
 > (UnsafeAsSet 4 [ (AsList 5 "Alice")
@@ -22,7 +26,30 @@ set2 = toSet ["Bob", "Xeno", "Charlie"]
 :p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
 > (AsList 3 [(AsList 5 "Alice"), (AsList 3 "Bob"), (AsList 7 "Charlie")])
 
+:p set1 == (setUnion set1 set1)
+> True
 
+:p set1 == (setIntersect set1 set1)
+> True
+
+'#### Empty set tests
+
+emptyset = toSet ([]:(Fin 0)=>String)
+
+:p emptyset == emptyset
+> True
+
+:p emptyset == (setUnion emptyset emptyset)
+> True
+
+:p emptyset == (setIntersect emptyset emptyset)
+> True
+
+:p set1 == (setUnion set1 emptyset)
+> True
+
+:p emptyset == (setIntersect set1 emptyset)
+> True
 
 '### Set Index Set tests
 
@@ -37,12 +64,18 @@ roundTrip = for i:(StringSetIx names2).
 :p all roundTrip
 > True
 
-setix : StringSetIx names2 = fromJust $ lookUpSetIx "Bob"
+-- Check that index to string and string to index are inverses.
+roundTrip2 = for i:(StringSetIx names2).
+  s = setIxToString i
+  ix = stringToSetIx s
+  i == fromJust ix
+:p all roundTrip2
+> True
+
+setix : StringSetIx names2 = fromJust $ stringToSetIx "Bob"
 :p setix
 > (MkSetIx 1)
 
-setix2 : StringSetIx names2 = fromJust $ lookUpSetIx "Charlie"
+setix2 : StringSetIx names2 = fromJust $ stringToSetIx "Charlie"
 :p setix2
 > (MkSetIx 2)
-
-

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -21,3 +21,28 @@ set2 = toSet ["Bob", "Xeno", "Charlie"]
 
 :p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
 > (AsList 3 [(AsList 5 "Alice"), (AsList 3 "Bob"), (AsList 7 "Charlie")])
+
+
+
+'### Set Index Set tests
+
+names2 = toSet ["Bob", "Alice", "Charlie", "Alice"]
+
+:p size (StringSetIx names2)
+> 3
+
+-- Check that ordinal and unsafeFromOrdinal are inverses.
+roundTrip = for i:(StringSetIx names2).
+  i == (unsafeFromOrdinal _ (ordinal i))
+:p all roundTrip
+> True
+
+setix : StringSetIx names2 = fromJust $ lookUpSetIx "Bob"
+:p setix
+> (MkSetIx 1)
+
+setix2 : StringSetIx names2 = fromJust $ lookUpSetIx "Charlie"
+:p setix2
+> (MkSetIx 2)
+
+

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -1,0 +1,7 @@
+-- check order invariance.
+:p (toSet ["Bob", "Alice", "Charlie"]) == (toSet ["Charlie", "Bob", "Alice"])
+> True
+
+-- check uniqueness.
+:p (toSet ["Bob", "Alice", "Alice", "Charlie"]) == (toSet ["Charlie", "Charlie", "Bob", "Alice"])
+> True

--- a/tests/sort-tests.dx
+++ b/tests/sort-tests.dx
@@ -4,3 +4,48 @@ import sort
 > True
 :p isSorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
 > True
+
+
+'### Lexical Sorting Tests
+
+:p "aaa" < "bbb"
+> True
+
+:p "aa" < "bbb"
+> True
+
+:p "a" < "aa"
+> True
+
+:p "aaa" > "bbb"
+> False
+
+:p "aa" > "bbb"
+> False
+
+:p "a" > "aa"
+> False
+
+:p "a" < "aa"
+> True
+
+:p ("": List Word8) > ("": List Word8)
+> False
+
+:p ("": List Word8) < ("": List Word8)
+> False
+
+:p "a" > "a"
+> False
+
+:p "a" < "a"
+> False
+
+:p "Thomas" < "Thompson"
+> True
+
+:p "Thomas" > "Thompson"
+> False
+
+:p isSorted $ sort ["Charlie", "Alice", "Bob", "Aaron"]
+> True


### PR DESCRIPTION
I think this is ready for review now - the test that fails is in the tutorial.

This PR adds sets, including a surprising use case for parallel monoidal reduction in removing duplicates from a sorted list.

It also adds an index set instance for sets, as well as various helper functions.

It also fixes an issue with `sort` which wasn't caught by the CI tests.