### PR TITLE
Make conversion from a SubstFrag to a ScopeFrag free

### DIFF
--- a/makefile
+++ b/makefile
@@ -148,9 +148,9 @@ doc-example-names = $(example-names:%=doc/examples/%.html)
 
 doc-lib-names = $(lib-names:%=doc/lib/%.html)
 
-module-tests:
+module-tests: build
 	misc/check-quine tests/module-tests.dx \
-           $(dex) --prelude lib/prelude.dx --lib-path tests script --allow-errors
+    $(dex) --prelude lib/prelude.dx --lib-path tests script --allow-errors
 
 
 tests: quine-tests repl-test module-tests


### PR DESCRIPTION
I started runnig some profiling builds and it turns out that the one
biggest cost we pay in the compiler is this conversion. The time needed
to run all tests and examples drops by ~23% with this patch, so I think
that the loss of safety is worth it.