### PR TITLE
Expand the surface pattern language to allow for binding multiple dynamic fields

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -45,7 +45,7 @@ that produce isos. We will start with the first two:
 %passes parse
 :t #b : Iso {a:Int & b:Float & c:Unit} _
 > (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
-> (MkIso {fwd=(\{b = (), ...()}. (,) x r), bwd=(\(x, r). {b=x, ...r})}
+> (MkIso {fwd=(\{b=x, ...r}. (,) x r), bwd=(\(x, r). {b=x, ...r})}
 >  : Iso {a: Int & b: Float & c: Unit} _)
 
 %passes parse
@@ -138,8 +138,8 @@ another. For instance:
 >    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
 > (MkIso
->    {fwd=(\({, ...()}, {a = (), ...()}). (,) {a=x, ...l} {...r})
->    , bwd=(\({a = (), ...()}, {, ...()}). (,) {...l} {a=x, ...r})}
+>    {fwd=(\({...l}, {a=x, ...r}). (,) {a=x, ...l} {...r})
+>    , bwd=(\({a=x, ...l}, {...r}). (,) {...l} {a=x, ...r})}
 >  : Iso ((&) {} {a: Int & b: Float & c: Unit}) _)
 
 :t (#&a &>> #&b) : Iso ({&} & {a:Int & b:Float & c:Unit}) _

--- a/src/lib/LabeledItems.hs
+++ b/src/lib/LabeledItems.hs
@@ -10,7 +10,7 @@
 module LabeledItems
   ( Label, LabeledItems (..), labeledSingleton, reflectLabels, getLabels
   , withLabels, lookupLabelHead, lookupLabel, ExtLabeledItems (..), prefixExtLabeledItems
-  , unzipExtLabeledItems, splitLabeledItems
+  , unzipExtLabeledItems, splitLabeledItems, popLabeledItems
   , pattern NoLabeledItems, pattern NoExt, pattern InternalSingletonLabel
   , pattern Unlabeled ) where
 
@@ -120,6 +120,11 @@ splitLabeledItems (LabeledItems litems) (LabeledItems fullItems) =
     splitRight fvs ltys = NE.nonEmpty $ NE.drop (length ltys) fvs
     left  = M.intersectionWith splitLeft fullItems litems
     right = M.differenceWith splitRight fullItems litems
+
+popLabeledItems :: Label -> LabeledItems b -> Maybe (b, LabeledItems b)
+popLabeledItems l items = case lookupLabelHead items l of
+  Just val -> Just (val, snd $ splitLabeledItems (labeledSingleton l ()) items)
+  Nothing  -> Nothing
 
 -- === instances ===
 

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -399,9 +399,9 @@ linearizeOp op = case op of
   RecordCons l r ->
     zipLin (la l) (la r) `bindLin` \(PairE l' r') ->
       emitOp $ RecordCons l' r'
-  RecordSplit vs r ->
-    zipLin (traverseLin la vs) (la r) `bindLin` \(PairE (ComposeE vs') r') ->
-      emitOp $ RecordSplit vs' r'
+  RecordSplit f r ->
+    zipLin (la f) (la r) `bindLin` \(PairE f' r') ->
+      emitOp $ RecordSplit f' r'
   VariantLift ts v ->
     zipLin (traverseLin pureLin ts) (la v) `bindLin`
       \(PairE (ComposeE ts') v') -> emitOp $ VariantLift ts' v'

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -67,7 +67,7 @@ module Name (
     pattern Case0, pattern Case1, pattern Case2, pattern Case3, pattern Case4, pattern Case5,
   EitherB1, EitherB2, EitherB3, EitherB4, EitherB5,
     pattern CaseB0, pattern CaseB1, pattern CaseB2, pattern CaseB3, pattern CaseB4,
-  splitNestAt, nestLength, nestToList, binderAnn,
+  splitNestAt, joinNest, nestLength, nestToList, binderAnn,
   OutReaderT (..), OutReader (..), runOutReaderT,
   ExtWitness (..),
   InFrag (..), InMap (..), OutFrag (..), OutMap (..), ExtOutMap (..),
@@ -770,6 +770,11 @@ splitNestAt _  Empty = error "split index too high"
 splitNestAt n (Nest b rest) =
   case splitNestAt (n-1) rest of
     PairB xs ys -> PairB (Nest b xs) ys
+
+joinNest :: Nest b n m -> Nest b m l -> Nest b n l
+joinNest l r = case l of
+  Empty     -> r
+  Nest b lt -> Nest b $ joinNest lt r
 
 binderAnn :: BinderP c ann n l -> ann n
 binderAnn (_:>ann) = ann

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -582,9 +582,10 @@ prettyUFieldRowPat separator bindwith pat =
     go :: UFieldRowPat n' l' -> [Doc ann]
     go = \case
       UEmptyRowPat          -> []
-      UDynFieldsPat UIgnore -> ["..."]
-      UDynFieldsPat b       -> ["..." <> p b]
-      UDynFieldPat    v r rest -> (p v <> bindwith <> p r) : go rest
+      URemFieldsPat UIgnore -> ["..."]
+      URemFieldsPat b       -> ["..." <> p b]
+      UDynFieldsPat   v r rest -> ("@..." <> p v <> bindwith <> p r) : go rest
+      UDynFieldPat    v r rest -> ("@" <> p v <> bindwith <> p r) : go rest
       UStaticFieldPat l r rest -> (p l <> bindwith <> p r) : go rest
 
 spaced :: (Foldable f, Pretty a) => f a -> Doc ann
@@ -774,9 +775,8 @@ instance PrettyPrec e => PrettyPrec (PrimOp e) where
     RecordCons items rest -> atPrec LowestPrec $ "RecordCons" <+> pArg items <+> pArg rest
     RecordConsDynamic lab val rec -> atPrec LowestPrec $
       "RecordConsDynamic" <+> pArg lab <+> pArg val <+> pArg rec
-    RecordSplit types val -> atPrec AppPrec $
-      "RecordSplit" <+> prettyLabeledItems types (line <> "&") ":" ArgPrec
-                    <+> pArg val
+    RecordSplit fields val -> atPrec AppPrec $
+      "RecordSplit" <+> pArg fields <+> pArg val
     VariantLift types val ->
       prettyVariantLift (fmap (const ()) types) val
     VariantSplit types val -> atPrec AppPrec $

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -46,7 +46,7 @@ module Syntax (
     UExpr, UExpr' (..), UConDef, UDataDef (..), UDataDefTrail (..), UDecl (..),
     UFieldRowElems, UFieldRowElem (..),
     ULamExpr (..), UPiExpr (..), UDeclExpr (..), UForExpr (..), UAlt (..),
-    UPat, UPat' (..), UPatAnn (..), UPatAnnArrow (..),
+    UPat, UPat' (..), UPatAnn (..), UPatAnnArrow (..), UFieldRowPat (..),
     UMethodDef (..), UAnnBinder (..),
     WithSrcE (..), WithSrcB (..), srcPos,
     SourceBlock (..), SourceBlock' (..), EnvQuery (..), ModuleName,
@@ -970,6 +970,15 @@ data UAnnBinder (c::C) (n::S) (l::S) = UAnnBinder (UBinder c n l) (UType n)
 data UAlt (n::S) where
   UAlt :: UPat n l -> UExpr l -> UAlt n
 
+data UFieldRowPat (n::S) (l::S) where
+  UEmptyRowPat    :: UFieldRowPat n n
+  UDynFieldsPat   :: UBinder AtomNameC n l -> UFieldRowPat n l
+  UStaticFieldPat :: Label               -> UPat n l' -> UFieldRowPat l' l -> UFieldRowPat n l
+  UDynFieldPat    :: SourceNameOr UVar n -> UPat n l' -> UFieldRowPat l' l -> UFieldRowPat n l
+
+instance Show (UFieldRowPat n l) where
+  show _ = "UFieldRowPat <TODO>"
+
 type UPat = WithSrcB UPat'
 data UPat' (n::S) (l::S) =
    UPatBinder (UBinder AtomNameC n l)
@@ -977,8 +986,7 @@ data UPat' (n::S) (l::S) =
  | UPatPair (PairB UPat UPat n l)
  | UPatUnit (UnitB n l)
  -- The name+ExtLabeledItems and the PairBs are parallel, constrained by the parser.
- | UPatRecord (Maybe (SourceNameOr UVar n)) (ExtLabeledItems () ())
-              (PairB (MaybeB UPat) (PairB (Nest UPat) (MaybeB UPat)) n l) -- {@v=x, a=y, b=z, ...rest}
+ | UPatRecord (UFieldRowPat n l)
  | UPatVariant (LabeledItems ()) Label (UPat n l)   -- {|a|b| a=x |}
  | UPatVariantLift (LabeledItems ()) (UPat n l)     -- {|a|b| ...rest |}
  | UPatTable (Nest UPat n l)

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -972,8 +972,9 @@ data UAlt (n::S) where
 
 data UFieldRowPat (n::S) (l::S) where
   UEmptyRowPat    :: UFieldRowPat n n
-  UDynFieldsPat   :: UBinder AtomNameC n l -> UFieldRowPat n l
+  URemFieldsPat   :: UBinder AtomNameC n l -> UFieldRowPat n l
   UStaticFieldPat :: Label               -> UPat n l' -> UFieldRowPat l' l -> UFieldRowPat n l
+  UDynFieldsPat   :: SourceNameOr UVar n -> UPat n l' -> UFieldRowPat l' l -> UFieldRowPat n l
   UDynFieldPat    :: SourceNameOr UVar n -> UPat n l' -> UFieldRowPat l' l -> UFieldRowPat n l
 
 instance Show (UFieldRowPat n l) where
@@ -1146,9 +1147,8 @@ data PrimOp e =
       -- Extensible record and variant operations:
       -- Concatenate two records.
       | RecordCons   e e
-      -- Split {a:A & b:B & ...rest} into (effectively) {a:A & b:B} & {&...rest}.
-      -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
-      | RecordSplit  (LabeledItems e) e
+      -- Split off a labeled row from the front of the record.
+      | RecordSplit  e e
       -- Add a dynamically named field to a record (on the left).
       -- Args are as follows: label, value, record.
       | RecordConsDynamic e e e

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -50,6 +50,11 @@ Syntax for records, variants, and their types.
   y
 > {a = 3, a = 4, a = 5., b = 2}
 
+:p
+  {b=b1, a=a1, c=c1, a=a2} = {a=1, a=2, b=3, c=4}
+  (a1, a2, b1, c1)
+> (1, (2, (3, 4)))
+
 'Variant (enum) types
 
 :p {|}
@@ -88,27 +93,27 @@ Syntax for records, variants, and their types.
 
 :p {a:Int & b:Float | c:Int }
 
-> Parse error:89:21:
+> Parse error:94:21:
 >    |
-> 89 | :p {a:Int & b:Float | c:Int }
+> 94 | :p {a:Int & b:Float | c:Int }
 >    |                     ^
 > unexpected '|'
 > expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', ':', '}', arrow, backquoted name, expression, or infix operator
 
 :p {a:Int,}
 
-> Parse error:98:10:
->    |
-> 98 | :p {a:Int,}
->    |          ^
+> Parse error:103:10:
+>     |
+> 103 | :p {a:Int,}
+>     |          ^
 > unexpected ','
 > expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', ''', '.', ':', '?', '_', '|', '}', alphanumeric character, arrow, backquoted name, expression, or infix operator
 
 :p {|3}
 
-> Parse error:107:6:
+> Parse error:112:6:
 >     |
-> 107 | :p {|3}
+> 112 | :p {|3}
 >     |      ^
 > unexpected '3'
 > expecting "...", '}', or field label
@@ -432,18 +437,14 @@ def concatRecords {f f'} (x: {&...f}) (y: {&...f'}) : ({...f & ...f'}) =
 concatRecords {a=1} {b=2}
 > {a = 1, b = 2}
 
--- TODO: Add support for richer pattern syntax
-def projectTwo {f a b} (l1: Label) (l2: Label) (x: {@l1:a & @l2:b & ...f}) : (a & b) = todo
+def projectTwo {f a b} (l1: Label) (l2: Label) (x: {@l1:a & @l2:b & ...f}) : (a & b) =
   {@l1=v1, @l2=v2, ...} = x
-  (v1 & v2)
+  (v1, v2)
 
-> Parse error:437:3:
->     |
-> 437 |   {@l1=v1, @l2=v2, ...} = x
->     |   ^^
-> unexpected "{@"
-> expecting end of line
--- TODO: Add support for richer pattern syntax
+projectTwo ##a ##b {c=1, b=2, a=4}
+> (4, 2)
+
+-- TODO: Add support a for richer pattern syntax
 def subsetRecord (f: Fields) {f'} (x: {...f & ...f'}) : ({&...f}) = todo
 
 -- This should at least typecheck for now

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -444,13 +444,12 @@ def projectTwo {f a b} (l1: Label) (l2: Label) (x: {@l1:a & @l2:b & ...f}) : (a 
 projectTwo ##a ##b {c=1, b=2, a=4}
 > (4, 2)
 
--- TODO: Add support a for richer pattern syntax
-def subsetRecord (f: Fields) {f'} (x: {...f & ...f'}) : ({&...f}) = todo
+def subsetRecord (f: Fields) {f'} (x: {...f & ...f'}) : ({&...f}) =
+  {@...f=v, ...} = x
+  v
 
--- This should at least typecheck for now
-subsetRecord {a: _ ? b: _} {a=1, b=2, c=4}
-> TODO: implement it!
-> Runtime error
+subsetRecord {a: _ ? c: _} {a=1, b=2, c=4}
+> {a = 1, c = 4}
 
 subsetRecord {? c: _ ?} {a=1, b=2}
 > Type error:


### PR DESCRIPTION
And also add support for record subset patterns.

Previously we could concat two records in a polymorphic context, but we
would never be able to separate them again. This makes it possible to
unpack a dynamic field row that's in the middle of a record using the
syntax (with `f` being the field row variable):
```
{@...f=x, ...rest} = record
```