### PR TITLE
Further increase coverage of the Linear A prototype; align a little more with the paper.

### DIFF
--- a/src/LinearA.hs
+++ b/src/LinearA.hs
@@ -614,6 +614,9 @@ unzipExpr orig scope subst expr = case expr of
     where
       ((sCtx, sCtxScope), us, us') = rec scope     subst s
       ((eCtx, eCtxScope), ue, ue') = rec sCtxScope subst e
+  Dup e -> ((ctx, ctxScope), ue, Dup ue')
+    where
+      ((ctx, ctxScope), ue, ue') = rec scope subst e
   _ -> error $ "Unzip not implemented: " ++ show (pretty expr)
   where
     rec = unzipExpr orig

--- a/test/LinearASpec.hs
+++ b/test/LinearASpec.hs
@@ -205,6 +205,10 @@ spec = do
         LetMixed ["z"] [] (BinOp Add (Var "x") (Var "y")) $
         Var "z"
 
+  let double_func = FuncDef [("x", FloatType)] [] (MixedType [FloatType] []) $
+        LetMixed ["z"] [] (BinOp Add (Var "x") (Var "x")) $
+        Var "z"
+
   describe "End-to-end reverse-mode" $ do
 
     it "x + y" $ do
@@ -221,3 +225,8 @@ spec = do
                 ]
       grad <- gradient p "f" [2.0, 2.0]
       grad `shouldBe` [FloatVal 1.0, FloatVal 1.0]
+
+    it "x + x should add dup" $ do
+      let p = Program $ M.fromList [("double", double_func)]
+      grad <- gradient p "double" [4.0]
+      grad `shouldBe` [FloatVal 2.0]

--- a/test/LinearASpec.hs
+++ b/test/LinearASpec.hs
@@ -126,7 +126,7 @@ spec = do
     it "accepts llam x y. 0" $ do
       shouldTypeCheck $ Program $ M.fromList
         [ ("f", FuncDef [] [("x", FloatType), ("y", FloatType)] (MixedType [] [FloatType]) $
-            LetMixed [] [] (Drop (LTuple [LVar "x", LVar "y"])) $
+            LetMixed [] [] (Drop (LTuple ["x", "y"])) $
             LetMixed [] ["z"] LZero $
             Ret [] ["z"])
         ]
@@ -219,5 +219,5 @@ spec = do
                     LetMixed ["z"] [] (App "add" ["x", "y"] []) $
                     Var "z")
                 ]
-      grad <- gradient p "add" [2.0, 2.0]
+      grad <- gradient p "f" [2.0, 2.0]
       grad `shouldBe` [FloatVal 1.0, FloatVal 1.0]


### PR DESCRIPTION
Specifically, tuples are now in A-normal form, and we can now end-to-end differentiate x + x (for which JVP introduces Dup, LTuple, and LetUnpackLin forms).