### PR TITLE
Make simplification faster

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -200,7 +200,7 @@ instance CheaplyReducibleE Expr Atom where
     Atom atom -> cheapReduceE atom
     App f' xs' -> do
       f <- cheapReduceE f'
-      case fromNaryLam (length xs') f of
+      case fromNaryLamExact (length xs') f of
         Just (NaryLamExpr bs _ body) -> do
           xs <- mapM cheapReduceE xs'
           let subst = bs @@> fmap SubstVal xs

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -261,7 +261,7 @@ translateExpr maybeDest expr = case expr of
     xs <- mapM substM xs'
     getType f >>= \case
       TabTy _ _ -> do
-        case fromNaryLam (length xs) f of
+        case fromNaryLamExact (length xs) f of
           Just (NaryLamExpr bs _ body) -> do
             let subst = bs @@> fmap SubstVal xs
             body' <- applySubst subst body

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -114,7 +114,7 @@ evalExpr :: Interp m => Expr i -> m i o (Atom o)
 evalExpr expr = case expr of
   App f xs -> do
     f' <- evalAtom f
-    case fromNaryLam (length xs) f' of
+    case fromNaryLamExact (length xs) f' of
       Just (NaryLamExpr bs _ body) -> do
         xs' <- mapM evalAtom xs
         let subst = bs @@> fmap SubstVal xs'


### PR DESCRIPTION
This tries to delay or bunch some eager substitutions we do in Simplification, which can cause the overall runtime to become quadratic in program size due to repeated traversals. Based on some crude benchmarks, the time spent in simplification over our example suite drops from 73s to 47s (a 35% decrease!).