### PR TITLE
Define unzipping and transposition rules for App in the Linear A prototype.

### DIFF
--- a/test/LinearASpec.hs
+++ b/test/LinearASpec.hs
@@ -44,8 +44,8 @@ gradient prog f args = do
   -- The tape is a tuple at the end; split it into a singleton list
   let (primal, tape) = splitAt (length primal_tape - 1) primal_tape
   (Result primal []) `shouldBe` expPrimal
-  let (Result empty grad) = evalFunc tujProg (f ++ ".lin") tape [FloatVal 1.0]
-  empty `shouldBe` []
+  let (Result empty2 grad) = evalFunc tujProg (f ++ ".lin") tape [FloatVal 1.0]
+  empty2 `shouldBe` []
   return grad
 
 spec :: Spec
@@ -212,7 +212,7 @@ spec = do
       grad <- gradient p "add" [2.0, 2.0]
       grad `shouldBe` [FloatVal 1.0, FloatVal 1.0]
 
-    xit "function call" $ do
+    it "function call" $ do
       let p = Program $ M.fromList
                 [ ("add", add_func)
                 , ("f", FuncDef [("x", FloatType), ("y", FloatType)] [] (MixedType [FloatType] []) $


### PR DESCRIPTION
Unzipping in the presence of App is a bit subtle, because we need to
typecheck the unzipped function body in order to know what type to
declare for the tape.  But the Program in which we need to typecheck
it must have all callees already unzipped!  For now, I tied the knot
with Haskell's laziness (instead of trying to explicitly compute the
call graph); seems to work on the examples present in the test suite.

I also carry around the original (pre-unzipping) program to look up
the number of results callees return, so that I know how many
variables to allocate to hold them.

Finally, added better error checking in case an unzipped program fails
to typecheck (for debugging the unzip transformation).