### PR TITLE
Add a worker thread to the evaluation driver

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -95,7 +95,7 @@ library
                        BlockArguments, GADTs, TypeOperators, DataKinds, KindSignatures
                        ConstraintKinds, FlexibleContexts, RankNTypes, QuantifiedConstraints,
                        TypeOperators, MultiParamTypeClasses, FunctionalDependencies,
-                       GeneralizedNewtypeDeriving
+                       GeneralizedNewtypeDeriving, BangPatterns
   pkgconfig-depends:   libpng
   if flag(cuda)
     include-dirs:      /usr/local/cuda/include

--- a/src/lib/Actor.hs
+++ b/src/lib/Actor.hs
@@ -8,7 +8,7 @@ module Actor (PChan, sendPChan, sendOnly, subChan,
               Actor, runActor, spawn,
               LogServerMsg (..), logServer) where
 
-import Control.Concurrent
+import Control.Concurrent (Chan, forkIO, newChan, readChan, ThreadId, writeChan)
 import Control.Monad.State.Strict
 
 import Util (onFst, onSnd)
@@ -32,7 +32,7 @@ type Actor a = Chan a -> IO ()
 newtype PChan a = PChan { sendPChan :: a -> IO () }
 
 sendOnly :: Chan a -> PChan a
-sendOnly chan = PChan $ writeChan chan
+sendOnly chan = PChan $ \ !x -> writeChan chan x
 
 subChan :: (a -> b) -> PChan b -> PChan a
 subChan f chan = PChan (sendPChan chan . f)

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -240,9 +240,10 @@ addSrcTextContext offset text m =
 
 catchIOExcept :: MonadIO m => IO a -> m (Except a)
 catchIOExcept m = liftIO $ (liftM Success m) `catches`
-  [ Handler \(e::Errs)          -> return $ Failure e
-  , Handler \(e::IOError)       -> return $ Failure $ Errs [Err DataIOErr   mempty $ show e]
-  , Handler \(e::SomeException) -> return $ Failure $ Errs [Err CompilerErr mempty $ show e]
+  [ Handler \(e::Errs)           -> return $ Failure e
+  , Handler \(e::IOError)        -> return $ Failure $ Errs [Err DataIOErr   mempty $ show e]
+  , Handler \(e::AsyncException) -> liftIO $ throwIO e
+  , Handler \(e::SomeException)  -> return $ Failure $ Errs [Err CompilerErr mempty $ show e]
   ]
 
 liftExcept :: Fallible m => Except a -> m a

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -242,6 +242,9 @@ catchIOExcept :: MonadIO m => IO a -> m (Except a)
 catchIOExcept m = liftIO $ (liftM Success m) `catches`
   [ Handler \(e::Errs)           -> return $ Failure e
   , Handler \(e::IOError)        -> return $ Failure $ Errs [Err DataIOErr   mempty $ show e]
+  -- Propagate asynchronous exceptions like ThreadKilled; they are
+  -- part of normal operation (of the live evaluation modes), not
+  -- compiler bugs.
   , Handler \(e::AsyncException) -> liftIO $ throwIO e
   , Handler \(e::SomeException)  -> return $ Failure $ Errs [Err CompilerErr mempty $ show e]
   ]


### PR DESCRIPTION
This way, Dex compute can be interrupted in response to external events (like the user editing the cell being computed).

Fixes #799 .