### PR TITLE
Sprinkle INLINE annotations

### DIFF
--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -48,6 +48,7 @@ liftInterpM :: (EnvReader m, MonadIO1 m) => InterpM n n a -> m n a
 liftInterpM cont = do
   resultIO <- liftEnvReaderT $ runSubstReaderT idSubst $ runInterpM' cont
   liftIO resultIO
+{-# INLINE liftInterpM #-}
 
 evalBlock :: Interp m => Block i -> m i o (Atom o)
 evalBlock (Block _ decls result) = evalDecls decls $ evalExpr result

--- a/stack-macos.yaml
+++ b/stack-macos.yaml
@@ -11,7 +11,7 @@ packages:
 
 extra-deps:
   - github: llvm-hs/llvm-hs
-    commit: eda85a2bbe362a0b89df5adce0cb65e4e755eac5
+    commit: 789e2b9e8b827d4c5e15b997f16e395fd2259c0f
     subdirs:
       - llvm-hs
       - llvm-hs-pure

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ packages:
 
 extra-deps:
   - github: llvm-hs/llvm-hs
-    commit: 92d153600930ef23efa163c12655c4d119ace610
+    commit: 789e2b9e8b827d4c5e15b997f16e395fd2259c0f
     subdirs:
       - llvm-hs
       - llvm-hs-pure


### PR DESCRIPTION
Without those GHC has trouble desugaring through the MTL-style monad
abstractions. We also like to define lots of helpers with tiny bodies.
Overall this yields an end-to-end speedup of approximately 27%!