### PR TITLE
Generalize untyped syntax and parser to support field row extensions 

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -45,21 +45,21 @@ that produce isos. We will start with the first two:
 %passes parse
 :t #b : Iso {a:Int & b:Float & c:Unit} _
 > (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
-> (MkIso {bwd = \(x, r). {b = x, ...r}, fwd = \{b = (), ...()}. (,) x r}
+> (MkIso {fwd=(\{b = (), ...()}. (,) x r), bwd=(\(x, r). {b=x, ...r})}
 >  : Iso {a: Int & b: Float & c: Unit} _)
 
 %passes parse
 :t #?b : Iso {a:Int | b:Float | c:Unit} _
 > (Iso {a: Int32 | b: Float32 | c: Unit} (Float32 | {a: Int32 | c: Unit}))
 > (MkIso
->    { bwd = \v. case v
->                ((Left x)) -> {| b = x |}
->                ((Right r)) -> {|b| ...r |}
->                
->    , fwd = \v. case v
->                {| b = x |} -> (Left x)
->                {|b| ...r |} -> (Right r)
->                }
+>    {fwd=(\v. case v
+>              {| b = x |} -> (Left x)
+>              {|b| ...r |} -> (Right r)
+>              )
+>    , bwd=(\v. case v
+>               ((Left x)) -> {| b = x |}
+>               ((Right r)) -> {|b| ...r |}
+>               )}
 >  : Iso {a: Int | b: Float | c: Unit} _)
 
 'There are also two "zipper" forms, described later on this page:
@@ -138,9 +138,9 @@ another. For instance:
 >    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
 > (MkIso
->    { bwd = \({a = (), ...()}, {, ...()}). (,) {, ...l} {a = x, ...r}
->    , fwd = \({, ...()}, {a = (), ...()}). (,) {a = x, ...l} {, ...r}}
->  : Iso ((&) { &} {a: Int & b: Float & c: Unit}) _)
+>    {fwd=(\({, ...()}, {a = (), ...()}). (,) {a=x, ...l} {...r})
+>    , bwd=(\({a = (), ...()}, {, ...()}). (,) {...l} {a=x, ...r})}
+>  : Iso ((&) {} {a: Int & b: Float & c: Unit}) _)
 
 :t (#&a &>> #&b) : Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
@@ -229,20 +229,20 @@ zipper isomorphisms:
 >    ({ |} | {a: Int32 | b: Float32 | c: Unit})
 >    ({a: Int32} | {b: Float32 | c: Unit}))
 > (MkIso
->    { bwd = \v. case v
->                ((Left w)) -> (case w
->                                 {| a = x |} -> (Right {| a = x |})
->                                 {|a| ...r |} -> (Left r)
->                                 )
->                ((Right l)) -> (Right {|a| ...l |})
->                
->    , fwd = \v. case v
->                ((Left l)) -> (Left {|a| ...l |})
->                ((Right w)) -> (case w
->                                  {| a = x |} -> (Left {| a = x |})
->                                  {|a| ...r |} -> (Right r)
->                                  )
->                }
+>    {fwd=(\v. case v
+>              ((Left l)) -> (Left {|a| ...l |})
+>              ((Right w)) -> (case w
+>                                {| a = x |} -> (Left {| a = x |})
+>                                {|a| ...r |} -> (Right r)
+>                                )
+>              )
+>    , bwd=(\v. case v
+>               ((Left w)) -> (case w
+>                                {| a = x |} -> (Right {| a = x |})
+>                                {|a| ...r |} -> (Left r)
+>                                )
+>               ((Right l)) -> (Right {|a| ...l |})
+>               )}
 >  : Iso ((|) { |} {a: Int | b: Float | c: Unit}) _)
 
 '`splitV` makes a prism zipper into an ordinary prism isomorphism:

--- a/makefile
+++ b/makefile
@@ -178,10 +178,7 @@ update-gpu-tests: tests/gpu-tests.dx build
 	$(dex) --backend llvm-cuda script --allow-errors $< > $<.tmp
 	mv $<.tmp $<
 
-uexpr-tests:
-	misc/check-quine examples/uexpr-tests.dx $(dex) script
-
-repl-test:
+repl-test: build
 	misc/check-no-diff \
 	  tests/repl-multiline-test-expected-output \
 	  <($(dex) repl < tests/repl-multiline-test.dx)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -396,9 +396,9 @@ linearizeOp op = case op of
           _                -> error "Expected at least one side of the CastOp to have a trivial tangent type"
         y <- emitOp $ CastOp t' x
         return $ WithTangent y do xt >> return (sink yt)
-  RecordCons vs r ->
-    zipLin (traverseLin la vs) (la r) `bindLin` \(PairE (ComposeE vs') r') ->
-      emitOp $ RecordCons vs' r'
+  RecordCons l r ->
+    zipLin (la l) (la r) `bindLin` \(PairE l' r') ->
+      emitOp $ RecordCons l' r'
   RecordSplit vs r ->
     zipLin (traverseLin la vs) (la r) `bindLin` \(PairE (ComposeE vs') r') ->
       emitOp $ RecordSplit vs' r'

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -760,8 +760,7 @@ instance PrettyPrec e => PrettyPrec (PrimOp e) where
     PrimEffect ref (MExtend _   x ) -> atPrec LowestPrec $ "extend" <+> pApp ref <+> pApp x
     PtrOffset ptr idx -> atPrec LowestPrec $ pApp ptr <+> "+>" <+> pApp idx
     PtrLoad   ptr     -> atPrec AppPrec $ pAppArg "load" [ptr]
-    RecordCons items rest ->
-      prettyExtLabeledItems (Ext items $ Just rest) Nothing (line' <> ",") " ="
+    RecordCons items rest -> atPrec LowestPrec $ "RecordCons" <+> pArg items <+> pArg rest
     RecordConsDynamic lab val rec -> atPrec LowestPrec $
       "RecordConsDynamic" <+> pArg lab <+> pArg val <+> pArg rec
     RecordSplit types val -> atPrec AppPrec $

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -44,6 +44,7 @@ module Syntax (
     IRVariant (..), SubstVal (..), AtomName, DataDefName, ClassName, AtomSubstVal,
     SourceName, SourceNameOr (..), UVar (..), UBinder (..),
     UExpr, UExpr' (..), UConDef, UDataDef (..), UDataDefTrail (..), UDecl (..),
+    UFieldRowElems, UFieldRowElem (..),
     ULamExpr (..), UPiExpr (..), UDeclExpr (..), UForExpr (..), UAlt (..),
     UPat, UPat' (..), UPatAnn (..), UPatAnnArrow (..),
     UMethodDef (..), UAnnBinder (..),
@@ -882,16 +883,21 @@ data UExpr' (n::S) =
  | UIndexRange (Limit (UExpr n)) (Limit (UExpr n))
  | UPrimExpr (PrimExpr (UExpr n))
  | ULabel String
- | URecord (Maybe (SourceNameOr UVar n, UExpr n))
-           (ExtLabeledItems (UExpr n) (UExpr n))     -- {@v=x, a=y, b=z, ...rest}
+ | URecord (UFieldRowElems n)                        -- {@v=x, a=y, b=z, ...rest}
  | UVariant (LabeledItems ()) Label (UExpr n)        -- {|a|b| a=x |}
  | UVariantLift (LabeledItems ()) (UExpr n)          -- {|a|b| ...rest |}
- | URecordTy (Maybe (SourceNameOr UVar n, UExpr n))
-             (ExtLabeledItems (UExpr n) (UExpr n))   -- {@v:X & a:Y & b:Z & ...rest}
+ | URecordTy (UFieldRowElems n)                      -- {@v:X & a:Y & b:Z & ...rest}
  | UVariantTy (ExtLabeledItems (UExpr n) (UExpr n))  -- {a:X | b:Y | ...rest}
  | UIntLit  Int
  | UFloatLit Double
   deriving (Show, Generic)
+
+type UFieldRowElems (n::S) = [UFieldRowElem n]
+data UFieldRowElem (n::S)
+  = UStaticField String                (UExpr n)
+  | UDynField    (SourceNameOr UVar n) (UExpr n)
+  | UDynFields   (UExpr n)
+  deriving (Show)
 
 data ULamExpr (n::S) where
   ULamExpr :: Arrow -> UPatAnn n l -> UExpr l -> ULamExpr n

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -1135,8 +1135,8 @@ data PrimOp e =
       | ThrowException e             -- Catchable exceptions (unlike `ThrowError`)
       | CastOp e e                   -- Type, then value. See Type.hs for valid coercions.
       -- Extensible record and variant operations:
-      -- Add fields to a record (on the left). Left arg contains values to add.
-      | RecordCons   (LabeledItems e) e
+      -- Concatenate two records.
+      | RecordCons   e e
       -- Split {a:A & b:B & ...rest} into (effectively) {a:A & b:B} & {&...rest}.
       -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
       | RecordSplit  (LabeledItems e) e

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -708,13 +708,13 @@ typeCheckPrimOp op = case op of
     destTy' <- substM destTy
     checkValidCast sourceTy' destTy'
     return $ destTy'
-  RecordCons items record -> do
-    types <- mapM getTypeE items
-    rty <- getTypeE record
-    case rty of
-      RecordTy rest -> return $ RecordTy $ prependFieldRowElem (StaticFields types) rest
-      _ -> throw TypeErr $ "Can't add fields to a non-record object "
-                        <> pprint record <> " (of type " <> pprint rty <> ")"
+  RecordCons l r -> do
+    lty <- getTypeE l
+    rty <- getTypeE r
+    case (lty, rty) of
+      (RecordTyWithElems lelems, RecordTyWithElems relems) ->
+        return $ RecordTyWithElems $ lelems ++ relems
+      _ -> throw TypeErr $ "Can't concatenate " <> pprint lty <> " and " <> pprint rty <> " as records"
   RecordConsDynamic lab val record -> do
     lab' <- checkTypeE (TC LabelType) lab
     vty <- getTypeE val

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -155,7 +155,7 @@ def getTwoFoosAndABar {a b c} {rest : Fields}
   (a1, a2, b)
 > Type error:
 > Expected: {a: c & a: d & b: e}
->   Actual: {a: a & b: b1}
+>   Actual: {a: b1 & b: a}
 > (Solving for: [a, b1, c, d, e])
 >
 >   ({b=b, a=a1, a=a2}) = {a=1, b=2}

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -425,3 +425,21 @@ def badProject (l: Label) (x: {@l:Int & l:Float}) : Float =
 >
 >   {l=lv, ...} = x
 >   ^^^^^^^^^^^^
+
+def concatRecords {f f'} (x: {&...f}) (y: {&...f'}) : ({...f & ...f'}) =
+  {...x, ...y}
+
+concatRecords {a=1} {b=2}
+> {a = 1, b = 2}
+
+-- TODO: Add support for richer pattern syntax
+def projectTwo {f a b} (l1: Label) (l2: Label) (x: {@l1:a & @l2:b & ...f}) : (a & b) = todo
+  {@l1=v1, @l2=v2, ...} = x
+  (v1 & v2)
+
+> Parse error:437:3:
+>     |
+> 437 |   {@l1=v1, @l2=v2, ...} = x
+>     |   ^^
+> unexpected "{@"
+> expecting end of line


### PR DESCRIPTION
This lets us spell out the new richer Core record types in the surface
language.