### PR TITLE
Compile first order monomorphic functions with `@noinline` annotation to object code

### DIFF
--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -13,8 +13,10 @@ data Geom =
 
 HtmlColor : Type = Fin 3 => Word8
 
+foreign "showHex" showHexFFI : Word8 -> {IO} (Int32 & RawPtr)
+
 def showHex (x:Word8) : String = unsafeIO \().
-  (n, ptr) = %ffi showHex (Int32 & RawPtr) x
+  (n, ptr) = showHexFFI x
   stringFromCharPtr n (MkPtr ptr)
 
 black : HtmlColor = [IToW8   0, IToW8   0, IToW8   0]

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -140,13 +140,13 @@ def optionalHtmlColor(c: Maybe HtmlColor) : String =
     Nothing -> "none"
     Just c' -> htmlColor c'
 
--- `@noinline` fails because the function can throw a hard error, which we don't handle
--- @noinline
+@noinline
 def attrString (attr:GeomStyle) : String =
   (   ("stroke"       <=> (optionalHtmlColor $ getAt #strokeColor attr))
   <+> ("fill"         <=> (optionalHtmlColor $ getAt #fillColor   attr))
   <+> ("stroke-width" <=> (getAt #strokeWidth attr)))
 
+@noinline
 def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
   -- For things that are solid. SVG says they have fill=stroke.
   solidAttr = setAt #fillColor (getAt #strokeColor attr) attr
@@ -184,6 +184,7 @@ def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
 
 BoundingBox : Type = (Point & Point)
 
+@noinline
 def computeBounds (d:Diagram) : BoundingBox =
   computeSubBound = \sel op (_, p, geom).
     sel p + case geom of
@@ -205,6 +206,7 @@ def computeBounds (d:Diagram) : BoundingBox =
     )
   )
 
+@noinline
 def renderSVG (d:Diagram) (bounds:BoundingBox) : String =
   ((xmin, ymin), (xmax, ymax)) = bounds
   imgWidth = 400.0

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -104,9 +104,9 @@ def removeFill                   : Diagram -> Diagram = updateGeom $ setAt #fill
 'Non-inlinable versions to improve compile times. (Non-inlined functions have to be monomorphic right now).
 
 @noinline
-def strCatUncurried ((xs,ys):(String & String)) : String = xs <> ys
+def strCat (xs:String) (ys:String) : String = xs <> ys
 
-def (<.>) (xs:String) (ys:String) : String = strCatUncurried (xs, ys)
+def (<.>) (xs:String) (ys:String) : String = strCat xs ys
 
 def quote (s:String) : String = "\"" <.> s <.> "\""
 
@@ -140,7 +140,8 @@ def optionalHtmlColor(c: Maybe HtmlColor) : String =
     Nothing -> "none"
     Just c' -> htmlColor c'
 
-@noinline
+-- `@noinline` fails because the function can throw a hard error, which we don't handle
+-- @noinline
 def attrString (attr:GeomStyle) : String =
   (   ("stroke"       <=> (optionalHtmlColor $ getAt #strokeColor attr))
   <+> ("fill"         <=> (optionalHtmlColor $ getAt #fillColor   attr))

--- a/lib/png.dx
+++ b/lib/png.dx
@@ -95,11 +95,13 @@ Html : Type = String
 Png  : Type = String
 Gif  : Type = String
 
+foreign "encodePNG" encodePNG : RawPtr -> Int32 -> Int32 -> {IO} (Int32 & RawPtr)
+
 def makePNG {n m} (img:n=>m=>(Fin 3)=>Word8) : Png = unsafeIO \().
   (AsList _ imgFlat) = toList for (i,j,k). img.i.j.k
   withTabPtr imgFlat \ptr.
     (MkPtr rawPtr) = ptr
-    (n, ptr') = %ffi encodePNG (Int & RawPtr) rawPtr (size m) (size n)
+    (n, ptr') = encodePNG rawPtr (size m) (size n)
     toList $ tabFromPtr (Fin n) $ MkPtr ptr'
 
 def pngsToGif {t} (delay:Int) (pngs:t=>Png) : Gif = unsafeIO \().

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1312,24 +1312,32 @@ interface Show a
 instance Show String
   show = id
 
+foreign "showInt32" showInt32 : Int32 -> {IO} (Int32 & RawPtr)
+
 instance Show Int32
   show = \x. unsafeIO do
-    (n, ptr) = %ffi showInt32 (Int32 & RawPtr) x
+    (n, ptr) = showInt32 x
     stringFromCharPtr n $ MkPtr ptr
+
+foreign "showInt64" showInt64 : Int64 -> {IO} (Int32 & RawPtr)
 
 instance Show Int64
   show = \x. unsafeIO do
-    (n, ptr) = %ffi showInt64 (Int32 & RawPtr) x
+    (n, ptr) = showInt64 x
     stringFromCharPtr n $ MkPtr ptr
+
+foreign "showFloat32" showFloat32 : Float32 -> {IO} (Int32 & RawPtr)
 
 instance Show Float32
   show = \x. unsafeIO do
-    (n, ptr) = %ffi showFloat32 (Int32 & RawPtr) x
+    (n, ptr) = showFloat32 x
     stringFromCharPtr n $ MkPtr ptr
+
+foreign "showFloat64" showFloat64 : Float64 -> {IO} (Int32 & RawPtr)
 
 instance Show Float64
   show = \x. unsafeIO do
-    (n, ptr) = %ffi showFloat64 (Int32 & RawPtr) x
+    (n, ptr) = showFloat64 x
     stringFromCharPtr n $ MkPtr ptr
 
 instance {a b} [Show a, Show b] Show (a & b)
@@ -1397,25 +1405,31 @@ def withCString {a} (s:String) (action: CString -> {IO} a) : {IO} a =
 
 '### Stream IO
 
+foreign "fopen" fopenFFI : RawPtr -> RawPtr -> {IO} RawPtr
+foreign "fclose" fcloseFFI : RawPtr -> {IO} Int64
+foreign "fwrite" fwriteFFI : RawPtr -> Int64 -> Int64 -> RawPtr -> {IO} Int64
+foreign "fread"  freadFFI : RawPtr -> Int64 -> Int64 -> RawPtr -> {IO} Int64
+foreign "fflush" fflushFFI : RawPtr -> {IO} Int64
+
 def fopen (path:String) (mode:StreamMode) : {IO} (Stream mode) =
   modeStr = case mode of
     ReadMode  -> "r"
     WriteMode -> "w"
   withCString path \(MkCString pathPtr).
     withCString modeStr \(MkCString modePtr).
-      MkStream $ %ffi fopen RawPtr pathPtr modePtr
+      MkStream $ fopenFFI pathPtr modePtr
 
 def fclose {mode} (stream:Stream mode) : {IO} Unit =
   (MkStream stream') = stream
-  %ffi fclose Int64 stream'
+  fcloseFFI stream'
   ()
 
 def fwrite (stream:Stream WriteMode) (s:String) : {IO} Unit =
   (MkStream stream') = stream
   (AsList n s') = s
   withTabPtr s' \(MkPtr ptr).
-    %ffi fwrite Int64 ptr (IToI64 1) (IToI64 n) stream'
-  %ffi fflush Int64 stream'
+    fwriteFFI ptr (IToI64 1) (IToI64 n) stream'
+  fflushFFI stream'
   ()
 
 '### Iteration
@@ -1468,9 +1482,11 @@ def fromCString (s:CString) : {IO} (Maybe String) =
             pushDynBuffer buf c
             Continue
 
+foreign "getenv" getenvFFI : RawPtr -> {IO} RawPtr
+
 def getEnv (name:String) : {IO} Maybe String =
   withCString name \(MkCString ptr).
-    fromCString $ MkCString $ %ffi getenv RawPtr ptr
+    fromCString $ MkCString $ getenvFFI ptr
 
 def checkEnv (name:String) : {IO} Bool =
   isJust $ getEnv name
@@ -1485,7 +1501,7 @@ def fread (stream:Stream ReadMode) : {IO} String =
     withDynamicBuffer \buf.
       iter \_.
         (MkPtr rawPtr) = ptr
-        numRead = I64ToI $ %ffi fread Int64 rawPtr (IToI64 1) (IToI64 n) stream'
+        numRead = I64ToI $ freadFFI rawPtr (IToI64 1) (IToI64 n) stream'
         extendDynBuffer buf $ stringFromCharPtr numRead ptr
         if numRead == n
           then Continue
@@ -1502,11 +1518,16 @@ def print (s:String) : {IO} Unit =
 
 '### Shelling Out
 
+foreign "popen" popenFFI : RawPtr -> RawPtr -> {IO} RawPtr
+foreign "remove" removeFFI : RawPtr -> {IO} Int64
+foreign "mkstemp" mkstempFFI : RawPtr -> {IO} Int32
+foreign "close" closeFFI : Int32 -> {IO} Int32
+
 def shellOut (command:String) : {IO} String =
   modeStr = "r"
   withCString command \(MkCString commandPtr).
     withCString modeStr \(MkCString modePtr).
-      pipe = MkStream %ffi popen RawPtr commandPtr modePtr
+      pipe = MkStream $ popenFFI commandPtr modePtr
       fread pipe
 
 '## Partial functions
@@ -1526,7 +1547,7 @@ def todo {a} : a = error "TODO: implement it!"
 
 def deleteFile (f:FilePath) : {IO} Unit =
   withCString f \(MkCString ptr).
-    %ffi remove Int64 ptr
+    removeFFI ptr
   ()
 
 def withFile {a} (f:FilePath) (mode:StreamMode)
@@ -1559,8 +1580,8 @@ def hasFile (f:FilePath) : {IO} Bool =
 
 def newTempFile (_:Unit) : {IO} FilePath =
   withCString "/tmp/dex-XXXXXX" \(MkCString ptr).
-    fd = %ffi mkstemp Int32 ptr
-    %ffi close Int32 fd
+    fd = mkstempFFI ptr
+    closeFFI fd
     stringFromCharPtr 15 (MkPtr ptr)
 
 def withTempFile {a} (action: FilePath -> {IO} a) : {IO} a =
@@ -1660,7 +1681,9 @@ def splitKey {n} (k:Key) : Fin n => Key = for i. ixkey k i
 These functions generate samples taken from, different distributions.
 Such as `randMat` with samples from the distribution of floating point matrices where each element is taken from a i.i.d. uniform distribution.
 
-def rand (k:Key) : Float =  unsafeIO do F64ToF $ %ffi randunif Float64 k
+foreign "randunif" randunifFFI : Word64 -> {IO} Float64
+
+def rand (k:Key) : Float =  unsafeIO do F64ToF $ randunifFFI k
 def randVec {a} (n:Int) (f: Key -> a) (k: Key) : Fin n => a =
   for i:(Fin n). f (ixkey k i)
 

--- a/misc/dex.el
+++ b/misc/dex.el
@@ -10,7 +10,7 @@
     ("^'\\(.\\|\n.\\)*\n\n"  . font-lock-comment-face)
     ("\\w+:"                 . font-lock-comment-face)
     ("^:\\w*"                . font-lock-preprocessor-face)
-    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bdo\\b\\|\\bview\\b\\|\\bimport\\b" .
+    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bdo\\b\\|\\bview\\b\\|\\bimport\\b\\|\\bforeign\\b" .
            font-lock-keyword-face)
     ("--o"                               . font-lock-variable-name-face)
     ("[-.,!$^&*:~+/=<>|?\\\\]"           . font-lock-variable-name-face)

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -11,7 +11,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Inference
-  ( inferTopUDecl, inferTopUExpr, applyUDeclAbs, trySynthDict, trySynthDictBlock
+  ( inferTopUDecl, checkTopUType, inferTopUExpr, applyUDeclAbs
+  , trySynthDict, trySynthDictBlock
   , synthTopBlock, UDeclInferenceResult (..), synthIx ) where
 
 import Prelude hiding ((.), id)
@@ -50,6 +51,13 @@ import Util
 
 
 -- === Top-level interface ===
+
+checkTopUType :: (Fallible1 m, EnvReader m) => UType n -> m n (Type n)
+checkTopUType ty = liftImmut $ liftInfererMTop do
+  solveLocal do
+    ty' <- checkUType ty
+    applyDefaults
+    return ty'
 
 inferTopUExpr :: (Fallible1 m, EnvReader m) => UExpr n -> m n (Block n)
 inferTopUExpr e = liftImmut $ liftInfererMTop do

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -52,9 +52,16 @@ import Logging
 import LLVMExec
 import Util (IsBool (..))
 
+-- === Compile monad ===
+
 type OperandSubstVal = SubstVal AtomNameC (LiftE Operand)
-type OperandEnv     i    = Subst     OperandSubstVal i    VoidS
-type OperandEnvFrag i i' = SubstFrag OperandSubstVal i i' VoidS
+type OperandEnvFrag = SubstFrag OperandSubstVal
+
+type Function = L.Global
+
+data ExternFunSpec =
+  ExternFunSpec L.Name L.Type [L.ParameterAttribute] [FA.FunctionAttribute] [L.Type]
+  deriving (Ord, Eq)
 
 data CompileState = CompileState { curBlocks   :: [BasicBlock]
                                  , curInstrs   :: [Named Instruction]
@@ -63,24 +70,36 @@ data CompileState = CompileState { curBlocks   :: [BasicBlock]
                                  , usedNames   :: M.Map RawName ()
                                  , funSpecs    :: S.Set ExternFunSpec
                                  , globalDefs  :: [L.Definition]
-                                 }
-data CompileEnv n = CompileEnv { operandEnv  :: OperandEnv n
-                               , curDevice   :: Device }
+                                 , curDevice   :: Device }
 
-type Compile n = ReaderT (CompileEnv n) (State CompileState)
-data ExternFunSpec = ExternFunSpec L.Name L.Type [L.ParameterAttribute] [FA.FunctionAttribute] [L.Type]
-                     deriving (Ord, Eq)
+newtype CompileM i o a =
+  CompileM { runCompileM' ::
+              SubstReaderT OperandSubstVal
+                (EnvReaderT (State CompileState)) i o a }
+  deriving ( Functor, Applicative, Monad, ScopeReader, EnvExtender
+           , EnvReader, SubstReader OperandSubstVal )
 
-type Function = L.Global
+instance MonadState CompileState (CompileM i o) where
+  state f = CompileM $ SubstReaderT $ lift $ EnvReaderT $ lift $ state f
+
+class MonadState CompileState m => LLVMBuilder (m::MonadKind)
+
+class ( SubstReader OperandSubstVal m
+      , (forall i o. LLVMBuilder (m i o))
+      , EnvReader2 m )
+      => Compiler (m::MonadKind2)
+
+instance LLVMBuilder (CompileM i o)
+instance Compiler CompileM
 
 -- === Imp to LLVM ===
 
 mainFuncName :: SourceName
 mainFuncName = "entryFun"
 
-impToLLVM :: Logger [Output] -> ImpFunction n -> IO L.Module
-impToLLVM logger f = do
-  (defns, externSpecs, globalDtors) <- compileFunction logger mainFuncName f
+impToLLVM :: Distinct n => Env n -> Logger [Output] -> ImpFunction n -> IO L.Module
+impToLLVM env logger f = do
+  (defns, externSpecs, globalDtors) <- compileFunction env logger mainFuncName f
   let externDefns = map externDecl $ toList externSpecs
   let dtorDef = defineGlobalDtors globalDtors
   return $ L.defaultModule
@@ -101,21 +120,22 @@ impToLLVM logger f = do
         , L.initializer = Just $ C.Array dtorRegEntryTy (makeDtorRegEntry <$> globalDtors)
         }
 
-compileFunction :: Logger [Output] -> SourceName -> ImpFunction n
+compileFunction :: Distinct n => Env n
+                -> Logger [Output] -> SourceName -> ImpFunction n
                 -> IO ([L.Definition], S.Set ExternFunSpec, [L.Name])
-compileFunction _ _ (FFIFunction f) = return ([], S.singleton (makeFunSpec f), [])
-compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
+compileFunction _ _ _ (FFIFunction f) = return ([], S.singleton (makeFunSpec f), [])
+compileFunction env logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
                 (Abs bs body)) = case cc of
   FFIFun            -> error "shouldn't be trying to compile an FFI function"
   FFIMultiResultFun -> error "shouldn't be trying to compile an FFI function"
-  CEntryFun -> return $ runCompile CPU $ do
+  CEntryFun -> return $ runCompile env CPU $ do
     (argParams, argOperands) <- unzip <$> traverse (freshParamOpPair [] . scalarTy) argTys
     unless (null retTys) $ error "CEntryFun doesn't support returning values"
-    void $ extendOperands (bs @@> map opSubstVal argOperands) $ compileBlock body
+    void $ extendSubst (bs @@> map opSubstVal argOperands) $ compileBlock body
     mainFun <- makeFunction (topLevelFunName (fName, fTy)) argParams (Just $ i64Lit 0)
     extraSpecs <- gets funSpecs
     return ([L.GlobalDefinition mainFun], extraSpecs, [])
-  EntryFun requiresCUDA -> return $ runCompile CPU $ do
+  EntryFun requiresCUDA -> return $ runCompile env CPU $ do
     (streamFDParam , streamFDOperand ) <- freshParamOpPair attrs $ i32
     (argPtrParam   , argPtrOperand   ) <- freshParamOpPair attrs $ hostPtrTy i64
     (resultPtrParam, resultPtrOperand) <- freshParamOpPair attrs $ hostPtrTy i64
@@ -123,7 +143,7 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
     argOperands <- forM (zip [0..] argTys) \(i, ty) ->
       gep argPtrOperand (i64Lit i) >>= castLPtr (scalarTy ty) >>= load
     when (toBool requiresCUDA) ensureHasCUDAContext
-    results <- extendOperands (bs @@> map opSubstVal argOperands) $ compileBlock body
+    results <- extendSubst (bs @@> map opSubstVal argOperands) $ compileBlock body
     forM_ (zip [0..] results) \(i, x) ->
       gep resultPtrOperand (i64Lit i) >>= castLPtr (L.typeOf x) >>= flip store x
     mainFun <- makeFunction (topLevelFunName (fName, fTy))
@@ -133,7 +153,7 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
     where attrs = [L.NoAlias, L.NoCapture, L.NonNull]
   CUDAKernelLaunch -> do
     arch <- getCudaArchitecture 0
-    (CUDAKernel kernelText) <- compileCUDAKernel logger (impKernelToLLVMGPU fun) arch
+    (CUDAKernel kernelText) <- compileCUDAKernel logger (impKernelToLLVMGPU env fun) arch
     let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) (B.unpack kernelText) ++ [0]
     let textArr = C.Array i8 chars
     let textArrTy = L.typeOf textArr
@@ -163,13 +183,13 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
     let textPtr = C.GetElementPtr True
                                   (C.GlobalReference (hostPtrTy textArrTy) textGlobalName)
                                   [C.Int 32 0, C.Int 32 0]
-    let loaderDef = runCompile CPU $ do
+    let loaderDef = runCompile env CPU $ do
           emitVoidExternCall kernelLoaderSpec
             [ L.ConstantOperand $ textPtr, kernelModuleCache, kernelFuncCache]
           kernelFunc <- load kernelFuncCache
           makeFunction (topLevelFunName (fName, fTy)) [] (Just kernelFunc)
     let dtorName = fromString $ pprint fName ++ "#dtor"
-    let dtorDef = runCompile CPU $ do
+    let dtorDef = runCompile env CPU $ do
           emitVoidExternCall kernelUnloaderSpec
             [ kernelModuleCache, kernelFuncCache ]
           makeFunction dtorName [] Nothing
@@ -182,7 +202,7 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
                                          [hostPtrTy i8, hostPtrTy hostVoidp, hostPtrTy hostVoidp]
       kernelUnloaderSpec = ExternFunSpec "dex_unloadKernelCUDA" L.VoidType [] []
                                          [hostPtrTy hostVoidp, hostPtrTy hostVoidp]
-  MCThreadLaunch -> return $ runCompile CPU $ do
+  MCThreadLaunch -> return $ runCompile env CPU $ do
     let numThreadInfoArgs = 4  -- [threadIdParam, nThreadParam, argArrayParam]
     let argTypes = drop numThreadInfoArgs $ nestToList (scalarTy . iBinderType) bs
     -- Set up arguments
@@ -194,9 +214,9 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
     (nThreadParam , nthrArg ) <- freshParamOpPair [] i32
     tid  <- tidArg  `asIntWidth` idxRepTy
     nthr <- nthrArg `asIntWidth` idxRepTy
-    let env = bs @@> map opSubstVal ([tid, wid, nthr, nthr] ++ args)
+    let subst = bs @@> map opSubstVal ([tid, wid, nthr, nthr] ++ args)
     -- Emit the body
-    void $ extendOperands env $ compileBlock body
+    void $ extendSubst subst $ compileBlock body
     kernel <- makeFunction (topLevelFunName (fName, fTy))
                 [threadIdParam, nThreadParam, argArrayParam] Nothing
     extraSpecs <- gets funSpecs
@@ -204,7 +224,7 @@ compileFunction logger fName fun@(ImpFunction fTy@(IFunType cc argTys retTys)
     where
       idxRepTy = scalarTy $ IIdxRepTy
 
-compileInstr :: ImpInstr n -> Compile n [Operand]
+compileInstr :: Compiler m => ImpInstr i -> m i o [Operand]
 compileInstr instr = case instr of
   IFor d n (Abs i body)  -> [] <$ do
     n' <- compileExpr n
@@ -235,7 +255,7 @@ compileInstr instr = case instr of
                                                   [hostPtrTy i8, i64, hostPtrTy i32, hostPtrTy i32]
       _                -> error $ "Unsupported calling convention: " ++ show cc
   ISyncWorkgroup -> do
-    dev <- asks curDevice
+    dev <- gets curDevice
     case dev of
       CPU -> error "Not yet implemented"
       GPU -> [] <$ emitVoidExternCall barrierSpec []
@@ -258,7 +278,7 @@ compileInstr instr = case instr of
         launchCUDAKernel kernelPtr size' kernelParams
       _ -> error $ "Not a valid calling convention for a launch: " ++ pprint cc
   IThrowError   -> do
-    dev <- asks curDevice
+    dev <- gets curDevice
     case dev of
       CPU -> [] <$ throwRuntimeError
       -- TODO: Implement proper error handling on GPUs.
@@ -360,7 +380,7 @@ makeFunSpec (name, IFunType FFIMultiResultFun argTys _) =
      (hostPtrTy hostVoidp : map scalarTy argTys)
 makeFunSpec (_, IFunType _ _ _) = error "not implemented"
 
-compileLoop :: Direction -> IBinder n l -> Operand -> Compile l () -> Compile n ()
+compileLoop :: Compiler m => Direction -> IBinder i i' -> Operand -> m i' o () -> m i o ()
 compileLoop d iBinder n compileBody = do
   let loopName = "loop_" ++ (fromString $ pprint $ binderName iBinder)
   loopBlock <- freshName $ fromString $ loopName
@@ -372,7 +392,7 @@ compileLoop d iBinder n compileBody = do
   entryCond <- (0 `withWidthOf` n) `ilt` n
   finishBlock (L.CondBr entryCond loopBlock nextBlock []) loopBlock
   iVal <- load i
-  extendOperands (iBinder @> opSubstVal iVal) $ compileBody
+  extendSubst (iBinder @> opSubstVal iVal) $ compileBody
   iValNew <- case d of Fwd -> add iVal (1 `withWidthOf` iVal)
                        Rev -> sub iVal (1 `withWidthOf` iVal)
   store i iValNew
@@ -380,7 +400,7 @@ compileLoop d iBinder n compileBody = do
                         Rev -> iValNew `ige` (0 `withWidthOf` iValNew)
   finishBlock (L.CondBr loopCond loopBlock nextBlock []) nextBlock
 
-compileIf :: Operand -> Compile n () -> Compile n () -> Compile n ()
+compileIf :: LLVMBuilder m => Operand -> m () -> m () -> m ()
 compileIf cond tb fb = do
   tbName   <- freshName "if_true"
   fbName   <- freshName "if_false"
@@ -391,7 +411,7 @@ compileIf cond tb fb = do
   fb
   finishBlock (L.Br contName []) contName
 
-compileWhile :: Compile n Operand -> Compile n ()
+compileWhile :: LLVMBuilder m => m Operand -> m ()
 compileWhile compileBody = do
   loopBlock <- freshName "whileLoop"
   nextBlock <- freshName "whileCont"
@@ -400,12 +420,12 @@ compileWhile compileBody = do
   loopCond <- compileBody >>= (`asIntWidth` i1)
   finishBlock (L.CondBr loopCond loopBlock nextBlock []) nextBlock
 
-throwRuntimeError :: Compile n ()
+throwRuntimeError :: LLVMBuilder m => m ()
 throwRuntimeError = do
   deadBlock <- freshName "deadBlock"
   finishBlock (L.Ret (Just $ i64Lit 1) []) deadBlock
 
-compilePrimOp :: PrimOp Operand -> Compile n Operand
+compilePrimOp :: LLVMBuilder m => PrimOp Operand -> m Operand
 compilePrimOp pop = case pop of
   ScalarBinOp op x y -> compileBinOp op x y
   VectorBinOp op x y -> compileBinOp op x y
@@ -425,14 +445,14 @@ compilePrimOp pop = case pop of
 
   _ -> error $ "Can't JIT primop: " ++ pprint pop
 
-compileUnOp :: UnOp -> Operand -> Compile n Operand
+compileUnOp :: LLVMBuilder m => UnOp -> Operand -> m Operand
 compileUnOp op x = case op of
   -- LLVM has "fneg" but it doesn't seem to be exposed by llvm-hs-pure
   FNeg            -> emitInstr (L.typeOf x) $ L.FSub mathFlags (0.0 `withWidthOfFP` x) x []
   BNot            -> emitInstr boolTy $ L.Xor x (i8Lit 1) []
   _               -> unaryIntrinsic op x
 
-compileBinOp :: BinOp -> Operand -> Operand -> Compile n Operand
+compileBinOp :: LLVMBuilder m => BinOp -> Operand -> Operand -> m Operand
 compileBinOp op x y = case op of
   IAdd   -> emitInstr (L.typeOf x) $ L.Add False False x y []
   ISub   -> emitInstr (L.typeOf x) $ L.Sub False False x y []
@@ -468,35 +488,35 @@ compileBinOp op x y = case op of
       GreaterEqual -> IP.SGE
       Equal        -> IP.EQ
 
-deviceFromAddr :: AddressSpace -> Compile n Device
+deviceFromAddr :: LLVMBuilder m => AddressSpace -> m Device
 deviceFromAddr addr = case addr of
   Heap dev -> return dev
-  Stack -> asks curDevice
+  Stack -> gets curDevice
 
 -- === MDImp to LLVM CUDA ===
 
-ensureHasCUDAContext :: Compile n ()
+ensureHasCUDAContext :: LLVMBuilder m => m ()
 ensureHasCUDAContext = emitVoidExternCall spec []
   where spec = ExternFunSpec "dex_ensure_has_cuda_context" L.VoidType [] [] []
 
-launchCUDAKernel :: Operand -> Operand -> Operand -> Compile n()
+launchCUDAKernel :: LLVMBuilder m => Operand -> Operand -> Operand -> m ()
 launchCUDAKernel ptx size args = emitVoidExternCall spec [ptx, size, args]
   where spec = ExternFunSpec "dex_cuLaunchKernel" L.VoidType [] []
                  [hostVoidp, i64, hostPtrTy $ hostVoidp]
 
-cuMemcpyDToH :: Operand -> Operand -> Operand -> Compile n ()
+cuMemcpyDToH :: LLVMBuilder m => Operand -> Operand -> Operand -> m ()
 cuMemcpyDToH bytes devPtr hostPtr = emitVoidExternCall spec [bytes, devPtr, hostPtr]
   where spec = ExternFunSpec "dex_cuMemcpyDtoH" L.VoidType [] [] [i64, deviceVoidp, hostVoidp]
 
-cuMemcpyHToD :: Operand -> Operand -> Operand -> Compile n ()
+cuMemcpyHToD :: LLVMBuilder m => Operand -> Operand -> Operand -> m ()
 cuMemcpyHToD bytes devPtr hostPtr = emitVoidExternCall spec [bytes, devPtr, hostPtr]
   where spec = ExternFunSpec "dex_cuMemcpyHtoD" L.VoidType [] [] [i64, deviceVoidp, hostVoidp]
 
-cuMemAlloc :: L.Type -> Operand -> Compile n Operand
+cuMemAlloc :: LLVMBuilder m => L.Type -> Operand -> m Operand
 cuMemAlloc ty bytes = castLPtr ty =<< emitExternCall spec [bytes]
   where spec = ExternFunSpec "dex_cuMemAlloc" deviceVoidp [] [] [i64]
 
-cuMemFree :: Operand -> Compile n ()
+cuMemFree :: LLVMBuilder m => Operand -> m ()
 cuMemFree ptr = do
   voidptr <- castVoidPtr ptr
   emitVoidExternCall spec [voidptr]
@@ -507,8 +527,8 @@ cuMemFree ptr = do
 -- * NVVM IR specification: https://docs.nvidia.com/cuda/nvvm-ir-spec/index.html
 -- * PTX docs: https://docs.nvidia.com/cuda/ptx-writers-guide-to-interoperability/index.html
 
-impKernelToLLVMGPU :: ImpFunction n -> LLVMKernel
-impKernelToLLVMGPU (ImpFunction _ (Abs args body)) = do
+impKernelToLLVMGPU :: Distinct n => Env n -> ImpFunction n -> LLVMKernel
+impKernelToLLVMGPU env (ImpFunction _ (Abs args body)) = do
   let numThreadInfoArgs = 4  -- [threadIdParam, nThreadParam, argArrayParam]
   let argTypes = drop numThreadInfoArgs $ nestToList (scalarTy . iBinderType) args
   let kernelMeta = L.MetadataNodeDefinition kernelMetaId $ L.MDTuple
@@ -517,15 +537,15 @@ impKernelToLLVMGPU (ImpFunction _ (Abs args body)) = do
                      , Just $ L.MDString "kernel"
                      , Just $ L.MDValue $ L.ConstantOperand $ C.Int 32 1
                      ]
-  runCompile GPU $ do
+  runCompile env GPU $ do
     (argParams, argOperands) <- unzip <$> mapM (freshParamOpPair ptrParamAttrs) argTypes
     tidx <- threadIdxX >>= (`asIntWidth` idxRepTy)
     bidx <- blockIdxX  >>= (`asIntWidth` idxRepTy)
     bsz  <- blockDimX  >>= (`asIntWidth` idxRepTy)
     gsz  <- gridDimX   >>= (`asIntWidth` idxRepTy)
     nthr <- mul bsz gsz
-    let env = args @@> map opSubstVal ([tidx, bidx, bsz, nthr] ++ argOperands)
-    void $ extendOperands env $ compileBlock body
+    let subst = args @@> map opSubstVal ([tidx, bidx, bsz, nthr] ++ argOperands)
+    void $ extendSubst subst $ compileBlock body
     kernel <- makeFunction "kernel" argParams Nothing
     LLVMKernel <$> makeModuleEx ptxDataLayout ptxTargetTriple
                      [L.GlobalDefinition kernel, kernelMeta, nvvmAnnotations]
@@ -534,28 +554,28 @@ impKernelToLLVMGPU (ImpFunction _ (Abs args body)) = do
     ptrParamAttrs = [L.NoAlias, L.NoCapture, L.NonNull, L.Alignment 256]
     kernelMetaId = L.MetadataNodeID 0
     nvvmAnnotations = L.NamedMetadataDefinition "nvvm.annotations" [kernelMetaId]
-impKernelToLLVMGPU _ = error "not implemented"
+impKernelToLLVMGPU _ _ = error "not implemented"
 
-threadIdxX :: Compile n Operand
+threadIdxX :: LLVMBuilder m => m Operand
 threadIdxX = emitExternCall spec []
   where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.tid.x"
 
-blockIdxX :: Compile n Operand
+blockIdxX :: LLVMBuilder m => m Operand
 blockIdxX = emitExternCall spec []
   where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.ctaid.x"
 
-blockDimX :: Compile n Operand
+blockDimX :: LLVMBuilder m => m Operand
 blockDimX = emitExternCall spec []
   where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.ntid.x"
 
-gridDimX :: Compile n Operand
+gridDimX :: LLVMBuilder m => m Operand
 gridDimX = emitExternCall spec []
   where spec = ptxSpecialReg "llvm.nvvm.read.ptx.sreg.nctaid.x"
 
 ptxSpecialReg :: L.Name -> ExternFunSpec
 ptxSpecialReg name = ExternFunSpec name i32 [] [FA.ReadNone, FA.NoUnwind] []
 
-gpuUnaryIntrinsic :: UnOp -> Operand -> Compile n Operand
+gpuUnaryIntrinsic :: LLVMBuilder m => UnOp -> Operand -> m Operand
 gpuUnaryIntrinsic op x = case L.typeOf x of
   L.FloatingPointType L.DoubleFP -> dispatchOp fp64 ""
   L.FloatingPointType L.FloatFP  -> dispatchOp fp32 "f"
@@ -580,7 +600,7 @@ gpuUnaryIntrinsic op x = case L.typeOf x of
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x]
 
-gpuBinaryIntrinsic :: BinOp -> Operand -> Operand -> Compile n Operand
+gpuBinaryIntrinsic :: LLVMBuilder m => BinOp -> Operand -> Operand -> m Operand
 gpuBinaryIntrinsic op x y = case L.typeOf x of
   L.FloatingPointType L.DoubleFP -> dispatchOp fp64 ""
   L.FloatingPointType L.FloatFP  -> dispatchOp fp32 "f"
@@ -592,7 +612,7 @@ gpuBinaryIntrinsic op x y = case L.typeOf x of
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty, ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x, y]
 
-_gpuDebugPrint :: Operand -> Compile n ()
+_gpuDebugPrint :: LLVMBuilder m => Operand -> m ()
 _gpuDebugPrint i32Val = do
   let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) "%d\n" ++ [0]
   let formatStrArr = L.ConstantOperand $ C.Array i8 chars
@@ -607,7 +627,7 @@ _gpuDebugPrint i32Val = do
     vprintfSpec = ExternFunSpec "vprintf" i32 [] [] [genericPtrTy i8, genericPtrTy i8]
 
 -- Takes a single int64 payload. TODO: implement a varargs version
-_debugPrintf :: String -> Operand -> Compile n ()
+_debugPrintf :: LLVMBuilder m => String -> Operand -> m ()
 _debugPrintf fmtStr x = do
   let chars = map (C.Int 8) $ map (fromIntegral . fromEnum) fmtStr ++ [0]
   let formatStrArr = L.ConstantOperand $ C.Array i8 chars
@@ -616,33 +636,33 @@ _debugPrintf fmtStr x = do
   void $ emitExternCall printfSpec [formatStrPtr, x]
   where printfSpec = ExternFunSpec "printf" i32 [] [] [hostVoidp, i64]
 
-_debugPrintfPtr :: String -> Operand -> Compile n ()
+_debugPrintfPtr :: LLVMBuilder m => String -> Operand -> m ()
 _debugPrintfPtr s x = do
   x' <- emitInstr i64 $ L.PtrToInt x i64 []
   _debugPrintf s x'
 
-compileBlock :: ImpBlock n -> Compile n [Operand]
+compileBlock :: Compiler m => ImpBlock i -> m i o [Operand]
 compileBlock (ImpBlock Empty result) = traverse compileExpr result
 compileBlock (ImpBlock (Nest decl rest) result) = do
   env <- compileDecl decl
-  extendOperands env $ compileBlock (ImpBlock rest result)
+  extendSubst env $ compileBlock (ImpBlock rest result)
 
-compileDecl :: ImpDecl n l -> Compile n (OperandEnvFrag n l)
+compileDecl :: Compiler m => ImpDecl i i' -> m i o (OperandEnvFrag i i' o)
 compileDecl (ImpLet bs instr) = do
   results <- compileInstr instr
   if length results == nestLength bs
     then return $ bs @@> map (SubstVal . LiftE) results
     else error "Unexpected number of results"
 
-compileVoidBlock :: ImpBlock n -> Compile n ()
+compileVoidBlock :: Compiler m => ImpBlock i -> m i o ()
 compileVoidBlock = void . compileBlock
 
-compileExpr :: IExpr n -> Compile n Operand
+compileExpr :: Compiler m => IExpr i -> m i o Operand
 compileExpr expr = case expr of
   ILit v   -> return (litVal v)
   IVar v _ -> lookupImpVar v
 
-packArgs :: [Operand] -> Compile n Operand
+packArgs :: LLVMBuilder m => [Operand] -> m Operand
 packArgs elems = do
   arr <- alloca (length elems) hostVoidp
   forM_ (zip [0..] elems) \(i, e) -> do
@@ -652,14 +672,14 @@ packArgs elems = do
     store earr =<< castVoidPtr eptr
   return arr
 
-unpackArgs :: Operand -> [L.Type] -> Compile n [Operand]
+unpackArgs :: LLVMBuilder m => Operand -> [L.Type] -> m [Operand]
 unpackArgs argArrayPtr types =
   forM (zip [0..] types) \(i, ty) -> do
     argVoidPtr <- gep argArrayPtr $ i64Lit i
     argPtr <- castLPtr (hostPtrTy ty) argVoidPtr
     load =<< load argPtr
 
-makeMultiResultAlloc :: [L.Type] -> Compile n Operand
+makeMultiResultAlloc :: LLVMBuilder m => [L.Type] -> m Operand
 makeMultiResultAlloc tys = do
   resultsPtr <- alloca (length tys) hostVoidp
   forM_ (zip [0..] tys) \(i, ty) -> do
@@ -668,7 +688,7 @@ makeMultiResultAlloc tys = do
     store resultsPtrOffset ptr
   return resultsPtr
 
-loadMultiResultAlloc :: [L.Type] -> Operand -> Compile n [Operand]
+loadMultiResultAlloc :: LLVMBuilder m => [L.Type] -> Operand -> m [Operand]
 loadMultiResultAlloc tys ptr =
   forM (zip [0..] tys) \(i, ty) ->
     gep ptr (i32Lit i) >>= load >>= castLPtr ty >>= load
@@ -724,42 +744,42 @@ withWidthOfFP x template = case L.typeOf template of
   L.FloatingPointType L.FloatFP  -> litVal $ Float32Lit $ realToFrac x
   _ -> error $ "Unsupported floating point type: " ++ show (L.typeOf template)
 
-store :: Operand -> Operand -> Compile n ()
+store :: LLVMBuilder m => Operand -> Operand -> m ()
 store ptr x =  addInstr $ L.Do $ L.Store False ptr x Nothing 0 []
 
-load :: Operand -> Compile n Operand
+load :: LLVMBuilder m => Operand -> m Operand
 load ptr = emitInstr ty $ L.Load False ptr Nothing 0 []
   where (L.PointerType ty _) = L.typeOf ptr
 
-ilt :: Operand -> Operand -> Compile n Operand
+ilt :: LLVMBuilder m => Operand -> Operand -> m Operand
 ilt x y = emitInstr i1 $ L.ICmp IP.SLT x y []
 
-ige :: Operand -> Operand -> Compile n Operand
+ige :: LLVMBuilder m => Operand -> Operand -> m Operand
 ige x y = emitInstr i1 $ L.ICmp IP.SGE x y []
 
-add :: Operand -> Operand -> Compile n Operand
+add :: LLVMBuilder m => Operand -> Operand -> m Operand
 add x y = emitInstr (L.typeOf x) $ L.Add False False x y []
 
-sub :: Operand -> Operand -> Compile n Operand
+sub :: LLVMBuilder m => Operand -> Operand -> m Operand
 sub x y = emitInstr (L.typeOf x) $ L.Sub False False x y []
 
-mul :: Operand -> Operand -> Compile n Operand
+mul :: LLVMBuilder m => Operand -> Operand -> m Operand
 mul x y = emitInstr (L.typeOf x) $ L.Mul False False x y []
 
-gep :: Operand -> Operand -> Compile n Operand
+gep :: LLVMBuilder m => Operand -> Operand -> m Operand
 gep ptr i = emitInstr (L.typeOf ptr) $ L.GetElementPtr False ptr [i] []
 
 sizeof :: L.Type -> Operand
 sizeof t = (L.ConstantOperand $ C.ZExt (C.sizeof t) i64)
 
-alloca :: Int -> L.Type -> Compile n Operand
+alloca :: LLVMBuilder m => Int -> L.Type -> m Operand
 alloca elems ty = do
   v <- freshName "v"
   modify $ setScalarDecls ((v L.:= instr):)
   return $ L.LocalReference (hostPtrTy ty) v
   where instr = L.Alloca ty (Just $ i32Lit elems) 0 []
 
-malloc :: Bool -> L.Type -> Operand -> Compile n Operand
+malloc :: LLVMBuilder m => Bool -> L.Type -> Operand -> m Operand
 malloc initialize ty bytes = do
   bytes64 <- asIntWidth bytes i64
   ptr <- if initialize
@@ -767,21 +787,21 @@ malloc initialize ty bytes = do
     else emitExternCall mallocFun            [bytes64]
   castLPtr ty ptr
 
-free :: Operand -> Compile n ()
+free :: LLVMBuilder m => Operand -> m ()
 free ptr = do
  ptr' <- castLPtr i8 ptr
  emitVoidExternCall freeFun [ptr']
 
-castLPtr :: L.Type -> Operand -> Compile n Operand
+castLPtr :: LLVMBuilder m => L.Type -> Operand -> m Operand
 castLPtr ty ptr = emitInstr newPtrTy $ L.BitCast ptr newPtrTy []
   where
     L.PointerType _ addr = L.typeOf ptr
     newPtrTy = L.PointerType ty addr
 
-castVoidPtr :: Operand -> Compile n Operand
+castVoidPtr :: LLVMBuilder m => Operand -> m Operand
 castVoidPtr = castLPtr i8
 
-zeroExtendTo :: Operand -> L.Type -> Compile n Operand
+zeroExtendTo :: LLVMBuilder m => Operand -> L.Type -> m Operand
 zeroExtendTo x t = emitInstr t $ L.ZExt x t []
 
 callInstr :: L.CallableOperand -> [L.Operand] -> L.Instruction
@@ -792,12 +812,12 @@ externCall :: ExternFunSpec -> [L.Operand] -> L.Instruction
 externCall (ExternFunSpec fname retTy _ _ argTys) xs = callInstr fun xs
   where fun = callableOperand (funTy retTy argTys) fname
 
-emitExternCall :: ExternFunSpec -> [L.Operand] -> Compile n Operand
+emitExternCall :: LLVMBuilder m => ExternFunSpec -> [L.Operand] -> m Operand
 emitExternCall f@(ExternFunSpec _ retTy _ _ _) xs = do
   modify $ setFunSpecs (S.insert f)
   emitInstr retTy $ externCall f xs
 
-emitVoidExternCall :: ExternFunSpec -> [L.Operand] -> Compile n ()
+emitVoidExternCall :: LLVMBuilder m => ExternFunSpec -> [L.Operand] -> m ()
 emitVoidExternCall f xs = do
   modify $ setFunSpecs (S.insert f)
   addInstr $ L.Do $ externCall f xs
@@ -830,14 +850,14 @@ lAddress s = case s of
 callableOperand :: L.Type -> L.Name -> L.CallableOperand
 callableOperand ty name = Right $ L.ConstantOperand $ C.GlobalReference ty name
 
-asIntWidth :: Operand -> L.Type -> Compile n Operand
+asIntWidth :: LLVMBuilder m => Operand -> L.Type -> m Operand
 asIntWidth op ~expTy@(L.IntegerType expWidth) = case compare expWidth opWidth of
   LT -> emitInstr expTy $ L.Trunc op expTy []
   EQ -> return op
   GT -> emitInstr expTy $ L.SExt  op expTy []
   where ~(L.IntegerType opWidth) = L.typeOf op
 
-freshParamOpPair :: [L.ParameterAttribute] -> L.Type -> Compile n (Parameter, Operand)
+freshParamOpPair :: LLVMBuilder m => [L.ParameterAttribute] -> L.Type -> m (Parameter, Operand)
 freshParamOpPair ptrAttrs ty = do
   v <- freshName "arg"
   let attrs = case ty of
@@ -857,7 +877,7 @@ externDecl (ExternFunSpec fname retTy retAttrs funAttrs argTys) =
   }
   where argName i = L.Name $ "arg" <> fromString (show i)
 
-cpuUnaryIntrinsic :: UnOp -> Operand -> Compile n Operand
+cpuUnaryIntrinsic :: LLVMBuilder m => UnOp -> Operand -> m Operand
 cpuUnaryIntrinsic op x = case L.typeOf x of
   L.FloatingPointType L.DoubleFP -> dispatchOp fp64 ".f64" ""
   L.FloatingPointType L.FloatFP  -> dispatchOp fp32 ".f32" "f"
@@ -882,7 +902,7 @@ cpuUnaryIntrinsic op x = case L.typeOf x of
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x]
 
-cpuBinaryIntrinsic :: BinOp -> Operand -> Operand -> Compile n Operand
+cpuBinaryIntrinsic :: LLVMBuilder m => BinOp -> Operand -> Operand -> m Operand
 cpuBinaryIntrinsic op x y = case L.typeOf x of
   L.FloatingPointType L.DoubleFP -> dispatchOp fp64 ".f64"
   L.FloatingPointType L.FloatFP  -> dispatchOp fp32 ".f32"
@@ -912,34 +932,34 @@ outputStreamPtr :: Operand
 outputStreamPtr = L.ConstantOperand $ C.GlobalReference
  (hostPtrTy hostVoidp) outputStreamPtrLName
 
-initializeOutputStream :: Operand -> Compile n ()
+initializeOutputStream :: LLVMBuilder m => Operand -> m ()
 initializeOutputStream streamFD = do
   streamPtr <- emitExternCall fdopenFun [streamFD]
   store outputStreamPtr streamPtr
 
 -- === Compile monad utilities ===
 
-runCompile :: Device -> Compile n a -> a
-runCompile dev m = evalState (runReaderT m env) initState
+runCompile :: Distinct n => Env n -> Device -> CompileM n n  a -> a
+runCompile env dev m =
+  flip evalState initState $
+    runEnvReaderT env $
+     runSubstReaderT idSubst $
+       runCompileM' m
   where
     -- TODO: figure out naming discipline properly
-    env = CompileEnv (unsafeCoerceE idSubst) dev
-    initState = CompileState [] [] [] "start_block" mempty mempty mempty
+    initState = CompileState [] [] [] "start_block" mempty mempty mempty dev
 
-extendOperands :: OperandEnvFrag i i' -> Compile i' a -> Compile i a
-extendOperands openv = withReaderT \env -> env { operandEnv = operandEnv env <>> openv }
-
-opSubstVal :: Operand -> OperandSubstVal AtomNameC VoidS
+opSubstVal :: Operand -> OperandSubstVal AtomNameC n
 opSubstVal x = SubstVal (LiftE x)
 
-lookupImpVar :: AtomName n -> Compile n Operand
+lookupImpVar :: Compiler m => AtomName i -> m i o Operand
 lookupImpVar v = do
-  env <- asks operandEnv
-  case env ! v of
+  subst <- getSubst
+  case subst ! v of
     SubstVal (LiftE x) -> return x
     Rename _ -> error "shouldn't happen?"
 
-finishBlock :: L.Terminator -> L.Name -> Compile n ()
+finishBlock :: LLVMBuilder m => L.Terminator -> L.Name -> m ()
 finishBlock term newName = do
   oldName <- gets blockName
   instrs  <- gets curInstrs
@@ -948,7 +968,7 @@ finishBlock term newName = do
          . setCurInstrs (const [])
          . setBlockName (const newName)
 
-freshName :: NameHint -> Compile n L.Name
+freshName :: LLVMBuilder m => NameHint -> m L.Name
 freshName hint = do
   used <- gets usedNames
   let v = freshRawName hint used
@@ -962,13 +982,13 @@ freshName hint = do
     showName (RawName tag counter) = docAsStr $ pretty tag <> "." <> pretty counter
 
 -- TODO: consider getting type from instruction rather than passing it explicitly
-emitInstr :: L.Type -> Instruction -> Compile n Operand
+emitInstr :: LLVMBuilder m => L.Type -> Instruction -> m Operand
 emitInstr ty instr = do
   v <- freshName "v"
   addInstr $ v L.:= instr
   return $ L.LocalReference ty v
 
-addInstr :: Named Instruction -> Compile n ()
+addInstr :: LLVMBuilder m => Named Instruction -> m ()
 addInstr instr = modify $ setCurInstrs (instr:)
 
 setScalarDecls :: ([Named Instruction] -> [Named Instruction]) -> CompileState -> CompileState
@@ -986,16 +1006,16 @@ setBlockName update s = s { blockName = update (blockName s) }
 setFunSpecs :: (S.Set ExternFunSpec -> S.Set ExternFunSpec) -> CompileState -> CompileState
 setFunSpecs update s = s { funSpecs = update (funSpecs s) }
 
-unaryIntrinsic :: UnOp -> Operand -> Compile n Operand
+unaryIntrinsic :: LLVMBuilder m => UnOp -> Operand -> m Operand
 unaryIntrinsic op x = do
-  device <- asks curDevice
+  device <- gets curDevice
   case device of
     CPU -> cpuUnaryIntrinsic op x
     GPU -> gpuUnaryIntrinsic op x
 
-binaryIntrinsic :: BinOp -> Operand -> Operand -> Compile n Operand
+binaryIntrinsic :: LLVMBuilder m => BinOp -> Operand -> Operand -> m Operand
 binaryIntrinsic op x y = do
-  device <- asks curDevice
+  device <- gets curDevice
   case device of
     CPU -> cpuBinaryIntrinsic op x y
     GPU -> gpuBinaryIntrinsic op x y
@@ -1054,7 +1074,7 @@ funTy retTy argTys = hostPtrTy $ L.FunctionType retTy argTys False
 
 -- === Module building ===
 
-makeFunction :: L.Name -> [Parameter] -> Maybe L.Operand -> Compile n Function
+makeFunction :: LLVMBuilder m => L.Name -> [Parameter] -> Maybe L.Operand -> m Function
 makeFunction name params returnVal = do
   finishBlock (L.Ret returnVal []) "<ignored>"
   decls <- gets scalarDecls
@@ -1068,7 +1088,8 @@ makeFunction name params returnVal = do
     , L.returnType  = returnTy
     , L.basicBlocks = blocks }
 
-makeModuleEx :: L.DataLayout -> ShortByteString -> [L.Definition] -> Compile n L.Module
+makeModuleEx :: LLVMBuilder m
+             => L.DataLayout -> ShortByteString -> [L.Definition] -> m L.Module
 makeModuleEx dataLayout triple defs = do
   specs     <- gets funSpecs
   extraDefs <- gets globalDefs

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -10,6 +10,7 @@
 
 module LLVMExec (LLVMKernel (..), ptxDataLayout, ptxTargetTriple,
                  compileAndEval, compileAndBench, exportObjectFile,
+                 exportObjectFileVal,
                  standardCompilationPipeline,
                  compileCUDAKernel,
                  storeLitVals, loadLitVals, allocaCells, loadLitVal) where
@@ -72,26 +73,26 @@ foreign import ccall "dynamic"
 type DexExecutable = FunPtr (Int32 -> Ptr () -> Ptr () -> IO DexExitCode)
 type DexExitCode = Int
 
-compileAndEval :: Logger [Output] -> L.Module -> String
+compileAndEval :: Logger [Output] -> [ObjectFile n] -> L.Module -> String
                -> [LitVal] -> [BaseType] -> IO [LitVal]
-compileAndEval logger ast fname args resultTypes = do
+compileAndEval logger objFiles ast fname args resultTypes = do
   withPipeToLogger logger \fd ->
     allocaCells (length args) \argsPtr ->
       allocaCells (length resultTypes) \resultPtr -> do
         storeLitVals argsPtr args
-        evalTime <- compileOneOff logger ast fname $
+        evalTime <- compileOneOff logger objFiles ast fname $
           checkedCallFunPtr fd argsPtr resultPtr
         logThis logger [EvalTime evalTime Nothing]
         loadLitVals resultPtr resultTypes
 
-compileAndBench :: Bool -> Logger [Output] -> L.Module -> String
+compileAndBench :: Bool -> Logger [Output] -> [ObjectFile n] -> L.Module -> String
                 -> [LitVal] -> [BaseType] -> IO [LitVal]
-compileAndBench shouldSyncCUDA logger ast fname args resultTypes = do
+compileAndBench shouldSyncCUDA logger objFiles ast fname args resultTypes = do
   withPipeToLogger logger \fd ->
     allocaCells (length args) \argsPtr ->
       allocaCells (length resultTypes) \resultPtr -> do
         storeLitVals argsPtr args
-        compileOneOff logger ast fname \fPtr -> do
+        compileOneOff logger objFiles ast fname \fPtr -> do
           ((avgTime, benchRuns, results), totalTime) <- measureSeconds $ do
             -- First warmup iteration, which we also use to get the results
             void $ checkedCallFunPtr fd argsPtr resultPtr fPtr
@@ -132,11 +133,13 @@ checkedCallFunPtr fd argsPtr resultPtr fPtr = do
   unless (exitCode == 0) $ throw RuntimeErr ""
   return duration
 
-compileOneOff :: Logger [Output] -> L.Module -> String -> (DexExecutable -> IO a) -> IO a
-compileOneOff logger ast name f = do
+compileOneOff :: Logger [Output] -> [ObjectFile n] -> L.Module -> String -> (DexExecutable -> IO a) -> IO a
+compileOneOff logger objFiles ast name f = do
   withHostTargetMachine \tm ->
-    withJIT tm \jit ->
-      withNativeModule jit ast (standardCompilationPipeline logger [name] tm) \compiled ->
+    withJIT tm \jit -> do
+      let pipeline = standardCompilationPipeline logger [name] tm
+      let objFileContents = [s | ObjectFile s _ _ <- objFiles]
+      withNativeModule jit objFileContents ast pipeline \compiled ->
         f =<< getFunctionPtr compiled name
 
 standardCompilationPipeline :: Logger [Output] -> [String] -> T.TargetMachine -> Mod.Module -> IO ()
@@ -152,6 +155,13 @@ standardCompilationPipeline logger exports tm m = do
 
 
 -- === object file export ===
+
+exportObjectFileVal :: [ObjectFileName n] -> L.Module -> String -> IO (ObjectFile n)
+exportObjectFileVal deps m fname = do
+  withSystemTempFile "objfile.o" \path h -> do
+    exportObjectFile path [(m, [fname])]
+    contents <- B.hGetContents h
+    return $ ObjectFile contents [fname] deps
 
 -- Each module comes with a list of exported functions
 exportObjectFile :: FilePath -> [(L.Module, [String])] -> IO ()

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -408,7 +408,6 @@ linearizeOp op = case op of
   VariantSplit ts v ->
     zipLin (traverseLin pureLin ts) (la v) `bindLin`
       \(PairE (ComposeE ts') v') -> emitOp $ VariantSplit ts' v'
-  FFICall _ _ _          -> error $ "Can't differentiate through an FFI call"
   ThrowException _       -> notImplemented
   SumToVariant _         -> notImplemented
   OutputStreamPtr        -> emitZeroT

--- a/src/lib/Logging.hs
+++ b/src/lib/Logging.hs
@@ -10,7 +10,8 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Logging (Logger, LoggerT (..), MonadLogger (..), logIO, runLoggerT,
-                runLogger, execLogger, logThis, readLog) where
+                MonadLogger1, MonadLogger2,
+                runLogger, execLogger, logThis, readLog, ) where
 
 import Control.Monad
 import Control.Monad.Reader
@@ -21,6 +22,7 @@ import System.IO
 
 import PPrint
 import Err
+import Name
 
 data Logger l = Logger (MVar l) (Maybe Handle)
 
@@ -56,6 +58,9 @@ class (Pretty l, Monoid l, Monad m) => MonadLogger l m | m -> l where
 
 instance (MonadIO m, Pretty l, Monoid l) => MonadLogger l (LoggerT l m) where
   getLogger = LoggerT ask
+
+type MonadLogger1 l (m :: MonadKind1) = forall (n::S) . MonadLogger l (m n)
+type MonadLogger2 l (m :: MonadKind2) = forall (n1::S) (n2::S) . MonadLogger l (m n1 n2)
 
 logIO :: MonadIO m => MonadLogger l m => l -> m ()
 logIO val = do

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -157,6 +157,17 @@ instance Pretty (Decl n l) where
     Let b (DeclBinding ann ty rhs) ->
       align $ p ann <+> p (b:>ty) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
 
+instance Pretty (NaryLamExpr n) where
+  pretty (NaryLamExpr (NonEmptyNest b bs) _ body) =
+    "\\" <> prettyBinderNest (Nest b bs) <+> "." <> nest 2 (p body)
+
+instance Pretty (NaryPiType n) where
+  pretty (NaryPiType (NonEmptyNest b bs) effs resultTy) =
+    prettyBinderNest (Nest b bs) <+> "->" <+> "{" <> p effs <> "}" <+> p resultTy
+
+instance Pretty (PiBinder n l) where
+  pretty (PiBinder b ty _) = p (b:>ty)
+
 instance Pretty (LamExpr n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (LamExpr n) where
   prettyPrec lamExpr = case lamExpr of
@@ -309,6 +320,7 @@ instance Pretty (AtomBinding n) where
     MiscBound   t -> p t
     SolverBound b -> p b
     PtrLitBound ty ptr -> p $ PtrLit ty ptr
+    SimpLamBound ty f -> p ty <> hardline <> p f
 
 instance Pretty (LamBinding n) where
   pretty (LamBinding arr ty) =
@@ -335,6 +347,7 @@ instance Pretty (Binding s n) where
       "Superclass" <+> pretty idx <+> "of" <+> pretty className
     MethodBinding     className idx _ ->
       "Method" <+> pretty idx <+> "of" <+> pretty className
+    ImpFunBinding f -> pretty f
 
 instance Pretty (DataDef n) where
   pretty (DataDef name bs cons) =

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -321,6 +321,7 @@ instance Pretty (AtomBinding n) where
     SolverBound b -> p b
     PtrLitBound ty ptr -> p $ PtrLit ty ptr
     SimpLamBound ty f -> p ty <> hardline <> p f
+    FFIFunBound _ f -> p f
 
 instance Pretty (LamBinding n) where
   pretty (LamBinding arr ty) =
@@ -610,7 +611,7 @@ instance Pretty (ImpFunction n) where
   pretty (ImpFunction (IFunType cc _ _) (Abs bs body)) =
     "def" <+> p cc <+> p bs
     <> nest 2 (hardline <> p body) <> hardline
-  pretty (FFIFunction f) = p f
+  pretty (FFIFunction _ f) = p f
 
 instance Pretty (ImpBlock n)  where
   pretty (ImpBlock Empty expr) = group $ line <> pLowest expr

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -349,6 +349,7 @@ instance Pretty (Binding s n) where
     MethodBinding     className idx _ ->
       "Method" <+> pretty idx <+> "of" <+> pretty className
     ImpFunBinding f -> pretty f
+    ObjectFileBinding _ -> "<object file>"
 
 instance Pretty (DataDef n) where
   pretty (DataDef name bs cons) =
@@ -399,7 +400,7 @@ instance Pretty Output where
   pretty (PassInfo _ s) = p s
   pretty (EvalTime  t _) = "Eval (s):  " <+> p t
   pretty (TotalTime t)   = "Total (s): " <+> p t <+> "  (eval + compile)"
-  pretty (MiscLog s) = "===" <+> p s <+> "==="
+  pretty (MiscLog s) = p s
 
 
 instance Pretty PassName where
@@ -573,13 +574,20 @@ instance Pretty (EnvFrag n l) where
     <> "Effects allowed:" <+> p effects
 
 instance Pretty (TopEnvFrag n l) where
-  pretty (TopEnvFrag bindings scs sourceMap) =
+  pretty (TopEnvFrag bindings scs sourceMap cache obj) =
        "bindings:"
     <>   indented (p bindings)
     <> "Synth candidats:"
     <>   indented (p scs)
     <> "Source map:"
     <>   indented (p sourceMap)
+    <> "Cache:"
+    <>   indented (p cache)
+    <> "Object files:"
+    <>   indented "<TODO: Pretty instance>"
+
+instance Pretty (Cache n) where
+  pretty (Cache _ _ _) = "<cache>" -- TODO
 
 instance Pretty (SynthCandidates n) where
   pretty scs =
@@ -609,7 +617,7 @@ instance Pretty IFunType where
 
 instance Pretty (ImpFunction n) where
   pretty (ImpFunction (IFunType cc _ _) (Abs bs body)) =
-    "def" <+> p cc <+> p bs
+    "impfun" <+> p cc <+> prettyBinderNest bs
     <> nest 2 (hardline <> p body) <> hardline
   pretty (FFIFunction _ f) = p f
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -8,7 +8,7 @@
 {-# LANGUAGE FlexibleInstances #-}
 {-# LANGUAGE TypeFamilies #-}
 
-module Simplify ( simplifyTopBlock, SimplifiedBlock (..)
+module Simplify ( simplifyTopBlock, simplifyTopFunction, SimplifiedBlock (..)
                 , simplifyBlock, liftSimplifyM, buildBlockSimplified
                 , IxCache, MonadIxCache1, SimpleIxInstance (..)
                 , simplifiedIxInstance, appSimplifiedIxMethod ) where
@@ -94,6 +94,13 @@ simplifyTopBlock block = liftImmut do
   return $ runSimplifyM env do
     (Abs UnitB block', recon) <- simplifyAbs $ Abs UnitB block
     return $ SimplifiedBlock block' recon
+
+simplifyTopFunction :: EnvReader m => NaryPiType n -> Atom n -> m n (NaryLamExpr n)
+simplifyTopFunction ty f = liftImmut do
+  DB env <- getDB
+  return $ runSimplifyM env do
+    buildNaryLamExpr ty \xs -> do
+      dropSubst $ simplifyExpr $ App (sink f) $ fmap Var xs
 
 instance GenericE SimplifiedBlock where
   type RepE SimplifiedBlock = PairE Block ReconstructAtom

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -119,7 +119,7 @@ instance SourceRenamableE (SourceNameOr UVar) where
       Just (WithColor DataDefNameRep _   ) -> error "Shouldn't find these in source map"
       Just (WithColor SuperclassNameRep _) -> error "Shouldn't find these in source map"
       Just (WithColor ImpFunNameRep     _) -> error "Shouldn't find these in source map"
-      Just (WithColor LLVMNameRep       _) -> error "Shouldn't find these in source map"
+      Just (WithColor ObjectFileNameRep _) -> error "Shouldn't find these in source map"
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 lookupSourceName :: Renamer m => SourceName -> m n (WithColor Name n)

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -118,6 +118,8 @@ instance SourceRenamableE (SourceNameOr UVar) where
       Just (WithColor MethodNameRep  name) -> return $ InternalName $ UMethodVar name
       Just (WithColor DataDefNameRep _   ) -> error "Shouldn't find these in source map"
       Just (WithColor SuperclassNameRep _) -> error "Shouldn't find these in source map"
+      Just (WithColor ImpFunNameRep     _) -> error "Shouldn't find these in source map"
+      Just (WithColor LLVMNameRep       _) -> error "Shouldn't find these in source map"
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 lookupSourceName :: Renamer m => SourceName -> m n (WithColor Name n)

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -345,7 +345,9 @@ evalLLVM block = do
                                         _        -> (EntryFun CUDANotRequired, False)
   ImpFunctionWithRecon impFun reconAtom <- checkPass ImpPass $
                                              toImpFunction backend cc blockAbs
-  llvmAST <- liftIO $ impToLLVM logger impFun
+  LiftE llvmAST <- liftImmut do
+    DB env <- getDB
+    liftM LiftE $ liftIO $ impToLLVM env logger impFun
   let IFunType _ _ resultTypes = impFunType impFun
   let llvmEvaluate = if bench then compileAndBench needsSync else compileAndEval
   resultVals <- liftIO $ llvmEvaluate logger llvmAST mainFuncName ptrVals resultTypes

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -226,7 +226,6 @@ transposeOp op ct = case op of
   ToOrdinal    _        -> notLinear
   IdxSetSize   _        -> notLinear
   ThrowError   _        -> notLinear
-  FFICall _ _ _         -> notLinear
   DataConTag _          -> notLinear
   ToEnum _ _            -> notLinear
   ThrowException _      -> notLinear

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -865,30 +865,27 @@ def fromLeftFloat (x:(Float | Int)) : Float =
 :p fromLeftFloat $ Left 1.2
 > 1.2
 
--- TODO: revive these tests once we have automatic inlining control
+@noinline
+def f1 (x:Int) : Int = x + 1
 
--- @noinline
--- def f1 (x:Int) : Int = x + 1
+@noinline
+def f2 (x:Int) : Int = f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ x
 
--- @noinline
--- def f2 (x:Int) : Int = f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ f1 $ x
+@noinline
+def f3 (x:Int) : Int = f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ x
 
--- @noinline
--- def f3 (x:Int) : Int = f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ f2 $ x
+@noinline
+def f4 (x:Int) : Int = f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ x
 
--- @noinline
--- def f4 (x:Int) : Int = f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ f3 $ x
+@noinline
+def f5 (x:Int) : Int = f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ x
 
--- @noinline
--- def f5 (x:Int) : Int = f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ x
+@noinline
+def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 
--- @noinline
--- def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
-
--- -- This will compile extremely slowly if non-inlining is broken
--- :p f6 0
--- > 100000
-
+-- This will compile extremely slowly if non-inlining is broken
+:p f6 0
+> 100000
 
 -- Testing integer powers
 


### PR DESCRIPTION
A first step towards not inlining everything.