### PR TITLE
Make Simplify super-fast!

### DIFF
--- a/makefile
+++ b/makefile
@@ -38,6 +38,10 @@ STACK_FLAGS = --flag dex:cuda
 CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
 endif
 
+ifeq (1,$(DEX_DUMP_GHC))
+STACK_FLAGS := $(STACK_FLAGS) --flag dex:optimized --ghc-options="-fno-prof-auto -ddump-simpl -ddump-stg -ddump-to-file -dsuppress-all -dno-suppress-type-signatures"
+endif
+
 # libpng
 ifneq (,$(wildcard /usr/local/include/png.h))
 CFLAGS := $(CFLAGS) -I/usr/local/include


### PR DESCRIPTION
This makes a few smallish adjustments to our Simplify pass, giving GHC
enough hints to _completely desugar_ the monad stack we use and most of
the details of the naming system. The generated code is roughly
what you'd get if you wrote it in an eager language! All monadic
functions get turned into top-level monomorphic declarations that return
an unboxed pair `(# a, BuilderEmissions UnsafeS UnsafeS #)`!

I haven't done extensive benchmarking, but it seems like it ends up
making quite a difference. On the kernel regression example we can save
600MB of allocations (out of ~7GB) and get a 14% end-to-end speedup.
Note that some of that might come from the extra INLINE rules I
discovered were necessary during optimizing this pass.