### PR TITLE
Track allocations in Imp and free them when they're no longer needed.

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -22,6 +22,7 @@ import Control.Category ((>>>))
 import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.State.Class
+import Control.Monad.Writer.Strict
 import GHC.Stack
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -109,7 +110,9 @@ instance Pretty (ImpFunctionWithRecon n) where
 type ImpBuilderEmissions = Nest ImpDecl
 
 newtype ImpM (n::S) (a:: *) =
-  ImpM { runImpM' :: ScopedT1 IxCache (InplaceT Env ImpBuilderEmissions HardFailM) n a }
+  ImpM { runImpM' :: ScopedT1 IxCache
+                       (WriterT1 (ListE IExpr)
+                         (InplaceT Env ImpBuilderEmissions HardFailM)) n a }
   deriving ( Functor, Applicative, Monad, ScopeReader, Fallible, MonadFail, MonadState (IxCache n))
 
 type SubstImpM = SubstReaderT AtomSubstVal ImpM :: S -> S -> * -> *
@@ -123,17 +126,22 @@ class ( ImpBuilder2 m, SubstReader AtomSubstVal m
       => Imper (m::MonadKind2) where
 
 instance EnvReader ImpM where
-  getEnv = ImpM $ lift11 $ getOutMapInplaceT
+  getEnv = ImpM $ lift11 $ lift11 $ getOutMapInplaceT
 
 instance EnvExtender ImpM where
-  extendEnv frag cont = ImpM $ ScopedT1 \s ->
-    fmap (,s) $ extendInplaceTLocal (\bindings -> extendOutMap bindings frag) $
-      withExtEvidence (toExtEvidence frag) $ flip runScopedT1 (sink s) $ runImpM' cont
+  extendEnv frag cont = ImpM $ ScopedT1 \s -> WriterT1 $ WriterT $
+    liftM (,ListE []) $ fmap (,s) $
+      extendInplaceTLocal (\bindings -> extendOutMap bindings frag) $
+        withExtEvidence (toExtEvidence frag) do
+          (result, ptrs) <- runWriterT1 $ flip runScopedT1 (sink s) $ runImpM' cont
+          case ptrs of
+            ListE [] -> return result
+            _ -> error "shouldn't be able to emit pointers without `Mut`"
 
 instance ImpBuilder ImpM where
   emitMultiReturnInstr instr = do
     tys <- impInstrTypes instr
-    ListE vs <- ImpM $ ScopedT1 \s ->
+    ListE vs <- ImpM $ ScopedT1 \s -> lift11 $
       (,s) <$> extendInplaceT do
         scope <- getScope
         let hints = map (const "v") tys
@@ -149,16 +157,23 @@ instance ImpBuilder ImpM where
      makeImpBinders (Nest b bs) (ty:tys) = Nest (IBinder b ty) $ makeImpBinders bs tys
      makeImpBinders _ _ = error "zip error"
 
-  buildScopedImp cont = ImpM $ ScopedT1 \s ->
-    fmap (,s) $ locallyMutableInplaceT $ flip runScopedT1 (sink s) $ runImpM' do
+  buildScopedImp cont = ImpM $ ScopedT1 \s -> WriterT1 $ WriterT $
+    liftM (, ListE []) $ liftM (,s) $ locallyMutableInplaceT do
       Emits <- fabricateEmitsEvidenceM
-      Distinct <- getDistinct
-      cont
+      (result, (ListE ptrs)) <- runWriterT1 $ flip runScopedT1 (sink s) $ runImpM' do
+         Distinct <- getDistinct
+         cont
+      _ <- runWriterT1 $ flip runScopedT1 (sink s) $ runImpM' do
+        forM ptrs \ptr -> emitStatement $ Free ptr
+      return result
+
+  extendAllocsToFree ptr = ImpM $ lift11 $ tell $ ListE [ptr]
 
 instance ImpBuilder m => ImpBuilder (SubstReaderT AtomSubstVal m i) where
   emitMultiReturnInstr instr = SubstReaderT $ lift $ emitMultiReturnInstr instr
   buildScopedImp cont = SubstReaderT $ ReaderT \env ->
     buildScopedImp $ runSubstReaderT (sink env) $ cont
+  extendAllocsToFree ptr = SubstReaderT $ lift $ extendAllocsToFree ptr
 
 instance ImpBuilder m => Imper (SubstReaderT AtomSubstVal m)
 
@@ -169,9 +184,10 @@ runImpM
   -> e n
 runImpM bindings cont =
   withImmutEvidence (toImmutEvidence bindings) $
-    case runHardFail $ runInplaceT bindings $ flip runScopedT1 mempty $ runImpM' $ runSubstReaderT idSubst $ cont of
-      (Empty, result) -> result
-      _ -> error "shouldn't be possible because of `Emits` constraint"
+    case runHardFail $ runInplaceT bindings $ runWriterT1 $
+      flip runScopedT1 mempty $ runImpM' $ runSubstReaderT idSubst $ cont of
+        (Empty, (result, ListE [])) -> result
+        _ -> error "shouldn't be possible because of `Emits` constraint"
 
 -- === the actual pass ===
 
@@ -1141,7 +1157,11 @@ makeAllocDestWithPtrs allocTy ty = do
   AbsPtrs absDest ptrDefs <- makeDest (backend, curDev, allocTy) ty
   ptrs <- forM ptrDefs \(DestPtrInfo ptrTy sizeBlock) -> do
     size <- liftBuilderImp $ emitBlock $ sink sizeBlock
-    emitAlloc ptrTy =<< fromScalarAtom size
+    ptr <- emitAlloc ptrTy =<< fromScalarAtom size
+    case ptrTy of
+      (Heap _, _) | allocTy == Managed -> extendAllocsToFree ptr
+      _ -> return ()
+    return ptr
   ptrAtoms <- mapM toScalarAtom ptrs
   dest' <- applyNaryAbs absDest $ map SubstVal ptrAtoms
   return (dest', ptrs)
@@ -1287,6 +1307,7 @@ class (EnvReader m, EnvExtender m, Fallible1 m, MonadIxCache1 m)
     :: (SinkableE e, Immut n)
     => (forall l. (Emits l, Ext n l, Distinct l) => m l (e l))
     -> m n (DistinctAbs (Nest ImpDecl) e n)
+  extendAllocsToFree :: Mut n => IExpr n -> m n ()
 
 type ImpBuilder2 (m::MonadKind2) = forall i. ImpBuilder (m i)
 

--- a/src/lib/MTL1.hs
+++ b/src/lib/MTL1.hs
@@ -40,7 +40,7 @@ class Monoid1 w => FallibleMonoid1 w where
 
 newtype WriterT1 (w :: E) (m :: MonadKind1) (n :: S) (a :: *) =
   WriterT1 { runWriterT1' :: (WriterT (w n) (m n) a) }
-  deriving (Functor, Applicative, Monad, MonadWriter (w n))
+  deriving (Functor, Applicative, Monad, MonadWriter (w n), MonadFail, Fallible)
 
 runWriterT1 :: WriterT1 w m n a -> m n (a, w n)
 runWriterT1 = runWriterT . runWriterT1'


### PR DESCRIPTION
We've been seeing memory blowups since the safe-names refactor. It turns out
that we were just ... not freeing any memory. A few crucial lines didn't make it
through the refactor. With that fixed, tests finally pass!