### PR TITLE
Generalize the Core representation of field rows

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -135,7 +135,7 @@ another. For instance:
 %passes parse
 :t #&a : Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
->    ({ &} & {a: Int32 & b: Float32 & c: Unit})
+>    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
 > (MkIso
 >    { bwd = \({a = (), ...()}, {, ...()}). (,) {, ...l} {a = x, ...r}
@@ -144,7 +144,7 @@ another. For instance:
 
 :t (#&a &>> #&b) : Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
->    ({ &} & {a: Int32 & b: Float32 & c: Unit})
+>    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32 & b: Float32} & {c: Unit}))
 
 '`#&a` and `#&b` are isomorphisms that move a given field from the record on the
@@ -159,7 +159,7 @@ when using a record type as an index set:
 >  ?-> (c:Type)
 >  ?-> (v:Type)
 >  ?-> (Ix b)
->  ?=> (Ix c) ?=> (Iso ({ &} & a) (b & c)) -> (Ix a) ?=> (a => v) -> b => c => v)
+>  ?=> (Ix c) ?=> (Iso ({&} & a) (b & c)) -> (Ix a) ?=> (a => v) -> b => c => v)
 
 -- :p
 --   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
@@ -176,7 +176,7 @@ when using a record type as an index set:
 `overLens`:
 
 :t splitR
-> ((a:Type) ?-> Iso a ({ &} & a))
+> ((a:Type) ?-> Iso a ({&} & a))
 
 :t overLens
 > ((a:Type)

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -737,7 +737,7 @@ zeroAt :: HasCallStack => Builder m => Type n -> m n (Atom n )
 zeroAt ty = case ty of
   BaseTy bt  -> return $ Con $ Lit $ zeroLit bt
   ProdTy tys -> ProdVal <$> mapM zeroAt tys
-  RecordTy Nothing (Ext tys Nothing) -> Record <$> mapM zeroAt tys
+  StaticRecordTy tys -> Record <$> mapM zeroAt tys
   TabTy b bodyTy ->
     liftEmitBuilder $ buildTabLam (getNameHint b) (binderType b) \i ->
       zeroAt =<< applySubst (b@>i) bodyTy
@@ -761,7 +761,7 @@ tangentType ty = case maybeTangentType ty of
 
 maybeTangentType :: Type n -> Maybe (Type n)
 maybeTangentType ty = case ty of
-  RecordTy Nothing (NoExt items) -> RecordTy Nothing <$> NoExt <$> mapM maybeTangentType items
+  StaticRecordTy items -> StaticRecordTy <$> mapM maybeTangentType items
   TypeCon _ _ _ -> Nothing -- Need to synthesize or look up a tangent ADT
   Pi (PiType b@(PiBinder _ _ TabArrow) Pure bodyTy) -> do
     bodyTanTy <- maybeTangentType bodyTy
@@ -788,7 +788,7 @@ tangentBaseMonoidFor ty = do
 addTangent :: (Emits n, Builder m) => Atom n -> Atom n -> m n (Atom n)
 addTangent x y = do
   getType x >>= \case
-    RecordTy Nothing (NoExt tys) -> do
+    StaticRecordTy tys -> do
       elems <- bindM2 (zipWithM addTangent) (getUnpacked x) (getUnpacked y)
       return $ Record $ restructure elems tys
     TabTy b _  -> liftEmitBuilder $ buildFor (getNameHint b) Fwd (binderType b) \i -> do

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -52,8 +52,7 @@ cheapReduceWithDecls decls result = publicResultFromE <$> liftImmut do
     cheapReduceWithDeclsB decls' $
       cheapReduceE result'
 
--- Reduction of atoms always succeeds (though it might get stuck immediately).
-cheapNormalize :: EnvReader m => Atom n -> m n (Atom n)
+cheapNormalize :: (EnvReader m, CheaplyReducibleE e e, NiceE e) => e n -> m n (e n)
 cheapNormalize a = fromJust . fst <$> cheapReduce a
 
 -- === internal ===
@@ -252,3 +251,6 @@ instance (CheaplyReducibleE e1 e1', CheaplyReducibleE e2 e2')
 
 instance CheaplyReducibleE EffectRow EffectRow where
   cheapReduceE row = cheapReduceFromSubst row
+
+instance CheaplyReducibleE FieldRowElems FieldRowElems where
+  cheapReduceE elems = cheapReduceFromSubst elems

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -859,7 +859,7 @@ makeDestRec idxs depVars ty = case ty of
       rTy' <- applySubst (lBinder@>v) rTy
       makeDestRec idxs' depVars' rTy'
     return $ DepPairRef lDest rDestAbs depPairTy
-  RecordTy Nothing (NoExt types) -> (Con . RecordRef) <$> forM types rec
+  StaticRecordTy types -> (Con . RecordRef) <$> forM types rec
   VariantTy (NoExt types) -> recSumType $ toList types
   TC con -> case con of
     BaseType b -> do

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -85,7 +85,7 @@ traverseSurfaceAtomNames atom doWithName = case atom of
     DataCon printName defName' <$> mapM rec params
                                <*> pure con <*> mapM rec args
   Record items -> Record <$> mapM rec items
-  RecordTy _ _ -> substM atom
+  RecordTy _ -> substM atom
   Variant ty l con payload ->
     Variant
        <$> (fromExtLabeledItemsE <$> substM (ExtLabeledItemsE ty))

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -269,7 +269,7 @@ linearizeAtom atom = case atom of
       return $ Variant (fromExtLabeledItemsE $ sink t') l i e'
   TypeCon _ _ _   -> emitZeroT
   LabeledRow _    -> emitZeroT
-  RecordTy _ _    -> emitZeroT
+  RecordTy _      -> emitZeroT
   VariantTy _     -> emitZeroT
   Pi _            -> emitZeroT
   DepPairTy _     -> emitZeroT

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -258,7 +258,7 @@ transposeAtom atom ct = case atom of
   Lam _           -> notTangent
   TypeCon _ _ _   -> notTangent
   LabeledRow _    -> notTangent
-  RecordTy _ _    -> notTangent
+  RecordTy _      -> notTangent
   VariantTy _     -> notTangent
   Pi _            -> notTangent
   DepPairTy _     -> notTangent

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -10,6 +10,7 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE UndecidableInstances #-}
 {-# LANGUAGE StandaloneDeriving #-}
+{-# LANGUAGE ViewPatterns #-}
 
 module Type (
   HasType (..), CheckableE (..), CheckableB (..),
@@ -374,17 +375,9 @@ instance HasType Atom where
       params' <- traverse checkE params
       void $ checkedApplyNaryAbs (Abs tyParamNest' (ListE absCons')) params'
       return TyKind
-    LabeledRow row -> checkLabeledRow row $> LabeledRowKind
-    Record items -> do
-      types <- mapM getTypeE items
-      return $ RecordTy Nothing (NoExt types)
-    RecordTy labExt row -> do
-      case labExt of
-        Nothing -> return ()
-        Just (labVar, ty) -> do
-          void $ checkTypeE (TC LabelType) (Var labVar)
-          void $ checkTypeE TyKind ty
-      checkLabeledRow row $> TyKind
+    LabeledRow elems -> checkFieldRowElems elems $> LabeledRowKind
+    Record items -> StaticRecordTy <$> mapM getTypeE items
+    RecordTy elems -> checkFieldRowElems elems $> TyKind
     Variant vtys@(Ext (LabeledItems types) _) label i arg -> do
       let ty = VariantTy vtys
       let argTy = do
@@ -440,8 +433,8 @@ instance HasType Atom where
           dropSubst $
             applyNaryAbs (Abs bsInit bTy) [ SubstVal (ProjectElt (j NE.:| is) v')
                                           | j <- iota $ nestLength bsInit]
-        RecordTy Nothing (NoExt types) -> return $ toList types !! i
-        RecordTy _ _ -> throw CompilerErr "Can't project partially-known records"
+        StaticRecordTy types -> return $ toList types !! i
+        RecordTy _ -> throw CompilerErr "Can't project partially-known records"
         ProdTy xs -> return $ xs !! i
         DepPairTy t | i == 0 -> return $ depPairLeftTy t
         DepPairTy t | i == 1 -> do v' <- substM v
@@ -609,7 +602,7 @@ typeCheckPrimCon con = case con of
       RawRefTy <$> substM ty
     _ -> error $ "Not a valid ref: " ++ pprint conRef
   ParIndexCon t v -> t|:TyKind >> v|:IdxRepTy >> substM t
-  RecordRef xs -> (RawRefTy . RecordTy Nothing . NoExt) <$> traverse typeCheckRef xs
+  RecordRef xs -> (RawRefTy . StaticRecordTy) <$> traverse typeCheckRef xs
   LabelCon _   -> return $ TC $ LabelType
 
 typeCheckPrimOp :: Typer m => PrimOp (Atom i) -> m i o (Type o)
@@ -718,54 +711,48 @@ typeCheckPrimOp op = case op of
   RecordCons items record -> do
     types <- mapM getTypeE items
     rty <- getTypeE record
-    rest <- case rty of
-      RecordTy Nothing rest -> return rest
-      RecordTy _ _ -> throw TypeErr $
-        "Can't add fields to a record " <> pprint record <> " with dynamic " <>
-        "label extension (it is of type " <> pprint rty <> ")"
+    case rty of
+      RecordTy rest -> return $ RecordTy $ prependFieldRowElem (StaticFields types) rest
       _ -> throw TypeErr $ "Can't add fields to a non-record object "
                         <> pprint record <> " (of type " <> pprint rty <> ")"
-    return $ RecordTy Nothing $ prefixExtLabeledItems types rest
   RecordConsDynamic lab val record -> do
     lab' <- checkTypeE (TC LabelType) lab
     vty <- getTypeE val
     rty <- getTypeE record
     case rty of
-      RecordTy Nothing rest -> case lab' of
-        Con (LabelCon l) -> return $ RecordTy Nothing $ prefixExtLabeledItems (labeledSingleton l vty) rest
-        Var labVar       -> return $ RecordTy (Just (labVar, vty)) rest
+      RecordTy rest -> case lab' of
+        Con (LabelCon l) -> return $ RecordTy $ prependFieldRowElem (StaticFields (labeledSingleton l vty)) rest
+        Var labVar       -> return $ RecordTy $ prependFieldRowElem (DynField labVar vty) rest
         _ -> error "Unexpected label atom"
-      RecordTy _ _ -> throw TypeErr $
-        "Can't add a dynamic field to a record that already has one"
       _ -> throw TypeErr $ "Can't add a dynamic field to a non-record value of type " <> pprint rty
   RecordSplitDynamic lab record -> do
     lab' <- cheapNormalize =<< checkTypeE (TC LabelType) lab
     rty <- getTypeE record
     case (lab', rty) of
-      (Con (LabelCon l), RecordTy Nothing (Ext items rest)) -> do
+      (Con (LabelCon l), RecordTyWithElems (StaticFields items:rest)) -> do
         -- We could cheap normalize the rest to increase the chance of this
-        -- succeeding, but no need to for now./
+        -- succeeding, but no need to for now.
         unless (isJust $ lookupLabelHead items l) $ throw TypeErr "Label not immediately present in record"
         let (h, items') = splitLabeledItems (labeledSingleton l ()) items
-        return $ PairTy (head $ toList h) $ RecordTy Nothing $ Ext items' rest
-      (Var labVar', RecordTy (Just (labVar'', ty)) rest) | labVar' == labVar'' ->
-        return $ PairTy ty $ RecordTy Nothing rest
+        return $ PairTy (head $ toList h) $ RecordTyWithElems (StaticFields items':rest)
+      (Var labVar', RecordTyWithElems (DynField labVar'' ty:rest)) | labVar' == labVar'' ->
+        return $ PairTy ty $ RecordTyWithElems rest
       -- There are more cases we could implement, but do we need to?
       _ -> throw TypeErr $ "Can't split a label " <> pprint lab' <> " from atom of type " <> pprint rty
   RecordSplit types record -> do
     mapM_ (|: TyKind) types
     types' <- mapM substM types
     fullty <- getTypeE record
-    full <- case fullty of
-      RecordTy Nothing full -> return full
-      RecordTy _ _ -> throw TypeErr $
+    (fullItems, rest) <- case fullty of
+      RecordTyWithElems (StaticFields items:rest) -> return (items, rest)
+      RecordTy _ -> throw TypeErr $
         "Can't split a record " <> pprint record <> " with dynamic " <>
         "label extension (it is of type " <> pprint fullty <> ")"
       _ -> throw TypeErr $ "Can't split a non-record object " <> pprint record
                         <> " (of type " <> pprint fullty <> ")"
-    diff <- labeledRowDifference full (NoExt types')
-    return $ RecordTy Nothing $ NoExt $
-      Unlabeled [ RecordTy Nothing (NoExt types'), RecordTy Nothing diff ]
+    NoExt diff <- labeledRowDifference (NoExt fullItems) (NoExt types')
+    return $ StaticRecordTy $ Unlabeled
+      [ StaticRecordTy types', RecordTyWithElems (StaticFields diff:rest) ]
   VariantLift types variant -> do
     mapM_ (|: TyKind) types
     types' <- mapM substM types
@@ -1192,7 +1179,7 @@ isSingletonType topTy =
     checkIsSingleton :: Type n -> Maybe ()
     checkIsSingleton ty = case ty of
       Pi (PiType _ _ body) -> checkIsSingleton body
-      RecordTy Nothing (NoExt items) -> mapM_ checkIsSingleton items
+      StaticRecordTy items -> mapM_ checkIsSingleton items
       TC con -> case con of
         ProdType tys -> mapM_ checkIsSingleton tys
         _ -> Nothing
@@ -1214,7 +1201,7 @@ singletonTypeVal' ty = case ty of
     substBinders b \b' -> do
       body' <- singletonTypeVal' body
       return $ Pi $ PiType b' Pure body'
-  RecordTy Nothing (NoExt items) -> Record <$> traverse singletonTypeVal' items
+  StaticRecordTy items -> Record <$> traverse singletonTypeVal' items
   TC con -> case con of
     ProdType tys -> ProdVal <$> traverse singletonTypeVal' tys
     _            -> notASingleton
@@ -1294,6 +1281,17 @@ oneEffect eff = EffectRow (S.singleton eff) Nothing
 
 -- === labeled row types ===
 
+checkFieldRowElems :: Typer m => FieldRowElems i -> m i o ()
+checkFieldRowElems els = mapM_ checkElem elemList
+  where
+    elemList = fromFieldRowElems els
+    checkElem = \case
+      StaticFields items -> checkLabeledRow $ NoExt items
+      DynField labVar ty -> do
+        Var labVar |: TC LabelType
+        ty |: TyKind
+      DynFields row -> checkLabeledRow $ Ext mempty $ Just row
+
 checkLabeledRow :: Typer m => ExtLabeledItems (Type i) (AtomName i) -> m i o ()
 checkLabeledRow (Ext items rest) = do
   mapM_ (|: TyKind) items
@@ -1334,7 +1332,7 @@ projectLength ty = case ty of
     def <- lookupDataDef defName
     [DataConDef _ (Abs bs UnitE)] <- instantiateDataDef def params
     return $ nestLength bs
-  RecordTy Nothing (NoExt types) -> return $ length types
+  StaticRecordTy types -> return $ length types
   ProdTy tys -> return $ length tys
   _ -> error $ "Projecting a type that doesn't support projecting: " ++ pprint ty
 
@@ -1410,7 +1408,7 @@ checkDataLike ty = case ty of
     Immut <- getImmut
     substBinders b \_ ->
       checkDataLike eltTy
-  RecordTy Nothing (NoExt items) -> mapM_ recur items
+  StaticRecordTy items -> mapM_ recur items
   VariantTy (NoExt items) -> mapM_ recur items
   DepPairTy (DepPairType b@(_:>l) r) -> do
     recur l

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -5,7 +5,7 @@ Syntax for records, variants, and their types.
 'Record types
 
 :p {&}
-> { &}
+> {&}
 
 :p {a:Int & b:Float}
 > {a: Int32 & b: Float32}
@@ -22,12 +22,12 @@ Syntax for records, variants, and their types.
 :p {}
 > {}
 :t {}
-> { &}
+> {&}
 
 :p {,}
 > {}
 :t {,}
-> { &}
+> {&}
 
 :p {a=3, b=4}
 > {a = 3, b = 4}


### PR DESCRIPTION
The new representation makes it possible to arbitrarily interleave
fields with statically known names, fields with dynamic names and field
rows (which now can also refer to dynamic names too). This extra
generality is inaccessible from the surface language yet, but exposing
it is the next step.