### PR TITLE
Optimize Imp

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1493,6 +1493,7 @@ extendInplaceT ab = do
   UnsafeMakeInplaceT \env ->
     refreshAbsPure (toScope env) ab \_ decls result ->
       return (unsafeCoerceE result, unsafeCoerceB decls)
+{-# INLINE extendInplaceT #-}
 
 locallyMutableInplaceT
   :: forall m b d n e.
@@ -1504,6 +1505,7 @@ locallyMutableInplaceT cont = do
     (e, decls) <- withMutEvidence (fabricateMutEvidence :: MutEvidence n) do
                     unsafeRunInplaceT cont bindings
     return (Abs (unsafeCoerceB decls) e, emptyOutFrag)
+{-# INLINE locallyMutableInplaceT #-}
 
 liftBetweenInplaceTs
   :: Monad m
@@ -1517,6 +1519,7 @@ liftBetweenInplaceTs liftInner lowerBindings liftDecls (UnsafeMakeInplaceT f) =
     (result, declsInner) <- liftInner $ f $ lowerBindings bindingsOuter
     withDistinctEvidence (fabricateDistinctEvidence :: DistinctEvidence UnsafeS) $
       return (result, liftDecls declsInner)
+{-# INLINE liftBetweenInplaceTs #-}
 
 -- === predicates for mutable and immutable scope parameters ===
 
@@ -1528,11 +1531,14 @@ instance Mut UnsafeS
 fabricateMutEvidence :: forall n. MutEvidence n
 fabricateMutEvidence =
   withMutEvidence (error "pure fabrication" :: MutEvidence n) Mut
+{-# INLINE fabricateMutEvidence #-}
 
 withMutEvidence :: forall n a. MutEvidence n -> (Mut n => a) -> a
 withMutEvidence _ cont = fromWrapWithMut
  ( TrulyUnsafe.unsafeCoerce ( WrapWithMut cont :: WrapWithMut n       a
                                              ) :: WrapWithMut UnsafeS a)
+{-# INLINE withMutEvidence #-}
+
 newtype WrapWithMut n r =
   WrapWithMut { fromWrapWithMut :: Mut n => r }
 

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -52,6 +52,7 @@ checkTypesM e = liftExcept =<< checkTypes e
 
 getType :: (EnvReader m, HasType e) => e n -> m n (Type n)
 getType e = liftHardFailTyperT $ getTypeE e
+{-# INLINE getType #-}
 
 getAppType :: EnvReader m => Type n -> [Atom n] -> m n (Type n)
 getAppType f xs = case nonEmpty xs of
@@ -192,9 +193,11 @@ liftTyperT cont =
   liftEnvReaderT $
     runSubstReaderT idSubst $
       runTyperT' cont
+{-# INLINE liftTyperT #-}
 
 liftHardFailTyperT :: EnvReader m' => TyperT HardFailM n n a -> m' n a
 liftHardFailTyperT cont = liftM runHardFail $ liftTyperT cont
+{-# INLINE liftHardFailTyperT #-}
 
 instance Fallible m => Typer (TyperT m)
 
@@ -333,6 +336,7 @@ instance HasType AtomName where
   getTypeE name = do
     name' <- substM name
     atomBindingType <$> lookupEnv name'
+  {-# INLINE getTypeE #-}
 
 instance HasType Atom where
   getTypeE atom = case atom of


### PR DESCRIPTION
Mostly based on tricks learned while optimizing simplification. All
functions are now monomorphized to the monad they need, some INLINE
annotations unblock further optimizations, and the `confuseGHC` hack
saves the day once again.

In the end it all adds up to a 20% end-to-end speedup on the kernel
regression example!