### PR TITLE
Scan standard library, benchmarks, and examples to reduce hanging indentation

### DIFF
--- a/benchmarks/matmul.dx
+++ b/benchmarks/matmul.dx
@@ -1,16 +1,20 @@
 -- We definitely want to improve this in the future, but it's fine if we only care
 -- about matrices that tile perfectly.
-def tile2d (n : Type) ?-> (m : Type) ?-> (b : Type) ?-> (nl : Type) ?-> (ml : Type) ?->
-           (fTile : Tile n nl -> Tile m ml -> nl=>ml=>b)
-           (fScalar : n -> m -> b) : n=>m=>b =
+def tile2d
+      (n : Type) ?-> (m : Type) ?-> (b : Type) ?-> (nl : Type) ?-> (ml : Type) ?->
+      (fTile : Tile n nl -> Tile m ml -> nl=>ml=>b)
+      (fScalar : n -> m -> b)
+      : n=>m=>b =
   (tile
     (\nt:(Tile n nl).
       (tile1 (\mt:(Tile m ml). fTile nt mt)
              (\mi:m. for ni:nl. fScalar (nt +> ni) mi)))
     (\ni:n. for mi:m. fScalar ni mi))
 
-def matmul (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
-           (a : n=>k=>Float) (b : k=>m=>Float) : n=>m=>Float =
+def matmul
+      (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
+      (a : n=>k=>Float) (b : k=>m=>Float)
+      : n=>m=>Float =
   rowTile = Fin 5
   colVectors = Fin 2
   vectorTile = Fin VectorWidth

--- a/benchmarks/parboil/mriq.dx
+++ b/benchmarks/parboil/mriq.dx
@@ -1,17 +1,19 @@
--- def mriq (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
---          (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
---          (phiR : ks=>Float) (phiI : ks=>Float)
---            : (cs=>Float & cs=>Float) =
+-- def mriq
+--       (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
+--       (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
+--       (phiR : ks=>Float) (phiI : ks=>Float)
+--       : (cs=>Float & cs=>Float) =
 --   phiMags = for i. phiR.i * phiR.i + phiI.i * phiI.i
 --   expArgs = for i:cs j:ks.  2.0 * pi * (kx.j * x.i + ky.j * y.i + kz.j * z.i)
 --   qr = for i. sum $ for j. cos $ expArgs.i.j * phiMags.j
 --   qi = for i. sum $ for j. sin $ expArgs.i.j * phiMags.j
 --   (qr, qi)
 
-def mriq (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
-         (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
-         (phiR : ks=>Float) (phiI : ks=>Float)
-           : (cs=>Float & cs=>Float) =
+def mriq
+      (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
+      (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
+      (phiR : ks=>Float) (phiI : ks=>Float)
+      : (cs=>Float & cs=>Float) =
   unzip $ for i.
     runAccum (AddMonoid Float) \qi.
       yieldAccum (AddMonoid Float) \qr.

--- a/benchmarks/rodinia/backprop.dx
+++ b/benchmarks/rodinia/backprop.dx
@@ -3,18 +3,20 @@ MOMENTUM = 0.3
 
 def squash (x : Float) : Float = 1.0 / (1.0 + exp (-x))
 
-def layerForward (input : in=>Float)
-                 (params : { b: Unit| w: in }=>out=>Float)
-                   : out=>Float =
+def layerForward
+      (input : in=>Float)
+      (params : { b: Unit| w: in }=>out=>Float)
+      : out=>Float =
   bias = params.{| b=() |}
   total = (sum $ for i:in j:out. params.{| w=i |}.j * input.i) + bias
   for i. squash total.i
 
-def adjustWeights (delta : out=>Float)
-                  (input : in=>Float)
-                  (weight : { b: Unit | w: in }=>out=>Float)
-                  (oldWeight : { b: Unit | w: in }=>out=>Float)
-                  : ({ b: Unit | w: in }=>out=>Float & { b: Unit | w: in }=>out=>Float) =
+def adjustWeights
+      (delta : out=>Float)
+      (input : in=>Float)
+      (weight : { b: Unit | w: in }=>out=>Float)
+      (oldWeight : { b: Unit | w: in }=>out=>Float)
+      : ({ b: Unit | w: in }=>out=>Float & { b: Unit | w: in }=>out=>Float) =
   weight' = for k:{ b: Unit | w: in } j:out.
     i = case k of
       {| b=() |} -> 1.0
@@ -23,9 +25,10 @@ def adjustWeights (delta : out=>Float)
     weight.k.j + d
   (weight', weight)
 
-def outputError (target : out=>Float)
-                (output : out=>Float)
-                  : (Float & out=>Float) =
+def outputError
+      (target : out=>Float)
+      (output : out=>Float)
+      : (Float & out=>Float) =
   swap $ runAccum (AddMonoid Float) \err.
     for i.
       o = output.i
@@ -33,10 +36,11 @@ def outputError (target : out=>Float)
       err += abs d
       d
 
-def hiddenError (outputDelta : out=>Float)
-                (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
-                (hidden : hid=>Float)
-                  : (Float & hid=>Float) =
+def hiddenError
+      (outputDelta : out=>Float)
+      (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
+      (hidden : hid=>Float)
+      : (Float & hid=>Float) =
   swap $ runAccum (AddMonoid Float) \err.
     for i:hid.
       mult = sum $ for j. outputDelta.j * hiddenWeights.{| w = i |}.j
@@ -44,16 +48,17 @@ def hiddenError (outputDelta : out=>Float)
       err += abs r
       r
 
-def backprop (input : in=>Float)
-             (target : out=>Float)
-             (inputWeights : { b: Unit | w: in }=>hid=>Float)
-             (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
-             (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
-             (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
-               : ( Float
-                 & Float
-                 & { b: Unit | w: in }=>hid=>Float
-                 & { b: Unit | w: hid }=>out=>Float) =
+def backprop
+      (input : in=>Float)
+      (target : out=>Float)
+      (inputWeights : { b: Unit | w: in }=>hid=>Float)
+      (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
+      (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
+      (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
+      : ( Float
+        & Float
+        & { b: Unit | w: in }=>hid=>Float
+        & { b: Unit | w: hid }=>out=>Float) =
   hidden = layerForward input  inputWeights
   output = layerForward hidden hiddenWeights
 

--- a/benchmarks/rodinia/backpropad.dx
+++ b/benchmarks/rodinia/backpropad.dx
@@ -3,9 +3,10 @@ MOMENTUM = 0.3
 
 def squash (x : Float) : Float = 1.0 / (1.0 + exp (-x))
 
-def layerForward (input : in=>Float)
-                 (params : { b: Unit| w: in }=>out=>Float)
-                   : out=>Float =
+def layerForward
+      (input : in=>Float)
+      (params : { b: Unit| w: in }=>out=>Float)
+      : out=>Float =
   bias = params.{| b=() |}
   total = (sum $ for i:in j:out. params.{| w=i |}.j  * input.i) + bias
   for i. squash total.i
@@ -13,22 +14,24 @@ def layerForward (input : in=>Float)
 def lossForward (input : n=>Float) (target : n=>Float) : Float =
   sum $ input - target
 
-def adjustWeights (gradWeight : { b: Unit | w: in }=>out=>Float)
-                  (weight : { b: Unit | w: in }=>out=>Float)
-                  (oldWeight : { b: Unit | w: in }=>out=>Float)
-                  : ({ b: Unit | w: in }=>out=>Float) =
+def adjustWeights
+      (gradWeight : { b: Unit | w: in }=>out=>Float)
+      (weight : { b: Unit | w: in }=>out=>Float)
+      (oldWeight : { b: Unit | w: in }=>out=>Float)
+      : ({ b: Unit | w: in }=>out=>Float) =
   for k j.
     d = ETA * gradWeight.k.j + MOMENTUM * oldWeight.k.j
     weight.k.j + d
 
-def backpropad (input : in=>Float)
-               (target : out=>Float)
-               (inputWeights : { b: Unit | w: in }=>hid=>Float)
-               (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
-               (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
-               (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
-                 : ( { b: Unit | w: in }=>hid=>Float
-                   & { b: Unit | w: hid }=>out=>Float) =
+def backpropad
+      (input : in=>Float)
+      (target : out=>Float)
+      (inputWeights : { b: Unit | w: in }=>hid=>Float)
+      (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
+      (oldInputWeights : { b: Unit | w: in }=>hid=>Float)
+      (oldHiddenWeights : { b: Unit | w: hid }=>out=>Float)
+      : ( { b: Unit | w: in }=>hid=>Float
+        & { b: Unit | w: hid }=>out=>Float) =
   (gradInputWeights, gradHiddenWeights) =
     flip grad (inputWeights, hiddenWeights) \(iw, hw).
       hidden = layerForward input  inputWeights

--- a/benchmarks/rodinia/hotspot.dx
+++ b/benchmarks/rodinia/hotspot.dx
@@ -25,10 +25,11 @@ def (-|) (i:n) (off:Int) : n =
     True  -> unsafeFromOrdinal _ newOrd
     False -> i
 
-def hotspot (numIterations: Int)
-            (tsInit : r=>c=>Float)
-            (p : r=>c=>Float)
-            : r=>c=>Float =
+def hotspot
+      (numIterations: Int)
+      (tsInit : r=>c=>Float)
+      (p : r=>c=>Float)
+      : r=>c=>Float =
   gridHeight = chipHeight / (IToF $ size r)
   gridWidth  = chipWidth  / (IToF $ size c)
   cap = factorChip * specHeatSI * tChip * gridWidth * gridHeight

--- a/benchmarks/rodinia/kmeans.dx
+++ b/benchmarks/rodinia/kmeans.dx
@@ -12,11 +12,12 @@ def centroidsOf (points : n=>d=>Float) (membership : n=>k) : k=>d=>Float =
 def argminBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : n =
   minimumBy (\i. f xs.i) (for i. i)
 
-def kmeans (points : n=>d=>Float)
-           (k : Int)
-           (threshold : Int)
-           (maxIterations : Int)
-           : (Fin k)=>d=>Float =
+def kmeans
+      (points : n=>d=>Float)
+      (k : Int)
+      (threshold : Int)
+      (maxIterations : Int)
+      : (Fin k)=>d=>Float =
   initCentroids = for i:(Fin k). points.(ordinal i@_)
   initMembership = for c:n. ((ordinal c `mod` k)@_)
   final = yieldState (initMembership, initCentroids, 0) \ref.

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -47,12 +47,11 @@ def logaddexp (x:Float) (y:Float) : Float =
   m = max x y
   m + ( log ( (exp (x - m) + exp (y - m))))
 
-def ctc {vocab time position}
-        [Eq vocab, Eq position, Eq time]
-        (blank:  vocab)
-        (logits: time=>vocab=>Float)
-        (labels: position=>vocab)
-        : Float =
+def ctc {vocab time position} [Eq vocab, Eq position, Eq time]
+      (blank:  vocab)
+      (logits: time=>vocab=>Float)
+      (labels: position=>vocab)
+      : Float =
   -- Computes log p(labels | logits), marginalizing over possible alignments.
   -- Todo: remove unnecessary implicit type annotations once
   -- Dex starts putting implicit types in scope.

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -8,9 +8,10 @@
 'This is a normal ADT, and you can construct your own isomorphisms.
 
 def cycleThree {a b c} : Iso (a & b & c) (b & c & a) =
-  MkIso { fwd = \(a, b, c). (b, c, a)
-        , bwd = \(b, c, a). (a, b, c)
-        }
+  MkIso {
+      fwd = \(a, b, c). (b, c, a)
+    , bwd = \(b, c, a). (a, b, c)
+    }
 
 'Isomorphisms can be applied with `appIso`, applied in reverse with `revIso`,
 and flipped with `flipIso`

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -87,9 +87,10 @@ def myLogProb (x:(Fin 2)=>Float) : LogProb =
   x' = x - [1.5, 2.5]
   neg $ 0.5 * inner x' [[1.,0.],[0.,20.]] x'
 
-numSamples = if dex_test_mode ()
-               then 1000
-               else 10000
+numSamples =
+  if dex_test_mode ()
+    then 1000
+    else 10000
 k0 = newKey 1
 
 mhParams = 0.1

--- a/examples/nn.dx
+++ b/examples/nn.dx
@@ -41,8 +41,8 @@ def dense (a:Type) (b:Type) : Layer (a=>Float) (b=>Float) (DenseParams a b) =
     forward = (\ ((weight, bias)) x .
                for j. (bias.j + sum for i. weight.i.j * x.i)),
     init = arb
-   }
-  
+  }
+
 
 ' CNN layer
 
@@ -50,18 +50,19 @@ def CNNParams (inc:Type) (outc:Type) (kw:Int) (kh:Int) : Type =
   ((outc=>inc=>Fin kh=>Fin kw=>Float) &
    (outc=>Float))
 
-def conv2d (x:inc=>(Fin h)=>(Fin w)=>Float)
-           (kernel:outc=>inc=>(Fin kh)=>(Fin kw)=>Float) :
-     outc=>(Fin h)=>(Fin w)=>Float =
-     for o i j.
-         (i', j') = (ordinal i, ordinal j)
-         case (i' + kh) <= h && (j' + kw) <= w of
-          True ->
-              sum for (ki, kj, inp).
-                  (di, dj) = (fromOrdinal (Fin h) (i' + (ordinal ki)),
-                              fromOrdinal (Fin w) (j' + (ordinal kj)))
-                  x.inp.di.dj * kernel.o.inp.ki.kj
-          False -> zero
+def conv2d
+      (x:inc=>(Fin h)=>(Fin w)=>Float)
+      (kernel:outc=>inc=>(Fin kh)=>(Fin kw)=>Float)
+      : outc=>(Fin h)=>(Fin w)=>Float =
+  for o i j.
+    (i', j') = (ordinal i, ordinal j)
+    case (i' + kh) <= h && (j' + kw) <= w of
+      True ->
+        sum for (ki, kj, inp).
+          (di, dj) = (fromOrdinal (Fin h) (i' + (ordinal ki)),
+                      fromOrdinal (Fin w) (j' + (ordinal kj)))
+          x.inp.di.dj * kernel.o.inp.ki.kj
+      False -> zero
 
 def cnn (h:Int) ?-> (w:Int) ?-> (inc:Type) (outc:Type) (kw:Int) (kh:Int) :
     Layer (inc=>(Fin h)=>(Fin w)=>Float)
@@ -75,14 +76,14 @@ def cnn (h:Int) ?-> (w:Int) ?-> (inc:Type) (outc:Type) (kw:Int) (kh:Int) :
 ' Pooling 
 
 def split (x: m=>v) : n=>o=>v =
-    for i j. x.((ordinal (i,j))@m)
+  for i j. x.((ordinal (i,j))@m)
             
 def imtile (x: a=>b=>v) : n=>o=>p=>q=>v =
-    for kw kh w h. (split (split x).w.kw).h.kh
+  for kw kh w h. (split (split x).w.kw).h.kh
 
 def meanpool (kh: Type) (kw: Type) (x : m=>n=> Float) : ( h=>w=> Float) =
-    out : (kh => kw => h => w => Float) = imtile x
-    mean for (i,j). out.i.j
+  out : (kh => kw => h => w => Float) = imtile x
+  mean for (i,j). out.i.j
 
 ' ## Simple point classifier
 
@@ -115,13 +116,14 @@ simple = \h1.
 ' Train a multiclass classifier with minibatch SGD
 ' `minibatch * minibatches = batch`
 
-def trainClass [VSpace p] (model: Layer a (b=>Float) p)
-                           (x: batch=>a)
-                           (y: batch=>b)
-                           (epochs : Type)
-                           (minibatch : Type)
-                           (minibatches : Type) :
-    (epochs => p & epochs => Float ) =
+def trainClass [VSpace p]
+      (model: Layer a (b=>Float) p)
+      (x: batch=>a)
+      (y: batch=>b)
+      (epochs : Type)
+      (minibatch : Type)
+      (minibatches : Type)
+      : (epochs => p & epochs => Float ) =
   xs : minibatches => minibatch => a = split x
   ys : minibatches => minibatch => b = split y
   unzip $ withState (init model $ newKey 0) $ \params .
@@ -142,8 +144,8 @@ simple_model = simple (Fin 10)
 
 span = linspace (Fin 10) (-1.0) (1.0)
 tests = for h : (Fin 50). for i . for j.
-        r = forward simple_model all_params.((ordinal h * 10)@_) [span.i, span.j]
-        [exp r.(1@_), exp r.(0@_), 0.0]
+    r = forward simple_model all_params.((ordinal h * 10)@_) [span.i, span.j]
+    [exp r.(1@_), exp r.(0@_), 0.0]
         
 
 :html imseqshow tests
@@ -182,9 +184,6 @@ lenet = \h1 h2 h3 .
 
 
 ' ## Data Loading
-
-
-
 
 
 Batch = Fin 5000
@@ -244,6 +243,3 @@ init_param = (init model  $ newKey 0)
 (all_params', losses') = trainClass model small_ims small_labels Epochs Minibatch Minibatches
 
 :p losses'
-
-
-

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -13,7 +13,8 @@ def length {d} (x: d=>Float) : Float = sqrt $ sum for i. sq x.i
 def (./) {d} (x: d=>Float) (y: d=>Float) : d=>Float = for i. x.i / y.i
 
 def fit_4th_order_polynomial {v} [VSpace v]
-    (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time) : (Fin 5)=>v =
+      (z0:v) (z1:v) (z_mid:v) (dz0:v) (dz1:v) (dt:Time)
+      : (Fin 5)=>v =
   -- dz0 and dz1 are gradient evaluations.
   a = -2. * dt .* dz0 + 2. * dt .* dz1 -  8. .* z0 -  8. .* z1 + 16. .* z_mid
   b =  5. * dt .* dz0 - 3. * dt .* dz1 + 18. .* z0 + 14. .* z1 - 32. .* z_mid
@@ -22,18 +23,22 @@ def fit_4th_order_polynomial {v} [VSpace v]
   e = z0
   [a, b, c, d, e]  -- polynomial coefficients.
 
-dps_c_mid = [6025192743. /30085553152. /2., 0., 51252292925. /65400821598. /2.,
-            -2691868925. /45128329728. /2., 187940372067. /1594534317056. /2.,
-            -1776094331. /19743644256. /2., 11237099. /235043384. /2.]
+dps_c_mid = [
+   6025192743. /30085553152. /2., 0., 51252292925. /65400821598. /2.,
+  -2691868925. /45128329728. /2., 187940372067. /1594534317056. /2.,
+  -1776094331. /19743644256. /2., 11237099. /235043384. /2.]
 
 def interp_fit_dopri {v} [VSpace v]
-    (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time) : (Fin 5)=>v =
+      (z0:v) (z1:v) (k:(Fin 7)=>v) (dt:Time)
+      : (Fin 5)=>v =
   -- Fit a polynomial to the results of a Runge-Kutta step.
   z_mid = z0 + dt .* (dot dps_c_mid k)
   fit_4th_order_polynomial z0 z1 z_mid k.(0@_) k.(1@_) dt
 
-def initial_step_size {d} (fun:d=>Float -> Time -> d=>Float) (t0:Time) (z0:d=>Float)
-                      (order:Int) (rtol:Float) (atol:Float) (f0:d=>Float) : Time =
+def initial_step_size {d}
+      (fun:d=>Float -> Time -> d=>Float) (t0:Time) (z0:d=>Float)
+      (order:Int) (rtol:Float) (atol:Float) (f0:d=>Float)
+      : Time =
   -- Algorithm from: E. Hairer, S. P. Norsett G. Wanner,
   -- Solving Ordinary Differential Equations I: Nonstiff Problems, Sec. II.4.
   scale = for i. atol + ((abs z0.i) * rtol)
@@ -52,20 +57,22 @@ def initial_step_size {d} (fun:d=>Float -> Time -> d=>Float) (t0:Time) (z0:d=>Fl
 alpha = [1. / 5., 3. / 10., 4. / 5., 8. / 9., 1., 1.]
 
 beta : (i:(Fin 6)=>(..i)=>Float) =  -- triangular array type.
-       [[1. / 5.],
-       [3. / 40., 9. / 40.],
-       [44. / 45., -56. / 15., 32.0 / 9.],
-       [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729.],
-       [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656.],
-       [35. / 384., 0., 500. / 1113., 125./192., -2187./6784., 11./84.]]
+  [[1. / 5.],
+   [3. / 40., 9. / 40.],
+   [44. / 45., -56. / 15., 32.0 / 9.],
+   [19372. / 6561., -25360. / 2187., 64448. / 6561., -212. / 729.],
+   [9017./3168., -355./33., 46732./5247., 49./176., -5103./18656.],
+   [35. / 384., 0., 500. / 1113., 125./192., -2187./6784., 11./84.]]
 
 c_sol = [35. /384., 0., 500. /1113., 125. /192., -2187. /6784., 11. / 84., 0.]
-c_error = [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
-           125. / 192. - 451. / 720., -2187. / 6784. + 12231. / 42400.,
-           11. / 84. - 649. / 6300., -1. / 60.]
+c_error =
+  [35. / 384. - 1951. / 21600., 0., 500. / 1113. - 22642. / 50085.,
+   125. / 192. - 451. / 720., -2187. / 6784. + 12231. / 42400.,
+   11. / 84. - 649. / 6300., -1. / 60.]
 
 def runge_kutta_step {v} [VSpace v] (func:v->Time->v)
-    (z0:v) (f0:v) (t0:Time) (dt:Time) : (v & v & v & (Fin 7)=>v) =
+      (z0:v) (f0:v) (t0:Time) (dt:Time)
+      : (v & v & v & (Fin 7)=>v) =
 
   evals_init = yieldState zero \r.
     r!(0@_) := f0
@@ -81,8 +88,10 @@ def runge_kutta_step {v} [VSpace v] (func:v->Time->v)
   f_last = evals_filled.(6@_)
   (z_last, f_last, z_last_error, evals_filled)
 
-def error_ratio {d} (error_estimates:d=>Float) (rtol:Float) (atol:Float)
-                (z0:d=>Float) (z1:d=>Float) : Float =
+def error_ratio {d}
+      (error_estimates:d=>Float) (rtol:Float) (atol:Float)
+      (z0:d=>Float) (z1:d=>Float)
+      : Float =
   err_tols = for i. atol + rtol * (max (abs z0.i) (abs z1.i))
   err_ratios = error_estimates ./ err_tols
   mean for i. sq err_ratios.i
@@ -99,8 +108,10 @@ def optimal_step_size (last_step:Time) (mean_error_ratio:Float) : Time =
   select (mean_error_ratio == 0.) (last_step * ifactor) (last_step / factor)
 
 
-def odeint {d n} (func: d=>Float -> Time -> d=>Float)
-           (z0: d=>Float) (t0: Time) (times: n=>Time) : n=>d=>Float =
+def odeint {d n}
+      (func: d=>Float -> Time -> d=>Float)
+      (z0: d=>Float) (t0: Time) (times: n=>Time)
+      : n=>d=>Float =
   -- Adaptive stepsize (Dormand-Prince) Runge-Kutta odeint implementation.
   --  Args:
   --    func: time derivative of the solution z at time t.

--- a/examples/quaternions.dx
+++ b/examples/quaternions.dx
@@ -79,10 +79,10 @@ $$
 
 instance Mul Quaternion
   mul = \ (Q{x,y,z,w}) (Q{x=x',y=y',z=z',w=w'}). Q {
-        x = w*x' + x*w' + y*z' - z*y',
-        y = w*y' - x*z' + y*w' + z*x',
-        z = w*z' + x*y' - y*x' + z*w',
-        w = w*w' - x*x' - y*y' - z*z'
+    x = w*x' + x*w' + y*z' - z*y',
+    y = w*y' - x*z' + y*w' + z*x',
+    z = w*z' + x*y' - y*x' + z*w',
+    w = w*w' - x*x' - y*y' - z*z'
   }
   one = ident
 

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -112,9 +112,10 @@ Filter   = Color
 
 -- TODO: use a record
 -- num samples, num bounces, share seed?
-Params = { numSamples : Int
-         & maxBounces : Int
-         & shareSeed  : Bool }
+Params = {
+    numSamples : Int
+  & maxBounces : Int
+  & shareSeed  : Bool }
 
 -- TODO: use a list instead, once they work
 data Scene n:Type [Ix n] = MkScene (n=>Object)
@@ -246,8 +247,8 @@ def trace {n} (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
             Continue
 
 -- Assumes we're looking towards -z.
-Camera =
-  { numPix     : Int
+Camera = {
+    numPix     : Int
   & pos        : Position  -- pinhole position
   & halfWidth  : Float     -- sensor half-width
   & sensorDist : Float }   -- pinhole-sensor distance
@@ -288,31 +289,33 @@ whiteWallColor = [255.0, 239.0, 196.0] / 255.0
 blockColor     = [200.0, 200.0, 255.0] / 255.0
 
 theScene = MkScene $
-    [ Light (1.9 .* yHat) 0.5 lightColor
-    , PassiveObject (Wall      xHat  2.0) (Matte leftWallColor)
-    , PassiveObject (Wall (neg xHat) 2.0) (Matte rightWallColor)
-    , PassiveObject (Wall      yHat  2.0) (Matte whiteWallColor)
-    , PassiveObject (Wall (neg yHat) 2.0) (Matte whiteWallColor)
-    , PassiveObject (Wall      zHat  2.0) (Matte whiteWallColor)
-    , PassiveObject (Block  [ 1.0, -1.6,  1.2] [0.6, 0.8, 0.6] 0.5) (Matte blockColor)
-    , PassiveObject (Sphere [-1.0, -1.2,  0.2] 0.8) (Matte (0.7.* whiteWallColor))
-    , PassiveObject (Sphere [ 2.0,  2.0, -2.0] 1.5) (Mirror)
-    ]
+  [ Light (1.9 .* yHat) 0.5 lightColor
+  , PassiveObject (Wall      xHat  2.0) (Matte leftWallColor)
+  , PassiveObject (Wall (neg xHat) 2.0) (Matte rightWallColor)
+  , PassiveObject (Wall      yHat  2.0) (Matte whiteWallColor)
+  , PassiveObject (Wall (neg yHat) 2.0) (Matte whiteWallColor)
+  , PassiveObject (Wall      zHat  2.0) (Matte whiteWallColor)
+  , PassiveObject (Block  [ 1.0, -1.6,  1.2] [0.6, 0.8, 0.6] 0.5) (Matte blockColor)
+  , PassiveObject (Sphere [-1.0, -1.2,  0.2] 0.8) (Matte (0.7.* whiteWallColor))
+  , PassiveObject (Sphere [ 2.0,  2.0, -2.0] 1.5) (Mirror)
+  ]
 
-defaultParams = { numSamples = 50
-                , maxBounces = 10
-                , shareSeed  = True }
+defaultParams = {
+    numSamples = 50
+  , maxBounces = 10
+  , shareSeed  = True }
 
-defaultCamera = { numPix     = 250
-                , pos        = 10.0 .* zHat
-                , halfWidth  = 0.3
-                , sensorDist = 1.0 }
+defaultCamera = {
+    numPix     = 250
+  , pos        = 10.0 .* zHat
+  , halfWidth  = 0.3
+  , sensorDist = 1.0 }
 
 -- We change to a small num pix here to reduce the compute needed for tests
 params = defaultParams
 camera = if dex_test_mode ()
-           then defaultCamera |> setAt #numPix 10
-           else defaultCamera
+  then defaultCamera |> setAt #numPix 10
+  else defaultCamera
 
 -- %time
 (MkImage _ _ image) = takePicture params theScene camera

--- a/examples/simplex.dx
+++ b/examples/simplex.dx
@@ -198,9 +198,10 @@ def cononicalize_constraint (inequality: Constraint vars):
     GreaterThan -> (-coeffs, -offset)
 
 def build_tableau [Eq cons]
-    (ineqs: cons=>Constraint vars)
-    (objective: vars=>Float)
-    (objType:ObjectiveType) : Tableau cons vars =
+      (ineqs: cons=>Constraint vars)
+      (objective: vars=>Float)
+      (objType:ObjectiveType)
+      : Tableau cons vars =
 
   table = for i. case i of
     {|constraints=i|} ->
@@ -221,7 +222,8 @@ def build_tableau [Eq cons]
   (basics, nonbasics, table)
 
 def negate_constraints_with_negative_offsets [Eq cons]
-  (tableau: (Tableau cons vars)): Tableau cons vars =
+      (tableau: (Tableau cons vars))
+      : Tableau cons vars =
   (basics, nonbasics, table) = tableau
   table' = yieldState table \tableRef.
     for i:cons.
@@ -232,7 +234,8 @@ def negate_constraints_with_negative_offsets [Eq cons]
   (basics, nonbasics, table')
 
 def build_feasibility_tableau [Eq cons]
-  (tableau: (Tableau cons vars)): FeasibilityTableau cons vars =
+      (tableau: (Tableau cons vars))
+      : FeasibilityTableau cons vars =
   -- Builds an expanded tableau, with an extra variable for each constraint.
   -- If these new variables can be driven to zero,
   -- while satisfying all constraints, then the original problem is feasible.
@@ -293,8 +296,9 @@ def chooseColumn (tableau: (AbsTableau cons vars extra)) : ColIx cons vars =
   col = argmax_suchthat objective_coeffs \x. x > 0.0
   nonbasics.col
 
-def findPivotIndex (tableau: (AbsTableau cons vars extra))
- : Maybe (RowIx cons extra & ColIx cons vars) =
+def findPivotIndex
+      (tableau: (AbsTableau cons vars extra))
+      : Maybe (RowIx cons extra & ColIx cons vars) =
   -- Chooses row and column to pivot around next.
   (_, _, table) = tableau
   pivotcol = chooseColumn tableau  
@@ -314,9 +318,9 @@ def findPivotIndex (tableau: (AbsTableau cons vars extra))
 
 
 def pivot [Eq cons, Eq extra, Eq vars]
-          (tableau:(AbsTableau cons vars extra))
-          ((pivotrow, pivotcol):(RowIx cons extra & ColIx cons vars)) :
-          (AbsTableau cons vars extra) =
+      (tableau:(AbsTableau cons vars extra))
+      ((pivotrow, pivotcol):(RowIx cons extra & ColIx cons vars))
+      : (AbsTableau cons vars extra) =
   (basics, nonbasics, table) = tableau
 
   newTable = for row.
@@ -340,9 +344,9 @@ def pivot [Eq cons, Eq extra, Eq vars]
 ' #### Transition between phase 1 and 2: `feasibilityTableauToNormalTableau`
 
 def find_non_artificial_pivcol [Eq cons, Eq vars]
-  (tableau: FeasibilityTableau cons vars)
-  (pivrow: RowIx cons Unit)
-  : ColIx cons {realvars: vars | artificials: cons} =
+      (tableau: FeasibilityTableau cons vars)
+      (pivrow: RowIx cons Unit)
+      : ColIx cons {realvars: vars | artificials: cons} =
   (basics, nonbasics, table) = tableau
   coeff = for i.
     col = nonbasics.i
@@ -356,7 +360,8 @@ def find_non_artificial_pivcol [Eq cons, Eq vars]
 
 
 def pivot_artificials [Eq cons, Eq vars]
-  (tableau: FeasibilityTableau cons vars) : (FeasibilityTableau cons vars) =
+      (tableau: FeasibilityTableau cons vars)
+      : (FeasibilityTableau cons vars) =
   -- Pivot out all the artificial variables out of the basis
   yieldState tableau \tRef.
     tableau = get tRef
@@ -373,31 +378,33 @@ def pivot_artificials [Eq cons, Eq vars]
             tRef := pivot tableau (pivrow, pivcol)
 
 def deduce_nonbasics [Eq cons, Eq vars]
-  (basics: cons=>(ColIx cons vars)) : vars=>(ColIx cons vars) =
+      (basics: cons=>(ColIx cons vars))
+      : vars=>(ColIx cons vars) =
 
-    not_in_basics = \c. not $ any for r.
-      case basics.r of
-        {|slacks=r|}    -> case c of
-          {|slacks=c|}    -> r == c
-          {|variables=_|} -> False
-          {|value=_|}     -> True
-        {|variables=r|} -> case c of
-          {|slacks=_|}    -> False
-          {|variables=c|} -> r == c
-          {|value=_|}     -> True
+  not_in_basics = \c. not $ any for r.
+    case basics.r of
+      {|slacks=r|}    -> case c of
+        {|slacks=c|}    -> r == c
+        {|variables=_|} -> False
+        {|value=_|}     -> True
+      {|variables=r|} -> case c of
+        {|slacks=_|}    -> False
+        {|variables=c|} -> r == c
+        {|value=_|}     -> True
 
-    all_columns = for i. i
-    nonBasicsList = filter not_in_basics all_columns
+  all_columns = for i. i
+  nonBasicsList = filter not_in_basics all_columns
 
-    -- We know that there will be one nonbasic for every variable,
-    -- but don't know how to tell the compiler that, so
-    -- need to use an unsafe cast.
-    (AsList n nonBasicsTable) = nonBasicsList
-    unsafeCastTable vars nonBasicsTable
+  -- We know that there will be one nonbasic for every variable,
+  -- but don't know how to tell the compiler that, so
+  -- need to use an unsafe cast.
+  (AsList n nonBasicsTable) = nonBasicsList
+  unsafeCastTable vars nonBasicsTable
 
 
 def eliminate_artificials [Eq cons, Eq vars]
-  (tableau: FeasibilityTableau cons vars) : (Tableau cons vars) =
+      (tableau: FeasibilityTableau cons vars)
+      : (Tableau cons vars) =
 
   (basics, nonbasics, table) = tableau
 
@@ -424,7 +431,8 @@ def eliminate_artificials [Eq cons, Eq vars]
 
 
 def feasibilityTableauToNormalTableau [Eq cons, Eq vars]
-  (tableau: FeasibilityTableau cons vars) : (Tableau cons vars) =
+      (tableau: FeasibilityTableau cons vars)
+      : (Tableau cons vars) =
   ft = pivot_artificials tableau
   eliminate_artificials ft
 
@@ -455,9 +463,10 @@ def extractSolution (tableau: AbsTableau cons vars extra) : vars=>Float =
 '# Main Simplex Algorithm
 
 def simplex [Eq cons, Eq vars]
-  (ineqs: cons=>Constraint vars)
-  (objective: vars=>Float)
-  (objType:ObjectiveType) : SimplexResult vars =
+      (ineqs: cons=>Constraint vars)
+      (objective: vars=>Float)
+      (objType:ObjectiveType)
+      : SimplexResult vars =
   -- Note: Also enforces that all vars are >= 0.0
   -- Operates in two phases:
   -- First, finds a point within the simplex (or return infeasible)
@@ -524,9 +533,10 @@ unbounded_constraints =
 -- Introduction to Linear Optimization
 -- by D. Bertsimas and J. Tsitsiklis
 obj = [10.0, 12.0, 12.0]
-a = [[1., 2., 2.],
-     [2., 1., 2.],
-     [2., 2., 1.]]
+a =
+  [[1., 2., 2.],
+   [2., 1., 2.],
+   [2., 2., 1.]]
 textbook_constraints =
   for i. {coeffs=a.i, offset=20.0, conType=LessThan}
 
@@ -536,9 +546,10 @@ textbook_constraints =
 
 -- A feasible problem from Waterloo notes
 obj' = [1., -1.,  1.]
-a' = [[ 2., -1.,  2.],
-     [ 2., -3.,  1.],
-     [-1.,  1., -2.]]
+a' =
+  [[ 2., -1.,  2.],
+   [ 2., -3.,  1.],
+   [-1.,  1., -2.]]
 b' = [4., -5., -1.]
 textbook_constraints' =
   for i. {coeffs=a'.i, offset=b'.i, conType=LessThan}

--- a/examples/tiled-matmul.dx
+++ b/examples/tiled-matmul.dx
@@ -1,16 +1,19 @@
 -- We definitely want to improve this in the future, but it's fine if we only care
 -- about matrices that tile perfectly.
-def tile2d (n : Type) ?-> (m : Type) ?-> (b : Type) ?-> (nl : Type) ?-> (ml : Type) ?->
-           (fTile : Tile n nl -> Tile m ml -> nl=>ml=>b)
-           (fScalar : n -> m -> b) : n=>m=>b =
+def tile2d
+      (n : Type) ?-> (m : Type) ?-> (b : Type) ?-> (nl : Type) ?-> (ml : Type) ?->
+      (fTile : Tile n nl -> Tile m ml -> nl=>ml=>b)
+      (fScalar : n -> m -> b)
+      : n=>m=>b =
   (tile
     (\nt:(Tile n nl).
       (tile1 (\mt:(Tile m ml). fTile nt mt)
              (\mi:m. for ni:nl. fScalar (nt +> ni) mi)))
     (\ni:n. for mi:m. fScalar ni mi))
 
-def matmul (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
-           (a : n=>k=>Float) (b : k=>m=>Float) : n=>m=>Float =
+def matmul
+      (k : Type) ?-> (n : Type) ?-> (m : Type) ?->
+      (a : n=>k=>Float) (b : k=>m=>Float) : n=>m=>Float =
   rowTile = Fin 3
   colVectors = Fin 3
   vectorTile = Fin VectorWidth

--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -250,7 +250,7 @@ add5 1.0
   the table argument.
 
 def tableAdd5' {n} (x : n => Float32) : n => Float32 =
-    for i. x.i + 5.0
+  for i. x.i + 5.0
 
 :t tableAdd5' y
 > ((Fin 3 & Fin 8) => Float32)
@@ -262,12 +262,12 @@ def tableAdd5' {n} (x : n => Float32) : n => Float32 =
 ' Imagine we have `transpose` function. We can encode the shape change in the type.
 
 def transFloat {m n} (x : m => n => Float32) : n => m => Float32 =
-    for i. for j. x.j.i
+  for i. for j. x.j.i
 
 ' We can even make it more generic by abstracting over the value type.
 
 def trans {m n v} (x : m => n => v) : n => m => v =
-    for i. for j. x.j.i
+  for i. for j. x.j.i
 
 ' We can also use this to check for shape errors:
 
@@ -275,7 +275,7 @@ def trans {m n v} (x : m => n => v) : n => m => v =
 > ((Fin 3) => (Fin 8) => Float32)
 
 def tableAdd' {m n} (x : m => n => Float32) (y : m => n => Float32) : m => n => Float32 =
-    for i. for j. x.i.j + y.i.j
+  for i. for j. x.i.j + y.i.j
 
 :t tableAdd' x x
 > ((Fin 3) => (Fin 8) => Float32)
@@ -316,23 +316,23 @@ Full = Fin ((size Batch) * (size IHeight) * (size IWidth))
   ignore it for now.
 
 def pixel (x:Char) : Float32 =
-     r = W8ToI x
-     IToF case r < 0 of
-             True -> 256 + r
-             False -> r
+  r = W8ToI x
+  IToF case r < 0 of
+    True -> 256 + r
+    False -> r
 
 def getIm : Batch => Image =
-    -- File is unsigned bytes offset with 16 starting bytes
-    (AsList _ im) = unsafeIO do readFile "examples/t10k-images-idx3-ubyte"
-    raw = unsafeCastTable Full (for i:Full. im.((ordinal i + 16) @ _))
-    for b: Batch i j.
-        pixel raw.((ordinal (b, i, j)) @ Full)
+  -- File is unsigned bytes offset with 16 starting bytes
+  (AsList _ im) = unsafeIO do readFile "examples/t10k-images-idx3-ubyte"
+  raw = unsafeCastTable Full (for i:Full. im.((ordinal i + 16) @ _))
+  for b: Batch i j.
+    pixel raw.((ordinal (b, i, j)) @ Full)
 
 def getLabel : Batch => Class =
-    -- File is unsigned bytes offset with 8 starting bytes
-    (AsList _ lab) = unsafeIO do readFile "examples/t10k-labels-idx1-ubyte"
-    r = unsafeCastTable Batch (for i:Batch. lab.((ordinal i + 8) @ _))
-    for i. (W8ToI r.i @ Class)
+  -- File is unsigned bytes offset with 8 starting bytes
+  (AsList _ lab) = unsafeIO do readFile "examples/t10k-labels-idx1-ubyte"
+  r = unsafeCastTable Batch (for i:Batch. lab.((ordinal i + 8) @ _))
+  for i. (W8ToI r.i @ Class)
 
 all_ims = getIm
 all_labels = getLabel
@@ -364,9 +364,9 @@ imscolor = for i. for j. for c:Channels. ims.((ordinal c)@_).i.j
 ' This one shows all the images on one channel over the base plot.
 
 imscolor2 = for b. for i. for j. for c:Channels.
-          case ordinal c == 0 of
-             True -> (sum ims).i.j / (IToF (size Batch))
-             False -> ims.b.i.j
+  case ordinal c == 0 of
+    True  -> (sum ims).i.j / (IToF (size Batch))
+    False -> ims.b.i.j
 
 :html imseqshow (imscolor2 / 255.0)
 > <html output>
@@ -377,12 +377,13 @@ imscolor2 = for b. for i. for j. for c:Channels.
   types.
 
 def split {m n o v} [Ix n, Ix o] (x: m=>v) : n=>o=>v =
-    for i j. x.(ordinal (i,j)@_)
+  for i j. x.(ordinal (i,j)@_)
 
 def imtile {a b n o p q v}
-           [Ix n, Ix o, Ix p, Ix q]
-           (x: a=>b=>v) : n=>o=>p=>q=>v =
-    for kh kw h w. (split (split x).h.kh).w.kw
+      [Ix n, Ix o, Ix p, Ix q]
+      (x: a=>b=>v)
+      : n=>o=>p=>q=>v =
+  for kh kw h w. (split (split x).h.kh).w.kw
 
 im1 : Fin 2 => Fin 2 => Fin 14 => Fin 14 => Float32 = imtile ims.(0@_)
 
@@ -420,14 +421,14 @@ im2 : Fin 4 => Fin 4 => Fin 7 => Fin 7 => Float32 = imtile ims.(0@_)
   and `:=` assignment). Here's what it looks like:
 
 def tableMean {n} (x : n => Float32) : Float32 =
-    -- acc = 0
-    withState 0.0 $ \acc.
-         -- for i in range(len(x))
-         for i.
-             -- acc = acc + x[i]
-             acc := (get acc) + x.i
-         -- return acc / len(x)
-         (get acc) / (IToF (size n))
+  -- acc = 0
+  withState 0.0 $ \acc.
+    -- for i in range(len(x))
+    for i.
+      -- acc = acc + x[i]
+      acc := (get acc) + x.i
+    -- return acc / len(x)
+    (get acc) / (IToF (size n))
 
 
 tableMean [0.0, 1.0, 0.5]
@@ -469,9 +470,9 @@ tableMean [0.0, 1.0, 0.5]
   Here's a simple example:
 
 withState 10 $ \ state.
-     state := 30
-     state := 10
-     get state
+  state := 30
+  state := 10
+  get state
 > 10
 
 ' The element returned is the body function's result (`10`)
@@ -597,11 +598,11 @@ instance {v w} [VSpace v, VSpace w] VSpace (v & w)
 Pixels = Fin 256
 
 def bincount {a b} [Ix b] (inp : a => b) : b => Int =
-    withState zero \acc .
-        for i.
-            v = acc!(inp.i)
-            v := (get v) + 1
-        get acc
+  withState zero \acc .
+    for i.
+      v = acc!(inp.i)
+      v := (get v) + 1
+    get acc
 
 ' Plot how many times each pixel value occurs in an image:
 
@@ -615,12 +616,12 @@ hist = bincount $ for (i,j). (FToI (ims.(0 @ _).i.j) @Pixels)
 ' Find nearest images in the dataset:
 
 def imdot {m n} (x : m=>n=>Float32) (y : m=>n=>Float32) : Float32 =
-    sum for (i, j). x.i.j * y.i.j
+  sum for (i, j). x.i.j * y.i.j
 
 dist = for b1. for b2.
-        case b1 == b2 of
-             True -> 0.0
-             False -> -imdot ims.b1 ims.b2
+  case b1 == b2 of
+    True  -> 0.0
+    False -> -imdot ims.b1 ims.b2
 
 nearest = for i. argmin dist.i
 
@@ -657,8 +658,7 @@ toList for i:Height. 0.0
 ' Tables of lists can be concatenated down to
   single lists.
 
-z = concat [toList [3.0],
-            toList [1.0, 2.0 ]]
+z = concat [toList [3.0], toList [1.0, 2.0 ]]
 z
 > (AsList 3 [3., 1., 2.])
 
@@ -674,9 +674,9 @@ temptab
 shoes = (5 @ Class)
 
 def findShoes {a b} (x : a=>b) (y : a=>Class) : List b =
-    concat for i. case (y.i == (5 @ _)) of
-            True -> toList [x.i]
-            False -> toList []
+  concat for i. case (y.i == (5 @ _)) of
+    True  -> toList [x.i]
+    False -> toList []
 
 ' Note though that the type here does not tell us
   how many there are. The type system cannot know this.

--- a/examples/vega-plotting.dx
+++ b/examples/vega-plotting.dx
@@ -134,16 +134,16 @@ data Channel =
      Size
 
 instance Show Channel
-         show = (\ x.
-              case x of
-                   Y -> "y"
-                   X -> "x"
-                   Color -> "color"
-                   Tooltip -> "tooltip"
-                   HREF -> "href"
-                   Size -> "size"
-                   Row -> "row"
-                   Col -> "col")
+     show = (\ x.
+          case x of
+               Y -> "y"
+               X -> "x"
+               Color -> "color"
+               Tooltip -> "tooltip"
+               HREF -> "href"
+               Size -> "size"
+               Row -> "row"
+               Col -> "col")
 
 
 ' The final aspect of Vega-Lite is the Mark.
@@ -166,17 +166,17 @@ data Mark =
      Tick
 
 instance Show Mark
-         show = (\ x.
-              case x of
-                   Area -> "area"
-                   Bar -> "bar"
-                   Circle -> "circle"
-                   Line -> "line"
-                   Point -> "point"
-                   Rect -> "rect"
-                   Rule-> "rule"
-                   Square -> "square"
-                   Tick -> "tick")
+     show = (\ x.
+          case x of
+               Area -> "area"
+               Bar -> "bar"
+               Circle -> "circle"
+               Line -> "line"
+               Point -> "point"
+               Rect -> "rect"
+               Rule-> "rule"
+               Square -> "square"
+               Tick -> "tick")
 
 ' Most things in VL can take in extra visual options.
   To avoid specifying these, we will take in as
@@ -189,7 +189,7 @@ def pure (x:a) : Opts a =
     WithOpts x AsNone
 
 def pureLs (x:a) : List (Opts a) =
-   AsList 1 [WithOpts x AsNone]
+    AsList 1 [WithOpts x AsNone]
 
 def mergeOpts [ToJSON a, ToJSON b] (x : a) (y : b) : Value =
      case toJSON x of
@@ -255,8 +255,9 @@ def showVega (x: Value) : String =
 
 ' Start with a well type and useful Dex record
 
-df1 = for i. {a = ["A", "B", "C", "D", "E", "F", "G", "H", "I"].i,
-              b = [28, 55, 43, 91, 81, 53, 19, 87, 52].i}
+df1 = for i.
+    {a = ["A", "B", "C", "D", "E", "F", "G", "H", "I"].i,
+     b = [28, 55, 43, 91, 81, 53, 19, 87, 52].i}
 
 
 chart1 = (AsVLDescriptor (pure Bar) [("title", "Bar Graph")]
@@ -300,21 +301,21 @@ key : Key = newKey 1
 
 
 df2 :(Fin 100) => {x1:Float & x2:Float & weight:Float & label:Class}  =  for i: (Fin 100).
-              [k1, k2, k3, k4] = splitKey $ ixkey key i
-              {x1=(arb k1),
-               x2=arb k2,
-               weight=arb k3,
-               label=arb k4}
+     [k1, k2, k3, k4] = splitKey $ ixkey key i
+     {x1=(arb k1),
+      x2=arb k2,
+      weight=arb k3,
+      label=arb k4}
 
 ' The descriptor has a mapping between the variable names and their encoding type.
 
 ' We use a different mark `Point` and pass in multiple Channels for some variables.
 
 chart2 = (AsVLDescriptor (pure Point) [("title", "Scatter")]
-            [{title="X1", encodings=pureLs X, encType=Quantitative, rows=wrapCol #x1 df2},
-             {title="X2", encodings=pureLs Y, encType=Quantitative, rows=wrapCol #x2 df2},
-             {title="Weight", encodings=pureLs Size, encType=Quantitative, rows=wrapCol #weight df2},
-             {title="Label", encodings=toList [pure Color, pure Tooltip], encType=Nominal, rows=wrapCol #label df2}])
+     [{title="X1", encodings=pureLs X, encType=Quantitative, rows=wrapCol #x1 df2},
+      {title="X2", encodings=pureLs Y, encType=Quantitative, rows=wrapCol #x2 df2},
+      {title="Weight", encodings=pureLs Size, encType=Quantitative, rows=wrapCol #weight df2},
+      {title="Label", encodings=toList [pure Color, pure Tooltip], encType=Nominal, rows=wrapCol #label df2}])
 
 
 :html showVega $ toJSON chart2
@@ -334,9 +335,9 @@ df3 = for i. cumSum . for j. select (y1.i.j > 0.0) (-1.0) 1.0
 > ((Fin 3) => (Fin 10) => Float32)
 
 chart3 = (AsVLDescriptor (pure Area) [("title", "Area"), ("height", "75")]
-            [{title="density", encodings=pureLs Y, encType=Quantitative, rows=for (i,j). toJSON df3.i.j},
-             {title="Runs", encodings=pureLs Row, encType=Nominal, rows= for (i,_). toJSON $ ["Run 1", "Run 2", "Run 3"].i},
-             {title="Round", encodings=pureLs X, encType=Ordinal, rows=for (_,j). toJSON $ ordinal j}]
+     [{title="density", encodings=pureLs Y, encType=Quantitative, rows=for (i,j). toJSON df3.i.j},
+      {title="Runs", encodings=pureLs Row, encType=Nominal, rows= for (i,_). toJSON $ ["Run 1", "Run 2", "Run 3"].i},
+      {title="Round", encodings=pureLs X, encType=Ordinal, rows=for (_,j). toJSON $ ordinal j}]
 )
 
 :html showVega $ toJSON chart3
@@ -349,11 +350,10 @@ words = ["the", "dog", "walked", "to", "the", "store"]
 z :  (Fin 6) => (Fin 6) => Float = arb $ newKey 0
 
 def showChart4 [ToJSON o] (opts:o) : Value  = toJSON (AsVLDescriptor (pure Rect) opts
-            [{title="match", encodings=pureLs Color, encType=Quantitative, rows=for (i,j). toJSON z.i.j},
-            {title="words", encodings=pureLs Tooltip, encType=Nominal, rows=for (i,j). toJSON (words.i <> " - " <> words.j)},
-            {title="row", encodings=pureLs X, encType=Ordinal, rows=for (i,_). toJSON (ordinal i)},
-            {title="col", encodings=pureLs Y, encType=Ordinal, rows=for (_,j). toJSON (ordinal j)}]
-        )
+     [{title="match", encodings=pureLs Color, encType=Quantitative, rows=for (i,j). toJSON z.i.j},
+     {title="words", encodings=pureLs Tooltip, encType=Nominal, rows=for (i,j). toJSON (words.i <> " - " <> words.j)},
+     {title="row", encodings=pureLs X, encType=Ordinal, rows=for (i,_). toJSON (ordinal i)},
+     {title="col", encodings=pureLs Y, encType=Ordinal, rows=for (_,j). toJSON (ordinal j)}])
 
 ' Default heat map
 
@@ -363,9 +363,9 @@ def showChart4 [ToJSON o] (opts:o) : Value  = toJSON (AsVLDescriptor (pure Rect)
 ' Customization through JSON options.
 
 
-:html showVega $ showChart4 $ mergeOpts [("title",  "HeatMap"), ("height", "200"), ("width",  "200")] [("config", toJSON [
-          ("axis", [("grid", "1"), ("tickBand",  "extent")])
-          ])]
+:html showVega $ showChart4 $ mergeOpts
+      [("title",  "HeatMap"), ("height", "200"), ("width",  "200")]
+      [("config", toJSON [("axis", [("grid", "1"), ("tickBand",  "extent")])])]
 > <html output>
 
 

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -25,13 +25,13 @@ red   : HtmlColor = [IToW8 255, IToW8   0, IToW8   0]
 green : HtmlColor = [IToW8   0, IToW8 255, IToW8   0]
 blue  : HtmlColor = [IToW8   0, IToW8   0, IToW8 255]
 
-GeomStyle : Type =
-  { fillColor   : Maybe HtmlColor
+GeomStyle : Type = {
+    fillColor   : Maybe HtmlColor
   & strokeColor : Maybe HtmlColor
   & strokeWidth : Int }
 
-defaultGeomStyle : GeomStyle =
-  { fillColor   = Nothing
+defaultGeomStyle : GeomStyle = {
+    fillColor   = Nothing
   , strokeColor = Just black
   , strokeWidth = 1 }
 

--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -24,8 +24,9 @@ def Color : Type = Fin 3 => Float
 
 def applyScale {a} (s:Scale a) (x:a) : Maybe Float = getAt #mapping s x
 
-unitTypeScale : Scale Unit = { mapping = \(). Just 0.0
-                             , range   = AsList _ [Singleton 0.0] }
+unitTypeScale : Scale Unit =
+  { mapping = \(). Just 0.0
+  , range   = AsList _ [Singleton 0.0] }
 
 def projectUnitInterval (x:Float) : Maybe Float =
   case x >= 0.0 && x <= 1.0 of
@@ -83,7 +84,7 @@ def blankData {n} [Ix n] : ScaledData n Unit =
   {scale = unitTypeScale, dat = for i. ()}
 
 def blankPlot {n} [Ix n] : Plot n Unit Unit Unit =
-  { xs = blankData, ys = blankData, cs = blankData }
+  {xs = blankData, ys = blankData, cs = blankData}
 
 -- -- TODO: generalize beyond Float with a type class for auto scaling
 def autoScale {n} (xs:n=>Float) : ScaledData n Float =
@@ -94,7 +95,7 @@ def autoScale {n} (xs:n=>Float) : ScaledData n Float =
   padding = maximum [space, max * 0.001, 0.000001]
   {scale = floatScale (min - padding) (max + padding), dat = xs}
 
-def setXData {n a b c new} (xs:ScaledData n new) (plot:Plot n a b c) : Plot n new b c=
+def setXData {n a b c new} (xs:ScaledData n new) (plot:Plot n a b c) : Plot n new b c =
   -- We can't use `setAt` here because we're changing the type
   {xs = xs, ys = getAt #ys plot, cs = getAt #cs plot}
 

--- a/lib/png.dx
+++ b/lib/png.dx
@@ -1,13 +1,14 @@
 '## Base 64 encoder
 
-encodingTable = ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
-                 'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
-                 'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
-                 'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
-                 'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
-                 'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
-                 'w', 'x', 'y', 'z', '0', '1', '2', '3',
-                 '4', '5', '6', '7', '8', '9', '+', '/']
+encodingTable =
+  ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
+   'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
+   'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
+   'Y', 'Z', 'a', 'b', 'c', 'd', 'e', 'f',
+   'g', 'h', 'i', 'j', 'k', 'l', 'm', 'n',
+   'o', 'p', 'q', 'r', 's', 't', 'u', 'v',
+   'w', 'x', 'y', 'z', '0', '1', '2', '3',
+   '4', '5', '6', '7', '8', '9', '+', '/']
 
 -- TODO: make `Word8` an index set instead of using `Fin 256`
 decodingTable : Fin 256 => Maybe Char =
@@ -22,8 +23,8 @@ Base64 = Byte -- first two bits should be zero
 -- This could go in the prelude, or in a library of array-dicing functions.
 -- An explicit "view" builder would be good here, to avoid copies
 def getChunks {n a}
-    (chunkSize:Int) (padVal:a) (xs:n=>a)
-    : List (Fin chunkSize => a) =
+      (chunkSize:Int) (padVal:a) (xs:n=>a)
+      : List (Fin chunkSize => a) =
   numChunks = idivCeil (size n) chunkSize
   paddedSize = numChunks * chunkSize
   xsPadded = padTo (Fin paddedSize) padVal xs

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1078,12 +1078,15 @@ def Tile (n : Type) (m : Type) : Type = %IndexSlice n m
 def (+>)  {n l} (t:Tile n l) (i : l) : n = %sliceOffset t i
 def (++>) {n u v} (t : Tile n (u & v)) (i : u) : Tile n v = %sliceCurry t i
 
-def tile  {n l a eff} [Ix n, Ix l]
-          (fTile : (t:(Tile n l) -> {|eff} l=>a))
-          (fScalar : n -> {|eff} a) : {|eff} n=>a = %tiled fTile fScalar
+def tile {n l a eff} [Ix n, Ix l]
+      (fTile : (t:(Tile n l) -> {|eff} l=>a))
+      (fScalar : n -> {|eff} a) : {|eff} n=>a =
+  %tiled fTile fScalar
+
 def tile1 {n m l a eff} [Ix m, Ix n, Ix l]
-          (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
-          (fScalar : n -> {|eff} m=>a) : {|eff} m=>n=>a = %tiledd fTile fScalar
+      (fTile : (t:(Tile n l) -> {|eff} m=>l=>a))
+      (fScalar : n -> {|eff} m=>a) : {|eff} m=>n=>a =
+  %tiledd fTile fScalar
 
 -- TODO: This should become just `loadVector $ for i. arr.(t +> i)`
 --       once we are able to eliminate temporary arrays. Until then, we inline for performance...
@@ -1229,7 +1232,8 @@ by using `splitR &>> iso`
 
 def splitR {a} : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 
-def overFields {a b c v} [Ix b, Ix c] (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
+def overFields {a b c v} [Ix b, Ix c]
+      (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
   overLens (splitR &>> iso) tab
 
 'Convert a variant zipper isomorphism to a normal prism-like isomorphism
@@ -1245,9 +1249,10 @@ def sliceFields {a b c v} [Ix b] (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v
 
 -- TODO: would be nice to be able to use records here
 data DynBuffer a =
-  MkDynBuffer { size    : Ptr Int
-              & maxSize : Ptr Int
-              & buffer  : Ptr (Ptr a) }
+  MkDynBuffer {
+      size    : Ptr Int
+    & maxSize : Ptr Int
+    & buffer  : Ptr (Ptr a) }
 
 def withDynamicBuffer {a b} [Storable a]
       (action: DynBuffer a -> {IO} b) : {IO} b =
@@ -1256,15 +1261,15 @@ def withDynamicBuffer {a b} [Storable a]
     store sizePtr 0
     store maxSizePtr initMaxSize
     store bufferPtr $ malloc initMaxSize
-    result = action $ MkDynBuffer { size    = sizePtr
-                                  , maxSize = maxSizePtr
-                                  , buffer  = bufferPtr }
-
+    result = action $ MkDynBuffer {
+        size    = sizePtr
+      , maxSize = maxSizePtr
+      , buffer  = bufferPtr }
     free $ load bufferPtr
     result
 
 def maybeIncreaseBufferSize {a} [Storable a]
-    ((MkDynBuffer db): DynBuffer a) (sizeDelta:Int) : {IO} Unit =
+      ((MkDynBuffer db): DynBuffer a) (sizeDelta:Int) : {IO} Unit =
   size    = load $ getAt #size    db
   maxSize = load $ getAt #maxSize db
   bufPtr  = load $ getAt #buffer  db
@@ -1282,7 +1287,7 @@ def addAtIntPtr (ptr: Ptr Int) (n:Int) : {IO} Unit =
   store ptr (load ptr + n)
 
 def extendDynBuffer {a} [Storable a]
-    (buf: DynBuffer a) (new:List a) : {IO} Unit =
+      (buf: DynBuffer a) (new:List a) : {IO} Unit =
   (AsList n xs) = new
   maybeIncreaseBufferSize buf n
   (MkDynBuffer db) = buf
@@ -1474,8 +1479,9 @@ def iter {a eff} (body: Int -> {|eff} IterResult a) : {|eff} a  =
     Just ans -> ans
     Nothing -> unreachable ()
 
-def boundedIter {a eff} (maxIters:Int) (fallback:a)
-                (body: Int -> {|eff} IterResult a) : {|eff} a  =
+def boundedIter {a eff}
+      (maxIters:Int) (fallback:a)
+      (body: Int -> {|eff} IterResult a) : {|eff} a  =
   iter \i.
     if i >= maxIters
       then Done fallback
@@ -1563,7 +1569,8 @@ def deleteFile (f:FilePath) : {IO} Unit =
     removeFFI ptr
   ()
 
-def withFile {a} (f:FilePath) (mode:StreamMode)
+def withFile {a}
+      (f:FilePath) (mode:StreamMode)
       (action: Stream mode -> {IO} a)
       : {IO} a =
   stream = fopen f mode
@@ -1741,8 +1748,8 @@ instance {n a} [Arbitrary a] Arbitrary (n=>a)
 
 instance {a b} [Arbitrary a, Arbitrary b] Arbitrary (a & b)
   arb = \key.
-      [k1, k2] = splitKey key
-      (arb k1, arb k2)
+    [k1, k2] = splitKey key
+    (arb k1, arb k2)
 
 instance {n} Arbitrary (Fin n)
   arb = randIdx
@@ -1799,32 +1806,32 @@ def argmin {n o} [Ord o] (xs:n=>o) : n = argscan (<) xs
 def argmax {n o} [Ord o] (xs:n=>o) : n = argscan (>) xs
 
 def lexicalOrder {n} [Ord n]
-  (compareElements:n->n->Bool)
-  (compareLengths:Int->Int->Bool)
-  ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
-    -- Orders Lists according to the order of their elements,
-    -- in the same way a dictionary does.
-    -- For example, this lets us sort Strings.
-    --
-    -- More precisely, it returns True iff compareElements xs.i ys.i is true
-    -- at the first location they differ.
-    --
-    -- This function operates serially and short-circuits
-    -- at the first difference.  One could also write this
-    -- function as a parallel reduction, but it would be
-    -- wasteful in the case where there is an early difference,
-    -- because we can't short circuit.
-    iter \i.
-      case i == min nx ny of
-        True -> Done $ compareLengths nx ny
-        False ->
-          xi = xs.(unsafeFromOrdinal _ i)
-          yi = ys.(unsafeFromOrdinal _ i)
-          case compareElements xi yi of
-            True -> Done True
-            False -> case xi == yi of
-              True -> Continue
-              False -> Done False
+      (compareElements:n->n->Bool)
+      (compareLengths:Int->Int->Bool)
+      ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
+  -- Orders Lists according to the order of their elements,
+  -- in the same way a dictionary does.
+  -- For example, this lets us sort Strings.
+  --
+  -- More precisely, it returns True iff compareElements xs.i ys.i is true
+  -- at the first location they differ.
+  --
+  -- This function operates serially and short-circuits
+  -- at the first difference.  One could also write this
+  -- function as a parallel reduction, but it would be
+  -- wasteful in the case where there is an early difference,
+  -- because we can't short circuit.
+  iter \i.
+    case i == min nx ny of
+      True -> Done $ compareLengths nx ny
+      False ->
+        xi = xs.(unsafeFromOrdinal _ i)
+        yi = ys.(unsafeFromOrdinal _ i)
+        case compareElements xi yi of
+          True -> Done True
+          False -> case xi == yi of
+            True -> Continue
+            False -> Done False
 
 instance {n} [Ord n] Ord (List n)
   (>) = lexicalOrder (>) (>)

--- a/lib/set.dx
+++ b/lib/set.dx
@@ -21,20 +21,20 @@ def allExceptLast {n a} (xs:n=>a) : List a =
   (AsList _ allButLast)
 
 def mergeUniqueSortedLists {a} [Eq a] (xlist:List a) (ylist:List a) : List a =
-    -- This function is associative, for use in a monoidal reduction.
-    -- Assumes all xs are <= all ys.
-    -- The element at the end of xs might equal the
-    -- element at the beginning of ys.  If so, this
-    -- function removes the duplicate when concatenating the lists.
-    (AsList nx xs) = xlist
-    (AsList _  ys) = ylist
-    case last xs of
-      Nothing -> ylist
-      Just last_x -> case first ys of
-        Nothing -> xlist
-        Just first_y -> case last_x == first_y of
-          False -> concat [xlist,            ylist]
-          True ->  concat [allExceptLast xs, ylist]
+  -- This function is associative, for use in a monoidal reduction.
+  -- Assumes all xs are <= all ys.
+  -- The element at the end of xs might equal the
+  -- element at the beginning of ys.  If so, this
+  -- function removes the duplicate when concatenating the lists.
+  (AsList nx xs) = xlist
+  (AsList _  ys) = ylist
+  case last xs of
+    Nothing -> ylist
+    Just last_x -> case first ys of
+      Nothing -> xlist
+      Just first_y -> case last_x == first_y of
+        False -> concat [xlist,            ylist]
+        True ->  concat [allExceptLast xs, ylist]
 
 def removeDuplicatesFromSorted {n a} [Eq a] (xs:n=>a) : List a =
   xlists = for i:n. (AsList 1 [xs.i])
@@ -61,21 +61,21 @@ instance {a} [Eq a] Eq (Set a)
     (AsList _ xs) == (AsList _ ys)
 
 def setUnion {a}
-  ((UnsafeAsSet nx xs):Set a)
-  ((UnsafeAsSet ny ys):Set a) : Set a =
-    combined = mergeSortedTables xs ys
-    (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted combined
-    UnsafeAsSet _ sorted_unique_xs
+      ((UnsafeAsSet nx xs):Set a)
+      ((UnsafeAsSet ny ys):Set a) : Set a =
+  combined = mergeSortedTables xs ys
+  (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted combined
+  UnsafeAsSet _ sorted_unique_xs
 
 def setIntersect {a}
-  ((UnsafeAsSet nx xs):Set a)
-  ((UnsafeAsSet ny ys):Set a) : Set a =
-    -- This could be done in O(nx + ny) instead of O(nx log ny).
-    isInYs = \x. case searchSorted ys x of
-      Just x -> True
-      Nothing -> False
-    (AsList n' intersection) = filter isInYs xs
-    UnsafeAsSet _ intersection
+      ((UnsafeAsSet nx xs):Set a)
+      ((UnsafeAsSet ny ys):Set a) : Set a =
+  -- This could be done in O(nx + ny) instead of O(nx log ny).
+  isInYs = \x. case searchSorted ys x of
+    Just x -> True
+    Nothing -> False
+  (AsList n' intersection) = filter isInYs xs
+  UnsafeAsSet _ intersection
 
 
 '### Index set for sets of strings


### PR DESCRIPTION
Hanging indentation is when the amount a line is indented depends on a name, usually one that occurs on the previous line.  For example,

```
def some_long_function (arg1: type1)
                       (arg2: type2)
                       : return =
  body
```

It's not clear that this actually aids readability much, relative to just breaking the line after `some_long_function`; and it's highly fragile to automatic renames that change the length of the function name.  Ergo, it seemed best to just not do this in our code.

The specific case of function signatures with long argument lists is fairly common, and merits some comment.  Following a few examples of Dougal's, I adopted a convention of indenting the argument list six spaces, and aligning the : return on a line by itself.  Conventionally, I also leave implicit arguments on the same line as the function name, if they fit.  This ends up looking like

```
def some_long_function
      (arg1: type1)
      (arg2: type2)
      : return =
  body
```

The signature indentation is not 2 spaces, so it doesn't align with the beginning of the body.  It's also not 4 spaces, so it doesn't align with the function name (since the `def` keyword is 3 characters long).