### PR TITLE
Add limited support for first-class record labels

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -22,6 +22,8 @@ Word64 = %Word64
 Byte = Word8
 Char = Byte
 
+Label = %Label
+
 RawPtr : Type = %Word8Ptr
 
 Int = Int32

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -859,7 +859,7 @@ makeDestRec idxs depVars ty = case ty of
       rTy' <- applySubst (lBinder@>v) rTy
       makeDestRec idxs' depVars' rTy'
     return $ DepPairRef lDest rDestAbs depPairTy
-  RecordTy (NoExt types) -> (Con . RecordRef) <$> forM types rec
+  RecordTy Nothing (NoExt types) -> (Con . RecordRef) <$> forM types rec
   VariantTy (NoExt types) -> recSumType $ toList types
   TC con -> case con of
     BaseType b -> do

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -269,7 +269,7 @@ linearizeAtom atom = case atom of
       return $ Variant (fromExtLabeledItemsE $ sink t') l i e'
   TypeCon _ _ _   -> emitZeroT
   LabeledRow _    -> emitZeroT
-  RecordTy _      -> emitZeroT
+  RecordTy _ _    -> emitZeroT
   VariantTy _     -> emitZeroT
   Pi _            -> emitZeroT
   DepPairTy _     -> emitZeroT
@@ -496,6 +496,7 @@ linearizePrimCon con = case con of
   IntRangeVal _ _ _     -> emitZeroT
   IndexRangeVal _ _ _ _ -> emitZeroT
   IndexSliceVal _ _ _   -> emitZeroT
+  LabelCon _     -> error "Unexpected label"
   BaseTypeRef _  -> error "Unexpected ref"
   TabRef _       -> error "Unexpected ref"
   ConRef _       -> error "Unexpected ref"

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -604,9 +604,7 @@ type MaybeB b = EitherB b UnitB
 pattern JustB :: b n l -> MaybeB b n l
 pattern JustB b = LeftB b
 
--- TODO: this doesn't seem to force n==n, e.g. see where we have to explicitly
--- write `RightB UnitB` in inference rule for instances.
-pattern NothingB :: MaybeB b n n
+pattern NothingB :: () => (n ~ l) => MaybeB b n l
 pattern NothingB = RightB UnitB
 
 data LiftB (e::E) (n::S) (l::S) where

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -210,6 +210,8 @@ transposeOp op ct = case op of
   VectorIndex  _ _      -> notImplemented
   CastOp       _ _      -> notImplemented
   RecordCons   _ _      -> notImplemented
+  RecordConsDynamic _ _ _ -> notImplemented
+  RecordSplitDynamic _ _  -> notImplemented
   RecordSplit  _ _      -> notImplemented
   VariantLift  _ _      -> notImplemented
   VariantSplit _ _      -> notImplemented
@@ -256,7 +258,7 @@ transposeAtom atom ct = case atom of
   Lam _           -> notTangent
   TypeCon _ _ _   -> notTangent
   LabeledRow _    -> notTangent
-  RecordTy _      -> notTangent
+  RecordTy _ _    -> notTangent
   VariantTy _     -> notTangent
   Pi _            -> notTangent
   DepPairTy _     -> notTangent
@@ -324,6 +326,7 @@ transposeCon con ct = case con of
   IndexRangeVal _ _ _ _ -> notTangent
   IndexSliceVal _ _ _   -> notTangent
   ParIndexCon _ _       -> notTangent
+  LabelCon _     -> notTangent
   BaseTypeRef _  -> notTangent
   TabRef _       -> notTangent
   ConRef _       -> notTangent

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -382,3 +382,46 @@ variantsAsIndices : {a:Fin 10 | b:Fin 3}=>{a:Fin 10 | b:Fin 3} = for i. i
 > , {| b = 0@Fin 3 |}
 > , {| b = 1@Fin 3 |}
 > , {| b = 2@Fin 3 |} ]@{a: Fin 10 | b: Fin 3}
+
+-- === First-class labels ===
+
+abc : Label = ##abc
+:t abc
+> Label
+
+q = {@abc=1, y=2}
+q
+> {abc = 1, y = 2}
+:t q
+> {abc: Int32 & y: Int32}
+
+:p
+  {@abc=xv, y=yv} = q
+  (xv, yv)
+> (1, 2)
+
+def projectField {r t} (l: Label) (x: {@l:t & ...r}) : t =
+  {@l=v, ...} = x
+  v
+
+projectField ##a {a=1, b=2}
+> 1
+
+def addField {r1 r2} (l: Label) (x: {@l:Int & ...r1}) (y: {@l:Int & ...r2}) : Int =
+  {@l=v1, ...} = x
+  {@l=v2, ...} = y
+  v1 + v2
+
+addField ##b {a=1, b=2} {b=2, c=4}
+> 4
+
+def badProject (l: Label) (x: {@l:Int & l:Float}) : Float =
+  {l=lv, ...} = x
+  lv
+> Type error:
+> Expected: {l: a & ...b1}
+>   Actual: {@l: Int32 & l: Float32}
+> (Solving for: [a, b1])
+>
+>   {l=lv, ...} = x
+>   ^^^^^^^^^^^^


### PR DESCRIPTION
This change extends our record system with an option to have a single
field with a statically unknown label in front of the static labels and
the row extension (which we supported previously). For example the type
```
{@v: Int & v: Float & ...rest}
```
represents to a record with a field of type `Int` and a _dynamic label name_,
specified by the variable `v` (which should be of type `Label` --- that's
another addition). The record also has a field with statically known
name called `v` (for maximum confusion) of type `Float` and a
polymorphic tail of other fields given by `rest`.

`Label`-typed values can be created using the `##name` syntax, similarly
to how we use `#name` for lenses. We might want to revisit this sugar in
the future, but this was the path of least resistance for now.

An interesting property of our type system is that it allows both
dynamic labels and label shaddowing, which to the best of my knowledge
is unique. Doing so lets us avoid dealing with lots of awkward typeclass
constraints of the form "dynamic label disjoint form record". It's
possible that there are some contradictions lurking there, but so far it
does seem to be sound. The trick was to forbid the projection of static
fields that are preceded by a dynamically named one. This means that to
unpack a record type as shown above, one _always_ has to unpack the `@v`
field before they project out the `v` field. So for example this is a
type error:
```
{v=vf, ...} = record
```
but this is allowed
```
{@v=dvf, v=vf, ...} = record
```
This makes it possible to resolve the unpacks statically without having
to worry whether the variable `v` could later get instantiaed to `##v`.