### PR TITLE
Rename toplevel names in the Dex corpus to snake_case

### DIFF
--- a/benchmarks/matmul.dx
+++ b/benchmarks/matmul.dx
@@ -20,7 +20,7 @@ def matmul
   vectorTile = Fin VectorWidth
   colTile = (colVectors & vectorTile)
   (tile2d (\nt:(Tile n rowTile). \mt:(Tile m colTile).
-             ct = snd $ withAccum \acc.
+             ct = snd $ with_accum \acc.
                for l:k.
                  for i:rowTile.
                    ail = broadcastVector a.(nt +> i).l
@@ -35,7 +35,7 @@ def matmul
 --m = 80
 --loops = 1
 
-prng = newKey 0
+prng = new_key 0
 a = for i:(Fin n). for j:(Fin k). rand $ ixkey prng (i, j)
 b = for i:(Fin k). for j:(Fin m). rand $ ixkey prng (i, j)
 

--- a/benchmarks/microbench.dx
+++ b/benchmarks/microbench.dx
@@ -3,21 +3,21 @@
 warmup = for i:(Fin 100). ordinal i + ordinal i
 
 def sum_bench (n:Int) (k:Int) : Fin n => Float =
-  xs = randVec n randn (newKey k)
-  for i. snd $ withState  0.0 \ref. for j. ref := get ref + xs.i + xs.j
+  xs = rand_vec n randn (new_key k)
+  for i. snd $ with_state  0.0 \ref. for j. ref := get ref + xs.i + xs.j
 
 %bench "sum"
 ans1 = sum_bench 10000 0
 
 def gaussian_bench (n:Int) (k:Int) : Fin n => Float =
-  randVec n randn (newKey 0)
+  rand_vec n randn (new_key 0)
 
 %bench "gaussian"
 ans2 = gaussian_bench 100000000 0
 
 
 def matmul_bench (n:Int) (k:Int) : Fin n => Fin n => Float =
-  mat = randMat n n randn (newKey k)
+  mat = rand_mat n n randn (new_key k)
   mat ** mat
 
 %bench "matmul"

--- a/benchmarks/parboil/histogram.dx
+++ b/benchmarks/parboil/histogram.dx
@@ -1,9 +1,9 @@
 def (+^) (x: Int) (y: Int) : Int = min (x + y) 255
 
 def histogram (hist_size: Int) (input : h=>w=>Int) : (Fin hist_size)=>Int =
-  snd $ withAccum \hist.
+  snd $ with_accum \hist.
     for i j.
       pos = input.i.j
       case 0 <= pos && pos < hist_size of
-        True  -> hist!(unsafeFromOrdinal _ pos) += 1
+        True  -> hist!(unsafe_from_ordinal _ pos) += 1
         False -> ()

--- a/benchmarks/parboil/mriq.dx
+++ b/benchmarks/parboil/mriq.dx
@@ -15,7 +15,7 @@ def mriq
       (phiR : ks=>Float) (phiI : ks=>Float)
       : (cs=>Float & cs=>Float) =
   unzip $ for i.
-    runAccum (AddMonoid Float) \qi.
+    run_accum (AddMonoid Float) \qi.
       yieldAccum (AddMonoid Float) \qr.
         for j.
           phiMag = phiR.j * phiR.j + phiI.j * phiI.j

--- a/benchmarks/parboil/stencil.dx
+++ b/benchmarks/parboil/stencil.dx
@@ -2,14 +2,14 @@
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 -- Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 def stencil (input : nx=>ny=>nz=>Float) : nx=>ny=>nz=>Float =

--- a/benchmarks/rodinia/backprop.dx
+++ b/benchmarks/rodinia/backprop.dx
@@ -29,7 +29,7 @@ def outputError
       (target : out=>Float)
       (output : out=>Float)
       : (Float & out=>Float) =
-  swap $ runAccum (AddMonoid Float) \err.
+  swap $ run_accum (AddMonoid Float) \err.
     for i.
       o = output.i
       d = o * (1.0 - o) * (target.i - o)
@@ -41,7 +41,7 @@ def hiddenError
       (hiddenWeights : { b: Unit | w: hid }=>out=>Float)
       (hidden : hid=>Float)
       : (Float & hid=>Float) =
-  swap $ runAccum (AddMonoid Float) \err.
+  swap $ run_accum (AddMonoid Float) \err.
     for i:hid.
       mult = sum $ for j. outputDelta.j * hiddenWeights.{| w = i |}.j
       r = hidden.i * (1.0 - hidden.i) * mult

--- a/benchmarks/rodinia/hotspot.dx
+++ b/benchmarks/rodinia/hotspot.dx
@@ -15,14 +15,14 @@ tAmb = 80.0
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 -- Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 def hotspot
@@ -30,15 +30,15 @@ def hotspot
       (tsInit : r=>c=>Float)
       (p : r=>c=>Float)
       : r=>c=>Float =
-  gridHeight = chipHeight / (IToF $ size r)
-  gridWidth  = chipWidth  / (IToF $ size c)
+  gridHeight = chipHeight / (i_to_f $ size r)
+  gridWidth  = chipWidth  / (i_to_f $ size c)
   cap = factorChip * specHeatSI * tChip * gridWidth * gridHeight
   Rx = gridWidth  / (2.0 * kSI * tChip * gridHeight)
   Ry = gridHeight / (2.0 * kSI * tChip * gridWidth )
   Rz = tChip / (kSI * gridHeight * gridWidth)
   maxSlope = maxPD / (factorChip * tChip * specHeatSI)
   step = precision / maxSlope
-  yieldState tsInit $ \tsRef.
+  yield_state tsInit $ \tsRef.
     for _:(Fin numIterations).
       ts = get tsRef
       tsRef := for r c.

--- a/benchmarks/rodinia/kmeans.dx
+++ b/benchmarks/rodinia/kmeans.dx
@@ -10,7 +10,7 @@ def centroidsOf (points : n=>d=>Float) (membership : n=>k) : k=>d=>Float =
   for i. clusterSums.i / (max clusterSizes.i 1.0)
 
 def argminBy (_:Ord o) ?=> (f:a->o) (xs:n=>a) : n =
-  minimumBy (\i. f xs.i) (for i. i)
+  minimum_by (\i. f xs.i) (for i. i)
 
 def kmeans
       (points : n=>d=>Float)
@@ -20,12 +20,12 @@ def kmeans
       : (Fin k)=>d=>Float =
   initCentroids = for i:(Fin k). points.(ordinal i@_)
   initMembership = for c:n. ((ordinal c `mod` k)@_)
-  final = yieldState (initMembership, initCentroids, 0) \ref.
+  final = yield_state (initMembership, initCentroids, 0) \ref.
     while do
       (membership, centroids, i) = get ref
       membership' = for i. argminBy (dist points.i) centroids
       centroids' = centroidsOf points membership'
-      delta = sum $ for i. BToI $ membership.i /= membership'.i
+      delta = sum $ for i. b_to_i $ membership.i /= membership'.i
       ref := (membership', centroids', i + 1)
       delta > threshold && i < maxIterations
   (_, centroids, _) = final

--- a/benchmarks/rodinia/pathfinder.dx
+++ b/benchmarks/rodinia/pathfinder.dx
@@ -2,18 +2,18 @@
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 -- Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of
-    True  -> unsafeFromOrdinal _ newOrd
+    True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
 def pathfinder (world : rows=>cols=>Int) : cols=>Int =
-  yieldState zero $ \costsRef.
+  yield_state zero $ \costsRef.
     for r.
       costs = get costsRef
       costsRef := for c. world.r.c + (min costs.c $ (min costs.(c -| 1)

--- a/benchmarks/time-tests.dx
+++ b/benchmarks/time-tests.dx
@@ -10,7 +10,7 @@ mmp'' m1 m2 =
 n = 1000
 
 mat : (Fin n)=>(Fin n)=>Float
-mat = for i j. rand $ ixkey2 (newKey 0) i j
+mat = for i j. rand $ ixkey2 (new_key 0) i j
 
 :time mmp mat mat
 > 0.804174504s

--- a/examples/brownian_motion.dx
+++ b/examples/brownian_motion.dx
@@ -5,7 +5,7 @@ UnitInterval = Float
 
 def bmIter ((key, y, sigma, t):(Key & Float & Float & UnitInterval)) :
                                (Key & Float & Float & UnitInterval) =
-  [kDraw, kL, kR] = splitKey key
+  [kDraw, kL, kR] = split_key key
   t' = abs (t - 0.5)
   y' = sigma * randn kDraw * (0.5 - t')
   key' = select (t > 0.5) kL kR
@@ -16,7 +16,7 @@ def sampleBM (key:Key) (t:UnitInterval) : Float =
   y
 
 xs = linspace (Fin 1000) 0.0 1.0
-ys = map (sampleBM (newKey 0)) xs
+ys = map (sampleBM (new_key 0)) xs
 
-:html showPlot $ xyPlot xs ys
+:html show_plot $ xy_plot xs ys
 > <html output>

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -41,7 +41,7 @@ def clipidx (n:Type) [Ix n] (i:Int) : n =
   -- Returns element at 0 if less than zero.
   -- Ideally we could have an alternative
   -- to Fin that just clips the index at its bounds.
-  fromOrdinal n (select (i < 0) 0 i)
+  from_ordinal n (select (i < 0) 0 i)
 
 def logaddexp (x:Float) (y:Float) : Float =
   m = max x y
@@ -103,7 +103,7 @@ def ctc {vocab time position} [Eq vocab, Eq position, Eq time]
 
 def randIdxNoZero (n:Type) [Ix n] (k:Key) : n =
   unif = rand k
-  fromOrdinal n $ (1 + (FToI (floor ( unif * IToF ((size n) - 1)))))
+  from_ordinal n $ (1 + (FToI (floor ( unif * i_to_f ((size n) - 1)))))
 
 Vocab = Fin 6
 position = Fin 3
@@ -111,10 +111,10 @@ blank = 0@Vocab
 
 -- Create random logits
 Time = Fin 4
-logits : Time => Vocab => Float = arb $ newKey 0
+logits : Time => Vocab => Float = arb $ new_key 0
 
 -- Create random labels
-labels = for i:position. randIdxNoZero Vocab (newKey (ordinal i))
+labels = for i:position. randIdxNoZero Vocab (new_key (ordinal i))
 :p labels
 > [(1@Fin 6), (5@Fin 6), (5@Fin 6)]
 

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -32,11 +32,11 @@ def butterfly_ixs {halfn n} [Ix halfn, Ix n] (j':halfn) (pow2:Int)
   -- Note: with fancier index sets, this might be replacable by reshapes.
   j = ordinal j'
   k = ((idiv j pow2) * pow2 * 2) + mod j pow2
-  left_write_ix  = unsafeFromOrdinal n k
-  right_write_ix = unsafeFromOrdinal n (k + pow2)
+  left_write_ix  = unsafe_from_ordinal n k
+  right_write_ix = unsafe_from_ordinal n (k + pow2)
 
-  left_read_ix  = unsafeFromOrdinal n j
-  right_read_ix = unsafeFromOrdinal n (j + size halfn)
+  left_read_ix  = unsafe_from_ordinal n j
+  right_read_ix = unsafe_from_ordinal n (j + size halfn)
   (left_read_ix, right_read_ix, left_write_ix, right_write_ix)
 
 def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
@@ -50,7 +50,7 @@ def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
   log2n = intlog2 (size n)
   halfn = idiv (size n) 2
   
-  ans = yieldState x \xRef.
+  ans = yield_state x \xRef.
     for i:(Fin log2n).
       ipow2 = intpow 2 (ordinal i)
       xRef := yieldAccum (AddMonoid Complex) \bufRef.
@@ -59,7 +59,7 @@ def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
            left_write_ix, right_write_ix) = butterfly_ixs j ipow2
 
           -- Read one element from the last buffer, scaled.
-          angle = dir_const * (IToF $ mod (ordinal j) ipow2) / IToF ipow2
+          angle = dir_const * (i_to_f $ mod (ordinal j) ipow2) / i_to_f ipow2
           v = (get xRef!right_read_ix) * (MkComplex (cos angle) (sin angle))
 
           -- Add and subtract it to the relevant places in the new buffer.
@@ -68,15 +68,15 @@ def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
 
   case direction of
     ForwardFT -> ans
-    InverseFT -> ans / (IToF (size n))
+    InverseFT -> ans / (i_to_f (size n))
 
 def convolve_complex {n m} (u:n=>Complex) (v:m=>Complex) :
   ((n|m)=>Complex) =  -- Alphabetical order matters here.
   -- Convolve by pointwise multiplication in the Fourier domain.
   convolved_size = (size n) + (size m) - 1
   working_size = nextpow2 convolved_size
-  u_padded = padTo (Fin working_size) zero u
-  v_padded = padTo (Fin working_size) zero v
+  u_padded = pad_to (Fin working_size) zero u
+  v_padded = pad_to (Fin working_size) zero v
   spectral_u = power_of_2_fft ForwardFT u_padded
   spectral_v = power_of_2_fft ForwardFT v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
@@ -95,7 +95,7 @@ def convolve {n m} (u:n=>Float) (v:m=>Float) : ((n|m)=>Float) =
 '## FFT Interface
 
 def fft {n} (x: n=>Complex): n=>Complex =
-  if isPowerOf2 (size n)
+  if is_power_of_2 (size n)
     then power_of_2_fft ForwardFT x
     else
       -- Bluestein's algorithm.
@@ -103,8 +103,8 @@ def fft {n} (x: n=>Complex): n=>Complex =
       -- which is then solved with calls to a power-of-2 FFT.
       im = MkComplex 0.0 1.0
       wks = for i.
-        i_squared = IToF $ sq $ ordinal i
-        exp $ (-im) * (MkComplex (pi * i_squared / (IToF (size n))) 0.0)
+        i_squared = i_to_f $ sq $ ordinal i
+        exp $ (-im) * (MkComplex (pi * i_squared / (i_to_f (size n))) 0.0)
 
       (AsList _ tailTable) = tail wks 1
       back_and_forth = odd_sized_palindrome (head wks) tailTable
@@ -115,11 +115,11 @@ def fft {n} (x: n=>Complex): n=>Complex =
       for i. wks.i * convslice.i
 
 def ifft {n} (xs: n=>Complex): n=>Complex =
-  if isPowerOf2 (size n)
+  if is_power_of_2 (size n)
     then power_of_2_fft InverseFT xs
     else
       unscaled_fft = fft (for i. complex_conj xs.i)
-      for i. (complex_conj unscaled_fft.i) / (IToF (size n))
+      for i. (complex_conj unscaled_fft.i) / (i_to_f (size n))
 
 def  fft_real {n} (x: n=>Float): n=>Complex =  fft for i. MkComplex x.i 0.0
 def ifft_real {n} (x: n=>Float): n=>Complex = ifft for i. MkComplex x.i 0.0
@@ -139,7 +139,7 @@ def ifft2_real {n m} (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex 
 
 a = for i. MkComplex [10.1, -2.2, 8.3, 4.5, 9.3].i 0.0
 b = for i:(Fin 20) j:(Fin 70).
-  MkComplex (randn $ ixkey2 (newKey 0) i j) 0.0
+  MkComplex (randn $ ixkey2 (new_key 0) i j) 0.0
 
 :p a ~~ (ifft $ fft a)
 > True

--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -44,15 +44,15 @@ def add_neighbours_2d {n m a} [Add a] (x:n=>m=>a) : (n=>m=>a) =
 def project {n m a} [VSpace a] (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
   -- Project the velocity field to be approximately mass-conserving,
   -- using a few iterations of Gauss-Seidel.
-  h = 1.0 / IToF (size n)
+  h = 1.0 / i_to_f (size n)
 
   -- unpack into two scalar fields
-  vx = for i j. v.i.j.(fromOrdinal _ 0)
-  vy = for i j. v.i.j.(fromOrdinal _ 1)
+  vx = for i j. v.i.j.(from_ordinal _ 0)
+  vy = for i j. v.i.j.(from_ordinal _ 1)
 
   div = -0.5 .* h .* (divergence vx vy)
 
-  p = yieldState zero \state.
+  p = yield_state zero \state.
     for i:(Fin 10).
       state := (1.0 / 4.0) .* (div + add_neighbours_2d (get state))
 
@@ -71,13 +71,13 @@ def advect {n m a} [VSpace a] (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
   -- Move field f according to x and y velocities (u and v)
   -- using an implicit Euler integrator.
 
-  cell_xs = linspace n 0.0 $ IToF (size n)
-  cell_ys = linspace m 0.0 $ IToF (size m)
+  cell_xs = linspace n 0.0 $ i_to_f (size n)
+  cell_ys = linspace m 0.0 $ i_to_f (size m)
 
   for i j.
     -- Location of source of flow for this cell.  No meshgrid!
-    center_xs = cell_xs.i - v.i.j.(fromOrdinal _ 0)
-    center_ys = cell_ys.j - v.i.j.(fromOrdinal _ 1)
+    center_xs = cell_xs.i - v.i.j.(from_ordinal _ 0)
+    center_ys = cell_ys.j - v.i.j.(from_ordinal _ 1)
 
     -- Index of source cell.
     source_col = floor center_xs
@@ -98,7 +98,7 @@ def advect {n m a} [VSpace a] (f: n=>m=>a) (v: n=>m=>(Fin 2)=>Float) : n=>m=>a =
 
 def fluidsim {n m a} [VSpace a] (num_steps: Int) (color_init: n=>m=>a)
   (v: n=>m=>(Fin 2)=>Float) : (Fin num_steps)=>n=>m=>a =
-  withState (color_init, v) \state.
+  with_state (color_init, v) \state.
     for i:(Fin num_steps).
       (color, v) = get state
       v = advect v v          -- Move velocities
@@ -116,13 +116,13 @@ M = Fin 50
 def ixkey3 {n m o} [Ix n, Ix m, Ix o] (k:Key) (i:n) (j:m) (k2:o) : Key =
   hash (hash (hash k (ordinal i)) (ordinal j)) (ordinal k2)
 init_velocity = for i:N j:M k:(Fin 2).
-  3.0 * (randn $ ixkey3 (newKey 0) i j k)
+  3.0 * (randn $ ixkey3 (new_key 0) i j k)
 
 -- Create diagonally-striped color pattern.
 init_color = for i:N j:M.
-  r = BToF $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
-  b = BToF $ (sin $ (IToF $ (ordinal j) - (ordinal i)) / 6.0) > 0.0
-  g = BToF $ (sin $ (IToF $ (ordinal j) + (ordinal i)) / 4.0) > 0.0
+  r = b_to_f $ (sin $ (i_to_f $ (ordinal j) + (ordinal i)) / 8.0) > 0.0
+  b = b_to_f $ (sin $ (i_to_f $ (ordinal j) - (ordinal i)) / 6.0) > 0.0
+  g = b_to_f $ (sin $ (i_to_f $ (ordinal j) + (ordinal i)) / 4.0) > 0.0
   [r, g, b]
 
 -- Run fluid sim and plot it.

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -16,21 +16,21 @@ def cycleThree {a b c} : Iso (a & b & c) (b & c & a) =
 'Isomorphisms can be applied with `appIso`, applied in reverse with `revIso`,
 and flipped with `flipIso`
 
-:p appIso cycleThree (1, 2.0, 3)
+:p app_iso cycleThree (1, 2.0, 3)
 > (2., (3, 1))
 
-:p revIso cycleThree (1, 2.0, 3)
+:p rev_iso cycleThree (1, 2.0, 3)
 > (3, (1, 2.))
 
-:p appIso (flipIso cycleThree) (1, 2.0, 3)
+:p app_iso (flip_iso cycleThree) (1, 2.0, 3)
 > (3, (1, 2.))
 
 'They can also be composed with `&>>`:
 
-:p appIso (cycleThree &>> cycleThree) (1, 2.0, 3)
+:p app_iso (cycleThree &>> cycleThree) (1, 2.0, 3)
 > (3, (1, 2.))
 
-:p appIso (cycleThree &>> cycleThree &>> cycleThree) (1, 2.0, 3)
+:p app_iso (cycleThree &>> cycleThree &>> cycleThree) (1, 2.0, 3)
 > (1, (2., 3))
 
 'Note that we assume but do not check that the isomorphism is lawful (i.e.
@@ -76,54 +76,54 @@ that produce isos. We will start with the first two:
 '## Record accessors and lens-like helpers
 Record accessor isomorphisms can be passed into the helper function `getAt`:
 
-:t getAt
+:t get_at
 > ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b & c)) -> a -> b)
 
-:p getAt #foo {foo=1, bar=2.0}
+:p get_at #foo {foo=1, bar=2.0}
 > 1
 
 'We can also do other types of things:
 
-:p popAt #foo {foo=1, bar=2.0}
+:p pop_at #foo {foo=1, bar=2.0}
 > {bar = 2.}
 
-:p pushAt #foo 3.0 {foo=1, bar=2.0}
+:p push_at #foo 3.0 {foo=1, bar=2.0}
 > {bar = 2., foo = 3., foo = 1}
 
-:p setAt #foo 2 {foo=1, bar=2.0}
+:p set_at #foo 2 {foo=1, bar=2.0}
 > {bar = 2., foo = 2}
 
 'These helper functions work with any "lens-like" isomorphism. For instance,
 we can select everything except for a particular field:
 
-:t exceptLens
+:t except_lens
 > ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b & c)) -> Iso a (c & b))
 
-:p getAt (exceptLens #foo) {foo=1, bar=2.0, baz=3}
+:p get_at (except_lens #foo) {foo=1, bar=2.0, baz=3}
 > {bar = 2., baz = 3}
 
 
 '## Variant accessors and prism-like helpers
 Similarly, there are prism-like helpers
 
-:t matchWith
+:t match_with
 > ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b | c)) -> a -> Maybe b)
 
-:t buildWith
+:t build_with
 > ((a:Type) ?-> (b:Type) ?-> (c:Type) ?-> (Iso a (b | c)) -> b -> a)
 
 'which can be used with variant accessors or any other prism-like isomorphism:
 
-:p matchWith #?foo $ {|foo = 1|}:{foo:Int | bar:Float}
+:p match_with #?foo $ {|foo = 1|}:{foo:Int | bar:Float}
 > (Just 1)
 
-:p matchWith #?foo $ {|bar = 1.0|}:{foo:Int | bar:Float}
+:p match_with #?foo $ {|bar = 1.0|}:{foo:Int | bar:Float}
 > Nothing
 
-:p buildWith #?foo 3 : {foo:Int | bar:Float}
+:p build_with #?foo 3 : {foo:Int | bar:Float}
 > {| foo = 3 |}
 
-:p matchWith (exceptPrism #?foo) $  {|bar = 1.0|}:{foo:Int | bar:Float}
+:p match_with (except_prism #?foo) $  {|bar = 1.0|}:{foo:Int | bar:Float}
 > (Just {| bar = 1. |})
 
 '## Record zipper isomorphisms
@@ -154,7 +154,7 @@ right to the record on the left; when composed, they move both fields.
 'The main use for record zipper isomorphisms is to specify multiple named axes
 when using a record type as an index set:
 
-:t overFields
+:t over_fields
 > ((a:Type)
 >  ?-> (b:Type)
 >  ?-> (c:Type)
@@ -176,10 +176,10 @@ when using a record type as an index set:
 'Note that `overFields` is just a simple wrapper combining `splitR` and
 `overLens`:
 
-:t splitR
+:t split_r
 > ((a:Type) ?-> Iso a ({&} & a))
 
-:t overLens
+:t over_lens
 > ((a:Type)
 >  ?-> (b:Type)
 >  ?-> (c:Type)
@@ -195,29 +195,29 @@ def abcToTuple {a b c} : Iso {a:a & b:b & c:c} (c&b&a) =
   bwd = \(c, b, a). {a, b, c}
   MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n & b:m & c:q}
-  getSize = \(). size n * size m * size q
-  ordinal = ordinal <<< appIso abcToTuple
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToTuple
+  get_size = \(). size n * size m * size q
+  ordinal = ordinal <<< app_iso abcToTuple
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abcToTuple
 
 def bcToPair {b c} : Iso {b:b & c:c} (c&b) =
   fwd = \{b, c}. (c, b)
   bwd = \(c, b). {b, c}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {b:n & c:m}
-  getSize = \(). size n * size m
-  ordinal = ordinal <<< appIso bcToPair
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso bcToPair
+  get_size = \(). size n * size m
+  ordinal = ordinal <<< app_iso bcToPair
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso bcToPair
 
 :p
   x = for {a, b, c}:{a:Fin 2 & b:Fin 2 & c:Fin 2}.
     ordinal a * 100 + ordinal b * 10 + ordinal c
-  overLens #a x
+  over_lens #a x
 > [ [0, 10, 1, 11]@{b: Fin 2 & c: Fin 2}
 > , [100, 110, 101, 111]@{b: Fin 2 & c: Fin 2} ]
 
 '`splitR` can be used if you want to process multiple fields at once:
 
-:p pushAt (splitR &>> #&a &>> #&b) {a=1, b=2.0} {c=3, d=4.0}
+:p push_at (split_r &>> #&a &>> #&b) {a=1, b=2.0} {c=3, d=4.0}
 > {a = 1, b = 2., c = 3, d = 4.}
 
 '## Variant zipper isomorphisms
@@ -248,12 +248,12 @@ zipper isomorphisms:
 
 '`splitV` makes a prism zipper into an ordinary prism isomorphism:
 
-:t splitV
+:t split_v
 > ((a:Type) ?-> Iso a ({ |} | a))
 
 :p
   vals : (Fin 3)=>{a:_ | b:_ | c:_ } = [{|a = 1|}, {|b = 2|}, {|c = 3|}]
-  for i. matchWith (splitV &>> #|a &>> #|b) vals.i
+  for i. match_with (split_v &>> #|a &>> #|b) vals.i
 > [(Just {| a = 1 |}), (Just {| b = 2 |}), Nothing]
 
 '`sliceFields` uses this to specific named variants from a variant-indexed
@@ -271,9 +271,9 @@ def abcToEither {a b c} : Iso {a:a | b:b | c:c} (a|(b|c)) =
       Right y -> {|c=y|}
   MkIso {fwd, bwd}
 instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n | b:m | c:q}
-  getSize = \(). size n + size m + size q
-  ordinal = ordinal <<< appIso abcToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abcToEither
+  get_size = \(). size n + size m + size q
+  ordinal = ordinal <<< app_iso abcToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abcToEither
 
 def abToEither {a b} : Iso {a:a | b:b} (a|b) =
   fwd = \v.  case v of
@@ -284,9 +284,9 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  getSize = \(). size n + size m
-  ordinal = ordinal <<< appIso abToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
+  get_size = \(). size n + size m
+  ordinal = ordinal <<< app_iso abToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToEither
 
 def acToEither {a c} : Iso {a:a | c:c} (a|c) =
   fwd = \v.  case v of
@@ -297,16 +297,16 @@ def acToEither {a c} : Iso {a:a | c:c} (a|c) =
     Right x -> {|c=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | c:m}
-  getSize = \(). size n + size m
-  ordinal = ordinal <<< appIso acToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso acToEither
+  get_size = \(). size n + size m
+  ordinal = ordinal <<< app_iso acToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso acToEither
 
 :p
   x = iota {a:Fin 2 | b:Fin 2 | c:Fin 2}
   v1 = x
-  v2 = sliceFields (#|a &>> #|b) x
-  v3 = sliceFields (#|a &>> #|c) x
-  v4 = sliceFields (#|a &>> #|b &>> #|c) x
+  v2 = slice_fields (#|a &>> #|b) x
+  v3 = slice_fields (#|a &>> #|c) x
+  v4 = slice_fields (#|a &>> #|b &>> #|c) x
   (v1, v2, v3, v4)
 > ( [0, 1, 2, 3, 4, 5]@{a: Fin 2 | b: Fin 2 | c: Fin 2}
 > , ( [0, 1, 2, 3]@{a: Fin 2 | b: Fin 2}

--- a/examples/kernelregression.dx
+++ b/examples/kernelregression.dx
@@ -19,7 +19,7 @@ def solve' {m} (mat:m=>m=>Float) (b:m=>Float) : m=>Float =
 
 def chol_solve {m} (l:LowerTriMat m Float) (b:m=>Float) : m=>Float =
     b' = forward_substitute l b
-    u = transposeLowerToUpper l
+    u = transpose_lower_to_upper l
     backward_substitute u b'
 
 ' # Kernel ridge regression
@@ -35,7 +35,7 @@ where $G_{ij}:=k(x_i, x_j)+\delta_{ij}\lambda$, $\lambda>0$ and $y = (y_1,\dots,
 -- Synthetic data
 Nx = Fin 100
 noise = 0.1
-[k1, k2] = splitKey (newKey 0)
+[k1, k2] = split_key (new_key 0)
 
 def trueFun (x:Float) : Float =
   x + sin (20.0 * x)
@@ -60,10 +60,10 @@ Nxtest = Fin 1000
 xtest : Nxtest=>Float = for i. rand (ixkey k1 i)
 preds = map predict xtest
 
-:html showPlot $ xyPlot xs ys
+:html show_plot $ xy_plot xs ys
 > <html output>
 
-:html showPlot $ xyPlot xtest preds
+:html show_plot $ xy_plot xtest preds
 > <html output>
 
 ' # Gaussian process regression
@@ -92,8 +92,8 @@ gp_predict = gp_regress (rbf 0.2) xs ys
 
 (gp_preds, vars) = unzip (map gp_predict xtest)
 
-:html showPlot $ xycPlot xtest gp_preds (map sqrt vars)
+:html show_plot $ xyc_plot xtest gp_preds (map sqrt vars)
 > <html output>
 
-:html showPlot $ xyPlot xtest vars
+:html show_plot $ xy_plot xtest vars
 > <html output>

--- a/examples/latex.dx
+++ b/examples/latex.dx
@@ -35,7 +35,7 @@
 def arraySum (x:a=>Int32) : Int32 =
   initAcc = 0
   -- Note: the following line has `$ ... $`, but it should not trigger KaTeX.
-  snd $ withState initAcc $ \acc.
+  snd $ with_state initAcc $ \acc.
     for i.
       acc := (get acc) + x.i
 

--- a/examples/mandelbrot.dx
+++ b/examples/mandelbrot.dx
@@ -12,7 +12,7 @@ def inBounds (z:Complex) : Bool = complex_abs z < tol
 def escapeTime (c:Complex) : Float =
   fst $ fold (0.0, zero) $ \i:(Fin 1000) (n, z).
     z' = update c z
-    (n + BToF (inBounds z'), z')
+    (n + b_to_f (inBounds z'), z')
 
 'Evaluate on a grid and plot the results
 

--- a/examples/manifold-gradients.dx
+++ b/examples/manifold-gradients.dx
@@ -94,7 +94,7 @@ def manifoldGrad
 As a sense check we make sure that these functions give the same output as the
 non-manifold versions on functions which are defined on $\mathbb{R}^n$.
 
-x = for i:(Fin 10). IToF (ordinal i) / 10.
+x = for i:(Fin 10). i_to_f (ordinal i) / 10.
 
 def myFunc {n} (x : (n => Float)) : Float =
   sum $ for i. if (mod (ordinal i) 2 == 0) then (exp x.i) else (sin x.i)
@@ -283,7 +283,7 @@ instance Add Quaternion
 useful for numerical computations.
 
 instance VSpace Quaternion
-  scaleVec = \ s x. quatFromVec (s .* quatAsVec x)
+  scale_vec = \ s x. quatFromVec (s .* quatAsVec x)
 
 instance HasAllClose Quaternion
   allclose = \atol rtol a b.

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -12,8 +12,8 @@ def runChain {a}
       (numSamples: Int)
       (k:Key)
       : Fin numSamples => a =
-  [k1, k2] = splitKey k
-  withState (initialize k1) \s.
+  [k1, k2] = split_key k
+  with_state (initialize k1) \s.
     for i:(Fin numSamples).
       x = step (ixkey k2 i) (get s)
       s := x
@@ -29,10 +29,10 @@ def propose {a}
   select accept proposal cur
 
 def meanAndCovariance {n d} (xs:n=>d=>Float) : (d=>Float & d=>d=>Float) =
-   xsMean :    d=>Float = (for i. sum for j. xs.j.i) / IToF (size n)
+   xsMean :    d=>Float = (for i. sum for j. xs.j.i) / i_to_f (size n)
    xsCov  : d=>d=>Float = (for i i'. sum for j.
                            (xs.j.i' - xsMean.i') *
-                           (xs.j.i  - xsMean.i )   ) / IToF (size n - 1)
+                           (xs.j.i  - xsMean.i )   ) / i_to_f (size n - 1)
    (xsMean, xsCov)
 
 '## Metropolis-Hastings implementation
@@ -45,8 +45,8 @@ def mhStep {d} [Ix d]
       (k:Key)
       (x:d=>Float)
       : d=>Float =
-  [k1, k2] = splitKey k
-  proposal = x + stepSize .* randnVec k1
+  [k1, k2] = split_key k
+  proposal = x + stepSize .* randn_vec k1
   propose logProb x proposal k2
 
 '## HMC implementation
@@ -60,7 +60,7 @@ def leapfrogIntegrate {a}
       ((x, p): (a & a))
       : (a & a) =
   x = x + (0.5 * dt) .* p
-  (x, p) = applyN nsteps (x, p) \(xOld, pOld).
+  (x, p) = apply_n nsteps (x, p) \(xOld, pOld).
     pNew = pOld + dt .* grad logProb xOld
     xNew = xOld + dt .* pNew
     (xNew, pNew)
@@ -74,8 +74,8 @@ def hmcStep {d} [Ix d]
       (x:d=>Float)
       : d=>Float =
   hamiltonian = \(x, p). logProb x - 0.5 * vdot p p
-  [k1, k2] = splitKey k
-  p = randnVec k1
+  [k1, k2] = split_key k
+  p = randn_vec k1
   proposal = leapfrogIntegrate params logProb (x, p)
   fst $ propose hamiltonian (x, p) proposal k2
 
@@ -91,24 +91,24 @@ numSamples =
   if dex_test_mode ()
     then 1000
     else 10000
-k0 = newKey 1
+k0 = new_key 1
 
 mhParams = 0.1
-mhSamples  = runChain randnVec (mhStep  mhParams  myLogProb) numSamples k0
+mhSamples  = runChain randn_vec (mhStep  mhParams  myLogProb) numSamples k0
 
 :p meanAndCovariance mhSamples
 > ([0.369159, 2.453517], [[0.575722, 0.08787], [0.08787, 0.125873]])
 
-:html showPlot $ yPlot $
+:html show_plot $ y_plot $
   slice (map head mhSamples) 0 (Fin 1000)
 > <html output>
 
 hmcParams = (10, 0.1)
-hmcSamples = runChain randnVec (hmcStep hmcParams myLogProb) numSamples k0
+hmcSamples = runChain randn_vec (hmcStep hmcParams myLogProb) numSamples k0
 
 :p meanAndCovariance hmcSamples
 > ([1.431633, 2.503093], [[0.964188, 0.005688], [0.005688, 0.049492]])
 
-:html showPlot $ yPlot $
+:html show_plot $ y_plot $
   slice (map head hmcSamples) 0 (Fin 1000)
 > <html output>

--- a/examples/nn.dx
+++ b/examples/nn.dx
@@ -14,7 +14,7 @@ instance [Add a, Add b] Add (a & b)
   zero = (zero, zero)
 
 instance [VSpace a, VSpace b] VSpace (a & b)
-  scaleVec = \ s (a, b) . (scaleVec s a, scaleVec s b)
+  scale_vec = \ s (a, b) . (scale_vec s a, scale_vec s b)
 
 data Layer inp:Type out:Type params:Type =
   AsLayer {forward:(params -> inp -> out) & init:(Key -> params)}
@@ -22,11 +22,11 @@ data Layer inp:Type out:Type params:Type =
 
 def forward (l:Layer i o p) (p : p) (x : i): o =
   (AsLayer l' ) = l
-  (getAt #forward l') p x
+  (get_at #forward l') p x
 
 def init (l:Layer i o p) (k:Key)  : p  =
   (AsLayer l') = l
-  (getAt #init l') k
+  (get_at #init l') k
 
 
 ' ## Layers 
@@ -59,8 +59,8 @@ def conv2d
     case (i' + kh) <= h && (j' + kw) <= w of
       True ->
         sum for (ki, kj, inp).
-          (di, dj) = (fromOrdinal (Fin h) (i' + (ordinal ki)),
-                      fromOrdinal (Fin w) (j' + (ordinal kj)))
+          (di, dj) = (from_ordinal (Fin h) (i' + (ordinal ki)),
+                      from_ordinal (Fin w) (j' + (ordinal kj)))
           x.inp.di.dj * kernel.o.inp.ki.kj
       False -> zero
 
@@ -87,7 +87,7 @@ def meanpool (kh: Type) (kw: Type) (x : m=>n=> Float) : ( h=>w=> Float) =
 
 ' ## Simple point classifier
 
-[k1, k2] = splitKey $ newKey 1
+[k1, k2] = split_key $ new_key 1
 x1 : Fin 100 => Float = arb k1
 x2 : Fin 100 => Float = arb k2
 y = for i. case ((x1.i > 0.0) && (x2.i > 0.0)) || ((x1.i < 0.0) && (x2.i < 0.0)) of
@@ -96,7 +96,7 @@ y = for i. case ((x1.i > 0.0) && (x2.i > 0.0)) || ((x1.i < 0.0) && (x2.i < 0.0))
 xs = for i. [x1.i, x2.i]
 
 
-:html showPlot $ xycPlot x1 x2 $ for i. IToF y.i
+:html show_plot $ xyc_plot x1 x2 $ for i. i_to_f y.i
 
 simple = \h1.
   ndense1 = dense (Fin 2) h1
@@ -107,7 +107,7 @@ simple = \h1.
          x1 = for i. relu x1'.i
          logsoftmax $ forward ndense2 dense2 x1),
     init = (\key.
-         [k1, k2] = splitKey key
+         [k1, k2] = split_key key
          (init ndense1 k1, init ndense2 k2))
   }
 
@@ -126,7 +126,7 @@ def trainClass [VSpace p]
       : (epochs => p & epochs => Float ) =
   xs : minibatches => minibatch => a = split x
   ys : minibatches => minibatch => b = split y
-  unzip $ withState (init model $ newKey 0) $ \params .
+  unzip $ with_state (init model $ new_key 0) $ \params .
      for _ : epochs.
        loss = sum $ for b : minibatches. 
               (loss, gradfn) =  vjp (\ params.
@@ -134,7 +134,7 @@ def trainClass [VSpace p]
                                        result = forward model params xs.b.j
                                        result.(ys.b.j)) (get params)
               gparams = gradfn 1.0
-              params := (get params) - scaleVec (0.05 / (IToF 100)) gparams
+              params := (get params) - scale_vec (0.05 / (i_to_f 100)) gparams
               loss
        (get params, loss)
 
@@ -175,7 +175,7 @@ lenet = \h1 h2 h3 .
          x4 = for i. relu x4'.i
          logsoftmax $ forward ndense2 dense2 x4),
     init = (\key.
-         [k1, k2, k3, k4] = splitKey key
+         [k1, k2, k3, k4] = split_key key
          (init ncnn1 k1, init ncnn2 k2,
          init ndense1 k3, init ndense2 k4))
   }
@@ -190,21 +190,21 @@ Batch = Fin 5000
 Full = Fin ((size Batch) * H * W)
 
 def pixel (x:Char) : Float32 =
-     r = W8ToI x
-     IToF case r < 0 of
-             True -> (abs r) + 128
-             False -> r
+     r = w8_to_i x
+     i_to_f case r < 0 of
+               True -> (abs r) + 128
+               False -> r
 
 def getIm : Batch => Image = 
-    (AsList _ im) = unsafeIO do readFile "examples/mnist.bin"
-    raw = unsafeCastTable Full im
+    (AsList _ im) = unsafe_io do read_file "examples/mnist.bin"
+    raw = unsafe_cast_table Full im
     for b: Batch  c: (Fin 1) i:(Fin W) j:(Fin H).
         pixel raw.((ordinal (b, i, j)) @ Full)
 
 def getLabel : Batch => Class =
-    (AsList _ im2) = unsafeIO do readFile "examples/labels.bin"
-    r = unsafeCastTable Batch im2
-    for i. (W8ToI r.i @ Class)
+    (AsList _ im2) = unsafe_io do read_file "examples/labels.bin"
+    r = unsafe_cast_table Batch im2
+    for i. (w8_to_i r.i @ Class)
 
 
 ' ## Training loop
@@ -233,7 +233,7 @@ Minibatch = (Fin 10)
 :t ims.(2@_)
 
 model = lenet (Fin 1) (Fin 1) (Fin 20) 
-init_param = (init model  $ newKey 0)
+init_param = (init model  $ new_key 0)
 :p forward model init_param (ims.(2@Batch))
 
 ' Sanity check

--- a/examples/ode-integrator.dx
+++ b/examples/ode-integrator.dx
@@ -49,7 +49,7 @@ def initial_step_size {d}
   f1 = fun z1 (t0 + h0)
   d2 = (length ((f1 - f0) ./ scale)) / h0
   left = max 1.0e-6 (h0 * 1.0e-3)
-  right = pow (0.01 / (d1 + d2)) (1. / ((IToF order) + 1.))
+  right = pow (0.01 / (d1 + d2)) (1. / ((i_to_f order) + 1.))
   h1 = select ((d1 <= 1.0e-15) && (d2 <= 1.0e-15)) left right
   min (100. * h0) h1
 
@@ -74,10 +74,10 @@ def runge_kutta_step {v} [VSpace v] (func:v->Time->v)
       (z0:v) (f0:v) (t0:Time) (dt:Time)
       : (v & v & v & (Fin 7)=>v) =
 
-  evals_init = yieldState zero \r.
+  evals_init = yield_state zero \r.
     r!(0@_) := f0
 
-  evals_filled = yieldState evals_init \func_evals. for i:(Fin 6).
+  evals_filled = yield_state evals_init \func_evals. for i:(Fin 6).
     cur_evals = for j:(..i). get func_evals!((ordinal j)@_)
     ti = t0 + dt .* alpha.i
     zi = z0 + dt .* dot beta.i cur_evals
@@ -145,7 +145,7 @@ def odeint {d n}
       select (ratio <= 1.0) move_state stay_state
 
     -- Take steps until we pass target_t
-    new_state = yieldState init_carry \stateRef.
+    new_state = yield_state init_carry \stateRef.
       iter \_.
         state = get stateRef
         if continue_condition state
@@ -186,5 +186,5 @@ exact_e = [[exp 1.0]]
 times = linspace (Fin 100) 0.00001 1.0
 ys = odeint myDyn z0 t0 times
 
-:html showPlot $ yPlot for i. ys.i.(fromOrdinal _ 0)
+:html show_plot $ y_plot for i. ys.i.(from_ordinal _ 0)
 > <html output>

--- a/examples/particle-filter.dx
+++ b/examples/particle-filter.dx
@@ -13,11 +13,11 @@ def sample {a} (d: Distribution a) (k: Key) : a =
 
 def simulate {s v} (model: Model s v) (t: Int) (key: Key) : Fin t=>(s & v) =
   (init, dynamics, observe) = model
-  [key, subkey] = splitKey key
+  [key, subkey] = split_key key
   s0 = sample init subkey
-  withState s0 \s_ref .
+  with_state s0 \s_ref .
     for i.
-      [k1, k2] = splitKey (ixkey key i)
+      [k1, k2] = split_key (ixkey key i)
       s = get s_ref
       s_next = sample (dynamics s) k1
       v = sample (observe s) k2
@@ -32,14 +32,14 @@ def particleFilter {s a v}
     (key: Key)
     : Fin num_timesteps => a =
   (init, dynamics, observe) = model
-  [key, init_key] = splitKey key
+  [key, init_key] = split_key key
   init_particles = for i: (Fin num_particles). sample init (ixkey init_key i)
-  withState init_particles \p_ref .
+  with_state init_particles \p_ref .
     for t: (Fin num_timesteps).
       p_prev = get p_ref
       logLikelihoods = for i. snd (observe p_prev.i) obs.t
-      [resample_key, dynamics_key] = splitKey (ixkey key t)
-      resampled_idxs = categoricalBatch logLikelihoods resample_key
+      [resample_key, dynamics_key] = split_key (ixkey key t)
+      resampled_idxs = categorical_batch logLikelihoods resample_key
       p_resampled = for i. p_prev.(resampled_idxs.i)
       p_next = for i. fst (dynamics p_resampled.i) (ixkey dynamics_key i)
       p_ref := p_next
@@ -60,9 +60,9 @@ timesteps = 10
 num_particles = 10000
 
 truth = for i:(Fin timesteps).
-  s = IToF (ordinal i)
-  (s, sample (normalDistn s 1.0) $ ixkey (newKey 0) i)
+  s = i_to_f (ordinal i)
+  (s, sample (normalDistn s 1.0) $ ixkey (new_key 0) i)
 
-filtered = particleFilter num_particles _ gaussModel mean (map snd truth) (newKey 0)
+filtered = particleFilter num_particles _ gaussModel mean (map snd truth) (new_key 0)
 
 -- :p for i. (truth.i, filtered.i)

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -9,8 +9,8 @@ rosenbrock : Float -> Float -> Float =
 
 rosenbrock2 : ((Fin 2)=>Float) -> Float =
   \xs.
-    x = xs.(fromOrdinal _ 0)
-    y = xs.(fromOrdinal _ 1)
+    x = xs.(from_ordinal _ 0)
+    y = xs.(from_ordinal _ 1)
     rosenbrock x y
 
 ' Min should be at 1.0, 1.0
@@ -30,9 +30,9 @@ rosenbrock2 : ((Fin 2)=>Float) -> Float =
 
 ' ## Helper functions
 
-def minbyfst {a} : (Float & a) -> (Float & a) -> (Float & a) = minBy fst
+def minbyfst {a} : (Float & a) -> (Float & a) -> (Float & a) = min_by fst
 
-def minimumbyfst {n a} : (n=>(Float & a)) -> (Float & a) = minimumBy fst
+def minimumbyfst {n a} : (n=>(Float & a)) -> (Float & a) = minimum_by fst
 
 ' ### Rand helpers
 
@@ -42,7 +42,7 @@ def randBounded {d} : Key -> (d=>Float)->(d=>Float)->(d=>Float) =
   \key lb ub.
     for i. lb.i + ((rand $ ixkey key i) * (ub.i - lb.i))
 
-:p randBounded (newKey 4) [1.0,  -2.0] [-1.0,  2.0]
+:p randBounded (new_key 4) [1.0,  -2.0] [-1.0,  2.0]
 > [-0.35101, 1.49355]
 
 ' ## The Optimizer itself.
@@ -72,7 +72,7 @@ def optimize
             minbyfst pbests.p (f newPositions.p, newPositions.p)
         newGbest:(Float & d=>Float) =
             minbyfst gbest (minimumbyfst newPbests)
-        [keyG, keyP, keyNext] = splitKey keyL
+        [keyG, keyP, keyNext] = split_key keyL
         (gscore, gloc) = gbest
         plocs = map snd pbests
         gVel:(np=>d=>Float) = for p i.
@@ -87,7 +87,7 @@ def optimize
         (keyNext,newGbest,newPbests,newPositions,newVelocities)
     randInit1 = \keyI1. randBounded keyI1 lb ub
     randInit  = \keyI. for p:np. randInit1 $ ixkey keyI p
-    [keyPos, keyVel, keyLoop] = splitKey key
+    [keyPos, keyVel, keyLoop] = split_key key
     initPositions:(np=>d=>Float) = randInit keyPos
     initVelocities:(np=>d=>Float) = randInit keyVel
     initPs:(np=>(Float & d=>Float)) = for p. (f initPositions.p, initPositions.p)
@@ -102,14 +102,14 @@ Lets see how it goes.
 Run it for more iterations and result should improve.
 Which it indeed does.
 
-:p optimize 50 10 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
+:p optimize 50 10 (new_key 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [0.076986, 0.232818]
 
-:p optimize 50 20 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
+:p optimize 50 20 (new_key 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [0.90125, 0.750447]
 
-:p optimize 50 100 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
+:p optimize 50 100 (new_key 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [0.999069, 0.998192]
 
-:p optimize 50 1000 (newKey 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
+:p optimize 50 1000 (new_key 0) rosenbrock2 ([-10.0, -10.0],[20.0, 20.0]) (0.5,0.3,0.4)
 > [1., 1.]

--- a/examples/pi.dx
+++ b/examples/pi.dx
@@ -13,11 +13,11 @@
 'To compute $\pi$, randomly sample points in the first quadrant unit square to estimate the $\frac{A_{quadrant}}{A_{square}}$ ratio. Then, multiply by $4$.
 
 def estimatePiArea (key:Key) : Float =
-  [k1, k2] = splitKey key
+  [k1, k2] = split_key key
   x = rand k1
   y = rand k2
   inBounds = (sq x + sq y) < 1.0
-  4.0 * BToF inBounds
+  4.0 * b_to_f inBounds
 
 def estimatePiAvgVal (key:Key) : Float =
   x = rand key
@@ -29,8 +29,8 @@ def meanAndStdDev (n:Int) (f: Key -> Float) (key:Key) : (Float & Float) =
 
 numSamps = 1000000
 
-:p meanAndStdDev numSamps estimatePiArea (newKey 0)
+:p meanAndStdDev numSamps estimatePiArea (new_key 0)
 > (3.143452, 1.640889)
 
-:p meanAndStdDev numSamps estimatePiAvgVal (newKey 0)
+:p meanAndStdDev numSamps estimatePiAvgVal (new_key 0)
 > (3.14379, 0.886499)

--- a/examples/psd.dx
+++ b/examples/psd.dx
@@ -5,13 +5,13 @@ import linalg
 def psdsolve {n} (mat:n=>n=>Float) (b:n=>Float) : n=>Float =
   l = chol mat
   b' = forward_substitute l b
-  u = transposeLowerToUpper l
+  u = transpose_lower_to_upper l
   backward_substitute u b'
 
 ' Test
 
 N = Fin 4
-[k1, k2] = splitKey $ newKey 0
+[k1, k2] = split_key $ new_key 0
 
 psd : N=>N=>Float =
   a = for i:N j:N. randn $ ixkey2 k1 i j

--- a/examples/quaternions.dx
+++ b/examples/quaternions.dx
@@ -50,7 +50,7 @@ instance Add Quaternion
   zero = from_vec $ zero
 
 instance VSpace Quaternion
-  scaleVec = \ s x. from_vec (s .* as_vec x)
+  scale_vec = \ s x. from_vec (s .* as_vec x)
 
 
 ' ## Identity quaternion

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -26,9 +26,9 @@ def randuniform (lower:Float) (upper:Float) (k:Key) : Float =
   lower + (rand k) * (upper - lower)
 
 def sampleAveraged {a} [VSpace a] (sample:Key -> a) (n:Int) (k:Key) : a =
-  yieldState zero \total.
+  yield_state zero \total.
     for i:(Fin n).
-      total := get total + sample (ixkey k i) / IToF n
+      total := get total + sample (ixkey k i) / i_to_f n
 
 def positiveProjection {n} (x:n=>Float) (y:n=>Float) : Bool = dot x y > 0.0
 
@@ -68,7 +68,7 @@ def rotateZ (p:Vec 3) (angle:Angle) : Vec 3 =
   [c*px - s*py, s*px+c*py, pz]
 
 def sampleCosineWeightedHemisphere (normal: Vec 3) (k:Key) : Vec 3 =
-  [k1, k2] = splitKey k
+  [k1, k2] = split_key k
   u1 = rand k1
   u2 = rand k2
   uu = normalize $ cross normal [0.0, 1.1, 1.1]
@@ -158,7 +158,7 @@ def sdObject (pos:Position) (obj:Object) : Distance =
 
 def sdScene {n} (scene:Scene n) (pos:Position) : (Object & Distance) =
   (MkScene objs) = scene
-  (i, d) = minimumBy snd $ for i. (i, sdObject pos objs.i)
+  (i, d) = minimum_by snd $ for i. (i, sdObject pos objs.i)
   (objs.i, d)
 
 def calcNormal (obj:Object) (pos:Position) : Direction =
@@ -176,8 +176,8 @@ def raymarch {n} (scene:Scene n) (ray:Ray) : RayMarchResult =
   tol = 0.01
   startLength = 10.0 * tol  -- trying to escape the current surface
   (rayOrigin, rayDir) = ray
-  withState (10.0 * tol) \rayLength.
-    boundedIter maxIters HitNothing \_.
+  with_state (10.0 * tol) \rayLength.
+    bounded_iter maxIters HitNothing \_.
       rayPos = rayOrigin + get rayLength .* rayDir
       (obj, d) = sdScene scene $ rayPos
       -- 0.9 ensures we come close to the surface but don't touch it
@@ -204,7 +204,7 @@ def rayDirectRadiance {n} (scene:Scene n) (ray:Ray) : Radiance =
     HitObj _ _ -> zero
 
 def sampleSquare (hw:Float) (k:Key) : Position =
- [kx, kz] = splitKey k
+ [kx, kz] = split_key k
  x = randuniform (- hw) hw kx
  z = randuniform (- hw) hw kz
  [x, 0.0, z]
@@ -230,16 +230,16 @@ def sampleLightRadiance {n}
 def trace {n} (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
   noFilter = [1.0, 1.0, 1.0]
   yieldAccum (AddMonoid Float) \radiance.
-    runState  noFilter \filter.
-     runState initRay  \ray.
-      boundedIter (getAt #maxBounces params) () \i.
+    run_state  noFilter \filter.
+     run_state initRay  \ray.
+      bounded_iter (get_at #maxBounces params) () \i.
         case raymarch scene $ get ray of
           HitNothing -> Done ()
           HitLight intensity ->
             if i == 0 then radiance += intensity   -- TODO: scale etc
             Done ()
           HitObj incidentRay osurf ->
-            [k1, k2] = splitKey $ hash k i
+            [k1, k2] = split_key $ hash k i
             lightRadiance = sampleLightRadiance scene osurf incidentRay k1
             ray    := sampleReflection osurf incidentRay k2
             filter := surfaceFilter (get filter) (snd osurf)
@@ -256,28 +256,28 @@ Camera = {
 -- TODO: might be better with an anonymous dependent pair for the result
 def cameraRays (n:Int) (camera:Camera) : Fin n => Fin n => (Key -> Ray) =
   -- images indexed from top-left
-  halfWidth = getAt #halfWidth camera
-  pixHalfWidth = halfWidth / IToF n
+  halfWidth = get_at #halfWidth camera
+  pixHalfWidth = halfWidth / i_to_f n
   ys = reverse $ linspace (Fin n) (neg halfWidth) halfWidth
   xs =           linspace (Fin n) (neg halfWidth) halfWidth
   for i j. \key.
-    [kx, ky] = splitKey key
+    [kx, ky] = split_key key
     x = xs.j + randuniform (-pixHalfWidth) pixHalfWidth kx
     y = ys.i + randuniform (-pixHalfWidth) pixHalfWidth ky
-    (getAt #pos camera, normalize [x, y, neg (getAt #sensorDist camera)])
+    (get_at #pos camera, normalize [x, y, neg (get_at #sensorDist camera)])
 
 def takePicture {m} (params:Params) (scene:Scene m) (camera:Camera) : Image =
-  n = getAt #numPix camera
+  n = get_at #numPix camera
   rays = cameraRays n camera
-  rootKey = newKey 0
+  rootKey = new_key 0
   image = for i j.
-    pixKey = if getAt #shareSeed params
+    pixKey = if get_at #shareSeed params
       then rootKey
       else ixkey (ixkey rootKey i) j
     sampleRayColor : Key -> Color =  \k.
-      [k1, k2] = splitKey k
+      [k1, k2] = split_key k
       trace params scene (rays.i.j k1) k2
-    sampleAveraged sampleRayColor (getAt #numSamples params) pixKey
+    sampleAveraged sampleRayColor (get_at #numSamples params) pixKey
   MkImage _ _ $ image / mean (for (i,j,k). image.i.j.k)
 
 ' ### Define the scene and render it
@@ -314,7 +314,7 @@ defaultCamera = {
 -- We change to a small num pix here to reduce the compute needed for tests
 params = defaultParams
 camera = if dex_test_mode ()
-  then defaultCamera |> setAt #numPix 10
+  then defaultCamera |> set_at #numPix 10
   else defaultCamera
 
 -- %time
@@ -325,7 +325,7 @@ camera = if dex_test_mode ()
 'Just for fun, here's what we get with a single sample (sharing the PRNG
 key among pixels)
 
-params2 = defaultParams |> setAt #numSamples 1
+params2 = defaultParams |> set_at #numSamples 1
 (MkImage _ _ image2) = takePicture params2 theScene camera
 
 :html imshow image2

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -22,7 +22,7 @@ def solve {m} (mat:m=>m=>Float) (b:m=>Float) : m=>Float =
 
 Nx = Fin 100
 noise = 0.1
-[k1, k2] = splitKey (newKey 0)
+[k1, k2] = split_key (new_key 0)
 
 def trueFun (x:Float) : Float =
   x + sin (5.0 * x)
@@ -30,7 +30,7 @@ def trueFun (x:Float) : Float =
 xs : Nx=>Float = for i. rand (ixkey k1 i)
 ys : Nx=>Float = for i. trueFun xs.i + noise * randn (ixkey k2 i)
 
-:html showPlot $ xyPlot xs ys
+:html show_plot $ xy_plot xs ys
 > <html output>
 
 'Implement basis function regression
@@ -43,7 +43,7 @@ def regress {d n} (featurize: Float -> d=>Float) (xRaw:n=>Float) (y:n=>Float) : 
 'Fit a third-order polynomial
 
 def poly {d} [Ix d] (x:Float) : d=>Float =
-  for i. pow x (IToF (ordinal i))
+  for i. pow x (i_to_f (ordinal i))
 
 params : (Fin 4)=>Float = regress poly xs ys
 
@@ -53,7 +53,7 @@ def predict (x:Float) : Float =
 
 xsTest = linspace (Fin 200) 0.0 1.0
 
-:html showPlot $ xyPlot xsTest (map predict xsTest)
+:html show_plot $ xy_plot xsTest (map predict xsTest)
 > <html output>
 
 'RMS error
@@ -73,9 +73,9 @@ def lrToEither {a b} : Iso {left:a | right:b} (a|b) =
     Right x -> {|right=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {left:n | right:m}
-  getSize = \(). size n + size m
-  ordinal = ordinal <<< appIso lrToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso lrToEither
+  get_size = \(). size n + size m
+  ordinal = ordinal <<< app_iso lrToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso lrToEither
 
 def tabCat {n m a} (xs:n=>a) (ys:m=>a) : ({left:n|right:m})=>a =
   for i. case i of
@@ -85,7 +85,7 @@ def tabCat {n m a} (xs:n=>a) (ys:m=>a) : ({left:n|right:m})=>a =
 xsPlot = tabCat xs xsTest
 ysPlot = tabCat ys $ map predict xsTest
 
-:html showPlot $ xycPlot xsPlot ysPlot $
+:html show_plot $ xyc_plot xsPlot ysPlot $
         for i. case i of
                  {| left  = _ |} -> 0.0
                  {| right = _ |} -> 1.0

--- a/examples/rejection-sampler.dx
+++ b/examples/rejection-sampler.dx
@@ -12,15 +12,15 @@ LogProb = Float
 
 -- log probability density of a Binomial distribution
 def logBinomialProb (n:Int) (p:Prob) (counts:Int) : LogProb =
-  pSuccess = log p * IToF counts
-  pFailure = log1p (-p) * IToF (n - counts)
-  normConst = (lbeta (1. + IToF counts) (1. + IToF n - IToF counts) +
-               log1p (IToF n))
+  pSuccess = log p * i_to_f counts
+  pFailure = log1p (-p) * i_to_f (n - counts)
+  normConst = (lbeta (1. + i_to_f counts) (1. + i_to_f n - i_to_f counts) +
+               log1p (i_to_f n))
   pSuccess + pFailure - normConst
 
 def trySampleBinomial (n:Int) (p:Prob) (k:Key) : Maybe Int =
-  [k1, k2] = splitKey k
-  proposal = FToI $ floor $ rand k1 * IToF (n + 1)
+  [k1, k2] = split_key k
+  proposal = FToI $ floor $ rand k1 * i_to_f (n + 1)
   if proposal > n
     then Nothing
     else
@@ -37,9 +37,9 @@ def trySampleBinomial (n:Int) (p:Prob) (k:Key) : Maybe Int =
 n = 10
 p = 0.4
 numSamples = 5000
-k0 = newKey 0
+k0 = new_key 0
 
-rejectionSamples = randVec numSamples (rejectionSample $ trySampleBinomial n p) k0
+rejectionSamples = rand_vec numSamples (rejectionSample $ trySampleBinomial n p) k0
 
 :p slice rejectionSamples 0 $ Fin 10
 > [4, 2, 5, 4, 6, 7, 3, 6, 4, 3]
@@ -48,7 +48,7 @@ rejectionSamples = randVec numSamples (rejectionSample $ trySampleBinomial n p) 
 
 def meanAndVariance {n} (xs:n=>Float) : (Float&Float) = (mean xs, sq $ std xs)
 
-:p meanAndVariance $ map IToF rejectionSamples
+:p meanAndVariance $ map i_to_f rejectionSamples
 > (3.9984, 2.361596)
 
 '## Alternative: Inversion sampling
@@ -60,12 +60,12 @@ def binomialSample (n:Int) (p:Prob) (k:Key) : Int =
   logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
   ordinal $ categorical logprobs k
 
-inversionSamples = randVec numSamples (binomialSample n p) k0
+inversionSamples = rand_vec numSamples (binomialSample n p) k0
 
 :p slice inversionSamples 0 $ Fin 10
 > [6, 7, 6, 5, 3, 2, 4, 4, 3, 4]
 
-:p meanAndVariance $ map IToF inversionSamples
+:p meanAndVariance $ map i_to_f inversionSamples
 > (3.9978, 2.409796)
 
 'The following variant is guaranteed to evaluate the CDF only once.
@@ -73,12 +73,12 @@ inversionSamples = randVec numSamples (binomialSample n p) k0
 def binomialBatch {a} [Ix a] (n:Int) (p:Prob) (k:Key) : a => Int =
   m = n + 1
   logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
-  map ordinal $ categoricalBatch logprobs k
+  map ordinal $ categorical_batch logprobs k
 
 inversionBatchSamples = (binomialBatch n p k0) : Fin numSamples => Int
 
 :p slice inversionBatchSamples 0 $ Fin 10
 > [6, 7, 6, 5, 3, 2, 4, 4, 3, 4]
 
-:p meanAndVariance $ map IToF inversionBatchSamples
+:p meanAndVariance $ map i_to_f inversionBatchSamples
 > (3.9978, 2.409796)

--- a/examples/schrodinger.dx
+++ b/examples/schrodinger.dx
@@ -23,7 +23,7 @@ gridSize = 41
 D = Fin gridSize
 
 -- Space discretization
-dx = 1. / IToF gridSize
+dx = 1. / i_to_f gridSize
 
 -- Time discretization (solution unstable if much higher)
 dt = 0.000001
@@ -44,17 +44,17 @@ def fToC (x:Float) : Complex = MkComplex x 0.
 
 -- Translate from index to Float representation of real space
 -- Simulates the range [0.0, 1.0] in each dimension
-def ixToF {n} [Ix n] (i:n) : Float = (IToF (ordinal i)) / (IToF gridSize - 1.)
+def ixToF {n} [Ix n] (i:n) : Float = (i_to_f (ordinal i)) / (i_to_f gridSize - 1.)
 
 -- Helper to generate zero-delay GIF animations
 def animate {t n m} (imgs:t=>n=>m=>(Fin 3)=>Float) : Html =
-  imgToHtml $ pngsToGif 0 $ map imgToPng imgs
+  img_to_html $ pngs_to_gif 0 $ map img_to_png imgs
 
 -- Cuts an array down to a smaller dimension.
 -- Useful for cutting out animation frames for a faster GIF.
 def cut {n m a} [Ix m] (x:n=>a) : m=>a =
   s = idiv (size n) (size m)
-  for i:m. x.(unsafeFromOrdinal _ $ s * ordinal i)
+  for i:m. x.(unsafe_from_ordinal _ $ s * ordinal i)
 
 -- Converts a given 2D matrix to a greyscale image.
 def toImg {n m} (xs:n=>m=>Float) : (n=>m=>Fin 3=>Float) =
@@ -72,7 +72,7 @@ def atBounds {n m} [Ix n, Ix m] (i:n) (j:m) : Bool =
    || ordinal j == (gridSize - 1))
 
 -- Operators for performing unsafe ordinal arithmetic
-def (+!) {n} [Ix n] (i:n) (off:Int) : n = unsafeFromOrdinal _ ((ordinal i) + off)
+def (+!) {n} [Ix n] (i:n) (off:Int) : n = unsafe_from_ordinal _ ((ordinal i) + off)
 def (-!) {n} [Ix n] (i:n) (off:Int) : n = i +! (-1 * off)
 
 -- Run a single forward-step to compute psi_(t+1) from psi_t with the given potential.
@@ -134,7 +134,7 @@ def run {m n} (psi:m=>n=>Complex) (v:m=>n=>Float) : Html =
 
 :html (run
         ((gaussian (0.5, 0.5) (0.1, 0.1)):(D=>D=>_))
-        (for i j. IToF $ ordinal i + ordinal j))
+        (for i j. i_to_f $ ordinal i + ordinal j))
 > <html output>
 
 ' Square wavefunction

--- a/examples/sgd.dx
+++ b/examples/sgd.dx
@@ -10,7 +10,7 @@ def sgd_step {a} [VSpace a] (step_size: Float) (decay: Float) (gradfunc: a -> In
 -- In-place optimization loop.
 def sgd {a} [VSpace a] (step_size:Float) (decay:Float) (num_steps:Int) (gradient: a -> Int -> a) (x0: a) : a =
   m0 = zero
-  (x_final, m_final) = yieldState (x0, m0) \state.
+  (x_final, m_final) = yield_state (x0, m0) \state.
     for i:(Fin num_steps).
       (x, m) = get state
       state := sgd_step step_size decay gradient x m (ordinal i)

--- a/examples/sierpinski.dx
+++ b/examples/sierpinski.dx
@@ -4,7 +4,7 @@ import diagram
 import plot
 
 def update {n} (points:n=>Point) (key:Key) ((x,y):Point) : Point =
-  (x', y') = points.(randIdx key)
+  (x', y') = points.(rand_idx key)
   (0.5 * (x + x'), 0.5 * (y + y'))
 
 def runChain {a} (n:Int) (f:Key -> a -> a) (key:Key) (x0:a) : Fin n => a =
@@ -12,7 +12,7 @@ def runChain {a} (n:Int) (f:Key -> a -> a) (key:Key) (x0:a) : Fin n => a =
 
 trianglePoints : (Fin 3)=>Point = [(0.0, 0.0), (1.0, 0.0), (0.5, sqrt 0.75)]
 
-(xs, ys) = unzip $ runChain 3000 (update trianglePoints) (newKey 0) (0.0, 0.0)
+(xs, ys) = unzip $ runChain 3000 (update trianglePoints) (new_key 0) (0.0, 0.0)
 
-:html showPlot $ xyPlot xs ys
+:html show_plot $ xy_plot xs ys
 > <html output>

--- a/examples/simplex.dx
+++ b/examples/simplex.dx
@@ -225,7 +225,7 @@ def negate_constraints_with_negative_offsets [Eq cons]
       (tableau: (Tableau cons vars))
       : Tableau cons vars =
   (basics, nonbasics, table) = tableau
-  table' = yieldState table \tableRef.
+  table' = yield_state table \tableRef.
     for i:cons.
       cur_constraint = tableRef!{|constraints=i|}
       if (get cur_constraint!{|value=()|}) < 0.0
@@ -328,10 +328,10 @@ def pivot [Eq cons, Eq extra, Eq vars]
       True  -> for col. table.row.col / table.row.pivotcol
       False -> for col. table.row.col - table.row.pivotcol * table.pivotrow.col / table.pivotrow.pivotcol
 
-  i' = fromJust $ (matchWith #?constraints) pivotrow
+  i' = from_just $ (match_with #?constraints) pivotrow
 
   -- Swap in new basic variable.
-  newBasics = yieldState basics \ref.
+  newBasics = yield_state basics \ref.
     ref!i' := pivotcol
 
   -- Move old basic variable to nonbasics.
@@ -363,7 +363,7 @@ def pivot_artificials [Eq cons, Eq vars]
       (tableau: FeasibilityTableau cons vars)
       : (FeasibilityTableau cons vars) =
   -- Pivot out all the artificial variables out of the basis
-  yieldState tableau \tRef.
+  yield_state tableau \tRef.
     tableau = get tRef
     (basics, _, _) = tableau
     for v:cons.
@@ -399,7 +399,7 @@ def deduce_nonbasics [Eq cons, Eq vars]
   -- but don't know how to tell the compiler that, so
   -- need to use an unsafe cast.
   (AsList n nonBasicsTable) = nonBasicsList
-  unsafeCastTable vars nonBasicsTable
+  unsafe_cast_table vars nonBasicsTable
 
 
 def eliminate_artificials [Eq cons, Eq vars]
@@ -475,7 +475,7 @@ def simplex [Eq cons, Eq vars]
   -- Find a feasible initial solution.
   init_tableau = build_tableau ineqs objective objType
   initFeasibilityTableau = build_feasibility_tableau init_tableau
-  feasibilityAns = yieldState initFeasibilityTableau \tableauRef. iter \_.
+  feasibilityAns = yield_state initFeasibilityTableau \tableauRef. iter \_.
     tableau = get tableauRef
     isopt = isOptimal tableau
     case isopt of
@@ -493,7 +493,7 @@ def simplex [Eq cons, Eq vars]
       tf = feasibilityTableauToNormalTableau feasibilityAns
 
       -- Optimize within the simplex.
-      withState tf \tableauRef. iter \_.
+      with_state tf \tableauRef. iter \_.
         tableau = get tableauRef  -- Whole tableau will be overwritten.
         isopt = isOptimal tableau
         case isopt of
@@ -604,13 +604,13 @@ redundant_constraints =
 '### Plotting routines
 
 def float2pix (v:Fin 2=>Float) : (n & m) =
-  x = (FToI ((v.(0@_) * (IToF (size n)))))@n
-  y = (FToI ((v.(1@_) * (IToF (size m)))))@m
+  x = (FToI ((v.(0@_) * (i_to_f (size n)))))@n
+  y = (FToI ((v.(1@_) * (i_to_f (size m)))))@m
   (x, y)
 
 def pixToReal (px:n) (py:m): (Fin 2)=>Float =
-  x = ((IToF ((ordinal px)))) / (IToF (size n))
-  y = ((IToF ((ordinal py)))) / (IToF (size m))
+  x = ((i_to_f ((ordinal px)))) / (i_to_f (size n))
+  y = ((i_to_f ((ordinal py)))) / (i_to_f (size m))
   [x, y]
 
 def draw_point [Eq n, Eq m]

--- a/examples/tiled-matmul.dx
+++ b/examples/tiled-matmul.dx
@@ -29,8 +29,8 @@ def matmul
                indexVector ct.i.j j')
           (\i:n. \j:m. fsum \l. a.i.l * b.l.j))
 
-a = for i:(Fin 5). for j:(Fin 8). IToF $ (iota _).(i,j)
-b = for i:(Fin 8). for j:(Fin 15). IToF $ (iota _).(i,j)
+a = for i:(Fin 5). for j:(Fin 8). i_to_f $ (iota _).(i,j)
+b = for i:(Fin 8). for j:(Fin 15). i_to_f $ (iota _).(i,j)
 c = matmul a b
 c.(0@_)
 > [ 2100.0

--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -176,7 +176,7 @@ row = x.(2 @ Height)
 ' If we want to convert these values to floats, we do it manually with the `IToF`
   function. We can use this to make an image gradient.
 
-gradient = for i:Height. for j:Width. IToF ((ordinal i) + (ordinal j))
+gradient = for i:Height. for j:Width. i_to_f ((ordinal i) + (ordinal j))
 :html matshow gradient
 > <html output>
 
@@ -316,23 +316,23 @@ Full = Fin ((size Batch) * (size IHeight) * (size IWidth))
   ignore it for now.
 
 def pixel (x:Char) : Float32 =
-  r = W8ToI x
-  IToF case r < 0 of
+  r = w8_to_i x
+  i_to_f case r < 0 of
     True -> 256 + r
     False -> r
 
 def getIm : Batch => Image =
   -- File is unsigned bytes offset with 16 starting bytes
-  (AsList _ im) = unsafeIO do readFile "examples/t10k-images-idx3-ubyte"
-  raw = unsafeCastTable Full (for i:Full. im.((ordinal i + 16) @ _))
+  (AsList _ im) = unsafe_io do read_file "examples/t10k-images-idx3-ubyte"
+  raw = unsafe_cast_table Full (for i:Full. im.((ordinal i + 16) @ _))
   for b: Batch i j.
     pixel raw.((ordinal (b, i, j)) @ Full)
 
 def getLabel : Batch => Class =
   -- File is unsigned bytes offset with 8 starting bytes
-  (AsList _ lab) = unsafeIO do readFile "examples/t10k-labels-idx1-ubyte"
-  r = unsafeCastTable Batch (for i:Batch. lab.((ordinal i + 8) @ _))
-  for i. (W8ToI r.i @ Class)
+  (AsList _ lab) = unsafe_io do read_file "examples/t10k-labels-idx1-ubyte"
+  r = unsafe_cast_table Batch (for i:Batch. lab.((ordinal i + 8) @ _))
+  for i. (w8_to_i r.i @ Class)
 
 all_ims = getIm
 all_labels = getLabel
@@ -365,7 +365,7 @@ imscolor = for i. for j. for c:Channels. ims.((ordinal c)@_).i.j
 
 imscolor2 = for b. for i. for j. for c:Channels.
   case ordinal c == 0 of
-    True  -> (sum ims).i.j / (IToF (size Batch))
+    True  -> (sum ims).i.j / (i_to_f (size Batch))
     False -> ims.b.i.j
 
 :html imseqshow (imscolor2 / 255.0)
@@ -422,13 +422,13 @@ im2 : Fin 4 => Fin 4 => Fin 7 => Fin 7 => Float32 = imtile ims.(0@_)
 
 def tableMean {n} (x : n => Float32) : Float32 =
   -- acc = 0
-  withState 0.0 $ \acc.
+  with_state 0.0 $ \acc.
     -- for i in range(len(x))
     for i.
       -- acc = acc + x[i]
       acc := (get acc) + x.i
     -- return acc / len(x)
-    (get acc) / (IToF (size n))
+    (get acc) / (i_to_f (size n))
 
 
 tableMean [0.0, 1.0, 0.5]
@@ -469,7 +469,7 @@ tableMean [0.0, 1.0, 0.5]
   "mutable value" reference (`acc` here), and returns the body function's result.
   Here's a simple example:
 
-withState 10 $ \ state.
+with_state 10 $ \ state.
   state := 30
   state := 10
   get state
@@ -560,16 +560,16 @@ instance Add (Float32 & Float32)
 ' And here is a `VSpace` instance for the float pair type:
 
 instance VSpace (Float32 & Float32)
-  scaleVec = \s (x, y). (x * s, y * s)
+  scale_vec = \s (x, y). (x * s, y * s)
 
 ' Once we have these two instance definitions, we can revisit our table sum
   function using them:
 
 def tableMean' {n v} [VSpace v] (x : n => v) : v =
-   withState zero $ \acc: (Ref _ v).
+   with_state zero $ \acc: (Ref _ v).
         for i.
             acc := add (get acc) x.i       -- `Add` requirement
-        (get acc) / (IToF (size n))  -- `VSpace` requirement
+        (get acc) / (i_to_f (size n))  -- `VSpace` requirement
 
 tableMean' [0.1, 0.5, 0.9]
 > 0.5
@@ -587,7 +587,7 @@ instance {v w} [Add v, Add w] Add (v & w)
   zero = (zero, zero)
 
 instance {v w} [VSpace v, VSpace w] VSpace (v & w)
-  scaleVec = \s (x, y). (scaleVec s x, scaleVec s y)
+  scale_vec = \s (x, y). (scale_vec s x, scale_vec s y)
 
 '## More Fashion MNist
 
@@ -598,7 +598,7 @@ instance {v w} [VSpace v, VSpace w] VSpace (v & w)
 Pixels = Fin 256
 
 def bincount {a b} [Ix b] (inp : a => b) : b => Int =
-  withState zero \acc .
+  with_state zero \acc .
     for i.
       v = acc!(inp.i)
       v := (get v) + 1
@@ -610,7 +610,7 @@ hist = bincount $ for (i,j). (FToI (ims.(0 @ _).i.j) @Pixels)
 :t hist
 > ((Fin 256) => Int32)
 
-:html showPlot $ yPlot (for i. (IToF hist.i))
+:html show_plot $ y_plot (for i. (i_to_f hist.i))
 > <html output>
 
 ' Find nearest images in the dataset:
@@ -649,16 +649,16 @@ double = for b i j. [ims.b.i.j, ims.(nearest.b).i.j, 0.0]
 :t for i:Height. 0.0
 > ((Fin 3) => Float32)
 
-toList for i:Height. 0.0
+to_list for i:Height. 0.0
 > (AsList 3 [0., 0., 0.])
 
-:t toList for i:Height. 0.0
+:t to_list for i:Height. 0.0
 > (List Float32)
 
 ' Tables of lists can be concatenated down to
   single lists.
 
-z = concat [toList [3.0], toList [1.0, 2.0 ]]
+z = concat [to_list [3.0], to_list [1.0, 2.0 ]]
 z
 > (AsList 3 [3., 1., 2.])
 
@@ -675,8 +675,8 @@ shoes = (5 @ Class)
 
 def findShoes {a b} (x : a=>b) (y : a=>Class) : List b =
   concat for i. case (y.i == (5 @ _)) of
-    True  -> toList [x.i]
-    False -> toList []
+    True  -> to_list [x.i]
+    False -> to_list []
 
 ' Note though that the type here does not tell us
   how many there are. The type system cannot know this.

--- a/examples/vega-plotting.dx
+++ b/examples/vega-plotting.dx
@@ -73,7 +73,7 @@ instance ToJSON Value
 instance [ToJSON v] ToJSON (n => v)
   toJSON = \x .
     sizen = (size n)
-    tab = castTable (Fin sizen) $ for i. serialize x.i
+    tab = cast_table (Fin sizen) $ for i. serialize x.i
     AsArray $ AsList sizen tab
 
 instance [ToJSON v] ToJSON (List v)
@@ -83,7 +83,7 @@ instance [ToJSON v] ToJSON (n => (String & v))
 
   toJSON = \x .
      sizen = (size n)
-     tab = castTable (Fin sizen) $ for i. (fst x.i, serialize $ snd x.i)
+     tab = cast_table (Fin sizen) $ for i. (fst x.i, serialize $ snd x.i)
      AsObject $ AsList _ tab
 
 instance [ToJSON v] ToJSON (List (String & v))
@@ -92,7 +92,7 @@ instance [ToJSON v] ToJSON (List (String & v))
 
 def wrapCol [ToJSON d]  (iso: Iso a (d & c)) (x:n=>a) : n=> Value =
     -- Helper function. Returns JSON of a column of a record
-    for i. toJSON $ getAt iso x.i
+    for i. toJSON $ get_at iso x.i
 
 ' ## Declarative Graph Grammars
 Graph grammars are a style of graphing that aims to separate the data representation
@@ -217,20 +217,20 @@ instance [ToJSON v] ToJSON (VLChart r c v)
     -- Make the data
     jdf = toJSON $ for row : r. toJSON $ for col : c.
                    ("col" <> (show $ ordinal col),
-                    toJSON (getAt #rows df.col).row)
+                    toJSON (get_at #rows df.col).row)
     jdata = ("data", toJSON [("values", jdf)])
 
     -- Make the encodings
     jencodings = toJSON $ concat $ for col : c.
-        (AsList v encopts) = getAt #encodings df.col
+        (AsList v encopts) = get_at #encodings df.col
         AsList v $ for f.
            (WithOpts channel encoptions) = encopts.f
            (show channel,
             mergeOpts encoptions
             [
               ("field", "col" <> (show $ ordinal col)),
-              ("type",  show $ getAt #encType df.col),
-              ("title", getAt #title df.col)
+              ("type",  show $ get_at #encType df.col),
+              ("title", get_at #title df.col)
               ])
     jencode = ("encoding", jencodings)
     mergeOpts opts [jdata, jmark, jencode]
@@ -297,11 +297,11 @@ instance ToJSON Class
 
 ' Then we will generate some random data.
 
-key : Key = newKey 1
+key : Key = new_key 1
 
 
 df2 :(Fin 100) => {x1:Float & x2:Float & weight:Float & label:Class}  =  for i: (Fin 100).
-     [k1, k2, k3, k4] = splitKey $ ixkey key i
+     [k1, k2, k3, k4] = split_key $ ixkey key i
      {x1=(arb k1),
       x2=arb k2,
       weight=arb k3,
@@ -315,7 +315,7 @@ chart2 = (AsVLDescriptor (pure Point) [("title", "Scatter")]
      [{title="X1", encodings=pureLs X, encType=Quantitative, rows=wrapCol #x1 df2},
       {title="X2", encodings=pureLs Y, encType=Quantitative, rows=wrapCol #x2 df2},
       {title="Weight", encodings=pureLs Size, encType=Quantitative, rows=wrapCol #weight df2},
-      {title="Label", encodings=toList [pure Color, pure Tooltip], encType=Nominal, rows=wrapCol #label df2}])
+      {title="Label", encodings=to_list [pure Color, pure Tooltip], encType=Nominal, rows=wrapCol #label df2}])
 
 
 :html showVega $ toJSON chart2
@@ -328,8 +328,8 @@ chart2 = (AsVLDescriptor (pure Point) [("title", "Scatter")]
   VL can auto-facet the chart based on Nominal variables.
 
 
-y1 :  (Fin 3) => (Fin 10) => Float = arb $ newKey 0
-df3 = for i. cumSum . for j. select (y1.i.j > 0.0) (-1.0) 1.0
+y1 :  (Fin 3) => (Fin 10) => Float = arb $ new_key 0
+df3 = for i. cumsum . for j. select (y1.i.j > 0.0) (-1.0) 1.0
 
 :t df3
 > ((Fin 3) => (Fin 10) => Float32)
@@ -347,7 +347,7 @@ chart3 = (AsVLDescriptor (pure Area) [("title", "Area"), ("height", "75")]
 ' ## Example: Heatmap
 
 words = ["the", "dog", "walked", "to", "the", "store"]
-z :  (Fin 6) => (Fin 6) => Float = arb $ newKey 0
+z :  (Fin 6) => (Fin 6) => Float = arb $ new_key 0
 
 def showChart4 [ToJSON o] (opts:o) : Value  = toJSON (AsVLDescriptor (pure Rect) opts
      [{title="match", encodings=pureLs Color, encType=Quantitative, rows=for (i,j). toJSON z.i.j},

--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -15,22 +15,22 @@ HtmlColor : Type = Fin 3 => Word8
 
 foreign "showHex" showHexFFI : Word8 -> {IO} (Int32 & RawPtr)
 
-def showHex (x:Word8) : String = unsafeIO \().
+def showHex (x:Word8) : String = unsafe_io \().
   (n, ptr) = showHexFFI x
-  stringFromCharPtr n (MkPtr ptr)
+  string_from_char_ptr n (MkPtr ptr)
 
-black : HtmlColor = [IToW8   0, IToW8   0, IToW8   0]
-white : HtmlColor = [IToW8 255, IToW8 255, IToW8 255]
-red   : HtmlColor = [IToW8 255, IToW8   0, IToW8   0]
-green : HtmlColor = [IToW8   0, IToW8 255, IToW8   0]
-blue  : HtmlColor = [IToW8   0, IToW8   0, IToW8 255]
+black : HtmlColor = [i_to_w8   0, i_to_w8   0, i_to_w8   0]
+white : HtmlColor = [i_to_w8 255, i_to_w8 255, i_to_w8 255]
+red   : HtmlColor = [i_to_w8 255, i_to_w8   0, i_to_w8   0]
+green : HtmlColor = [i_to_w8   0, i_to_w8 255, i_to_w8   0]
+blue  : HtmlColor = [i_to_w8   0, i_to_w8   0, i_to_w8 255]
 
 GeomStyle : Type = {
     fillColor   : Maybe HtmlColor
   & strokeColor : Maybe HtmlColor
   & strokeWidth : Int }
 
-defaultGeomStyle : GeomStyle = {
+default_geom_style : GeomStyle = {
     fillColor   = Nothing
   , strokeColor = Just black
   , strokeWidth = 1 }
@@ -42,7 +42,7 @@ instance Monoid Diagram
   mempty = MkDiagram mempty
   mcombine = \(MkDiagram d1) (MkDiagram d2). MkDiagram $ d1 <> d2
 
-def concatDiagrams {n} (diagrams:n=>Diagram) : Diagram =
+def concat_diagrams {n} (diagrams:n=>Diagram) : Diagram =
   MkDiagram $ concat for i.
     (MkDiagram d) = diagrams.i
     d
@@ -50,17 +50,17 @@ def concatDiagrams {n} (diagrams:n=>Diagram) : Diagram =
 -- TODO: arbitrary affine transformations. Our current representation of
 -- rectangles and circles means we can only do scale/flip/rotate90.
 -- Should we use lenses/isomorphisms for these instead?
-def applyTransformation
+def apply_transformation
       (transformPoint: Point -> Point)
       (transformGeom:  Geom -> Geom)
       (d:Diagram) : Diagram =
   (MkDiagram (AsList _ objs)) = d
-  MkDiagram $ toList for i.
+  MkDiagram $ to_list for i.
     (attr, p, geom) = objs.i
     (attr, transformPoint p, transformGeom geom)
 
-flipY : Diagram -> Diagram =
-  applyTransformation (\(x,y). (x, -y)) \geom. case geom of
+flip_y : Diagram -> Diagram =
+  apply_transformation (\(x,y). (x, -y)) \geom. case geom of
     PointGeom     -> PointGeom
     Circle r      -> Circle r
     Rectangle w h -> Rectangle w h
@@ -68,113 +68,113 @@ flipY : Diagram -> Diagram =
     Text x        -> Text x
 
 def scale (s:Float) : (Diagram -> Diagram) =
-  applyTransformation ( \(x,y). (s * x, s * y) ) \geom. case geom of
+  apply_transformation ( \(x,y). (s * x, s * y) ) \geom. case geom of
     PointGeom     -> PointGeom
     Circle r      -> Circle (s * r)
     Rectangle w h -> Rectangle (s * w) (s * h)
     Line (x, y)   -> Line (s * x, s * y)
     Text x        -> Text x
 
-def moveXY ((offX, offY) : Point) : (Diagram -> Diagram) =
-  applyTransformation (\(x,y). (x + offX, y + offY) ) id
+def move_xy ((offX, offY) : Point) : (Diagram -> Diagram) =
+  apply_transformation (\(x,y). (x + offX, y + offY) ) id
 
-def singletonDefault (geom:Geom) : Diagram =
-  MkDiagram $ toList [(defaultGeomStyle, (0.0, 0.0), geom)]
+def singleton_default (geom:Geom) : Diagram =
+  MkDiagram $ to_list [(default_geom_style, (0.0, 0.0), geom)]
 
-def pointDiagram               : Diagram = singletonDefault PointGeom
-def circle (r:Float)           : Diagram = singletonDefault $ Circle r
-def rect   (w:Float) (h:Float) : Diagram = singletonDefault $ Rectangle w h
-def line   (p:Point)           : Diagram = singletonDefault $ Line p
-def text   (x:String)          : Diagram = singletonDefault $ Text x
+def point_diagram               : Diagram = singleton_default PointGeom
+def circle (r:Float)           : Diagram = singleton_default $ Circle r
+def rect   (w:Float) (h:Float) : Diagram = singleton_default $ Rectangle w h
+def line   (p:Point)           : Diagram = singleton_default $ Line p
+def text   (x:String)          : Diagram = singleton_default $ Text x
 
-def updateGeom (update: GeomStyle -> GeomStyle) (d:Diagram) : Diagram =
+def update_geom (update: GeomStyle -> GeomStyle) (d:Diagram) : Diagram =
   (MkDiagram (AsList _ objs)) = d
-  MkDiagram $ toList for i.
+  MkDiagram $ to_list for i.
     (attr       , geoms) = objs.i
     (update attr, geoms)
 
-def setFillColor   (c:HtmlColor) : Diagram -> Diagram = updateGeom $ setAt #fillColor   (Just c)
-def setStrokeColor (c:HtmlColor) : Diagram -> Diagram = updateGeom $ setAt #strokeColor (Just c)
-def setStrokeWidth (w:Int)       : Diagram -> Diagram = updateGeom $ setAt #strokeWidth w
-def removeStroke                 : Diagram -> Diagram = updateGeom $ setAt #strokeColor Nothing
-def removeFill                   : Diagram -> Diagram = updateGeom $ setAt #fillColor   Nothing
+def set_fill_color   (c:HtmlColor) : Diagram -> Diagram = update_geom $ set_at #fillColor   (Just c)
+def set_stroke_color (c:HtmlColor) : Diagram -> Diagram = update_geom $ set_at #strokeColor (Just c)
+def set_stroke_width (w:Int)       : Diagram -> Diagram = update_geom $ set_at #strokeWidth w
+def remove_stroke                 : Diagram -> Diagram = update_geom $ set_at #strokeColor Nothing
+def remove_fill                   : Diagram -> Diagram = update_geom $ set_at #fillColor   Nothing
 
 '## Serialization to SVG string
 
 'Non-inlinable versions to improve compile times. (Non-inlined functions have to be monomorphic right now).
 
 @noinline
-def strCat (xs:String) (ys:String) : String = xs <> ys
+def str_cat (xs:String) (ys:String) : String = xs <> ys
 
-def (<.>) (xs:String) (ys:String) : String = strCat xs ys
+def (<.>) (xs:String) (ys:String) : String = str_cat xs ys
 
 def quote (s:String) : String = "\"" <.> s <.> "\""
 
 @noinline
-def strSpaceCatUncurried ((s1,s2):(String & String)) : String =
+def str_space_cat_uncurried ((s1,s2):(String & String)) : String =
   s1 <.> " " <.> s2
 
 def (<+>) {a b} [Show a, Show b] (s1:a) (s2:b) : String =
-  strSpaceCatUncurried ((show s1), (show s2))
+  str_space_cat_uncurried ((show s1), (show s2))
 
-def selfClosingBrackets (s:String) : String = "<" <.> s <.> "/>"
+def self_closing_brackets (s:String) : String = "<" <.> s <.> "/>"
 
-def tagBrackets (tag:String) (s:String) : String =
+def tag_brackets (tag:String) (s:String) : String =
   "<" <.> tag <.> ">" <.> s <.> "</" <.> tag <.> ">"
 
 @noinline
-def tagBracketsAttrUncurried ((tag, attr, s):(String & String & String)) : String =
+def tag_brackets_attr_uncurried ((tag, attr, s):(String & String & String)) : String =
   "<" <.> tag <+> attr <.> ">" <.> s <.> "</" <.> tag <.> ">"
 
-def tagBracketsAttr (tag:String) (attr:String) (s:String) : String =
-  tagBracketsAttrUncurried (tag, attr, s)
+def tag_brackets_attr (tag:String) (attr:String) (s:String) : String =
+  tag_brackets_attr_uncurried (tag, attr, s)
 
 def (<=>) {b} [Show b] (attr:String) (val:b) : String =
   attr <.> "=" <.> quote (show val)
 
-def htmlColor(cs:HtmlColor) : String =
+def html_color(cs:HtmlColor) : String =
   "#" <> (concat $ for i. showHex cs.i)
 
-def optionalHtmlColor(c: Maybe HtmlColor) : String =
+def optional_html_color(c: Maybe HtmlColor) : String =
   case c of
     Nothing -> "none"
-    Just c' -> htmlColor c'
+    Just c' -> html_color c'
 
 @noinline
-def attrString (attr:GeomStyle) : String =
-  (   ("stroke"       <=> (optionalHtmlColor $ getAt #strokeColor attr))
-  <+> ("fill"         <=> (optionalHtmlColor $ getAt #fillColor   attr))
-  <+> ("stroke-width" <=> (getAt #strokeWidth attr)))
+def attr_string (attr:GeomStyle) : String =
+  (   ("stroke"       <=> (optional_html_color $ get_at #strokeColor attr))
+  <+> ("fill"         <=> (optional_html_color $ get_at #fillColor   attr))
+  <+> ("stroke-width" <=> (get_at #strokeWidth attr)))
 
 @noinline
-def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
+def render_geom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
   -- For things that are solid. SVG says they have fill=stroke.
-  solidAttr = setAt #fillColor (getAt #strokeColor attr) attr
+  solidAttr = set_at #fillColor (get_at #strokeColor attr) attr
 
-  groupEle = \attr. tagBracketsAttr "g" (attrString attr)
+  groupEle = \attr. tag_brackets_attr "g" (attr_string attr)
   case geom of
     PointGeom ->
-      pointAttr = setAt #fillColor (getAt #strokeColor attr) attr
-      groupEle solidAttr $ selfClosingBrackets $
+      pointAttr = set_at #fillColor (get_at #strokeColor attr) attr
+      groupEle solidAttr $ self_closing_brackets $
         ("circle" <+>
          "cx" <=> x <.>
          "cy" <=> y <.>
          "r=\"1\"")
     Circle r ->
-      groupEle attr $ selfClosingBrackets $
+      groupEle attr $ self_closing_brackets $
         ("circle" <+>
          "cx" <=> x <.>
          "cy" <=> y <.>
          "r"  <=> r)
     Rectangle w h ->
-      groupEle attr $ selfClosingBrackets $
+      groupEle attr $ self_closing_brackets $
         ("rect" <+>
          "width"  <=> w <.>
          "height" <=> h <.>
          "x"      <=> (x - (w/2.0)) <.>
          "y"      <=> (y - (h/2.0)))
     Text content ->
-      textEle = tagBracketsAttr "text" $
+      textEle = tag_brackets_attr "text" $
         ("x" <=> x <.>
          "y" <=> y <.>
          "text-anchor" <=> "middle" <.>    -- horizontal center
@@ -185,7 +185,7 @@ def renderGeom (attr:GeomStyle) ((x,y):Point) (geom:Geom) : String =
 BoundingBox : Type = (Point & Point)
 
 @noinline
-def computeBounds (d:Diagram) : BoundingBox =
+def compute_bounds (d:Diagram) : BoundingBox =
   computeSubBound = \sel op (_, p, geom).
     sel p + case geom of
       PointGeom     -> 0.0
@@ -207,28 +207,28 @@ def computeBounds (d:Diagram) : BoundingBox =
   )
 
 @noinline
-def renderSVG (d:Diagram) (bounds:BoundingBox) : String =
+def render_svg (d:Diagram) (bounds:BoundingBox) : String =
   ((xmin, ymin), (xmax, ymax)) = bounds
   imgWidth = 400.0
   scaleFactor = imgWidth / (xmax - xmin)
   imgHeight = (ymax - ymin) * scaleFactor
   imgXMin   =  xmin * scaleFactor
   imgYMin   = -ymax * scaleFactor
-  (MkDiagram (AsList _ objs)) = d |> flipY |> scale scaleFactor
+  (MkDiagram (AsList _ objs)) = d |> flip_y |> scale scaleFactor
   svgAttrStr = (    "width"   <=> imgWidth
                 <+> "height"  <=> imgHeight
                 <+> "viewBox" <=> (imgXMin <+> imgYMin <+> imgWidth <+> imgHeight))
-  tagBracketsAttr "svg" svgAttrStr $
+  tag_brackets_attr "svg" svgAttrStr $
     concat for i.
       (attr, pos, geom) = objs.i
-      renderGeom attr pos geom
+      render_geom attr pos geom
 
-renderScaledSVG = \d. renderSVG d (computeBounds d)
+render_scaled_svg = \d. render_svg d (compute_bounds d)
 
 '## Derived convenience methods and combinators
 
-moveX : Float -> Diagram -> Diagram = \x. moveXY (x, 0.0)
-moveY : Float -> Diagram -> Diagram = \y. moveXY (0.0, y)
+move_x : Float -> Diagram -> Diagram = \x. move_xy (x, 0.0)
+move_y : Float -> Diagram -> Diagram = \y. move_xy (0.0, y)
 
 ' A Demo showing all kind of features
 ```
@@ -244,10 +244,10 @@ mydiagram : Diagram =
 
 ' Another demo that shows things are all center aligned:
 ```
-concentricDiagram : Diagram = (
+concentric_diagram : Diagram = (
      (rect 2.0 2.0 |> setFillColor red)
   <> (circle 1.0 |> setFillColor blue)
   <> (text "DexLang" |> setStrokeColor white)
 ) |> moveXY (5.0, 5.0)
-:html renderScaledSVG concentricDiagram
+:html renderScaledSVG concentric_diagram
 ```

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -11,17 +11,17 @@ def cast {a m} [Ix a, Ix m] (d:a) : m = (ordinal d)@m
 def LowerTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..i)=>v
 def UpperTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(i..)=>v
 
-def upperTriDiag {n v} (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
-def lowerTriDiag {n v} (l:LowerTriMat n v) : n=>v = for i. l.i.(cast i)
+def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
+def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = for i. l.i.(cast i)
 
-def transposeLowerToUpper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
+def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
   for i:n. for j':(i..).
     j = %inject j'
     lower.j.(cast i)
 
 def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v =
   -- Solves lower triangular linear system (inverse a) **. b
-  yieldState zero \sRef.
+  yield_state zero \sRef.
     for i:n.
       s = sum for k:(..<i).  -- dot product
         a.i.(cast k) .* get sRef!(%inject k)
@@ -29,25 +29,25 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =
   -- Solves upper triangular linear system (inverse a) **. b
-  yieldState zero \sRef.
+  yield_state zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
         a.i.(cast k) .* get sRef!(%inject k)
       sRef!i := (b.i - s) / a.i.(0@_) -- 0 is the diagonal index
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
-def lowerTriMat {a b h} (ref:Ref h (LowerTriMat a b)) (i:a) (j:(..i)) : Ref h b =
+def lower_tri_mat {a b h} (ref:Ref h (LowerTriMat a b)) (i:a) (j:(..i)) : Ref h b =
   d = %indexRef ref i
   d!j
-def upperTriMat {a b h} (ref:Ref h (UpperTriMat a b)) (i:a) (j:(i..)) : Ref h b =
+def upper_tri_mat {a b h} (ref:Ref h (UpperTriMat a b)) (i:a) (j:(i..)) : Ref h b =
   d = %indexRef ref i
   d!j
 
 '### Cholesky decomposition
 
 def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
-  yieldState zero \buf.
-    mat = lowerTriMat buf
+  yield_state zero \buf.
+    mat = lower_tri_mat buf
     for i:n. for j':(..i).
       j = %inject j'
       row  = for k:(..<j). get $ mat i (cast k)
@@ -73,15 +73,15 @@ def apply_permutation {n t} ((perm, _):Permutation n) (xs: n=>t) : n=>t =
 def identity_permutation {n} [Ix n] : Permutation n =
   (for i. i, 1.0)
 
-def swapInPlace {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
-  (permRef, signRef) = (fstRef pRef, sndRef pRef)
+def swap_in_place {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
+  (permRef, signRef) = (fst_ref pRef, snd_ref pRef)
   tempj = get permRef!j
   permRef!j := get permRef!i
   permRef!i := tempj
   signRef := -(get signRef)
 
-def permToTable {n} ((perm, _):Permutation n) : n=>n = perm
-def permSign    {n} ((_, sign):Permutation n) : PermutationSign = sign
+def perm_to_table {n} ((perm, _):Permutation n) : n=>n = perm
+def perm_sign    {n} ((_, sign):Permutation n) : PermutationSign = sign
 
 
 
@@ -89,12 +89,12 @@ def permSign    {n} ((_, sign):Permutation n) : PermutationSign = sign
 
 def pivotize {n} (a:n=>n=>Float) : Permutation n =
   -- Gives a row permutation that makes Gaussian elimination more stable.
-  yieldState identity_permutation \permRef.
+  yield_state identity_permutation \permRef.
     for j:n.
       row_with_largest = argmin for i:(j..). (-(abs a.(%inject i).j))
       case ordinal j == ordinal row_with_largest of
         True -> ()
-        False -> swapInPlace permRef j (%inject row_with_largest)
+        False -> swap_in_place permRef j (%inject row_with_largest)
 
 def lu {n} (a: n=>n=>Float) :
        (LowerTriMat n Float & UpperTriMat n Float & Permutation n) =
@@ -107,9 +107,9 @@ def lu {n} (a: n=>n=>Float) :
     select (ordinal i == (ordinal (%inject j'))) 1.0 0.0
   init_upper = zero
 
-  (lower, upper) = yieldState (init_lower, init_upper) \stateRef.
-    lRef = fstRef stateRef
-    uRef = sndRef stateRef
+  (lower, upper) = yield_state (init_lower, init_upper) \stateRef.
+    lRef = fst_ref stateRef
+    uRef = snd_ref stateRef
 
   -- For reference, here's code to computed the LU decomposition
   -- without dependent tables (i.e. with standard flat matrices):
@@ -129,8 +129,8 @@ def lu {n} (a: n=>n=>Float) :
   --      lRef!i!j := (a.i.j - s) / (get uRef!j!j)
   --    for i:n. ()
 
-    lmat = lowerTriMat lRef
-    umat = upperTriMat uRef
+    lmat = lower_tri_mat lRef
+    umat = upper_tri_mat uRef
     for j:n.
       for i:(..j).
         i' = %inject i
@@ -177,17 +177,17 @@ def invert {n} (a:n=>n=>Float) : n=>n=>Float =
 
 def determinant {n} (a:n=>n=>Float) : Float =
   (l, u, perm) = lu a
-  prod (for i. (upperTriDiag u).i * (lowerTriDiag l).i) * permSign perm
+  prod (for i. (upper_tri_diag u).i * (lower_tri_diag l).i) * perm_sign perm
 
 def sign_and_log_determinant {n} (a:n=>n=>Float) : (Float & Float) =
   (l, u, perm) = lu a
-  diags = for i. (upperTriDiag u).i * (lowerTriDiag l).i
-  sign = (permSign perm) * prod for i. sign diags.i
+  diags = for i. (upper_tri_diag u).i * (lower_tri_diag l).i
+  sign = (perm_sign perm) * prod for i. sign diags.i
   sum_of_log_abs = sum for i. log (abs diags.i)
   (sign, sum_of_log_abs)
 
 def matrix_power {n} (base:n=>n=>Float) (power:Int) : n=>n=>Float =
-  generalIntegerPower (**) eye base power
+  general_integer_power (**) eye base power
 
 def trace {n a} [Add a] (x:n=>n=>a) : a =
   sum for i. x.i.i

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -2,9 +2,9 @@
 
 'Utilities unrelated to parsing
 
-def fromOrdinalExc (n:Type) [Ix n] (i:Int) : {Except} n =
+def from_ordinal_exc (n:Type) [Ix n] (i:Int) : {Except} n =
   if (0 <= i) && (i < size n)
-    then unsafeFromOrdinal _ i
+    then unsafe_from_ordinal _ i
     else throw ()
 
 -- TODO: allow this to happen in-place
@@ -13,9 +13,9 @@ def push {h a} (ref:Ref h (List a)) (x:a) : {State h} Unit =
   l = get ref
   ref := l <> AsList _ [x]
 
-def indexList {a} (l:List a) (i:Int) : {Except} a =
+def index_list {a} (l:List a) (i:Int) : {Except} a =
   (AsList n xs) = l
-  xs.(fromOrdinalExc _ i)
+  xs.(from_ordinal_exc _ i)
 
 'The Parser type
 
@@ -28,22 +28,22 @@ def parse {a h} (handle:ParserHandle h) (parser:Parser a) : {Except, State h} a 
   (MkParser f) = parser
   f handle
 
-def runParserPartial {a} (s:String) (parser:Parser a) : Maybe a =
+def run_parser_partial {a} (s:String) (parser:Parser a) : Maybe a =
   (MkParser f) = parser
-  withState 0 \pos.
+  with_state 0 \pos.
     catch $ do
       f (s, pos)
 
 'Primitive combinators
 
-def pChar (c:Char) : Parser Unit = MkParser \(s, posRef).
+def p_char (c:Char) : Parser Unit = MkParser \(s, posRef).
   i = get posRef
-  c' = indexList s i
+  c' = index_list s i
   assert (c == c')
   posRef := i + 1
 
-def pEOF : Parser Unit = MkParser \(s, posRef).
-  assert $ get posRef >= listLength s
+def p_eof : Parser Unit = MkParser \(s, posRef).
+  assert $ get posRef >= list_length s
 
 def (<|>) {a} (p1:Parser a) (p2:Parser a) : Parser a = MkParser \h.
   (s, posRef) = h
@@ -56,16 +56,16 @@ def (<|>) {a} (p1:Parser a) (p2:Parser a) : Parser a = MkParser \h.
 
 def return {a} (x:a) : Parser a = MkParser \_. x
 
-def runParser {a} (s:String) (parser:Parser a) : Maybe a =
-  runParserPartial s $ MkParser \h.
+def run_parser {a} (s:String) (parser:Parser a) : Maybe a =
+  run_parser_partial s $ MkParser \h.
     ans = parse h parser
-    _   = parse h pEOF
+    _   = parse h p_eof
     ans
 
-def parseAny : Parser Char = MkParser \h.
+def parse_any : Parser Char = MkParser \h.
   (s, posRef) = h
   i = get posRef
-  c' = indexList s i
+  c' = index_list s i
   posRef := i + 1
   c'
 
@@ -81,17 +81,17 @@ def try {a} (parser:Parser a) : Parser a = MkParser \h.
 
 'Derived combinators
 
-def parseDigit : Parser Int = try $ MkParser \h.
-  c = parse h $ parseAny
-  i = W8ToI c - 48
+def parse_digit : Parser Int = try $ MkParser \h.
+  c = parse h $ parse_any
+  i = w8_to_i c - 48
   assert $ 0 <= i && i < 10
   i
 
 def optional {a} (p:Parser a) : Parser (Maybe a) =
   (MkParser \h. Just (parse h p)) <|> return Nothing
 
-def parseMany {a} (parser:Parser a) : Parser (List a) = MkParser \h.
-  yieldState (AsList _ []) \results.
+def parse_many {a} (parser:Parser a) : Parser (List a) = MkParser \h.
+  yield_state (AsList _ []) \results.
     iter \_.
       maybeVal = parse h $ optional parser
       case maybeVal of
@@ -100,14 +100,14 @@ def parseMany {a} (parser:Parser a) : Parser (List a) = MkParser \h.
           push results x
           Continue
 
-def parseUnsignedInt : Parser Int = MkParser \h.
-  (AsList _ digits) = parse h $ parseMany parseDigit
-  yieldState 0 \ref.
+def parse_unsigned_int : Parser Int = MkParser \h.
+  (AsList _ digits) = parse h $ parse_many parse_digit
+  yield_state 0 \ref.
     for i. ref := 10 * get ref + digits.i
 
-def parseInt : Parser Int = MkParser \h.
-  negSign = parse h $ optional $ pChar '-'
-  x       = parse h $ parseUnsignedInt
+def parse_int : Parser Int = MkParser \h.
+  negSign = parse h $ optional $ p_char '-'
+  x       = parse h $ parse_unsigned_int
   case negSign of
     Nothing -> x
     Just () -> (-1) * x
@@ -120,4 +120,4 @@ def bracketed {a} (l:Parser Unit) (r:Parser Unit) (body:Parser a) : Parser a =
     ans
 
 def parens {a} (parser:Parser a) : Parser a =
-  bracketed (pChar '(') (pChar ')') parser
+  bracketed (p_char '(') (p_char ')') parser

--- a/lib/plot.dx
+++ b/lib/plot.dx
@@ -22,101 +22,101 @@ def Plot (n:Type) [Ix n] (a:Type) (b:Type) (c:Type) : Type =
 
 def Color : Type = Fin 3 => Float
 
-def applyScale {a} (s:Scale a) (x:a) : Maybe Float = getAt #mapping s x
+def apply_scale {a} (s:Scale a) (x:a) : Maybe Float = get_at #mapping s x
 
-unitTypeScale : Scale Unit =
+unit_type_scale : Scale Unit =
   { mapping = \(). Just 0.0
   , range   = AsList _ [Singleton 0.0] }
 
-def projectUnitInterval (x:Float) : Maybe Float =
+def project_unit_interval (x:Float) : Maybe Float =
   case x >= 0.0 && x <= 1.0 of
     True  -> Just x
     False -> Nothing
 
-unitIntervalScale : Scale Float =
-  { mapping = projectUnitInterval
+unit_interval_scale : Scale Float =
+  { mapping = project_unit_interval
   , range   = AsList _ [Interval 0.0 1.0] }
 
-def mapScale {a b} (s:Scale a) (f: b -> a) : Scale b =
-  { mapping = \x. getAt #mapping s (f x)
-  , range = getAt #range s }
+def map_scale {a b} (s:Scale a) (f: b -> a) : Scale b =
+  { mapping = \x. get_at #mapping s (f x)
+  , range = get_at #range s }
 
-def floatScale (xmin:Float) (xmax:Float) : Scale Float =
-  mapScale unitIntervalScale (\x. (x - xmin) / (xmax - xmin))
+def float_scale (xmin:Float) (xmax:Float) : Scale Float =
+  map_scale unit_interval_scale (\x. (x - xmin) / (xmax - xmin))
 
-def getScaled {a n} (sd:ScaledData n a) (i:n) : Maybe Float =
-  applyScale (getAt #scale sd) (getAt #dat sd).i
+def get_scaled {a n} (sd:ScaledData n a) (i:n) : Maybe Float =
+  apply_scale (get_at #scale sd) (get_at #dat sd).i
 
-lowColor  = [1.0, 0.5, 0.0]
-highColor = [0.0, 0.5, 1.0]
+low_color  = [1.0, 0.5, 0.0]
+high_color = [0.0, 0.5, 1.0]
 
 def interpolate {a} [VSpace a] (low:a) (high:a) (x:Float) : a =
   x' = clip (0.0, 1.0) x
   (x' .* low) + ((1.0 - x') .* high)
 
-def makeRGBColor (c : Color) : HtmlColor =
-  for i. IToW8 $ FToI $ floor (255.0 * c.i)
+def make_rgb_color (c : Color) : HtmlColor =
+  for i. i_to_w8 $ FToI $ floor (255.0 * c.i)
 
-def colorScale (x:Float) : HtmlColor =
-  makeRGBColor $ interpolate lowColor highColor x
+def color_scale (x:Float) : HtmlColor =
+  make_rgb_color $ interpolate low_color high_color x
 
-def plotToDiagram {a b c n} (plot:Plot n a b c) : Diagram =
-  points = concatDiagrams for i.
-    x = getScaled (getAt #xs plot) i
-    y = getScaled (getAt #ys plot) i
-    c = getScaled (getAt #cs plot) i
+def plot_to_diagram {a b c n} (plot:Plot n a b c) : Diagram =
+  points = concat_diagrams for i.
+    x = get_scaled (get_at #xs plot) i
+    y = get_scaled (get_at #ys plot) i
+    c = get_scaled (get_at #cs plot) i
     -- TODO: nested may-fail patterns would make this much better
     case x of
       Just x' -> case y of
         Just y' -> case c of
           Just c' ->
-            pointDiagram |> moveXY (x', y') |> setStrokeColor (colorScale c' )
+            point_diagram |> move_xy (x', y') |> set_stroke_color (color_scale c' )
           Nothing -> mempty
         Nothing -> mempty
       Nothing -> mempty
-  boundingBox = moveXY (0.5, 0.5) $ rect 1.0 1.0
+  boundingBox = move_xy (0.5, 0.5) $ rect 1.0 1.0
   boundingBox <> points
 
-def showPlot {a b c n} (plot:Plot n a b c) : String =
-  renderSVG (plotToDiagram plot) ((0.0, 0.0), (1.0, 1.0))
+def show_plot {a b c n} (plot:Plot n a b c) : String =
+  render_svg (plot_to_diagram plot) ((0.0, 0.0), (1.0, 1.0))
 
-def blankData {n} [Ix n] : ScaledData n Unit =
-  {scale = unitTypeScale, dat = for i. ()}
+def blank_data {n} [Ix n] : ScaledData n Unit =
+  {scale = unit_type_scale, dat = for i. ()}
 
-def blankPlot {n} [Ix n] : Plot n Unit Unit Unit =
-  {xs = blankData, ys = blankData, cs = blankData}
+def blank_plot {n} [Ix n] : Plot n Unit Unit Unit =
+  {xs = blank_data, ys = blank_data, cs = blank_data}
 
 -- -- TODO: generalize beyond Float with a type class for auto scaling
-def autoScale {n} (xs:n=>Float) : ScaledData n Float =
+def auto_scale {n} (xs:n=>Float) : ScaledData n Float =
   max = maximum xs
   min = minimum xs
   -- Add 10% padding away from the plot area
   space = (max - min) * 0.05
   padding = maximum [space, max * 0.001, 0.000001]
-  {scale = floatScale (min - padding) (max + padding), dat = xs}
+  {scale = float_scale (min - padding) (max + padding), dat = xs}
 
-def setXData {n a b c new} (xs:ScaledData n new) (plot:Plot n a b c) : Plot n new b c =
+def set_x_data {n a b c new} (xs:ScaledData n new) (plot:Plot n a b c) : Plot n new b c =
   -- We can't use `setAt` here because we're changing the type
-  {xs = xs, ys = getAt #ys plot, cs = getAt #cs plot}
+  {xs = xs, ys = get_at #ys plot, cs = get_at #cs plot}
 
-def setYData {n a b c new} (ys:ScaledData n new) (plot:Plot n a b c) : Plot n a new c =
-  {xs = getAt #xs plot, ys = ys, cs = getAt #cs plot}
+def set_y_data {n a b c new} (ys:ScaledData n new) (plot:Plot n a b c) : Plot n a new c =
+  {xs = get_at #xs plot, ys = ys, cs = get_at #cs plot}
 
-def setCData {n a b c new} (cs:ScaledData n new) (plot:Plot n a b c) : Plot n a b new =
-  {xs = getAt #xs plot, ys = getAt #ys plot, cs = cs}
+def set_c_data {n a b c new} (cs:ScaledData n new) (plot:Plot n a b c) : Plot n a b new =
+  {xs = get_at #xs plot, ys = get_at #ys plot, cs = cs}
 
-def xyPlot {n} (xs:n=>Float) (ys:n=>Float) : Plot n Float Float Unit =
-  blankPlot |> setXData (autoScale xs) |> setYData (autoScale ys)
+def xy_plot {n} (xs:n=>Float) (ys:n=>Float) : Plot n Float Float Unit =
+  blank_plot |> set_x_data (auto_scale xs) |> set_y_data (auto_scale ys)
 
-def xycPlot {n} (xs:n=>Float) (ys:n=>Float) (cs:n=>Float) : Plot n Float Float Float =
-  blankPlot |>
-    setXData (autoScale xs) |>
-    setYData (autoScale ys) |>
-    setCData (autoScale cs)
+def xyc_plot {n} (xs:n=>Float) (ys:n=>Float) (cs:n=>Float) : Plot n Float Float Float =
+  blank_plot |>
+    set_x_data (auto_scale xs) |>
+    set_y_data (auto_scale ys) |>
+    set_c_data (auto_scale cs)
 
-def yPlot {n} (ys:n=>Float) : Plot n Float Float Unit =
-  xs = for i. IToF $ ordinal i
-  xyPlot xs ys
+def y_plot {n} (ys:n=>Float) : Plot n Float Float Unit =
+  xs = for i. i_to_f $ ordinal i
+  xy_plot xs ys
 
 -- xs = linspace (Fin 100) 0. 1.0
 -- :html showPlot $ xycPlot xs xs xs
@@ -128,8 +128,8 @@ def matshow {n m} (img:n=>m=>Float) : Html =
   low  = minimum  $ for (i,j). img.i.j
   high = maximum $ for (i,j). img.i.j
   range = high - low
-  imgToHtml $ makePNG for i j.
+  img_to_html $ make_png for i j.
     x = if range == 0.0
-      then floatTo8Bit $ 0.5
-      else floatTo8Bit $ (img.i.j - low) / range
+      then float_to_8bit $ 0.5
+      else float_to_8bit $ (img.i.j - low) / range
     [x, x, x]

--- a/lib/png.dx
+++ b/lib/png.dx
@@ -1,6 +1,6 @@
 '## Base 64 encoder
 
-encodingTable =
+encoding_table =
   ['A', 'B', 'C', 'D', 'E', 'F', 'G', 'H',
    'I', 'J', 'K', 'L', 'M', 'N', 'O', 'P',
    'Q', 'R', 'S', 'T', 'U', 'V', 'W', 'X',
@@ -11,33 +11,33 @@ encodingTable =
    '4', '5', '6', '7', '8', '9', '+', '/']
 
 -- TODO: make `Word8` an index set instead of using `Fin 256`
-decodingTable : Fin 256 => Maybe Char =
+decoding_table : Fin 256 => Maybe Char =
   for i:(Fin 256).
-    idx = linearSearch encodingTable (IToW8 (ordinal i))
+    idx = linear_search encoding_table (i_to_w8 (ordinal i))
     case idx of
       Nothing -> Nothing
-      Just x  -> Just $ IToW8 $ ordinal x
+      Just x  -> Just $ i_to_w8 $ ordinal x
 
 Base64 = Byte -- first two bits should be zero
 
 -- This could go in the prelude, or in a library of array-dicing functions.
 -- An explicit "view" builder would be good here, to avoid copies
-def getChunks {n a}
+def get_chunks {n a}
       (chunkSize:Int) (padVal:a) (xs:n=>a)
       : List (Fin chunkSize => a) =
-  numChunks = idivCeil (size n) chunkSize
+  numChunks = idiv_ceil (size n) chunkSize
   paddedSize = numChunks * chunkSize
-  xsPadded = padTo (Fin paddedSize) padVal xs
-  toList for i:(Fin numChunks).
+  xsPadded = pad_to (Fin paddedSize) padVal xs
+  to_list for i:(Fin numChunks).
     slice xsPadded (ordinal i * chunkSize) (Fin chunkSize)
 
-def base64sToBytes (chunk : Fin 4 => Base64) : Fin 3 => Byte =
+def base64s_to_bytes (chunk : Fin 4 => Base64) : Fin 3 => Byte =
   [a, b, c, d] = chunk
   [ (a .<<. 2) .|. (b .>>. 4)
   , (b .<<. 4) .|. (c .>>. 2)
   , (c .<<. 6) .|.  d       ]
 
-def bytesToBase64s (chunk : Fin 3 => Byte) : Fin 4 => Base64 =
+def bytes_to_base64s (chunk : Fin 3 => Byte) : Fin 4 => Base64 =
   [a, b, c] = chunk
   -- '?' is 00111111
   map ((.&.) '?') $
@@ -46,31 +46,31 @@ def bytesToBase64s (chunk : Fin 3 => Byte) : Fin 4 => Base64 =
     , (b .<<. 2) .|. (c .>>. 6)
     ,  c                    ]
 
-def base64ToAscii (x:Base64) : Char =
-  encodingTable.(fromOrdinal _ (W8ToI x))
+def base64_to_ascii (x:Base64) : Char =
+  encoding_table.(from_ordinal _ (w8_to_i x))
 
-def encodeChunk (chunk : Fin 3 => Char) : Fin 4 => Char =
-  map base64ToAscii $ bytesToBase64s chunk
+def encode_chunk (chunk : Fin 3 => Char) : Fin 4 => Char =
+  map base64_to_ascii $ bytes_to_base64s chunk
 
 -- TODO: the `AsList` unpacking is very tedious. Daniel's change will help
-def base64Encode (s:String) : String =
+def base64_encode (s:String) : String =
   (AsList n cs) = s
-  (AsList numChunks chunks) = getChunks 3 '\NUL' cs
-  encodedChunks = map encodeChunk chunks
+  (AsList numChunks chunks) = get_chunks 3 '\NUL' cs
+  encodedChunks = map encode_chunk chunks
   flattened = for (i,j). encodedChunks.i.j
   padChars = rem (3 - rem n 3) 3
   validOutputChars = (numChunks * 4) - padChars
-  toList for i. case ordinal i < validOutputChars of
+  to_list for i. case ordinal i < validOutputChars of
     True  -> flattened.i
     False -> '='
 
-def asciiToBase64 (c:Char) : Maybe Base64 =
-  decodingTable.(fromOrdinal _ (W8ToI c))
+def ascii_to_base64 (c:Char) : Maybe Base64 =
+  decoding_table.(from_ordinal _ (w8_to_i c))
 
-def decodeChunk (chunk : Fin 4 => Char) : Maybe (Fin 3 => Char) =
-  case seqMaybes $ map asciiToBase64 chunk of
+def decode_chunk (chunk : Fin 4 => Char) : Maybe (Fin 3 => Char) =
+  case seq_maybes $ map ascii_to_base64 chunk of
     Nothing -> Nothing
-    Just base64s -> Just $ base64sToBytes base64s
+    Just base64s -> Just $ base64s_to_bytes base64s
 
 -- TODO: put this in prelude?
 def replace {a} [Eq a] ((old,new):(a&a)) (x:a) : a =
@@ -78,17 +78,17 @@ def replace {a} [Eq a] ((old,new):(a&a)) (x:a) : a =
     True  -> new
     False -> x
 
-def base64Decode (s:String) : Maybe String =
+def base64_decode (s:String) : Maybe String =
   (AsList n cs) = s
-  numValidInputChars = sum for i. BToI $ cs.i /= '='
+  numValidInputChars = sum for i. b_to_i $ cs.i /= '='
   numValidOutputChars = idiv (numValidInputChars * 3) 4
   csZeroed = map (replace ('=', 'A')) cs  -- swap padding char with 'zero' char
-  (AsList _ chunks) = getChunks 4 '\NUL' csZeroed
-  case seqMaybes $ map decodeChunk chunks of
+  (AsList _ chunks) = get_chunks 4 '\NUL' csZeroed
+  case seq_maybes $ map decode_chunk chunks of
     Nothing -> Nothing
     Just decodedChunks ->
       resultPadded = for (i,j). decodedChunks.i.j
-      Just $ toList $ slice resultPadded 0 (Fin numValidOutputChars)
+      Just $ to_list $ slice resultPadded 0 (Fin numValidOutputChars)
 
 '## PNG FFI
 
@@ -98,38 +98,38 @@ Gif  : Type = String
 
 foreign "encodePNG" encodePNG : RawPtr -> Int32 -> Int32 -> {IO} (Int32 & RawPtr)
 
-def makePNG {n m} (img:n=>m=>(Fin 3)=>Word8) : Png = unsafeIO \().
-  (AsList _ imgFlat) = toList for (i,j,k). img.i.j.k
-  withTabPtr imgFlat \ptr.
+def make_png {n m} (img:n=>m=>(Fin 3)=>Word8) : Png = unsafe_io \().
+  (AsList _ imgFlat) = to_list for (i,j,k). img.i.j.k
+  with_table_ptr imgFlat \ptr.
     (MkPtr rawPtr) = ptr
     (n, ptr') = encodePNG rawPtr (size m) (size n)
-    toList $ tabFromPtr (Fin n) $ MkPtr ptr'
+    to_list $ table_from_ptr (Fin n) $ MkPtr ptr'
 
-def pngsToGif {t} (delay:Int) (pngs:t=>Png) : Gif = unsafeIO \().
-  withTempFiles \pngFiles.
-    for i. writeFile pngFiles.i pngs.i
-    withTempFile \gifFile.
-      shellOut $
+def pngs_to_gif {t} (delay:Int) (pngs:t=>Png) : Gif = unsafe_io \().
+  with_temp_files \pngFiles.
+    for i. write_file pngFiles.i pngs.i
+    with_temp_file \gifFile.
+      shell_out $
          "convert" <> " -delay " <> show delay <> " " <>
           concat (for i. "png:" <> pngFiles.i <> " ") <>
          "gif:" <> gifFile
-      readFile gifFile
+      read_file gifFile
 
-def imgToHtml (png:String) : Html =
+def img_to_html (png:String) : Html =
   ("<img class=\"plot-img\" src=\"data:image/png;base64, "
-   <> base64Encode png
+   <> base64_encode png
    <> "\">")
 
-def floatTo8Bit (x:Float) : Word8 =
-  IToW8 $ FToI $ 255.0 * clip (0.0, 1.0) x
+def float_to_8bit (x:Float) : Word8 =
+  i_to_w8 $ FToI $ 255.0 * clip (0.0, 1.0) x
 
-def imgToPng {n m} (img:n=>m=>(Fin 3)=>Float) : Png =
-  makePNG for i j k. floatTo8Bit img.i.j.k
+def img_to_png {n m} (img:n=>m=>(Fin 3)=>Float) : Png =
+  make_png for i j k. float_to_8bit img.i.j.k
 
 '## API entry point
 
 def imshow {n m} (img:n=>m=>(Fin 3)=>Float) : Html =
-  imgToHtml $ imgToPng img
+  img_to_html $ img_to_png img
 
 def imseqshow {t n m} (imgs:t=>n=>m=>(Fin 3)=>Float) : Html =
-  imgToHtml $ pngsToGif 50 $ map imgToPng imgs
+  img_to_html $ pngs_to_gif 50 $ map img_to_png imgs

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -31,40 +31,40 @@ Float = Float32
 
 '### Casting
 
-def internalCast {a} (b:Type) (x:a) : b = %cast b x
+def internal_cast {a} (b:Type) (x:a) : b = %cast b x
 
-def F64ToF (x : Float64) : Float   = internalCast _ x
-def F32ToF (x : Float32) : Float   = internalCast _ x
-def FToF64 (x : Float)   : Float64 = internalCast _ x
-def FToF32 (x : Float)   : Float32 = internalCast _ x
-def I64ToI (x : Int64)   : Int     = internalCast _ x
-def I32ToI (x : Int32)   : Int     = internalCast _ x
-def W8ToI  (x : Word8)   : Int     = internalCast _ x
-def IToI64 (x : Int)     : Int64   = internalCast _ x
-def IToI32 (x : Int)     : Int32   = internalCast _ x
-def IToW8  (x : Int)     : Word8   = internalCast _ x
-def IToW32 (x : Int)     : Word32  = internalCast _ x
-def IToW64 (x : Int)     : Word64  = internalCast _ x
-def W32ToW64 (x : Word32): Word64  = internalCast _ x
-def IToF (x:Int) : Float = internalCast _ x
-def FToI (x:Float) : Int = internalCast _ x
-def I64ToRawPtr (x:Int64 ) : RawPtr = internalCast _ x
-def RawPtrToI64 (x:RawPtr) : Int64  = internalCast _ x
+def f64_to_f (x : Float64) : Float   = internal_cast _ x
+def f32_to_f (x : Float32) : Float   = internal_cast _ x
+def f_to_f64 (x : Float)   : Float64 = internal_cast _ x
+def f_to_f32 (x : Float)   : Float32 = internal_cast _ x
+def i64_to_i (x : Int64)   : Int     = internal_cast _ x
+def i32_to_i (x : Int32)   : Int     = internal_cast _ x
+def w8_to_i  (x : Word8)   : Int     = internal_cast _ x
+def i_to_i64 (x : Int)     : Int64   = internal_cast _ x
+def i_to_i32 (x : Int)     : Int32   = internal_cast _ x
+def i_to_w8  (x : Int)     : Word8   = internal_cast _ x
+def i_to_w32 (x : Int)     : Word32  = internal_cast _ x
+def i_to_w64 (x : Int)     : Word64  = internal_cast _ x
+def w32_to_w64 (x : Word32): Word64  = internal_cast _ x
+def i_to_f (x:Int) : Float = internal_cast _ x
+def FToI (x:Float) : Int = internal_cast _ x
+def i64_to_raw_ptr (x:Int64 ) : RawPtr = internal_cast _ x
+def raw_ptr_to_i64 (x:RawPtr) : Int64  = internal_cast _ x
 
 interface FromInteger a
-  fromInteger : Int64 -> a
+  from_integer : Int64 -> a
 
 instance FromInteger Float32
-  fromInteger = \x. IToF $ I64ToI x
+  from_integer = \x. i_to_f $ i64_to_i x
 
 instance FromInteger Int32
-  fromInteger = \x. I64ToI x
+  from_integer = \x. i64_to_i x
 
 instance FromInteger Float64
-  fromInteger = \x. FToF64 $ IToF $ I64ToI x
+  from_integer = \x. f_to_f64 $ i_to_f $ i64_to_i x
 
 instance FromInteger Int64
-  fromInteger = \x. x
+  from_integer = \x. x
 
 '## Bitwise operations
 
@@ -76,28 +76,28 @@ interface Bits a
   (.^.)   : a -> a -> a
 
 instance Bits Word8
-  (.<<.)  = \x y. %shl x (IToW8 y)
-  (.>>.)  = \x y. %shr x (IToW8 y)
+  (.<<.)  = \x y. %shl x (i_to_w8 y)
+  (.>>.)  = \x y. %shr x (i_to_w8 y)
   (.|.)   = \x y. %or x y
   (.&.)   = \x y. %and x y
   (.^.)   = \x y. %xor x y
 
 instance Bits Word32
-  (.<<.)  = \x y. %shl x (IToW32 y)
-  (.>>.)  = \x y. %shr x (IToW32 y)
+  (.<<.)  = \x y. %shl x (i_to_w32 y)
+  (.>>.)  = \x y. %shr x (i_to_w32 y)
   (.|.)   = \x y. %or x y
   (.&.)   = \x y. %and x y
   (.^.)   = \x y. %xor x y
 
 instance Bits Word64
-  (.<<.)  = \x y. %shl x (IToW64 y)
-  (.>>.)  = \x y. %shr x (IToW64 y)
+  (.<<.)  = \x y. %shl x (i_to_w64 y)
+  (.>>.)  = \x y. %shr x (i_to_w64 y)
   (.|.)   = \x y. %or x y
   (.&.)   = \x y. %and x y
   (.^.)   = \x y. %xor x y
 
-def lowWord  (x : Word64) : Word32 = internalCast _ (x .>>. 32)
-def highWord (x : Word64) : Word32 = internalCast _ x
+def low_word  (x : Word64) : Word32 = internal_cast _ (x .>>. 32)
+def high_word (x : Word64) : Word32 = internal_cast _ x
 
 '### Basic Arithmetic
 #### Add
@@ -115,37 +115,37 @@ def (-) {a} [Add a] : a -> a -> a = sub
 instance Add Float64
   add = \x y. %fadd x y
   sub = \x y. %fsub x y
-  zero = FToF64 0.0
+  zero = f_to_f64 0.0
 
 instance Add Float32
   add = \x y. %fadd x y
   sub = \x y. %fsub x y
-  zero = FToF32 0.0
+  zero = f_to_f32 0.0
 
 instance Add Int64
   add = \x y. %iadd x y
   sub = \x y. %isub x y
-  zero = IToI64 0
+  zero = i_to_i64 0
 
 instance Add Int32
   add = \x y. %iadd x y
   sub = \x y. %isub x y
-  zero = IToI32 0
+  zero = i_to_i32 0
 
 instance Add Word8
   add = \x y. %iadd x y
   sub = \x y. %isub x y
-  zero = IToW8 0
+  zero = i_to_w8 0
 
 instance Add Word32
   add = \x y. %iadd x y
   sub = \x y. %isub x y
-  zero = IToW32 0
+  zero = i_to_w32 0
 
 instance Add Word64
   add = \x y. %iadd x y
   sub = \x y. %isub x y
-  zero = IToW64 0
+  zero = i_to_w64 0
 
 instance Add Unit
   add = \x y. ()
@@ -169,23 +169,23 @@ def (*) {a} [Mul a] : a -> a -> a = mul
 
 instance Mul Float64
   mul = \x y. %fmul x y
-  one = FToF64 1.0
+  one = f_to_f64 1.0
 
 instance Mul Float32
   mul = \x y. %fmul x y
-  one = FToF32 1.0
+  one = f_to_f32 1.0
 
 instance Mul Int64
   mul = \x y. %imul x y
-  one = IToI64 1
+  one = i_to_i64 1
 
 instance Mul Int32
   mul = \x y. %imul x y
-  one = IToI32 1
+  one = i_to_i32 1
 
 instance Mul Word8
   mul = \x y. %imul x y
-  one = IToW8 1
+  one = i_to_w8 1
 
 instance Mul Unit
   mul = \x y. ()
@@ -230,71 +230,71 @@ instance Fractional Float32
 '## Index set interface and instances
 
 interface Ix n
-  getSize n : Unit -> Int
+  get_size n : Unit -> Int
   ordinal : n -> Int
-  unsafeFromOrdinal n : Int -> n
+  unsafe_from_ordinal n : Int -> n
 
-def size (n : Type) [Ix n] : Int = getSize n ()
+def size (n : Type) [Ix n] : Int = get_size n ()
 
 def Range (low:Int) (high:Int) : Type = %IntRange low high
 def Fin (n:Int) : Type = Range 0 n
 
 -- A max(a, 0) that is friendly to our algebraic simplifier
-def clampNonnegPrim (a: Int) : Int =
+def clamp_nonneg_prim (a: Int) : Int =
   z : Int = 0
   isNeg = %ilt a z
   %select isNeg z a
 
 -- TODO: Define Range in surface syntax
 instance {l h} Ix (Range l h)
-  getSize = \(). clampNonnegPrim $ h - l
+  get_size = \(). clamp_nonneg_prim $ h - l
   ordinal = \i. %cast Int i
-  unsafeFromOrdinal = \i. %cast (Range l h) i
+  unsafe_from_ordinal = \i. %cast (Range l h) i
 
 instance {q:Type} {i:q} [Ix q] Ix (i..)
-  getSize = \(). size q - ordinal i
+  get_size = \(). size q - ordinal i
   ordinal = \j. %cast Int j
-  unsafeFromOrdinal = \j. %cast (i..) j
+  unsafe_from_ordinal = \j. %cast (i..) j
 
 instance {q:Type} {i:q} [Ix q] Ix (i<..)
-  getSize = \(). size q - ordinal i - 1
+  get_size = \(). size q - ordinal i - 1
   ordinal = \j. %cast Int j
-  unsafeFromOrdinal = \j. %cast (i<..) j
+  unsafe_from_ordinal = \j. %cast (i<..) j
 
 instance {q:Type} {i:q} [Ix q] Ix (..i)
-  getSize = \(). ordinal i + 1
+  get_size = \(). ordinal i + 1
   ordinal = \j. %cast Int j
-  unsafeFromOrdinal = \j. %cast (..i) j
+  unsafe_from_ordinal = \j. %cast (..i) j
 
 instance {q:Type} {i:q} [Ix q] Ix (..<i)
-  getSize = \(). ordinal i
+  get_size = \(). ordinal i
   ordinal = \j. %cast Int j
-  unsafeFromOrdinal = \j. %cast (..<i) j
+  unsafe_from_ordinal = \j. %cast (..<i) j
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
-  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j + 1
+  get_size = \(). clamp_nonneg_prim $ ordinal i - ordinal j + 1
   ordinal = \k. %cast Int k
-  unsafeFromOrdinal = \k. %cast (j..i) k
+  unsafe_from_ordinal = \k. %cast (j..i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
-  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j
+  get_size = \(). clamp_nonneg_prim $ ordinal i - ordinal j
   ordinal = \k. %cast Int k
-  unsafeFromOrdinal = \k. %cast (j..<i) k
+  unsafe_from_ordinal = \k. %cast (j..<i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
-  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j
+  get_size = \(). clamp_nonneg_prim $ ordinal i - ordinal j
   ordinal = \k. %cast Int k
-  unsafeFromOrdinal = \k. %cast (j<..i) k
+  unsafe_from_ordinal = \k. %cast (j<..i) k
 
 instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
-  getSize = \(). clampNonnegPrim $ ordinal i - ordinal j - 1
+  get_size = \(). clamp_nonneg_prim $ ordinal i - ordinal j - 1
   ordinal = \k. %cast Int k
-  unsafeFromOrdinal = \k. %cast (j<..<i) k
+  unsafe_from_ordinal = \k. %cast (j<..<i) k
 
 instance Ix Unit
-  getSize = \(). 1
+  get_size = \(). 1
   ordinal = \_. 0
-  unsafeFromOrdinal = \_. ()
+  unsafe_from_ordinal = \_. ()
 
 def iota (n:Type) [Ix n] : n=>Int = view i. ordinal i
 
@@ -328,11 +328,11 @@ def snd {a b} ((_, y): (a & b)) : b = y
 def swap {a b} ((x, y):(a&b)) : (b&a) = (y, x)
 
 instance {a b} [Ix a, Ix b] Ix (a & b)
-  getSize = \(). size a * size b
+  get_size = \(). size a * size b
   ordinal = \(i, j). (ordinal i * size b) + ordinal j
-  unsafeFromOrdinal = \o.
+  unsafe_from_ordinal = \o.
     bs = size b
-    (unsafeFromOrdinal a (idiv o bs), unsafeFromOrdinal b (rem o bs))
+    (unsafe_from_ordinal a (idiv o bs), unsafe_from_ordinal b (rem o bs))
 
 def (<<<) {a b c} (f: b -> c) (g: a -> b) : a -> c = \x. f (g x)
 def (>>>) {a b c} (g: a -> b) (f: b -> c) : a -> c = \x. f (g x)
@@ -344,24 +344,24 @@ def const   {a b}   (x: a) (_: b) : a = x
 '## Vector spaces
 
 interface [Add a] VSpace a
-  scaleVec : Float -> a -> a
+  scale_vec : Float -> a -> a
 
-def (.*) {a} [VSpace a] : Float -> a -> a = scaleVec
-def (*.) {a} [VSpace a] : a -> Float -> a = flip scaleVec
+def (.*) {a} [VSpace a] : Float -> a -> a = scale_vec
+def (*.) {a} [VSpace a] : a -> Float -> a = flip scale_vec
 def (/)  {a} [VSpace a] (v:a) (s:Float) : a = divide 1.0 s .* v
 def neg  {a} [VSpace a] (v:a) : a = (-1.0) .* v
 
 instance VSpace Float
-  scaleVec = \x y. x * y
+  scale_vec = \x y. x * y
 
 instance {a n} [VSpace a] VSpace (n=>a)
-  scaleVec = \s xs. for i. s .* xs.i
+  scale_vec = \s xs. for i. s .* xs.i
 
 instance {a n} [VSpace a] VSpace (n->a)
-  scaleVec = \s f. \x. s .* (f x)
+  scale_vec = \s f. \x. s .* (f x)
 
 instance VSpace Unit
-  scaleVec = \_ _. ()
+  scale_vec = \_ _. ()
 
 '## Boolean type
 
@@ -369,23 +369,23 @@ data Bool =
   False
   True
 
-def BToW8 (x : Bool) : Word8 = %dataConTag x
+def b_to_w8 (x : Bool) : Word8 = %dataConTag x
 
-def W8ToB (x : Word8) : Bool = %toEnum Bool x
+def w8_to_b (x : Word8) : Bool = %toEnum Bool x
 
 def (&&) (x:Bool) (y:Bool) : Bool =
-  x' = BToW8 x
-  y' = BToW8 y
-  W8ToB $ %and x' y'
+  x' = b_to_w8 x
+  y' = b_to_w8 y
+  w8_to_b $ %and x' y'
 
 def (||) (x:Bool) (y:Bool) : Bool =
-  x' = BToW8 x
-  y' = BToW8 y
-  W8ToB $ %or x' y'
+  x' = b_to_w8 x
+  y' = b_to_w8 y
+  w8_to_b $ %or x' y'
 
 def not  (x:Bool) : Bool =
-  x' = BToW8 x
-  W8ToB $ %not x'
+  x' = b_to_w8 x
+  w8_to_b $ %not x'
 
 '## More Boolean operations
 TODO: move these with the others?
@@ -394,8 +394,8 @@ def select {a} (p:Bool) (x:a) (y:a) : a = case p of
   True  -> x
   False -> y
 
-def BToI (x:Bool) : Int  = W8ToI $ BToW8 x
-def BToF (x:Bool) : Float = IToF (BToI x)
+def b_to_i (x:Bool) : Int  = w8_to_i $ b_to_w8 x
+def b_to_f (x:Bool) : Float = i_to_f (b_to_i x)
 
 '## Ordering
 TODO: move this down to with `Ord`?
@@ -405,7 +405,7 @@ data Ordering =
   EQ
   GT
 
-def OToW8 (x : Ordering) : Word8 = %dataConTag x
+def o_to_w8 (x : Ordering) : Word8 = %dataConTag x
 
 '## Sum types
 A [sum type, or tagged union](https://en.wikipedia.org/wiki/Tagged_union) can hold values from a fixed set of types, distinguished by tags.
@@ -416,11 +416,11 @@ data Maybe a =
   Nothing
   Just a
 
-def isNothing {a} (x:Maybe a) : Bool = case x of
+def is_nothing {a} (x:Maybe a) : Bool = case x of
   Nothing -> True
   Just _ -> False
 
-def isJust {a} (x:Maybe a) : Bool = not $ isNothing x
+def is_just {a} (x:Maybe a) : Bool = not $ is_nothing x
 
 def maybe {a b} (d: b) (f : (a -> b)) (x: Maybe a) : b =
   case x of
@@ -432,16 +432,16 @@ data (|) a b =
   Right b
 
 instance {a b} [Ix a, Ix b] Ix (a | b)
-  getSize = \(). size a + size b
+  get_size = \(). size a + size b
   ordinal = \i. case i of
     Left ai  -> ordinal ai
     Right bi -> ordinal bi + size a
-  unsafeFromOrdinal = \o.
+  unsafe_from_ordinal = \o.
     as = size a
     -- TODO: Reshuffle the prelude to be able to use (<) here
-    case W8ToB $ %ilt o as of
-      True  -> Left $ unsafeFromOrdinal a o
-      False -> Right $ unsafeFromOrdinal b (o - as)
+    case w8_to_b $ %ilt o as of
+      True  -> Left $ unsafe_from_ordinal a o
+      False -> Right $ unsafe_from_ordinal b (o - as)
 
 '### Monoid
 A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.
@@ -508,10 +508,10 @@ def (+=) {h w} [am:AccumMonoid h w] (ref:Ref h w) (x:w) : {Accum h} Unit =
   %mextend ref empty combine x
 
 def (!) {h n a} (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
-def fstRef {h a b} (ref: Ref h (a & b)) : Ref h a = %fstRef ref
-def sndRef {h a b} (ref: Ref h (a & b)) : Ref h b = %sndRef ref
+def fst_ref {h a b} (ref: Ref h (a & b)) : Ref h a = %fstRef ref
+def snd_ref {h a b} (ref: Ref h (a & b)) : Ref h b = %sndRef ref
 
-def runReader
+def run_reader
       {r a eff}
       (init:r)
       (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
@@ -519,16 +519,16 @@ def runReader
     def explicitAction (h':Type) (ref:Ref h' r) : {Read h'|eff} a = action ref
     %runReader init explicitAction
 
-def withReader
+def with_reader
       {r a eff}
       (init:r)
       (action: (h:Type ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
-    runReader init action
+    run_reader init action
 
 def MonoidLifter (b:Type) (w:Type) : Type = h:Type ?-> AccumMonoid h b ?=> AccumMonoid h w
 
-def runAccum
+def run_accum
       {a b w eff}
       [mlift:MonoidLifter b w]
       (bm:Monoid b)
@@ -550,9 +550,9 @@ def yieldAccum
       (m:Monoid b)
       (action: (h:Type ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} w =
-  snd $ runAccum m action
+  snd $ run_accum m action
 
-def runState
+def run_state
       {a s eff}
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
@@ -560,22 +560,22 @@ def runState
   def explicitAction (h':Type) (ref:Ref h' s) : {State h'|eff} a = action ref
   %runState init explicitAction
 
-def withState
+def with_state
       {a s eff}
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
-      : {|eff} a = fst $ runState init action
+      : {|eff} a = fst $ run_state init action
 
-def yieldState
+def yield_state
       {a s eff}
       (init:s)
       (action: h:Type ?-> Ref h s -> {State h |eff} a)
-      : {|eff} s = snd $ runState init action
+      : {|eff} s = snd $ run_state init action
 
-def unsafeIO {a eff} (f: Unit -> {IO|eff} a) : {|eff} a =
+def unsafe_io {a eff} (f: Unit -> {IO|eff} a) : {|eff} a =
   %runIO f
 
-def unreachable {a} (():Unit) : a = unsafeIO do
+def unreachable {a} (():Unit) : a = unsafe_io do
   %throwError a
 
 '## Type classes
@@ -606,48 +606,48 @@ def (<=) {a} [Ord a] (x:a) (y:a) : Bool = x<y || x==y
 def (>=) {a} [Ord a] (x:a) (y:a) : Bool = x>y || x==y
 
 instance Eq Float64
-  (==) = \x y. W8ToB $ %feq x y
+  (==) = \x y. w8_to_b $ %feq x y
 
 instance Eq Float32
-  (==) = \x y. W8ToB $ %feq x y
+  (==) = \x y. w8_to_b $ %feq x y
 
 instance Eq Int64
-  (==) = \x y. W8ToB $ %ieq x y
+  (==) = \x y. w8_to_b $ %ieq x y
 
 instance Eq Int32
-  (==) = \x y. W8ToB $ %ieq x y
+  (==) = \x y. w8_to_b $ %ieq x y
 
 instance Eq Word8
-  (==) = \x y. W8ToB $ %ieq x y
+  (==) = \x y. w8_to_b $ %ieq x y
 
 instance Eq Bool
-  (==) = \x y. BToW8 x == BToW8 y
+  (==) = \x y. b_to_w8 x == b_to_w8 y
 
 instance Eq Unit
   (==) = \x y. True
 
 instance Eq RawPtr
-  (==) = \x y. RawPtrToI64 x == RawPtrToI64 y
+  (==) = \x y. raw_ptr_to_i64 x == raw_ptr_to_i64 y
 
 instance Ord Float64
-  (>) = \x y. W8ToB $ %fgt x y
-  (<) = \x y. W8ToB $ %flt x y
+  (>) = \x y. w8_to_b $ %fgt x y
+  (<) = \x y. w8_to_b $ %flt x y
 
 instance Ord Float32
-  (>) = \x y. W8ToB $ %fgt x y
-  (<) = \x y. W8ToB $ %flt x y
+  (>) = \x y. w8_to_b $ %fgt x y
+  (<) = \x y. w8_to_b $ %flt x y
 
 instance Ord Int64
-  (>) = \x y. W8ToB $ %igt x y
-  (<) = \x y. W8ToB $ %ilt x y
+  (>) = \x y. w8_to_b $ %igt x y
+  (<) = \x y. w8_to_b $ %ilt x y
 
 instance Ord Int32
-  (>) = \x y. W8ToB $ %igt x y
-  (<) = \x y. W8ToB $ %ilt x y
+  (>) = \x y. w8_to_b $ %igt x y
+  (<) = \x y. w8_to_b $ %ilt x y
 
 instance Ord Word8
-  (>) = \x y. W8ToB $ %igt x y
-  (<) = \x y. W8ToB $ %ilt x y
+  (>) = \x y. w8_to_b $ %igt x y
+  (<) = \x y. w8_to_b $ %ilt x y
 
 instance Ord Unit
   (>) = \x y. False
@@ -661,7 +661,7 @@ instance {a b} [Ord a, Ord b] Ord (a & b)
   (<) = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
 
 instance Eq Ordering
-  (==) = \x y. OToW8 x == OToW8 y
+  (==) = \x y. o_to_w8 x == o_to_w8 y
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`
 instance {n} Eq (Fin n)
@@ -672,7 +672,7 @@ instance {n} Ord (Fin n)
   (<) = \x y. ordinal x < ordinal y
 
 def scan {a b n} [Ix n] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
-  swap $ runState init \s. for i.
+  swap $ run_state init \s. for i.
     c = get s
     (c', y) = body i c
     s := c'
@@ -745,10 +745,10 @@ def float32_cosh (x:Float32) : Float32 = %fdiv (%fadd (%exp x) (%exp (%fsub 0.0 
 def float32_tanh (x:Float32) : Float32 = %fdiv (%fsub (%exp x) (%exp (%fsub 0.0 x))) (%fadd (%exp x) (%exp (%fsub 0.0 x)))
 
 -- Todo: unify this with float32 functions.
-def float64_sinh (x:Float64) : Float64 = %fdiv (%fsub (%exp x) (%exp (%fsub (FToF64 0.0) x))) (FToF64 2.0)
-def float64_cosh (x:Float64) : Float64 = %fdiv (%fadd (%exp x) (%exp (%fsub (FToF64 0.0) x))) (FToF64 2.0)
-def float64_tanh (x:Float64) : Float64 = (%fdiv (%fsub (%exp x) (%exp (%fsub (FToF64 0.0) x)))
-                                                (%fadd (%exp x) (%exp (%fsub (FToF64 0.0) x))))
+def float64_sinh (x:Float64) : Float64 = %fdiv (%fsub (%exp x) (%exp (%fsub (f_to_f64 0.0) x))) (f_to_f64 2.0)
+def float64_cosh (x:Float64) : Float64 = %fdiv (%fadd (%exp x) (%exp (%fsub (f_to_f64 0.0) x))) (f_to_f64 2.0)
+def float64_tanh (x:Float64) : Float64 = (%fdiv (%fsub (%exp x) (%exp (%fsub (f_to_f64 0.0) x)))
+                                                (%fadd (%exp x) (%exp (%fsub (f_to_f64 0.0) x))))
 
 instance Floating Float64
   exp    = \x. %exp x
@@ -794,39 +794,39 @@ instance Floating Float32
 
 data Ptr a = MkPtr RawPtr
 
-def castPtr {a b} (ptr: Ptr a) : Ptr b =
+def cast_ptr {a b} (ptr: Ptr a) : Ptr b =
   (MkPtr rawPtr) = ptr
   MkPtr rawPtr
 
 interface Storable a
   store : Ptr a -> a -> {IO} Unit
   load  : Ptr a ->      {IO} a
-  storageSize a : Int
+  storage_size a : Int
 
 instance Storable Word8
   store = \(MkPtr ptr) x. %ptrStore ptr x
   load  = \(MkPtr ptr)  . %ptrLoad  ptr
-  storageSize = 1
+  storage_size = 1
 
 instance Storable Int32
-  store = \(MkPtr ptr) x. %ptrStore (internalCast %Int32Ptr ptr) x
-  load  = \(MkPtr ptr)  . %ptrLoad  (internalCast %Int32Ptr ptr)
-  storageSize = 4
+  store = \(MkPtr ptr) x. %ptrStore (internal_cast %Int32Ptr ptr) x
+  load  = \(MkPtr ptr)  . %ptrLoad  (internal_cast %Int32Ptr ptr)
+  storage_size = 4
 
 instance Storable Float32
-  store = \(MkPtr ptr) x. %ptrStore (internalCast %Float32Ptr ptr) x
-  load = \(MkPtr ptr)   . %ptrLoad  (internalCast %Float32Ptr ptr)
-  storageSize = 4
+  store = \(MkPtr ptr) x. %ptrStore (internal_cast %Float32Ptr ptr) x
+  load = \(MkPtr ptr)   . %ptrLoad  (internal_cast %Float32Ptr ptr)
+  storage_size = 4
 
 instance {a} Storable (Ptr a)
-  store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internalCast %PtrPtr ptr) x
-  load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internalCast %PtrPtr ptr)
-  storageSize = 8  -- TODO: something more portable?
+  store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internal_cast %PtrPtr ptr) x
+  load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internal_cast %PtrPtr ptr)
+  storage_size = 8  -- TODO: something more portable?
 
 -- TODO: Storable instances for other types
 
 def malloc {a} [Storable a] (n:Int) : {IO} (Ptr a) =
-  numBytes = storageSize a * n
+  numBytes = storage_size a * n
   MkPtr $ %alloc numBytes
 
 def free {a} (ptr:Ptr a) : {IO} Unit =
@@ -835,11 +835,11 @@ def free {a} (ptr:Ptr a) : {IO} Unit =
 
 def (+>>) {a} [Storable a] (ptr:Ptr a) (i:Int) : Ptr a =
   (MkPtr ptr') = ptr
-  i' = i * storageSize a
+  i' = i * storage_size a
   MkPtr $ %ptrOffset ptr' i'
 
 -- TODO: consider making a Storable instance for tables instead
-def storeTab {a n} [Storable a] (ptr: Ptr a) (tab:n=>a) : {IO} Unit =
+def store_table {a n} [Storable a] (ptr: Ptr a) (tab:n=>a) : {IO} Unit =
   for_ i. store (ptr +>> ordinal i) tab.i
 
 def memcpy {a} [Storable a] (dest:Ptr a) (src:Ptr a) (n:Int) : {IO} Unit =
@@ -849,18 +849,18 @@ def memcpy {a} [Storable a] (dest:Ptr a) (src:Ptr a) (n:Int) : {IO} Unit =
 
 -- TODO: generalize these brackets to allow other effects
 -- TODO: make sure that freeing happens even if there are run-time errors
-def withAlloc {a b} [Storable a] (n:Int) (action: Ptr a -> {IO} b) : {IO} b =
+def with_alloc {a b} [Storable a] (n:Int) (action: Ptr a -> {IO} b) : {IO} b =
   ptr = malloc n
   result = action ptr
   free ptr
   result
 
-def withTabPtr {a b n} [Storable a] (xs:n=>a) (action : Ptr a -> {IO} b) : {IO} b =
-  withAlloc (size n) \ptr.
+def with_table_ptr {a b n} [Storable a] (xs:n=>a) (action : Ptr a -> {IO} b) : {IO} b =
+  with_alloc (size n) \ptr.
     for i. store (ptr +>> ordinal i) xs.i
     action ptr
 
-def tabFromPtr {a} [Storable a] (n:Type) [Ix n] (ptr:Ptr a) : {IO} n=>a =
+def table_from_ptr {a} [Storable a] (n:Type) [Ix n] (ptr:Ptr a) : {IO} n=>a =
   for i. load $ ptr +>> ordinal i
 
 '## Miscellaneous common utilities
@@ -919,22 +919,22 @@ def scan' {a n} [Ix n] (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. du
 def fsum {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs.i
 def sum  {n v} [Add v] (xs:n=>v) : v = reduce zero (+) xs
 def prod {n v} [Mul v] (xs:n=>v) : v = reduce one  (*) xs
-def mean {n v} [VSpace v] (xs:n=>v) : v = sum xs / IToF (size n)
+def mean {n v} [VSpace v] (xs:n=>v) : v = sum xs / i_to_f (size n)
 def std  {n v} [Mul v, VSpace v, Floating v] (xs:n=>v) : v = sqrt $ mean (map sq xs) - sq (mean xs)
 def any {n} (xs:n=>Bool) : Bool = reduce False (||) xs
 def all {n} (xs:n=>Bool) : Bool = reduce True  (&&) xs
 
-'### ApplyN
+'### apply_n
 
-def applyN {a} (n:Int) (x:a) (f:a -> a) : a =
-  yieldState x \ref. for _:(Fin n).
+def apply_n {a} (n:Int) (x:a) (f:a -> a) : a =
+  yield_state x \ref. for _:(Fin n).
     ref := f (get ref)
 
 '### Linear Algebra
 
 def linspace (n:Type) [Ix n] (low:Float) (high:Float) : n=>Float =
-  dx = (high - low) / IToF (size n)
-  for i:n. low + IToF (ordinal i) * dx
+  dx = (high - low) / i_to_f (size n)
+  for i:n. low + i_to_f (ordinal i) * dx
 
 def transpose {n m a} (x:n=>m=>a) : m=>n=>a = view i j. x.j.i
 def vdot {n} (x:n=>Float) (y:n=>Float) : Float = fsum view i. x.i * y.i
@@ -958,8 +958,8 @@ def eye {n a} [Add a, Mul a, Ix n] : n=>n=>a =
 TODO: Move this to be with reductions?
 It's a kind of `scan`.
 
-def cumSum {n} (xs: n=>Float) : n=>Float =
-  withState 0.0 \total.
+def cumsum {n} (xs: n=>Float) : n=>Float =
+  with_state 0.0 \total.
     for i.
       newTotal = get total + xs.i
       total := newTotal
@@ -982,7 +982,7 @@ def grad {a} (f:a->Float) (x:a) : a = snd (vjp f x) 1.0
 
 def deriv (f:Float->Float) (x:Float) : Float = jvp f x 1.0
 
-def derivRev (f:Float->Float) (x:Float) : Float = snd (vjp f x) 1.0
+def deriv_rev (f:Float->Float) (x:Float) : Float = snd (vjp f x) 1.0
 
 '### Approximate Equality
 TODO: move this outside the AD section to be with equality?
@@ -1003,12 +1003,12 @@ instance HasAllClose Float64
   allclose = \atol rtol x y. abs (x - y) <= (atol + rtol * abs y)
 
 instance HasDefaultTolerance Float32
-  atol = FToF32 0.00001
-  rtol = FToF32 0.0001
+  atol = f_to_f32 0.00001
+  rtol = f_to_f32 0.0001
 
 instance HasDefaultTolerance Float64
-  atol = FToF64 0.00000001
-  rtol = FToF64 0.00001
+  atol = f_to_f64 0.00000001
+  rtol = f_to_f64 0.00001
 
 instance {n t} [HasAllClose t] HasAllClose (n=>t)
   allclose = \atol rtol a b.
@@ -1020,15 +1020,15 @@ instance {n t} [HasDefaultTolerance t] HasDefaultTolerance (n=>t)
 
 '### AD Checking tools
 
-def checkDerivBase (f:Float->Float) (x:Float) : Bool =
+def check_deriv_base (f:Float->Float) (x:Float) : Bool =
   eps = 0.01
   ansFwd  = deriv    f x
-  ansRev  = derivRev f x
+  ansRev  = deriv_rev f x
   ansNumeric = (f (x + eps) - f (x - eps)) / (2. * eps)
   ansFwd ~~ ansNumeric && ansRev ~~ ansNumeric
 
-def checkDeriv (f:Float->Float) (x:Float) : Bool =
-  checkDerivBase f x && checkDerivBase (deriv f) x
+def check_deriv (f:Float->Float) (x:Float) : Bool =
+  check_deriv_base f x && check_deriv_base (deriv f) x
 
 '## Vector support
 
@@ -1107,14 +1107,14 @@ instance {a} [Eq a] Eq (List a)
     if nx /= ny
       then False
       else all for i:(Fin nx).
-        xs.i == ys.(unsafeFromOrdinal _ (ordinal i))
+        xs.i == ys.(unsafe_from_ordinal _ (ordinal i))
 
-def unsafeCastTable {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
-  for i. xs.(unsafeFromOrdinal _ (ordinal i))
+def unsafe_cast_table {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
+  for i. xs.(unsafe_from_ordinal _ (ordinal i))
 
-def toList {n a} (xs:n=>a) : List a =
+def to_list {n a} (xs:n=>a) : List a =
   n' = size n
-  AsList _ $ unsafeCastTable (Fin n') xs
+  AsList _ $ unsafe_cast_table (Fin n') xs
 
 instance {a} Monoid (List a)
   mempty = AsList _ []
@@ -1125,8 +1125,8 @@ instance {a} Monoid (List a)
     AsList _ $ for i:(Fin nz).
       i' = ordinal i
       case i' < nx of
-        True  -> xs.(unsafeFromOrdinal _ i')
-        False -> ys.(unsafeFromOrdinal _ (i' - nx))
+        True  -> xs.(unsafe_from_ordinal _ i')
+        False -> ys.(unsafe_from_ordinal _ (i' - nx))
 
 def ListMonoid (a:Type) : Monoid (List a) =
   A = a -- XXX: Typing `Monoid a` below would quantify it over a,
@@ -1146,7 +1146,7 @@ def filter {a n} (condition:a->Bool) (xs:n=>a) : List a =
       if condition xs.i
         then append list xs.i
 
-def argFilter {a n} (condition:a->Bool) (xs:n=>a) : List n =
+def arg_filter {a n} (condition:a->Bool) (xs:n=>a) : List n =
   -- Returns all indices where the condition is true.
   yieldAccum (ListMonoid n) \list.
     for i.
@@ -1157,17 +1157,17 @@ def argFilter {a n} (condition:a->Bool) (xs:n=>a) : List n =
 
 data Iso a b = MkIso { fwd: a -> b & bwd: b -> a }
 
-def appIso {a b} (iso: Iso a b) (x:a) : b =
+def app_iso {a b} (iso: Iso a b) (x:a) : b =
   (MkIso {fwd, bwd}) = iso
   fwd x
 
-def flipIso {a b} (iso: Iso a b) : Iso b a =
+def flip_iso {a b} (iso: Iso a b) : Iso b a =
   (MkIso {fwd, bwd}) = iso
   MkIso {fwd=bwd, bwd=fwd}
 
-def revIso {a b} (iso: Iso a b) (x:b) : a = appIso (flipIso iso) x
+def rev_iso {a b} (iso: Iso a b) (x:b) : a = app_iso (flip_iso iso) x
 
-def idIso {a} : Iso a a = MkIso {fwd=id, bwd=id}
+def id_iso {a} : Iso a a = MkIso {fwd=id, bwd=id}
 
 def (&>>) {a b c} (iso1: Iso a b) (iso2: Iso b c) : Iso a c =
   (MkIso {fwd=fwd1, bwd=bwd1}) = iso1
@@ -1179,30 +1179,30 @@ def (<<&) {a b c} (iso2: Iso b c) (iso1: Iso a b) : Iso a c = iso1 &>> iso2
 '### Lens-like accessors
 note: `#foo is an Iso {foo: a & ...b} (a & {&...b}))`
 
-def getAt  {a b c} (iso: Iso a (b & c)) : a -> b = fst <<< appIso iso
-def popAt  {a b c} (iso: Iso a (b & c)) : a -> c = snd <<< appIso iso
-def pushAt {a b c} (iso: Iso a (b & c)) (x:b) (r:c) : a = revIso iso (x, r)
-def setAt  {a b c} (iso: Iso a (b & c)) (x:b) (r:a) : a =
-  pushAt iso x $ popAt iso r
+def get_at  {a b c} (iso: Iso a (b & c)) : a -> b = fst <<< app_iso iso
+def pop_at  {a b c} (iso: Iso a (b & c)) : a -> c = snd <<< app_iso iso
+def push_at {a b c} (iso: Iso a (b & c)) (x:b) (r:c) : a = rev_iso iso (x, r)
+def set_at  {a b c} (iso: Iso a (b & c)) (x:b) (r:a) : a =
+  push_at iso x $ pop_at iso r
 
 '### Prism-like accessors
 note: `#?foo is an Iso {foo: a | ...b} (a | {|...b}))`
 
-def matchWith {a b c} (iso: Iso a (b | c)) (x: a) : Maybe b =
-  case appIso iso x of
+def match_with {a b c} (iso: Iso a (b | c)) (x: a) : Maybe b =
+  case app_iso iso x of
     Left x -> Just x
     Right _ -> Nothing
-def buildWith {a b c} (iso: Iso a (b | c)) (x: b) : a = revIso iso $ Left x
+def build_with {a b c} (iso: Iso a (b | c)) (x: b) : a = rev_iso iso $ Left x
 
-def swapPairIso {a b} : Iso (a & b) (b & a) =
+def swap_pair_iso {a b} : Iso (a & b) (b & a) =
   MkIso {fwd = \(a, b). (b, a), bwd = \(b, a). (a, b)}
 
 '### Complement lens
 Complement the focus of a lens-like isomorphism
 
-def exceptLens {a b c} (iso: Iso a (b & c)) : Iso a (c & b) = iso &>> swapPairIso
+def except_lens {a b c} (iso: Iso a (b & c)) : Iso a (c & b) = iso &>> swap_pair_iso
 
-def swapEitherIso {a b} : Iso (a | b) (b | a) =
+def swap_either_iso {a b} : Iso (a | b) (b | a) =
   fwd = \x. case x of
     Left l -> Right l
     Right r -> Left r
@@ -1214,11 +1214,11 @@ def swapEitherIso {a b} : Iso (a | b) (b | a) =
 '### Complement prism
 Complement the focus of a prism-like isomorphism
 
-def exceptPrism {a b c} : Iso a (b | c) -> Iso a (c | b) = \iso. iso &>> swapEitherIso
+def except_prism {a b c} : Iso a (b | c) -> Iso a (c | b) = \iso. iso &>> swap_either_iso
 
 -- Use a lens-like iso to split a 1d table into a 2d table
-def overLens {a b c v} [Ix b, Ix c] (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
-  for i j. tab.(revIso iso (i, j))
+def over_lens {a b c v} [Ix b, Ix c] (iso: Iso a (b & c)) (tab: a=>v) : (b=>c=>v) =
+  for i j. tab.(rev_iso iso (i, j))
 
 '### Zipper
 Zipper isomorphisms to easily specify many record/variant fields:
@@ -1230,20 +1230,20 @@ Zipper isomorphisms to easily specify many record/variant fields:
 ' Convert a record zipper isomorphism to a normal lens-like isomorphism
 by using `splitR &>> iso`
 
-def splitR {a} : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
+def split_r {a} : Iso a ({&} & a) = MkIso {fwd=\x. ({}, x), bwd=\({}, x). x}
 
-def overFields {a b c v} [Ix b, Ix c]
+def over_fields {a b c v} [Ix b, Ix c]
       (iso: Iso ({&} & a) (b & c)) (tab: a=>v) : b=>c=>v =
-  overLens (splitR &>> iso) tab
+  over_lens (split_r &>> iso) tab
 
 'Convert a variant zipper isomorphism to a normal prism-like isomorphism
 by using `splitV &>> iso`
 
-def splitV {a} : Iso a ({|} | a) =
+def split_v {a} : Iso a ({|} | a) =
   MkIso {fwd=\x. Right x, bwd=\v. case v of Right x -> x}
 
-def sliceFields {a b c v} [Ix b] (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
-  reindex (buildWith $ splitV &>> iso) tab
+def slice_fields {a b c v} [Ix b] (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
+  reindex (build_with $ split_v &>> iso) tab
 
 '## Dynamic buffer
 
@@ -1254,10 +1254,10 @@ data DynBuffer a =
     & maxSize : Ptr Int
     & buffer  : Ptr (Ptr a) }
 
-def withDynamicBuffer {a b} [Storable a]
+def with_dynamic_buffer {a b} [Storable a]
       (action: DynBuffer a -> {IO} b) : {IO} b =
   initMaxSize = 256
-  withAlloc 1 \sizePtr. withAlloc 1 \maxSizePtr. withAlloc 1 \bufferPtr.
+  with_alloc 1 \sizePtr. with_alloc 1 \maxSizePtr. with_alloc 1 \bufferPtr.
     store sizePtr 0
     store maxSizePtr initMaxSize
     store bufferPtr $ malloc initMaxSize
@@ -1268,54 +1268,54 @@ def withDynamicBuffer {a b} [Storable a]
     free $ load bufferPtr
     result
 
-def maybeIncreaseBufferSize {a} [Storable a]
+def maybe_increase_buffer_size {a} [Storable a]
       ((MkDynBuffer db): DynBuffer a) (sizeDelta:Int) : {IO} Unit =
-  size    = load $ getAt #size    db
-  maxSize = load $ getAt #maxSize db
-  bufPtr  = load $ getAt #buffer  db
+  size    = load $ get_at #size    db
+  maxSize = load $ get_at #maxSize db
+  bufPtr  = load $ get_at #buffer  db
   newSize = sizeDelta + size
   if newSize > maxSize then
     -- TODO: maybe this should use integer arithmetic?
-    newMaxSize = FToI $ pow 2.0 (ceil $ log2 $ IToF newSize)
+    newMaxSize = FToI $ pow 2.0 (ceil $ log2 $ i_to_f newSize)
     newBufPtr = malloc newMaxSize
     memcpy newBufPtr bufPtr size
     free bufPtr
-    store (getAt #maxSize db) newMaxSize
-    store (getAt #buffer  db) newBufPtr
+    store (get_at #maxSize db) newMaxSize
+    store (get_at #buffer  db) newBufPtr
 
-def addAtIntPtr (ptr: Ptr Int) (n:Int) : {IO} Unit =
+def add_at_int_ptr (ptr: Ptr Int) (n:Int) : {IO} Unit =
   store ptr (load ptr + n)
 
-def extendDynBuffer {a} [Storable a]
+def extend_dynamic_buffer {a} [Storable a]
       (buf: DynBuffer a) (new:List a) : {IO} Unit =
   (AsList n xs) = new
-  maybeIncreaseBufferSize buf n
+  maybe_increase_buffer_size buf n
   (MkDynBuffer db) = buf
-  bufPtr = load $ getAt #buffer db
-  size   = load $ getAt #size db
-  storeTab (bufPtr +>> size) xs
-  addAtIntPtr (getAt #size db) n
+  bufPtr = load $ get_at #buffer db
+  size   = load $ get_at #size db
+  store_table (bufPtr +>> size) xs
+  add_at_int_ptr (get_at #size db) n
 
-def loadDynBuffer {a} [Storable a]
+def load_dynamic_buffer {a} [Storable a]
       (buf: DynBuffer a) : {IO} (List a) =
   (MkDynBuffer db) = buf
-  bufPtr = load $ getAt #buffer db
-  size   = load $ getAt #size db
-  AsList size $ tabFromPtr _ bufPtr
+  bufPtr = load $ get_at #buffer db
+  size   = load $ get_at #size db
+  AsList size $ table_from_ptr _ bufPtr
 
-def pushDynBuffer {a} [Storable a]
+def push_dynamic_buffer {a} [Storable a]
       (buf: DynBuffer a) (x:a) : {IO} Unit =
-  extendDynBuffer buf $ AsList _ [x]
+  extend_dynamic_buffer buf $ AsList _ [x]
 
 '## Strings and Characters
 
 String : Type = List Char
 
-def stringFromCharPtr (n:Int) (ptr:Ptr Char) : {IO} String =
-  AsList n $ tabFromPtr _ ptr
+def string_from_char_ptr (n:Int) (ptr:Ptr Char) : {IO} String =
+  AsList n $ table_from_ptr _ ptr
 
 -- TODO. This is ASCII code point. It really should be Int32 for Unicode codepoint
-def codepoint (c:Char) : Int = W8ToI c
+def codepoint (c:Char) : Int = w8_to_i c
 
 '### Show interface
 For things that can be shown.
@@ -1333,30 +1333,30 @@ instance Show String
 foreign "showInt32" showInt32 : Int32 -> {IO} (Int32 & RawPtr)
 
 instance Show Int32
-  show = \x. unsafeIO do
+  show = \x. unsafe_io do
     (n, ptr) = showInt32 x
-    stringFromCharPtr n $ MkPtr ptr
+    string_from_char_ptr n $ MkPtr ptr
 
 foreign "showInt64" showInt64 : Int64 -> {IO} (Int32 & RawPtr)
 
 instance Show Int64
-  show = \x. unsafeIO do
+  show = \x. unsafe_io do
     (n, ptr) = showInt64 x
-    stringFromCharPtr n $ MkPtr ptr
+    string_from_char_ptr n $ MkPtr ptr
 
 foreign "showFloat32" showFloat32 : Float32 -> {IO} (Int32 & RawPtr)
 
 instance Show Float32
-  show = \x. unsafeIO do
+  show = \x. unsafe_io do
     (n, ptr) = showFloat32 x
-    stringFromCharPtr n $ MkPtr ptr
+    string_from_char_ptr n $ MkPtr ptr
 
 foreign "showFloat64" showFloat64 : Float64 -> {IO} (Int32 & RawPtr)
 
 instance Show Float64
-  show = \x. unsafeIO do
+  show = \x. unsafe_io do
     (n, ptr) = showFloat64 x
-    stringFromCharPtr n $ MkPtr ptr
+    string_from_char_ptr n $ MkPtr ptr
 
 instance {a b} [Show a, Show b] Show (a & b)
   show = \(a, b). "(" <> show a <> ", " <> show b <> ")"
@@ -1399,16 +1399,16 @@ def either_is_nan (x:Float) (y:Float) : Bool = (isnan x) || (isnan y)
 FilePath : Type = String
 data CString = MkCString RawPtr
 
-def nullRawPtr : RawPtr = I64ToRawPtr $ IToI64 0
+def null_raw_ptr : RawPtr = i64_to_raw_ptr $ i_to_i64 0
 
-def fromNullableRawPtr {a} (ptr:RawPtr) : Maybe (Ptr a) =
-  if ptr == nullRawPtr
+def from_nullable_raw_ptr {a} (ptr:RawPtr) : Maybe (Ptr a) =
+  if ptr == null_raw_ptr
     then Nothing
     else Just $ MkPtr ptr
 
-def cStringPtr (s:CString) : Maybe (Ptr Char) =
+def c_string_ptr (s:CString) : Maybe (Ptr Char) =
   (MkCString ptr) = s
-  fromNullableRawPtr ptr
+  from_nullable_raw_ptr ptr
 
 data StreamMode =
   ReadMode
@@ -1417,9 +1417,9 @@ data StreamMode =
 data Stream mode:StreamMode = MkStream RawPtr
 
 -- TODO: check the string contains no nulls
-def withCString {a} (s:String) (action: CString -> {IO} a) : {IO} a =
+def with_c_string {a} (s:String) (action: CString -> {IO} a) : {IO} a =
   (AsList n s') = s <> "\NUL"
-  withTabPtr s' \(MkPtr ptr). action $ MkCString ptr
+  with_table_ptr s' \(MkPtr ptr). action $ MkCString ptr
 
 '### Stream IO
 
@@ -1433,8 +1433,8 @@ def fopen (path:String) (mode:StreamMode) : {IO} (Stream mode) =
   modeStr = case mode of
     ReadMode  -> "r"
     WriteMode -> "w"
-  withCString path \(MkCString pathPtr).
-    withCString modeStr \(MkCString modePtr).
+  with_c_string path \(MkCString pathPtr).
+    with_c_string modeStr \(MkCString modePtr).
       MkStream $ fopenFFI pathPtr modePtr
 
 def fclose {mode} (stream:Stream mode) : {IO} Unit =
@@ -1445,8 +1445,8 @@ def fclose {mode} (stream:Stream mode) : {IO} Unit =
 def fwrite (stream:Stream WriteMode) (s:String) : {IO} Unit =
   (MkStream stream') = stream
   (AsList n s') = s
-  withTabPtr s' \(MkPtr ptr).
-    fwriteFFI ptr (IToI64 1) (IToI64 n) stream'
+  with_table_ptr s' \(MkPtr ptr).
+    fwriteFFI ptr (i_to_i64 1) (i_to_i64 n) stream'
   fflushFFI stream'
   ()
 
@@ -1454,7 +1454,7 @@ def fwrite (stream:Stream WriteMode) (s:String) : {IO} Unit =
 TODO: move this out of the file-system section
 
 def while {eff} (body: Unit -> {|eff} Bool) : {|eff} Unit =
-  body' : Unit -> {|eff} Word8 = \_. BToW8 $ body ()
+  body' : Unit -> {|eff} Word8 = \_. b_to_w8 $ body ()
   %while body'
 
 data IterResult a =
@@ -1462,16 +1462,16 @@ data IterResult a =
   Done a
 
 -- TODO: can we improve effect inference so we don't need this?
-def liftState {a b c h eff} (ref: Ref h c) (f:a -> {|eff} b) (x:a) : {State h|eff} b =
+def lift_state {a b c h eff} (ref: Ref h c) (f:a -> {|eff} b) (x:a) : {State h|eff} b =
   f x
 
 -- A little iteration combinator
 def iter {a eff} (body: Int -> {|eff} IterResult a) : {|eff} a  =
-  result = yieldState Nothing \resultRef. withState 0 \i.
+  result = yield_state Nothing \resultRef. with_state 0 \i.
     while do
-      continue = isNothing $ get resultRef
+      continue = is_nothing $ get resultRef
       if continue then
-        case liftState resultRef (liftState i body) (get i) of
+        case lift_state resultRef (lift_state i body) (get i) of
           Continue -> i := get i + 1
           Done result -> resultRef := Just result
       continue
@@ -1479,7 +1479,7 @@ def iter {a eff} (body: Int -> {|eff} IterResult a) : {|eff} a  =
     Just ans -> ans
     Nothing -> unreachable ()
 
-def boundedIter {a eff}
+def bounded_iter {a eff}
       (maxIters:Int) (fallback:a)
       (body: Int -> {|eff} IterResult a) : {|eff} a  =
   iter \i.
@@ -1489,26 +1489,26 @@ def boundedIter {a eff}
 
 '### Environment Variables
 
-def fromCString (s:CString) : {IO} (Maybe String) =
-  case cStringPtr s of
+def from_c_string (s:CString) : {IO} (Maybe String) =
+  case c_string_ptr s of
     Nothing -> Nothing
     Just ptr ->
-      Just $ withDynamicBuffer \buf. iter \i.
+      Just $ with_dynamic_buffer \buf. iter \i.
         c = load $ ptr +>> i
         if c == '\NUL'
-          then Done $ loadDynBuffer buf
+          then Done $ load_dynamic_buffer buf
           else
-            pushDynBuffer buf c
+            push_dynamic_buffer buf c
             Continue
 
 foreign "getenv" getenvFFI : RawPtr -> {IO} RawPtr
 
-def getEnv (name:String) : {IO} Maybe String =
-  withCString name \(MkCString ptr).
-    fromCString $ MkCString $ getenvFFI ptr
+def get_env (name:String) : {IO} Maybe String =
+  with_c_string name \(MkCString ptr).
+    from_c_string $ MkCString $ getenvFFI ptr
 
-def checkEnv (name:String) : {IO} Bool =
-  isJust $ getEnv name
+def check_env (name:String) : {IO} Bool =
+  is_just $ get_env name
 
 '### More Stream IO
 
@@ -1516,24 +1516,24 @@ def fread (stream:Stream ReadMode) : {IO} String =
   (MkStream stream') = stream
   -- TODO: allow reading longer files!
   n = 4096
-  withAlloc n \ptr:(Ptr Char).
-    withDynamicBuffer \buf.
+  with_alloc n \ptr:(Ptr Char).
+    with_dynamic_buffer \buf.
       iter \_.
         (MkPtr rawPtr) = ptr
-        numRead = I64ToI $ freadFFI rawPtr (IToI64 1) (IToI64 n) stream'
-        extendDynBuffer buf $ stringFromCharPtr numRead ptr
+        numRead = i64_to_i $ freadFFI rawPtr (i_to_i64 1) (i_to_i64 n) stream'
+        extend_dynamic_buffer buf $ string_from_char_ptr numRead ptr
         if numRead == n
           then Continue
           else Done ()
-      loadDynBuffer buf
+      load_dynamic_buffer buf
 
 '### Print
 
-def getOutputStream (_:Unit) : {IO} Stream WriteMode =
+def get_output_stream (_:Unit) : {IO} Stream WriteMode =
   MkStream $ %ptrLoad %outputStreamPtr
 
 def print (s:String) : {IO} Unit =
-  fwrite (getOutputStream ()) (s <> "\n")
+  fwrite (get_output_stream ()) (s <> "\n")
 
 '### Shelling Out
 
@@ -1542,10 +1542,10 @@ foreign "remove" removeFFI : RawPtr -> {IO} Int64
 foreign "mkstemp" mkstempFFI : RawPtr -> {IO} Int32
 foreign "close" closeFFI : Int32 -> {IO} Int32
 
-def shellOut (command:String) : {IO} String =
+def shell_out (command:String) : {IO} String =
   modeStr = "r"
-  withCString command \(MkCString commandPtr).
-    withCString modeStr \(MkCString modePtr).
+  with_c_string command \(MkCString commandPtr).
+    with_c_string modeStr \(MkCString modePtr).
       pipe = MkStream $ popenFFI commandPtr modePtr
       fread pipe
 
@@ -1556,7 +1556,7 @@ Not to be confused with a partially applied function
 
 '### Error throwing
 
-def error {a} (s:String) : a = unsafeIO do
+def error {a} (s:String) : a = unsafe_io do
   print s
   %throwError a
 
@@ -1564,18 +1564,18 @@ def todo {a} : a = error "TODO: implement it!"
 
 '### File Operations
 
-def deleteFile (f:FilePath) : {IO} Unit =
-  withCString f \(MkCString ptr).
+def delete_file (f:FilePath) : {IO} Unit =
+  with_c_string f \(MkCString ptr).
     removeFFI ptr
   ()
 
-def withFile {a}
+def with_file {a}
       (f:FilePath) (mode:StreamMode)
       (action: Stream mode -> {IO} a)
       : {IO} a =
   stream = fopen f mode
   (MkStream stream') = stream
-  if stream' == nullRawPtr
+  if stream' == null_raw_ptr
     then
       error $ "Unable to open file: " <> f
     else
@@ -1583,66 +1583,66 @@ def withFile {a}
       fclose stream
       result
 
-def writeFile (f:FilePath) (s:String) : {IO} Unit =
-  withFile f WriteMode \stream. fwrite stream s
+def write_file (f:FilePath) (s:String) : {IO} Unit =
+  with_file f WriteMode \stream. fwrite stream s
 
-def readFile (f:FilePath) : {IO} String =
-  withFile f ReadMode \stream. fread stream
+def read_file (f:FilePath) : {IO} String =
+  with_file f ReadMode \stream. fread stream
 
-def hasFile (f:FilePath) : {IO} Bool =
+def has_file (f:FilePath) : {IO} Bool =
   stream = fopen f ReadMode
   (MkStream stream') = stream
-  result = stream' /= nullRawPtr
+  result = stream' /= null_raw_ptr
   if result then fclose stream
   result
 
 '### Temporary Files
 
-def newTempFile (_:Unit) : {IO} FilePath =
-  withCString "/tmp/dex-XXXXXX" \(MkCString ptr).
+def new_temp_file (_:Unit) : {IO} FilePath =
+  with_c_string "/tmp/dex-XXXXXX" \(MkCString ptr).
     fd = mkstempFFI ptr
     closeFFI fd
-    stringFromCharPtr 15 (MkPtr ptr)
+    string_from_char_ptr 15 (MkPtr ptr)
 
-def withTempFile {a} (action: FilePath -> {IO} a) : {IO} a =
-  tmpFile = newTempFile ()
+def with_temp_file {a} (action: FilePath -> {IO} a) : {IO} a =
+  tmpFile = new_temp_file ()
   result = action tmpFile
-  deleteFile tmpFile
+  delete_file tmpFile
   result
 
-def withTempFiles {n a} [Ix n] (action: (n=>FilePath) -> {IO} a) : {IO} a =
-  tmpFiles = for i. newTempFile ()
+def with_temp_files {n a} [Ix n] (action: (n=>FilePath) -> {IO} a) : {IO} a =
+  tmpFiles = for i. new_temp_file ()
   result = action tmpFiles
-  for i. deleteFile tmpFiles.i
+  for i. delete_file tmpFiles.i
   result
 
 '### Table operations
 
-def fromOrdinal (n:Type) [Ix n] (i:Int) : n =
+def from_ordinal (n:Type) [Ix n] (i:Int) : n =
   case (0 <= i) && (i < size n) of
-    True  -> unsafeFromOrdinal _ i
+    True  -> unsafe_from_ordinal _ i
     False -> error $
       "Ordinal index out of range:" <> show i <> " >= " <> show (size n)
 
 -- TODO: could make an `unsafeCastIndex` and this could avoid the runtime copy
 -- TODO: safe (runtime-checked) and unsafe versions
-def castTable {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
+def cast_table {n a} (m:Type) [Ix m] (xs:n=>a) : m=>a =
   case size m == size n of
-     True  -> unsafeCastTable _ xs
+     True  -> unsafe_cast_table _ xs
      False -> error $
        "Table size mismatch in cast: " <> show (size m) <> " vs " <> show (size n)
 
-def asidx {n} [Ix n] (i:Int) : n = fromOrdinal n i
-def (@) (i:Int) (n:Type) [Ix n] : n = fromOrdinal n i
+def asidx {n} [Ix n] (i:Int) : n = from_ordinal n i
+def (@) (i:Int) (n:Type) [Ix n] : n = from_ordinal n i
 
 def slice {n a} (xs:n=>a) (start:Int) (m:Type) [Ix m] : m=>a =
-  for i. xs.(fromOrdinal _ (ordinal i + start))
+  for i. xs.(from_ordinal _ (ordinal i + start))
 
 def head {n a} (xs:n=>a) : a = xs.(0@_)
 
 def tail {n a} (xs:n=>a) (start:Int) : List a =
   numElts = size n - start
-  toList $ slice xs start (Fin numElts)
+  to_list $ slice xs start (Fin numElts)
 
 
 '## Pseudorandom number generator utilities
@@ -1655,47 +1655,47 @@ Dex's PRNG system is modelled directly after [JAX's](https://github.com/google/j
 -- TODO: newtype
 Key = Word64
 
-def threeFry2x32 (k:Word64) (count:Word64) : Word64 =
+def threefry_2x32 (k:Word64) (count:Word64) : Word64 =
   -- Based on jax's threefry_2x32 by Matt Johnson and Peter Hawkins
   rotations1 = [13, 15, 26, 6]
   rotations2 = [17, 29, 16, 24]
 
-  k0 = lowWord k
-  k1 = highWord k
+  k0 = low_word k
+  k1 = high_word k
   -- TODO: add a fromHex
-  k2 = k0 .^. k1 .^. (IToW32 466688986) -- 0x1BD11BDA
+  k2 = k0 .^. k1 .^. (i_to_w32 466688986) -- 0x1BD11BDA
 
-  x = lowWord count
-  y = highWord count
+  x = low_word count
+  y = high_word count
   x = x + k0
   y = y + k1
 
   rotations = [rotations1, rotations2]
   ks = [k1, k2, k0]
-  (x, y) = yieldState (x, y) \ref. for i:(Fin 5).
+  (x, y) = yield_state (x, y) \ref. for i:(Fin 5).
     for j.
       (x, y) = get ref
-      rotationIndex = unsafeFromOrdinal _ (mod (ordinal i) 2)
+      rotationIndex = unsafe_from_ordinal _ (mod (ordinal i) 2)
       rot = rotations.rotationIndex.j
       x = x + y
       y = (y .<<. rot) .|. (y .>>. (32 - rot))
       y = x .^. y
       ref := (x, y)
     (x, y) = get ref
-    x = x + ks.(unsafeFromOrdinal _ (mod (ordinal i) 3))
-    y = y + ks.(unsafeFromOrdinal _ (mod ((ordinal i)+1) 3)) + IToW32 ((ordinal i)+1)
+    x = x + ks.(unsafe_from_ordinal _ (mod (ordinal i) 3))
+    y = y + ks.(unsafe_from_ordinal _ (mod ((ordinal i)+1) 3)) + i_to_w32 ((ordinal i)+1)
     ref := (x, y)
 
-  (W32ToW64 x .<<. 32) .|. (W32ToW64 y)
+  (w32_to_w64 x .<<. 32) .|. (w32_to_w64 y)
 
 def hash (x:Key) (y:Int32) : Key =
-  y64 = IToW64 y
-  threeFry2x32 x y64
-def newKey (x:Int) : Key = hash (IToW64 0) x
+  y64 = i_to_w64 y
+  threefry_2x32 x y64
+def new_key (x:Int) : Key = hash (i_to_w64 0) x
 def many {a n} [Ix n] (f:Key->a) (k:Key) (i:n) : a = f (hash k (ordinal i))
 def ixkey {n} (k:Key) (i:n) [Ix n] : Key = hash k (ordinal i)
 def ixkey2 {n m} (k:Key) (i:n) (j:m) [Ix n, Ix m] : Key = hash (hash k (ordinal i)) (ordinal j)
-def splitKey {n} (k:Key) : Fin n => Key = for i. ixkey k i
+def split_key {n} (k:Key) : Fin n => Key = for i. ixkey k i
 
 '### Sample Generators
 These functions generate samples taken from, different distributions.
@@ -1703,30 +1703,30 @@ Such as `randMat` with samples from the distribution of floating point matrices 
 
 foreign "randunif" randunifFFI : Word64 -> {IO} Float64
 
-def rand (k:Key) : Float =  unsafeIO do F64ToF $ randunifFFI k
-def randVec {a} (n:Int) (f: Key -> a) (k: Key) : Fin n => a =
+def rand (k:Key) : Float =  unsafe_io do f64_to_f $ randunifFFI k
+def rand_vec {a} (n:Int) (f: Key -> a) (k: Key) : Fin n => a =
   for i:(Fin n). f (ixkey k i)
 
-def randMat {a} (n:Int) (m:Int) (f: Key -> a) (k: Key) : Fin n => Fin m => a =
+def rand_mat {a} (n:Int) (m:Int) (f: Key -> a) (k: Key) : Fin n => Fin m => a =
   for i j. f (ixkey2 k i j)
 
 def randn (k:Key) : Float =
-  [k1, k2] = splitKey k
+  [k1, k2] = split_key k
   u1 = rand k1
   u2 = rand k2
   sqrt ((-2.0) * log u1) * cos (2.0 * pi * u2)
 
 -- TODO: Make this better...
-def randInt (k:Key) : Int = (internalCast Int k) `mod` 2147483647
+def rand_int (k:Key) : Int = (internal_cast Int k) `mod` 2147483647
 
 def bern (p:Float) (k:Key) : Bool = rand k < p
 
-def randnVec {n} [Ix n] (k:Key) : n=>Float =
+def randn_vec {n} [Ix n] (k:Key) : n=>Float =
   for i. randn (ixkey k i)
 
-def randIdx {n} [Ix n] (k:Key) : n =
+def rand_idx {n} [Ix n] (k:Key) : n =
   unif = rand k
-  fromOrdinal n $ FToI $ floor $ unif * IToF (size n)
+  from_ordinal n $ FToI $ floor $ unif * i_to_f (size n)
 
 '## Arbitrary
 Type class for generating example values
@@ -1748,11 +1748,11 @@ instance {n a} [Arbitrary a] Arbitrary (n=>a)
 
 instance {a b} [Arbitrary a, Arbitrary b] Arbitrary (a & b)
   arb = \key.
-    [k1, k2] = splitKey key
+    [k1, k2] = split_key key
     (arb k1, arb k2)
 
 instance {n} Arbitrary (Fin n)
-  arb = randIdx
+  arb = rand_idx
 
 '## Ord on Arrays
 
@@ -1760,37 +1760,37 @@ instance {n} Arbitrary (Fin n)
 
 'returns the highest index `i` such that `xs.i <= x`
 
-def searchSorted {n a} [Ord a] (xs:n=>a) (x:a) : Maybe n =
+def search_sorted {n a} [Ord a] (xs:n=>a) (x:a) : Maybe n =
   if size n == 0
     then Nothing
-    else if x < xs.(fromOrdinal _ 0)
+    else if x < xs.(from_ordinal _ 0)
       then Nothing
-      else withState 0 \low. withState (size n) \high. iter \_.
+      else with_state 0 \low. with_state (size n) \high. iter \_.
         numLeft = get high - get low
         if numLeft == 1
-          then Done $ Just $ fromOrdinal _ $ get low
+          then Done $ Just $ from_ordinal _ $ get low
           else
             centerIx = get low + idiv numLeft 2
-            if x < xs.(fromOrdinal _ centerIx)
+            if x < xs.(from_ordinal _ centerIx)
               then high := centerIx
               else low  := centerIx
             Continue
 
 '### min / max etc
 
-def minBy {a o} [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x < f y) x y
-def maxBy {a o} [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x > f y) x y
+def min_by {a o} [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x < f y) x y
+def max_by {a o} [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x > f y) x y
 
-def min {o} [Ord o] (x1: o) (x2: o) : o = minBy id x1 x2
-def max {o} [Ord o] (x1: o) (x2: o) : o = maxBy id x1 x2
+def min {o} [Ord o] (x1: o) (x2: o) : o = min_by id x1 x2
+def max {o} [Ord o] (x1: o) (x2: o) : o = max_by id x1 x2
 
-def minimumBy {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
-  reduce xs.(0@_) (minBy f) xs
-def maximumBy {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
-  reduce xs.(0@_) (maxBy f) xs
+def minimum_by {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
+  reduce xs.(0@_) (min_by f) xs
+def maximum_by {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
+  reduce xs.(0@_) (max_by f) xs
 
-def minimum {n o} [Ord o] (xs:n=>o) : o = minimumBy id xs
-def maximum {n o} [Ord o] (xs:n=>o) : o = maximumBy id xs
+def minimum {n o} [Ord o] (xs:n=>o) : o = minimum_by id xs
+def maximum {n o} [Ord o] (xs:n=>o) : o = maximum_by id xs
 
 '### argmin/argmax
 TODO: put in same section as `searchsorted`
@@ -1805,7 +1805,7 @@ def argscan {n o} (comp:o->o->Bool) (xs:n=>o) : n =
 def argmin {n o} [Ord o] (xs:n=>o) : n = argscan (<) xs
 def argmax {n o} [Ord o] (xs:n=>o) : n = argscan (>) xs
 
-def lexicalOrder {n} [Ord n]
+def lexical_order {n} [Ord n]
       (compareElements:n->n->Bool)
       (compareLengths:Int->Int->Bool)
       ((AsList nx xs):List n) ((AsList ny ys):List n) : Bool =
@@ -1825,8 +1825,8 @@ def lexicalOrder {n} [Ord n]
     case i == min nx ny of
       True -> Done $ compareLengths nx ny
       False ->
-        xi = xs.(unsafeFromOrdinal _ i)
-        yi = ys.(unsafeFromOrdinal _ i)
+        xi = xs.(unsafe_from_ordinal _ i)
+        yi = ys.(unsafe_from_ordinal _ i)
         case compareElements xi yi of
           True -> Done True
           False -> case xi == yi of
@@ -1834,8 +1834,8 @@ def lexicalOrder {n} [Ord n]
             False -> Done False
 
 instance {n} [Ord n] Ord (List n)
-  (>) = lexicalOrder (>) (>)
-  (<) = lexicalOrder (<) (<)
+  (>) = lexical_order (>) (>)
+  (<) = lexical_order (<) (<)
 
 '### clip
 
@@ -1911,7 +1911,7 @@ instance Mul Complex
   one = MkComplex 1.0 0.0
 
 instance VSpace Complex
-  scaleVec = \a:Float (MkComplex c d):Complex. MkComplex (a * c) (a * d)
+  scale_vec = \a:Float (MkComplex c d):Complex. MkComplex (a * c) (a * d)
 
 -- Todo: Hook up to (/) operator.  Might require two-parameter VSpace.
 def complex_division (MkComplex a b:Complex) (MkComplex c d:Complex): Complex =
@@ -2008,12 +2008,12 @@ instance Floating Complex
 TODO: all of these should be in some other section
 
 def reflect {n} [Ix n] (i:n) : n =
-  unsafeFromOrdinal n ((size n) - 1 - ordinal i)
+  unsafe_from_ordinal n ((size n) - 1 - ordinal i)
 
 def reverse {n a} (x:n=>a) : n=>a =
   for i. x.(reflect i)
 
-def padTo {n a} (m:Type) [Ix m] (x:a) (xs:n=>a) : m=>a =
+def pad_to {n a} (m:Type) [Ix m] (x:a) (xs:n=>a) : m=>a =
   n' = size n
   for i.
     i' = ordinal i
@@ -2021,13 +2021,13 @@ def padTo {n a} (m:Type) [Ix m] (x:a) (xs:n=>a) : m=>a =
       True  -> xs.(i'@_)
       False -> x
 
-def idivCeil (x:Int) (y:Int) : Int = idiv x y + BToI (rem x y /= 0)
+def idiv_ceil (x:Int) (y:Int) : Int = idiv x y + b_to_i (rem x y /= 0)
 def intdiv2 (x:Int) : Int = %shr x (1 : Int)
 def intpow2 (power:Int) : Int = %shl (1 : Int) power
-def isOdd  (x:Int) : Bool = rem x 2 == 1
-def isEven (x:Int) : Bool = rem x 2 == 0
+def is_odd  (x:Int) : Bool = rem x 2 == 1
+def is_even (x:Int) : Bool = rem x 2 == 0
 
-def isPowerOf2 (x:Int) : Bool =
+def is_power_of_2 (x:Int) : Bool =
   -- A fast trick based on bitwise AND.
   -- This works on integer types larger than 8 bits.
   -- Note: The bitwise and operator (.&.)
@@ -2038,8 +2038,8 @@ def isPowerOf2 (x:Int) : Bool =
     else 0 == %and x (x - 1)
 
 def intlog2 (x:Int) : Int =
-  yieldState (-1) \ansRef.
-    runState 1 \cmpRef.
+  yield_state (-1) \ansRef.
+    run_state 1 \cmpRef.
       while do
         if x >= (get cmpRef)
           then
@@ -2049,21 +2049,21 @@ def intlog2 (x:Int) : Int =
           else
             False
 
-def nextpow2 (x:Int) : Int = case isPowerOf2 x of
+def nextpow2 (x:Int) : Int = case is_power_of_2 x of
   True -> x
   False -> intpow2 (1 + intlog2 x)
 
-def generalIntegerPower {a} (times:a->a->a) (one:a) (base:a) (power:Int) : a =
+def general_integer_power {a} (times:a->a->a) (one:a) (base:a) (power:Int) : a =
   -- Implements exponentiation by squaring.
   -- Todo: Make power a Nat when it's available.
   -- This could be nicer if there were a way to explicitly
   -- specify which typelcass instance to use for Mul.
-  yieldState one \ans.
-    withState power \pow. withState base \z.
+  yield_state one \ans.
+    with_state power \pow. with_state base \z.
       while do
         if get pow > 0
           then
-            if isOdd (get pow)
+            if is_odd (get pow)
               then ans := times (get ans) (get z)
             z := times (get z) (get z)
             pow := intdiv2 (get pow)
@@ -2072,36 +2072,36 @@ def generalIntegerPower {a} (times:a->a->a) (one:a) (base:a) (power:Int) : a =
             False
 
 def intpow {a} [Mul a] (base:a) (power:Int) : a =
-  generalIntegerPower (*) one base power
+  general_integer_power (*) one base power
 
-def fromJust {a} (x:Maybe a) : a = case x of Just x' -> x'
+def from_just {a} (x:Maybe a) : a = case x of Just x' -> x'
 
-def anySat {a n} (f:a -> Bool) (xs:n=>a) : Bool = any (map f xs)
+def any_sat {a n} (f:a -> Bool) (xs:n=>a) : Bool = any (map f xs)
 
-def seqMaybes {n a} (xs : n=>Maybe a) : Maybe (n => a) =
+def seq_maybes {n a} (xs : n=>Maybe a) : Maybe (n => a) =
   -- is it possible to implement this safely? (i.e. without using partial
   -- functions)
-  case anySat isNothing xs of
+  case any_sat is_nothing xs of
     True  -> Nothing
-    False -> Just $ map fromJust xs
+    False -> Just $ map from_just xs
 
-def linearSearch {n a} [Eq a] (xs:n=>a) (query:a) : Maybe n =
-  yieldState Nothing \ref. for i.
+def linear_search {n a} [Eq a] (xs:n=>a) (query:a) : Maybe n =
+  yield_state Nothing \ref. for i.
     case xs.i == query of
       True  -> ref := Just i
       False -> ()
 
-def listLength {a} ((AsList n _):List a) : Int = n
+def list_length {a} ((AsList n _):List a) : Int = n
 
 -- This is for efficiency (rather than using `<>` repeatedly)
 -- TODO: we want this for any monoid but this implementation won't work.
 def concat {n a} (lists:n=>(List a)) : List a =
-  totalSize = sum for i. listLength lists.i
-  AsList _ $ withState 0 \listIdx.
-    withState 0 \eltIdx.
+  totalSize = sum for i. list_length lists.i
+  AsList _ $ with_state 0 \listIdx.
+    with_state 0 \eltIdx.
       for i:(Fin totalSize).
         while do
-          continue = get eltIdx >= listLength (lists.((get listIdx)@_))
+          continue = get eltIdx >= list_length (lists.((get listIdx)@_))
           if continue
             then
               eltIdx := 0
@@ -2115,33 +2115,33 @@ def concat {n a} (lists:n=>(List a)) : List a =
 
 '## Probability
 
-def cumSumLow {n} (xs: n=>Float) : n=>Float =
-  withState 0.0 \total.
+def cumsum_low {n} (xs: n=>Float) : n=>Float =
+  with_state 0.0 \total.
     for i.
       oldTotal = get total
       total := oldTotal + xs.i
       oldTotal
 
 -- cdf should include 0.0 but not 1.0
-def categoricalFromCDF {n} (cdf: n=>Float) (key: Key) : n =
+def categorical_from_cdf {n} (cdf: n=>Float) (key: Key) : n =
   r = rand key
-  case searchSorted cdf r of
+  case search_sorted cdf r of
     Just i -> i
 
-def normalizePdf {d} (xs: d=>Float) : d=>Float = xs / sum xs
+def normalize_pdf {d} (xs: d=>Float) : d=>Float = xs / sum xs
 
-def cdfForCategorical {n} (logprobs: n=>Float) : n=>Float =
+def cdf_for_categorical {n} (logprobs: n=>Float) : n=>Float =
   maxLogProb = maximum logprobs
-  cumSumLow $ normalizePdf $ map exp $ for i. logprobs.i - maxLogProb
+  cumsum_low $ normalize_pdf $ map exp $ for i. logprobs.i - maxLogProb
 
 def categorical {n} (logprobs: n=>Float) (key: Key) : n =
-  categoricalFromCDF (cdfForCategorical logprobs) key
+  categorical_from_cdf (cdf_for_categorical logprobs) key
 
 -- batch variant to share the work of forming the cumsum
 -- (alternatively we could rely on hoisting of loop constants)
-def categoricalBatch {n m} [Ix m] (logprobs: n=>Float) (key: Key) : m=>n =
-  cdf = cdfForCategorical logprobs
-  for i. categoricalFromCDF cdf $ ixkey key i
+def categorical_batch {n m} [Ix m] (logprobs: n=>Float) (key: Key) : m=>n =
+  cdf = cdf_for_categorical logprobs
+  for i. categorical_from_cdf cdf $ ixkey key i
 
 def logsumexp {n} (x: n=>Float) : Float =
   m = maximum x
@@ -2167,7 +2167,7 @@ def evalpoly {n v} [VSpace v] (coefficients:n=>v) (x:Float) : v =
 '## TestMode
 TODO: move this to be in Testing Helpers
 
-def dex_test_mode (():Unit) : Bool = unsafeIO do checkEnv "DEX_TEST_MODE"
+def dex_test_mode (():Unit) : Bool = unsafe_io do check_env "DEX_TEST_MODE"
 
 '## Exception effect
 TODO: move `error` and `todo` to here.

--- a/lib/set.dx
+++ b/lib/set.dx
@@ -7,20 +7,20 @@ def last {n a} (xs:n=>a) : Maybe a =
   s = size n
   case s == 0 of
     True -> Nothing
-    False -> Just xs.(unsafeFromOrdinal n (s - 1))
+    False -> Just xs.(unsafe_from_ordinal n (s - 1))
 
 def first {n a} (xs:n=>a) : Maybe a =
   s = size n
   case s == 0 of
     True -> Nothing
-    False -> Just xs.(unsafeFromOrdinal n 0)
+    False -> Just xs.(unsafe_from_ordinal n 0)
 
-def allExceptLast {n a} (xs:n=>a) : List a =
+def all_except_last {n a} (xs:n=>a) : List a =
   shortSize = Fin (max 0 ((size n) - 1))
-  allButLast = view i:shortSize. xs.(unsafeFromOrdinal _ (ordinal i))
+  allButLast = view i:shortSize. xs.(unsafe_from_ordinal _ (ordinal i))
   (AsList _ allButLast)
 
-def mergeUniqueSortedLists {a} [Eq a] (xlist:List a) (ylist:List a) : List a =
+def merge_unique_sorted_lists {a} [Eq a] (xlist:List a) (ylist:List a) : List a =
   -- This function is associative, for use in a monoidal reduction.
   -- Assumes all xs are <= all ys.
   -- The element at the end of xs might equal the
@@ -34,11 +34,11 @@ def mergeUniqueSortedLists {a} [Eq a] (xlist:List a) (ylist:List a) : List a =
       Nothing -> xlist
       Just first_y -> case last_x == first_y of
         False -> concat [xlist,            ylist]
-        True ->  concat [allExceptLast xs, ylist]
+        True ->  concat [all_except_last xs, ylist]
 
-def removeDuplicatesFromSorted {n a} [Eq a] (xs:n=>a) : List a =
+def remove_duplicates_from_sorted {n a} [Eq a] (xs:n=>a) : List a =
   xlists = for i:n. (AsList 1 [xs.i])
-  reduce (AsList 0 []) mergeUniqueSortedLists xlists
+  reduce (AsList 0 []) merge_unique_sorted_lists xlists
 
 
 '### Sets
@@ -49,29 +49,29 @@ data Set a [Ord a] =
   -- Instead use the "toSet" function below.
   UnsafeAsSet n:Int elements:(Fin n => a)
 
-def toSet {n a} [Ord a] (xs:n=>a) : Set a =
+def to_set {n a} [Ord a] (xs:n=>a) : Set a =
   sorted_xs = sort xs
-  (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted sorted_xs
+  (AsList n' sorted_unique_xs) = remove_duplicates_from_sorted sorted_xs
   UnsafeAsSet n' sorted_unique_xs
 
-def setSize {a} ((UnsafeAsSet n _):Set a) : Int = n
+def set_size {a} ((UnsafeAsSet n _):Set a) : Int = n
 
 instance {a} [Eq a] Eq (Set a)
   (==) = \(UnsafeAsSet _ xs) (UnsafeAsSet _ ys).
     (AsList _ xs) == (AsList _ ys)
 
-def setUnion {a}
+def set_union {a}
       ((UnsafeAsSet nx xs):Set a)
       ((UnsafeAsSet ny ys):Set a) : Set a =
-  combined = mergeSortedTables xs ys
-  (AsList n' sorted_unique_xs) = removeDuplicatesFromSorted combined
+  combined = merge_sorted_tables xs ys
+  (AsList n' sorted_unique_xs) = remove_duplicates_from_sorted combined
   UnsafeAsSet _ sorted_unique_xs
 
-def setIntersect {a}
+def set_intersect {a}
       ((UnsafeAsSet nx xs):Set a)
       ((UnsafeAsSet ny ys):Set a) : Set a =
   -- This could be done in O(nx + ny) instead of O(nx log ny).
-  isInYs = \x. case searchSorted ys x of
+  isInYs = \x. case search_sorted ys x of
     Just x -> True
     Nothing -> False
   (AsList n' intersection) = filter isInYs xs
@@ -87,9 +87,9 @@ data StringSetIx l:(Set String) =
   MkSetIx Int   -- TODO: Use (Fin (setSize l)) instead.
 
 instance {set} Ix (StringSetIx set)
-  getSize = \(). setSize set
+  get_size = \(). set_size set
   ordinal = \(MkSetIx i). i
-  unsafeFromOrdinal = \k. MkSetIx k
+  unsafe_from_ordinal = \k. MkSetIx k
 
 instance {set} Eq (StringSetIx set)
   (==) = \ix1 ix2. ordinal ix1 == ordinal ix2
@@ -101,14 +101,14 @@ instance {set} Eq (StringSetIx set)
 --   ixValue  : n -> IxValueType n
 --   lookupIx : IxValueType n -> n
 
-def stringToSetIx {set:Set String} (s:String) : Maybe (StringSetIx set) =
+def string_to_set_ix {set:Set String} (s:String) : Maybe (StringSetIx set) =
   (UnsafeAsSet n elements) = set
-  maybeIx = searchSorted elements s
+  maybeIx = search_sorted elements s
   case maybeIx of
     Nothing -> Nothing
     Just i -> Just $ MkSetIx (ordinal i)
 
-def setIxToString {set:Set String} (ix:StringSetIx set) : String =
+def set_ix_to_string {set:Set String} (ix:StringSetIx set) : String =
   (UnsafeAsSet n elements) = set
-  elements.(unsafeFromOrdinal _ (ordinal ix))
+  elements.(unsafe_from_ordinal _ (ordinal ix))
 

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -10,41 +10,41 @@ it's doing bubble / insertion sort with quadratic time cost.
 However, if breaks the list in half recursively, it'll be doing parallel mergesort.
 Currently it'll do the quadratic time version.
 
-def concatTable {a b v} (leftin: a=>v) (rightin: b=>v) : ((a|b)=>v) =
+def concat_table {a b v} (leftin: a=>v) (rightin: b=>v) : ((a|b)=>v) =
   for idx. case idx of
     Left i  -> leftin.i
     Right i -> rightin.i
 
-def mergeSortedTables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ((m|n)=>a) =
+def merge_sorted_tables {a m n} [Ord a] (xs:m=>a) (ys:n=>a) : ((m|n)=>a) =
   -- Possible improvements:
   --  1) Using a SortedTable type.
   --  2) Avoid needlessly initializing the return array.
-  init = concatTable xs ys  -- Initialize array of correct size.
-  yieldState init \buf.
-    withState (0, 0) \countrefs.
+  init = concat_table xs ys  -- Initialize array of correct size.
+  yield_state init \buf.
+    with_state (0, 0) \countrefs.
       for i:(m|n).
         (cur_x, cur_y) = get countrefs
         if cur_y >= size n  -- no ys left
           then
             countrefs := (cur_x + 1, cur_y)
-            buf!i := xs.(unsafeFromOrdinal _ cur_x)
+            buf!i := xs.(unsafe_from_ordinal _ cur_x)
           else
             if cur_x < size m -- still xs left
               then 
-                if xs.(unsafeFromOrdinal _ cur_x) <= ys.(unsafeFromOrdinal _ cur_y)
+                if xs.(unsafe_from_ordinal _ cur_x) <= ys.(unsafe_from_ordinal _ cur_y)
                   then
                     countrefs := (cur_x + 1, cur_y)
-                    buf!i := xs.(unsafeFromOrdinal _ cur_x)
+                    buf!i := xs.(unsafe_from_ordinal _ cur_x)
                   else
                     countrefs := (cur_x, cur_y + 1)
-                    buf!i := ys.(unsafeFromOrdinal _ cur_y)
+                    buf!i := ys.(unsafe_from_ordinal _ cur_y)
 
-def mergeSortedLists {a} [Ord a] (AsList nx xs: List a) (AsList ny ys: List a) : List a =
+def merge_sorted_lists {a} [Ord a] (AsList nx xs: List a) (AsList ny ys: List a) : List a =
   -- Need this wrapper because Dex can't automatically weaken
   -- (a | b)=>c to ((Fin d)=>c)
-  sorted = mergeSortedTables xs ys
+  sorted = merge_sorted_tables xs ys
   newsize = nx + ny
-  AsList _ $ unsafeCastTable (Fin newsize) sorted
+  AsList _ $ unsafe_cast_table (Fin newsize) sorted
 
 def sort {a n} [Ord a] (xs: n=>a) : n=>a =
   -- Warning: Has quadratic runtime cost for now.
@@ -53,15 +53,15 @@ def sort {a n} [Ord a] (xs: n=>a) : n=>a =
 
   -- Merge sort monoid:
   mempty = AsList 0 []
-  mcombine = mergeSortedLists
+  mcombine = merge_sorted_lists
 
   -- reduce might someday recursively subdivide the problem.
   (AsList _ r) = reduce mempty mcombine xlists
-  unsafeCastTable n r
+  unsafe_cast_table n r
 
 def (+|) {n} [Ix n] (i:n) (delta:Int) : n =
   i' = ordinal i + delta
-  fromOrdinal _ $ select (i' >= size n) (size n - 1) i'
+  from_ordinal _ $ select (i' >= size n) (size n - 1) i'
 
-def isSorted {a n} [Ord a] (xs:n=>a) : Bool =
+def is_sorted {a n} [Ord a] (xs:n=>a) : Bool =
   all for i. xs.i <= xs.(i +| 1)

--- a/python/dex/interop/jax/jax2dex.py
+++ b/python/dex/interop/jax/jax2dex.py
@@ -373,7 +373,7 @@ def _make_bcast_expr(idx_names, out_shape, in_shape, x):
           for idx_name, out_size, in_size
           in zip(idx_names[-ndim:], out_shape[-ndim:], in_shape)]
   return Idx(x, tuple(idxs))
-unitIdx = App(App(Var('unsafeFromOrdinal'), FinType(Literal(1))), Literal(0))
+unitIdx = App(App(Var('unsafe_from_ordinal'), FinType(Literal(1))), Literal(0))
 
 expr_makers[lax.add_p] = partial(_broadcasting_binop, Var('add'))
 expr_makers[lax.sub_p] = partial(_broadcasting_binop, Var('sub'))
@@ -420,7 +420,7 @@ def _slice_lowering(ctx, x, start_indices, limit_indices, strides):
   idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(Literal(sz)))
                               for sz in out_aval.shape)
   input_ixs = [Var(ix) if in_size == out_size else
-               App(App(Var('unsafeFromOrdinal'), FinType(Literal(in_size))),
+               App(App(Var('unsafe_from_ordinal'), FinType(Literal(in_size))),
                    BinOp(Literal(start), '+', App(Var('ordinal'), Var(ix))))
                for ix, in_size, out_size, start
                in zip(idx_names, in_aval.shape, out_aval.shape, start_indices)]
@@ -456,7 +456,7 @@ def _concatenate_lowering(ctx, *xs, dimension):
     xs_v = ctx.fresh('xs')
     return Block([
         Decl(xs_v, Table(tuple(xs)))
-      ], App(App(Var('unsafeCastTable'), FinType(Literal(dim_size * len(xs)))),
+      ], App(App(Var('unsafe_cast_table'), FinType(Literal(dim_size * len(xs)))),
               For((i,), (PairType(FinType(Literal(len(xs))), FinType(Literal(dim_size))),),
                   TabApp(TabApp(Var(xs_v), App(Var('fst'), Var(i))), App(Var('snd'), Var(i))))))
   # Irregular concatenation
@@ -464,6 +464,6 @@ def _concatenate_lowering(ctx, *xs, dimension):
   xs_v = ctx.fresh('xs')
   return Block([
         Decl(ConPattern('AsList', (None, xs_v)),
-             App(Var('concat'), Table(tuple(App(Var('toList'), x) for x in xs)))),
-      ], App(App(Var('unsafeCastTable'), FinType(Literal(out_aval.shape[0]))), Var(xs_v)))
+             App(Var('concat'), Table(tuple(App(Var('to_list'), x) for x in xs)))),
+      ], App(App(Var('unsafe_cast_table'), FinType(Literal(out_aval.shape[0]))), Var(xs_v)))
 expr_makers[lax.concatenate_p] = _concatenate_lowering

--- a/python/tests/jax_test.py
+++ b/python/tests/jax_test.py
@@ -130,7 +130,7 @@ class JAXTest(unittest.TestCase):
   def test_grad(self):
     f_dex = primitive(dex.eval(
         r'\x:((Fin 10) => Float). '
-        'sum $ for i. (IToF $ ordinal i) * x.i * x.i'))
+        'sum $ for i. (i_to_f $ ordinal i) * x.i * x.i'))
 
     def f_jax(x):
       return jnp.sum(jnp.arange(10.) * x**2)
@@ -145,7 +145,7 @@ class JAXTest(unittest.TestCase):
   def test_grad_jit(self):
     f_dex = primitive(dex.eval(
         r'\x:((Fin 10) => Float). '
-        'sum $ for i. (IToF $ ordinal i) * x.i * x.i'))
+        'sum $ for i. (i_to_f $ ordinal i) * x.i * x.i'))
 
     def f_jax(x):
       return jnp.sum(jnp.arange(10.) * x**2)

--- a/python/tests/jit_test.py
+++ b/python/tests/jit_test.py
@@ -39,7 +39,7 @@ class JITTest(unittest.TestCase):
                              ((x + 0.01, y) for x, y in it.product(example_floats, repeat=2)
                               if (x, y) != (0.0, 0.0)))
 
-  test_int_arg = expr_test(r"\x:Int64 y:Int. I64ToI x + y",
+  test_int_arg = expr_test(r"\x:Int64 y:Int. i64_to_i x + y",
                            lambda x, y: x + y,
                            it.product(example_ints, example_ints))
 

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -847,7 +847,7 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
     prev <- mapM (\() -> freshType TyKind) labels
     matchRequirement =<< emitOp (VariantLift prev value')
   UIntLit x  -> do
-    lookupSourceMap "fromInteger" >>= \case
+    lookupSourceMap "from_integer" >>= \case
       Nothing ->
         -- fallback for missing protolude
         matchRequirement $ Con $ Lit $ Int32Lit $ fromIntegral x

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -246,7 +246,7 @@ uString = do
   (s, pos) <- withPos $ strLit
   let addSrc = WithSrcE (Just pos)
   let cs = map (addSrc . charExpr) s
-  return $ mkApp (addSrc "toList") $ addSrc $ UTabCon cs
+  return $ mkApp (addSrc "to_list") $ addSrc $ UTabCon cs
 
 uLit :: Parser (UExpr VoidS)
 uLit = withSrc $ uLitParser

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -105,28 +105,28 @@ f : Float -> Float = \x. yieldAccum (AddMonoid Float) \ref. ref += x
 :p (cos 1.0, deriv (deriv (deriv sin)) 1.0)
 > (0.540302, -0.540302)
 
-:p checkDeriv sin 1.0
+:p check_deriv sin 1.0
 > True
 
-:p checkDeriv cos 1.0
+:p check_deriv cos 1.0
 > True
 
-:p checkDeriv exp 2.0
+:p check_deriv exp 2.0
 > True
 
-:p checkDeriv log 2.0
+:p check_deriv log 2.0
 > True
 
-:p checkDeriv (\x. exp (sin (cos x))) 2.0
+:p check_deriv (\x. exp (sin (cos x))) 2.0
 > True
 
-:p checkDeriv (deriv sin) 1.0
+:p check_deriv (deriv sin) 1.0
 > True
 
-:p checkDeriv (deriv cos) 1.0
+:p check_deriv (deriv cos) 1.0
 > True
 
-:p checkDeriv sqrt 4.0
+:p check_deriv sqrt 4.0
 > True
 
 -- badDerivFun : Float -> Float
@@ -169,7 +169,7 @@ tripleit : Float --o Float = \x. x + x + x
 myOtherSquare : Float -> Float =
   \x. yieldAccum (AddMonoid Float) \w. w += x * x
 
-:p checkDeriv myOtherSquare 3.0
+:p check_deriv myOtherSquare 3.0
 > True
 
 :p
@@ -181,7 +181,7 @@ myOtherSquare : Float -> Float =
 
 :p
   f : Float -> Float = \x.
-    x * IToF (1 + 1)
+    x * i_to_f (1 + 1)
 
   jvp f 1.0 2.0
 > 4.
@@ -234,25 +234,25 @@ vec = [1.]
 :p
   f : Float -> Float = \x.
     x2 = x * x
-    withReader x \xr.
-      withReader x2 \x2r.
+    with_reader x \xr.
+      with_reader x2 \x2r.
         5.0 * (ask x2r) + 4.0 * (ask xr) + 2.0
-  checkDeriv f 2.0
+  check_deriv f 2.0
 > True
 
 :p
   f : Float -> Float = \x.
-    yieldState x \xr.
+    yield_state x \xr.
       for i:(Fin 2).
         xr := get xr * get xr
-  checkDeriv f 2.0
+  check_deriv f 2.0
 > True
 
 :p
   f = \rec.
     ({x=x, y=y, z=z}) = rec
-    x * y * IToF z
-  (checkDeriv (\x. f {x=x, y=4.0, z=5}) 2.0, checkDeriv (\y. f {x=2.0, y=y, z=5}) 4.0)
+    x * y * i_to_f z
+  (check_deriv (\x. f {x=x, y=4.0, z=5}) 2.0, check_deriv (\y. f {x=2.0, y=y, z=5}) 4.0)
 > (True, True)
 
 -- TODO: Re-enable once the big PR is merged
@@ -267,7 +267,7 @@ vec = [1.]
 -- > True
 
 :p
-  f = \x. for i:(Fin 4). { x=x * x * (IToF $ ordinal i) }
+  f = \x. for i:(Fin 4). { x=x * x * (i_to_f $ ordinal i) }
   jvp f 2.0 1.0
 > [{x = 0.}, {x = 4.}, {x = 8.}, {x = 12.}]
 
@@ -280,36 +280,36 @@ vec = [1.]
       {| a=a |} -> 2.0 * (a + x)
       {| b=b |} -> b * x
   (y, df) = linearize f 2.0
-  checkDerivBase f 2.0
+  check_deriv_base f 2.0
 > True
 
 :p
   f = max 0.0
-  (checkDerivBase f 1.0, checkDerivBase f (-1.0))
+  (check_deriv_base f 1.0, check_deriv_base f (-1.0))
 > (True, True)
 
 :p
   xs = for i:(Fin 2). 2.0
   f = \x. sum xs
-  checkDeriv f 1.0
+  check_deriv f 1.0
 > True
 
 :p
   f = \c.
     v = for i:(Fin 2). 2.0
-    (c, v) = yieldState (c, v) \r. for i:(Fin 2).
+    (c, v) = yield_state (c, v) \r. for i:(Fin 2).
       (c, v) = get r
       r := (c + sum v, v)
     c
-  checkDeriv f 1.0
+  check_deriv f 1.0
 > True
 
 -- Test reference indexing
 :p
   f = \x.
-    i = unsafeFromOrdinal (Fin 3) 0
-    mat = yieldState zero \m. m!i!i := x
+    i = unsafe_from_ordinal (Fin 3) 0
+    mat = yield_state zero \m. m!i!i := x
     mat.i.i
 
-  checkDeriv f 1.0
+  check_deriv f 1.0
 > True

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -131,8 +131,8 @@ threeCaseTab : (Fin 4)=>ThreeCases =
   yieldAccum (AddMonoid Float) \ref.
     for i. case threeCaseTab.i of
       TheEmptyCase    -> ref += 1000.0
-      ThePairCase x y -> ref +=  100.0 + y + IToF x
-      TheIntCase x    -> ref +=   10.0 + IToF (x * 2)
+      ThePairCase x y -> ref +=  100.0 + y + i_to_f x
+      TheIntCase x    -> ref +=   10.0 + i_to_f (x * 2)
 > 2118.1
 
 data MyIntish = MkIntish Int
@@ -194,8 +194,8 @@ def catLists {a} (xs:List a) (ys:List a) : List a =
   zs = for i:(Fin nz).
     i' = ordinal i
     case i' < nx of
-      True  -> xs'.(fromOrdinal _ i')
-      False -> ys'.(fromOrdinal _ (i' - nx))
+      True  -> xs'.(from_ordinal _ i')
+      False -> ys'.(from_ordinal _ (i' - nx))
   AsList _ zs
 
 :p
@@ -223,7 +223,7 @@ def listToTable {a} ((AsList n xs): List a) : (Fin n)=>a = xs
   sum $ listToTable l
 > 6
 
-def listToTable2 {a} (l: List a) : (Fin (listLength l))=>a =
+def listToTable2 {a} (l: List a) : (Fin (list_length l))=>a =
   (AsList _ xs) = l
   xs
 
@@ -239,8 +239,8 @@ l2 = AsList _ [1, 2, 3]
 :p sum $ listToTable2 l2
 > 6
 
-def zerosLikeList {a} (l : List a) : (Fin (listLength l))=>Float =
-  for i:(Fin $ listLength l). 0.0
+def zerosLikeList {a} (l : List a) : (Fin (list_length l))=>Float =
+  for i:(Fin $ list_length l). 0.0
 
 :p zerosLikeList l2
 > [0., 0., 0.]
@@ -250,7 +250,7 @@ data Graph n:Type a:Type [Ix n] =
 
 def graphToAdjacencyMatrix {n a} ((MkGraph nodes (AsList _ edges)):Graph n a) : n=>n=>Bool =
   init = for i j. False
-  yieldState init \mRef.
+  yield_state init \mRef.
     for i.
       (from, to) = edges.i
       mRef!from!to := True
@@ -310,8 +310,8 @@ data MySum2 =
 > (AsList 4 [(Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2)])
 
 -- reproducer for a shadowing bug (PR #440)
-:p concat $ for i:(Fin 2). toList [(Just [0,0,0], Just [0,0,0]),
-                                   (Just [0,0,0], Just [0,0,0])]
+:p concat $ for i:(Fin 2). to_list [(Just [0,0,0], Just [0,0,0]),
+                                    (Just [0,0,0], Just [0,0,0])]
 > (AsList 4 [ ((Just [0, 0, 0]), (Just [0, 0, 0]))
 >           , ((Just [0, 0, 0]), (Just [0, 0, 0]))
 >           , ((Just [0, 0, 0]), (Just [0, 0, 0]))

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -23,14 +23,14 @@
    vdot' : n:Type ?-> n=>Float -> n=>Float -> Float =
      \x y. sum (for i. x.i * y.i * 2.0)
    x = iota (Fin 3)
-   y = map IToF x
+   y = map i_to_f x
    vdot' y y
 > 10.
 
 :p
    x = iota $ Fin 3
    y = iota $ Fin 4
-   z = for i j. IToF x.i * IToF y.j
+   z = for i j. i_to_f x.i * i_to_f y.j
    sum (for i. sum z.i)
 > 18.
 
@@ -48,7 +48,7 @@ arr = iota NArr
 :p sum for i:NArr. 1
 > 7
 
-fun = \y. sum (map IToF arr) + y
+fun = \y. sum (map i_to_f arr) + y
 
 :p fun 3.0
 > 24.
@@ -161,7 +161,7 @@ def cumsumplus {n} : n=>Float -> n=>Float =
 :p 1.0 < 2.0
 > True
 
-:p BToI (1.0 < 2.0)
+:p b_to_i (1.0 < 2.0)
 > 1
 
 :p [ 1 < 2, 1.0 < 2.0,  2 < 2, 2.0 < 2.0, 2 < 1, 2.0 < 1.0]
@@ -211,27 +211,27 @@ litArr = [10, 5, 3]
 > [3, 4, 5, 6, 7, 8]
 
 :p
-   k = newKey 0
+   k = new_key 0
    mean for i:(Fin 100). randn (ixkey k i)
 > -0.1158
 
-:p hash (IToW64 0) 0
+:p hash (i_to_w64 0) 0
 > 0x6b20015999ba4efe
 
-:p hash (IToW64 123) 456
+:p hash (i_to_w64 123) 456
 > 0x500945c565c98701
 
-key = (W32ToW64 (IToW32 320440878) .<<. 32) .|. (W32ToW64 (IToW32 57701188)) -- 0x13198a2e03707344
-count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355)) -- 0x243f6a8885a308d3
-:p threeFry2x32 key count
+key = (w32_to_w64 (i_to_w32 320440878) .<<. 32) .|. (w32_to_w64 (i_to_w32 57701188)) -- 0x13198a2e03707344
+count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242054355)) -- 0x243f6a8885a308d3
+:p threefry_2x32 key count
 > 0xc4923a9c483df7a0
 
 :p
-   k = newKey 0
+   k = new_key 0
    mean for i:(Fin 100). sq $ randn (ixkey k i)
 > 1.25819
 
-:p for i:(Fin 3) j:(Fin 2). rand $ ixkey2 (newKey 11) i j
+:p for i:(Fin 3) j:(Fin 2). rand $ ixkey2 (new_key 11) i j
 > [[0.474153, 0.914516], [0.79446, 0.276799], [0.589586, 0.711625]]
 
 :p
@@ -244,7 +244,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
    x
 > [[0, 0, 0, 0], [0, 0, 0, 0], [0, 0, 0, 0]]
 
-:p fold (for i:(Fin 3). 0.0) $ \i:(Fin 2) c. (for j. c.j + IToF (ordinal j))
+:p fold (for i:(Fin 3). 0.0) $ \i:(Fin 2) c. (for j. c.j + i_to_f (ordinal j))
 > [0., 2., 4.]
 
 :p
@@ -270,7 +270,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p for i:(Fin 3). i
 > [(0@Fin 3), (1@Fin 3), (2@Fin 3)]
 
-:p fromOrdinal (Fin 1) 0
+:p from_ordinal (Fin 1) 0
 > (0@Fin 1)
 
 :p 0@(Fin 1)
@@ -317,7 +317,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p select False [1,2,3] [10,20,30]
 > [10, 20, 30]
 
-:p [(1, (for i:(Fin 2) . 3))].(fromOrdinal _ 0)
+:p [(1, (for i:(Fin 2) . 3))].(from_ordinal _ 0)
 > (1, [3, 3])
 
 :p (False && False, False && True, True && False, True && True)
@@ -354,7 +354,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p select False () ()
 > ()
 
-:p [1,2,3].(fromOrdinal (Fin 3) 1 )
+:p [1,2,3].(from_ordinal (Fin 3) 1 )
 > 2
 
 :p fold (1.0, 2.0) \i:(Fin 2) (x, y). (y, x)
@@ -368,25 +368,25 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p min 2.0 3.0
 > 2.
 
-:p minBy sq 0.5 (-2.0)
+:p min_by sq 0.5 (-2.0)
 > 0.5
 
 :p minimum [2.0, 3.0, 4.0, 1.5, 7.0]
 > 1.5
 
-:p minimumBy fst [(2.0, 20), (1.5, 15), (10.0, 100)]
+:p minimum_by fst [(2.0, 20), (1.5, 15), (10.0, 100)]
 > (1.5, 15)
 
 :p max 2.0 3.0
 > 3.
 
-:p maxBy sq 0.5 (-2.0)
+:p max_by sq 0.5 (-2.0)
 > -2.
 
 :p maximum [2.0, 4.0, 1.5, 7.0]
 > 7.
 
-:p maximumBy fst [(2.0, 20), (1.5, 15), (10.0, 100)]
+:p maximum_by fst [(2.0, 20), (1.5, 15), (10.0, 100)]
 > (10., 100)
 
 :p (1 == 2, (-1) == (-1), 1 < 2, -1 < 2, 2 < (-1))
@@ -395,7 +395,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p (1. == 2., (-1.) == (-1.), 1. < 2., (-1.) < 2., 2. < (-1.))
 > (False, (True, (True, (True, False))))
 
-:p for i:(Fin 7). select (i < (fromOrdinal _ 3)) 1 2
+:p for i:(Fin 7). select (i < (from_ordinal _ 3)) 1 2
 > [1, 1, 1, 2, 2, 2, 2]
 
 σ = 1.0 + 2.0
@@ -447,27 +447,27 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 > 4.
 
 :p
-  one = fromOrdinal (Fin 4) 1
+  one = from_ordinal (Fin 4) 1
   for i:(Fin 4). sum for j:(one..i). 1.0
 > [0., 1., 2., 3.]
 
 :p
-  one = fromOrdinal (Fin 4) 1
+  one = from_ordinal (Fin 4) 1
   for i:(Fin 4). sum for j:(one<..i). 1.0
 > [0., 0., 1., 2.]
 
 :p
-  one = fromOrdinal (Fin 4) 1
+  one = from_ordinal (Fin 4) 1
   for i:(Fin 4). sum for j:(one<..i). 1.0
 > [0., 0., 1., 2.]
 
 :p
-  one = fromOrdinal (Fin 4) 1
+  one = from_ordinal (Fin 4) 1
   for i:(Fin 4). sum for j:(one..<i). 1.0
 > [0., 0., 1., 2.]
 
 :p
-  one = fromOrdinal (Fin 4) 1
+  one = from_ordinal (Fin 4) 1
   for i:(Fin 4). sum for j:(one<..<i). 1.0
 > [0., 0., 0., 1.]
 
@@ -518,7 +518,7 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 :p argmin [1.0, 2.0, 0.4, 5.0]
 > (2@Fin 4)
 
-:p select True (fromOrdinal (Fin 2) 0) (fromOrdinal (Fin 2) 1)
+:p select True (from_ordinal (Fin 2) 0) (from_ordinal (Fin 2) 1)
 > (0@Fin 2)
 
 -- TODO: printing (also parsing) tables with alternative index sets
@@ -536,14 +536,14 @@ count = (W32ToW64 (IToW32 608135816) .<<. 32) .|. (W32ToW64 (IToW32 2242054355))
 -- > [2.0, 2.0, 2.0]
 
 :p
-  runState 0.0 \ref. for i:(Fin 4).
+  run_state 0.0 \ref. for i:(Fin 4).
       c = get ref
       ref := c + 1.0
       c
 > ([0., 1., 2., 3.], 4.)
 
 :p
-  runState 0.0 \ref. rof i:(Fin 4).
+  run_state 0.0 \ref. rof i:(Fin 4).
       c = get ref
       ref := c + 1.0
       c
@@ -571,17 +571,17 @@ def wbToEither {a b} : Iso {weights:a | biases:b} (a|b) =
   MkIso {fwd, bwd}
 
 instance {n m} [Ix n, Ix m] Ix {weights:n | biases:m}
-  getSize = \(). size n + size m
-  ordinal = ordinal <<< appIso wbToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso wbToEither
+  get_size = \(). size n + size m
+  ordinal = ordinal <<< app_iso wbToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso wbToEither
 
 -- Sum types as flattened index sets!
 def Weights (n:Type) (m:Type) [Ix n, Ix m] : Type = n=>m=>Float
 def Biases  (n:Type)          [Ix n]       : Type = n=>Float
 def Params  (n:Type) (m:Type) [Ix n, Ix m] : Type = {weights:(n&m) | biases:n}=>Float
 
-w = for i:(Fin 2). for j:(Fin 3). (IToF (ordinal i)) * 3.0 + (IToF (ordinal j))
-b = for j:(Fin 2). neg (IToF (ordinal j) + 1.0)
+w = for i:(Fin 2). for j:(Fin 3). (i_to_f (ordinal i)) * 3.0 + (i_to_f (ordinal j))
+b = for j:(Fin 2). neg (i_to_f (ordinal j) + 1.0)
 
 def flatten {n m} ((w,b):(Weights n m & Biases n)): Params n m =
   for idx. case idx of
@@ -663,8 +663,8 @@ for i:(Fin 2 & Fin 2). 1.0
 > ((0@Fin 2), (1@Fin 2))
 
 for i:(Fin 5). for j:(..i).
-  ir = IToF $ ordinal i
-  jr = IToF $ ordinal j
+  ir = i_to_f $ ordinal i
+  jr = i_to_f $ ordinal j
   ir * (ir + 1.0) / 2.0 + jr
 > [ [0.]@(..(0@Fin 5))
 > , [1., 2.]@(..(1@Fin 5))
@@ -694,7 +694,7 @@ def newtonIter (f: Float -> Float) (x:Float) : Float =
   x - (f x / deriv f x)
 
 def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
-  yieldState x0 \x.
+  yield_state x0 \x.
     iter \i.
       if abs (f $ get x) <= tol
         then Done ()
@@ -737,7 +737,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 > [0, 2, 4, 6]
 
 :p
-  f = withState 1 \ref.
+  f = with_state 1 \ref.
     x = get ref
     ref := 3 + x
     y = get ref
@@ -746,7 +746,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 > 415
 
 :p
-  (f, w) = runAccum (AddMonoid Float) \ref.
+  (f, w) = run_accum (AddMonoid Float) \ref.
     ref += 2.0
     w = 2
     \z. z + w
@@ -908,7 +908,7 @@ def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 
 -- Integer utility tests
 
-:p map isPowerOf2 [0, 1, 2, 3, 256, 1024, 1024*1024, 1024*1024 + 1]
+:p map is_power_of_2 [0, 1, 2, 3, 256, 1024, 1024*1024, 1024*1024 + 1]
 > [False, True, True, False, True, True, True, False]
 
 :p map intlog2 [-1, 0, 1, 2, 3, 4, 5, 1023, 1024, 1025]

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -20,7 +20,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 :p catch do checkFloatInUnitInterval 0.2
 > (Just 0.2)
 
-:p yieldState 0 \ref.
+:p yield_state 0 \ref.
      catch do
        ref := 1
        assert False
@@ -42,7 +42,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 > (Just [23, 23, 23])
 
 -- Is this the result we want?
-:p yieldState zero \ref.
+:p yield_state zero \ref.
      catch do
        for i:(Fin 6).
          if (ordinal i `rem` 2) == 0
@@ -52,7 +52,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 > [0, 1, 0, 1, 0, 1]
 
 :p catch do
-     runState 0 \ref.
+     run_state 0 \ref.
        ref := 1
        assert False
        ref := 2
@@ -60,7 +60,7 @@ def checkFloatInUnitInterval (x:Float) : {Except} Float =
 
 -- https://github.com/google-research/dex-lang/issues/612
 def sashabug (h: Unit) : {Except} List Int =
-  yieldState mempty \results.
+  yield_state mempty \results.
       results := (get results) <> AsList 1 [2]
 
 catch do (catch do sashabug ())

--- a/tests/gpu-tests.dx
+++ b/tests/gpu-tests.dx
@@ -1,5 +1,5 @@
 
-x = for i:(Fin 5). IToF $ ordinal i
+x = for i:(Fin 5). i_to_f $ ordinal i
 x
 > [0., 1., 2., 3., 4.]
 
@@ -10,7 +10,7 @@ x + x
 testNestedParallelism =
   for i:(Fin 10).
     x = ordinal i
-    q = for j:(Fin 2000). IToF $ x * ordinal j
+    q = for j:(Fin 2000). i_to_f $ x * ordinal j
     (2.0 .* q, 4.0 .* q)
 (fst testNestedParallelism.(2@_)).(5@_)
 > 20.

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -1,26 +1,26 @@
 
-:p unsafeIO \().
-  withTempFile \fname.
-    withFile fname WriteMode \stream.
+:p unsafe_io \().
+  with_temp_file \fname.
+    with_file fname WriteMode \stream.
       fwrite stream "lorem ipsum\n"
       fwrite stream "dolor sit amet\n"
-    readFile fname
+    read_file fname
 > (AsList 27 "lorem ipsum
 > dolor sit amet
 > ")
 
-:p unsafeIO \().
-  withAlloc 4 \ptr:(Ptr Int).
+:p unsafe_io \().
+  with_alloc 4 \ptr:(Ptr Int).
     for i:(Fin 4). store (ptr +>> ordinal i) (ordinal i)
-    tabFromPtr (Fin 4) ptr
+    table_from_ptr (Fin 4) ptr
 > [0, 1, 2, 3]
 
-unsafeIO \().
+unsafe_io \().
   print "testing log"
 > testing log
 > ()
 
-unsafeIO \().
+unsafe_io \().
   for i':(Fin 10).
     i = ordinal i'
     if rem i 2 == 0
@@ -38,36 +38,36 @@ unsafeIO \().
 > 9 is odd
 > [(), (), (), (), (), (), (), (), (), ()]
 
-:p storageSize Int
+:p storage_size Int
 > 4
 
-:p unsafeIO \().
-  withAlloc 1 \ptr:(Ptr Int).
+:p unsafe_io \().
+  with_alloc 1 \ptr:(Ptr Int).
     store ptr 3
     load ptr
 > 3
 
-:p unsafeIO \().
-  withDynamicBuffer \buf.
-    extendDynBuffer buf $ toList for i:(Fin 1000). ordinal i
-    extendDynBuffer buf $ toList for i:(Fin 1000). ordinal i
-    (AsList _ xs) = loadDynBuffer buf
+:p unsafe_io \().
+  with_dynamic_buffer \buf.
+    extend_dynamic_buffer buf $ to_list for i:(Fin 1000). ordinal i
+    extend_dynamic_buffer buf $ to_list for i:(Fin 1000). ordinal i
+    (AsList _ xs) = load_dynamic_buffer buf
     sum xs
 > 999000
 
-:p unsafeIO \().
-  s = for i:(Fin 10000). IToW8 $ FToI $ 128.0 * rand (ixkey (newKey 0) i)
-  withTempFile \fname.
-    withFile fname WriteMode \stream.
+:p unsafe_io \().
+  s = for i:(Fin 10000). i_to_w8 $ FToI $ 128.0 * rand (ixkey (new_key 0) i)
+  with_temp_file \fname.
+    with_file fname WriteMode \stream.
       fwrite stream $ AsList _ s
-    (AsList _ s') = readFile fname
-    sum (for i. W8ToI s.i) == sum (for i. W8ToI s'.i)
+    (AsList _ s') = read_file fname
+    sum (for i. w8_to_i s.i) == sum (for i. w8_to_i s'.i)
 > True
 
-:p unsafeIO do getEnv "NOT_AN_ENV_VAR"
+:p unsafe_io do get_env "NOT_AN_ENV_VAR"
 > Nothing
 
-:p unsafeIO do getEnv "DEX_TEST_MODE"
+:p unsafe_io do get_env "DEX_TEST_MODE"
 > (Just (AsList 1 "t"))
 
 :p dex_test_mode ()

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -1,17 +1,17 @@
 
 :p
    def m {h:Type} (ref:Ref h Int) : {State h} Int = get ref
-   runState 2 m
+   run_state 2 m
 > (2, 2)
 
 :p
    def m {h:Type} (ref:Ref h Int) : {State h} Unit = ref := 3
-   runState 0 m
+   run_state 0 m
 > ((), 3)
 
 :p
    def m {h:Type} (ref:Ref h Int) : {Read h} Int = ask ref
-   withReader 5 m
+   with_reader 5 m
 > 5
 
 :p
@@ -21,7 +21,7 @@
      z = get ref
      ref := (z * 3.0)
 
-  runState 1.0 stateAction
+  run_state 1.0 stateAction
 > ((), 9.)
 
 :p
@@ -37,22 +37,22 @@
     w += 4.0
     r + 2
 
-  withReader 2 \r.
-    runState True \s.
-      runAccum (AddMonoid Float) \w.
+  with_reader 2 \r.
+    run_state True \s.
+      run_accum (AddMonoid Float) \w.
         rwsAction r w s
 > ((4, 6.), False)
 
 :p
    def m {h:Type} (s:Ref h (Fin 3=>Int)) : {State h} Unit =
-     s!(fromOrdinal _ 0) := 10
-     s!(fromOrdinal _ 2) := 20
-     x = get (s!(fromOrdinal _ 0))
-     s!(fromOrdinal _ 1) := x
-   runState [0,0,0] m
+     s!(from_ordinal _ 0) := 10
+     s!(from_ordinal _ 2) := 20
+     x = get (s!(from_ordinal _ 0))
+     s!(from_ordinal _ 1) := x
+   run_state [0,0,0] m
 > ((), [10, 10, 20])
 
-:p withReader [1,2,3] \r . ask r!(fromOrdinal _ 1)
+:p with_reader [1,2,3] \r . ask r!(from_ordinal _ 1)
 > 2
 
 :p
@@ -62,7 +62,7 @@
         : {Accum wh, State sh} Unit =
     x = get s
     w += x
-  runState 1.0 \s. runAccum (AddMonoid Float) \w . m w s
+  run_state 1.0 \s. run_accum (AddMonoid Float) \w . m w s
 > (((), 1.), 1.)
 
 def myAction {hw hr} [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : {Read hr, Accum hw} Unit =
@@ -70,7 +70,7 @@ def myAction {hw hr} [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : 
   w += x
   w += 2.0
 
-:p withReader 1.5 \r. runAccum (AddMonoid Float) \w. myAction w r
+:p with_reader 1.5 \r. run_accum (AddMonoid Float) \w. myAction w r
 > ((), 3.5)
 
 :p
@@ -81,14 +81,14 @@ def myAction {hw hr} [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : 
     w1 += 1.0
     w2 += 3.0
     w1 += 1.0
-  runAccum (AddMonoid Float) \w1. runAccum (AddMonoid Float) \w2. m w1 w2
+  run_accum (AddMonoid Float) \w1. run_accum (AddMonoid Float) \w2. m w1 w2
 > (((), 3.), 2.)
 
 def foom {h:Type} (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
-  s!(fromOrdinal _ 0) := 1
-  s!(fromOrdinal _ 2) := 2
+  s!(from_ordinal _ 0) := 1
+  s!(from_ordinal _ 2) := 2
 
-:p runState [0,0,0] foom
+:p run_state [0,0,0] foom
 > ((), [1, 0, 2])
 
 -- TODO: handle effects returning functions
@@ -127,10 +127,10 @@ def foom {h:Type} (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 -- TODO: some way to explicitly give type to `runAccum`
 --       (maybe just explicit implicit args)
 :p
-  withReader 2.0 \r.
-    runAccum (AddMonoid Float) \w.
-      runAccum (AddMonoid Float) \w'.
-        runState 3 \s.
+  with_reader 2.0 \r.
+    run_accum (AddMonoid Float) \w.
+      run_accum (AddMonoid Float) \w'.
+        run_state 3 \s.
           x = ask r
           y = get s
           w += x
@@ -140,7 +140,7 @@ def foom {h:Type} (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
 > ((((2., 3), 4), 4.), 2.)
 
 def symmetrizeInPlace {n} (mat:n=>n=>Float) : n=>n=>Float =
-  yieldState mat \ref.
+  yield_state mat \ref.
     for i j.
        x = get ref!i!j
        y = get ref!j!i
@@ -151,7 +151,7 @@ def symmetrizeInPlace {n} (mat:n=>n=>Float) : n=>n=>Float =
 symmetrizeInPlace [[1.,2.],[3.,4.]]
 > [[1., 2.5], [2.5, 4.]]
 
-:p withReader 5 \r. ()
+:p with_reader 5 \r. ()
 > ()
 
 :p yieldAccum (AddMonoid Float) \w.
@@ -175,13 +175,13 @@ def effectsAtZero {eff:Effects} (f: Int ->{|eff} Unit) : {|eff} Unit =
   f 0
   ()
 
-:p runState 0 \ref. effectsAtZero \_. ref := 1
+:p run_state 0 \ref. effectsAtZero \_. ref := 1
 > ((), 1)
 
 :p filter (\x. x > 5) [0, 7, -1, 6]
 > (AsList 2 [7, 6])
 
-:p argFilter (\x. x > 5) [0, 7, -1, 6]
+:p arg_filter (\x. x > 5) [0, 7, -1, 6]
 > (AsList 2 [(1@Fin 4), (3@Fin 4)])
 
 -- Test list equality

--- a/tests/parser-combinator-tests.dx
+++ b/tests/parser-combinator-tests.dx
@@ -2,28 +2,28 @@
 import parser
 
 parseABC : Parser Unit = MkParser \h.
-  parse h $ pChar 'A'
-  parse h $ pChar 'B'
-  parse h $ pChar 'C'
+  parse h $ p_char 'A'
+  parse h $ p_char 'B'
+  parse h $ p_char 'C'
 
-:p runParser "AAA" parseABC
+:p run_parser "AAA" parseABC
 > Nothing
 
-:p runParser "ABCABC" parseABC
+:p run_parser "ABCABC" parseABC
 > Nothing
 
-:p runParser "AB" parseABC
+:p run_parser "AB" parseABC
 > Nothing
 
-:p runParser "ABC" parseABC
+:p run_parser "ABC" parseABC
 > (Just ())
 
 def parseT : Parser Bool = MkParser \h.
-  parse h $ pChar 'T'
+  parse h $ p_char 'T'
   True
 
 def parseF : Parser Bool = MkParser \h.
-  parse h $ pChar 'F'
+  parse h $ p_char 'F'
   False
 
 def parseTF : Parser Bool =
@@ -32,23 +32,23 @@ def parseTF : Parser Bool =
 def parserTFTriple : Parser (Fin 3=>Bool) = MkParser \h.
   for i. parse h parseTF
 
-:p runParser "TTF" parserTFTriple
+:p run_parser "TTF" parserTFTriple
 > (Just [True, True, False])
 
-:p runParser "TTFX" parserTFTriple
+:p run_parser "TTFX" parserTFTriple
 > Nothing
 
-:p runParser "TTFFTT" $ parseMany parseTF
+:p run_parser "TTFFTT" $ parse_many parseTF
 > (Just (AsList 6 [True, True, False, False, True, True]))
 
-:p runParser "1021389" $ parseMany parseDigit
+:p run_parser "1021389" $ parse_many parse_digit
 > (Just (AsList 7 [1, 0, 2, 1, 3, 8, 9]))
 
-:p runParser "1389" $ parseInt
+:p run_parser "1389" $ parse_int
 > (Just 1389)
 
-:p runParser "01389" $ parseInt
+:p run_parser "01389" $ parse_int
 > (Just 1389)
 
-:p runParser "-1389" $ parseInt
+:p run_parser "-1389" $ parse_int
 > (Just -1389)

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -65,7 +65,7 @@ lam4 = \{n m}. (Fin n, Fin m)
 > [1, 0, 0]
 
 :p
-  runState 5 \ref.
+  run_state 5 \ref.
     n = get ref
     for_ i:(Fin n).
       ref := get ref + 1

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -209,9 +209,9 @@ x : {a:Int | a:Float | a:Int} = {| a | a = 3.0 |}
 :p
   x : {a:Int | a:Float | b:Int} = {| a | a = 3.0 |}
   case x of
-    {| a = x |} -> IToF x
+    {| a = x |} -> i_to_f x
     {| a | a = x |} -> x
-    {| b = x |} -> IToF x
+    {| b = x |} -> i_to_f x
 > 3.
 
 'Table values and imp lowering
@@ -322,15 +322,15 @@ def abToPair {a b} : Iso {a:a & b:b} (b&a) =
   bwd = \(b, a). {a, b}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
-  getSize = \(). size n * size m
-  ordinal = ordinal <<< appIso abToPair
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToPair
+  get_size = \(). size n * size m
+  ordinal = ordinal <<< app_iso abToPair
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToPair
 
 :p size {a:Fin 10 & b:Fin 3}
 > 30
 :p ordinal {a=(7@Fin 10), b=(2@Fin 3)}
 > 27
-:p fromOrdinal {a:Fin 10 & b:Fin 3} 14
+:p from_ordinal {a:Fin 10 & b:Fin 3} 14
 > {a = (4@Fin 10), b = (1@Fin 3)}
 
 recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
@@ -354,9 +354,9 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
 instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
-  getSize = \(). size n + size m
-  ordinal = ordinal <<< appIso abToEither
-  unsafeFromOrdinal = unsafeFromOrdinal _ >>> revIso abToEither
+  get_size = \(). size n + size m
+  ordinal = ordinal <<< app_iso abToEither
+  unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToEither
 
 :p size {a:Fin 10 | b:Fin 3}
 > 13
@@ -366,10 +366,10 @@ instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
   ordinal x
 > 12
 
-:p fromOrdinal {a:Fin 10 | b:Fin 3} 4
+:p from_ordinal {a:Fin 10 | b:Fin 3} 4
 > {| a = 4@Fin 10 |}
 
-:p fromOrdinal {a:Fin 10 | b:Fin 3} 11
+:p from_ordinal {a:Fin 10 | b:Fin 3} 11
 > {| b = 1@Fin 3 |}
 
 variantsAsIndices : {a:Fin 10 | b:Fin 3}=>{a:Fin 10 | b:Fin 3} = for i. i

--- a/tests/serialize-tests.dx
+++ b/tests/serialize-tests.dx
@@ -10,7 +10,7 @@
 :p [[1.0, 2.0, 3.0], [4.0, 5.0, 6.0]]
 > [[1., 2., 3.], [4., 5., 6.]]
 
-:p fromOrdinal (Fin 10) 7
+:p from_ordinal (Fin 10) 7
 > (7@Fin 10)
 
 :p [True, False]

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -1,81 +1,81 @@
 import set
 
 -- check order invariance.
-:p (toSet ["Bob", "Alice", "Charlie"]) == (toSet ["Charlie", "Bob", "Alice"])
+:p (to_set ["Bob", "Alice", "Charlie"]) == (to_set ["Charlie", "Bob", "Alice"])
 > True
 
 -- check uniqueness.
-:p (toSet ["Bob", "Alice", "Alice", "Charlie"]) == (toSet ["Charlie", "Charlie", "Bob", "Alice"])
+:p (to_set ["Bob", "Alice", "Alice", "Charlie"]) == (to_set ["Charlie", "Charlie", "Bob", "Alice"])
 > True
 
-set1 = toSet ["Xeno", "Alice", "Bob"]
-set2 = toSet ["Bob", "Xeno", "Charlie"]
+set1 = to_set ["Xeno", "Alice", "Bob"]
+set2 = to_set ["Bob", "Xeno", "Charlie"]
 
 :p set1 == set2
 > False
 
-:p setUnion set1 set2
+:p set_union set1 set2
 > (UnsafeAsSet 4 [ (AsList 5 "Alice")
 >                , (AsList 3 "Bob")
 >                , (AsList 7 "Charlie")
 >                , (AsList 4 "Xeno") ])
 
-:p setIntersect set1 set2
+:p set_intersect set1 set2
 > (UnsafeAsSet 2 [(AsList 3 "Bob"), (AsList 4 "Xeno")])
 
-:p removeDuplicatesFromSorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
+:p remove_duplicates_from_sorted ["Alice", "Alice", "Alice", "Bob", "Bob", "Charlie", "Charlie", "Charlie"]
 > (AsList 3 [(AsList 5 "Alice"), (AsList 3 "Bob"), (AsList 7 "Charlie")])
 
-:p set1 == (setUnion set1 set1)
+:p set1 == (set_union set1 set1)
 > True
 
-:p set1 == (setIntersect set1 set1)
+:p set1 == (set_intersect set1 set1)
 > True
 
 '#### Empty set tests
 
-emptyset = toSet ([]:(Fin 0)=>String)
+emptyset = to_set ([]:(Fin 0)=>String)
 
 :p emptyset == emptyset
 > True
 
-:p emptyset == (setUnion emptyset emptyset)
+:p emptyset == (set_union emptyset emptyset)
 > True
 
-:p emptyset == (setIntersect emptyset emptyset)
+:p emptyset == (set_intersect emptyset emptyset)
 > True
 
-:p set1 == (setUnion set1 emptyset)
+:p set1 == (set_union set1 emptyset)
 > True
 
-:p emptyset == (setIntersect set1 emptyset)
+:p emptyset == (set_intersect set1 emptyset)
 > True
 
 '### Set Index Set tests
 
-names2 = toSet ["Bob", "Alice", "Charlie", "Alice"]
+names2 = to_set ["Bob", "Alice", "Charlie", "Alice"]
 
 :p size (StringSetIx names2)
 > 3
 
 -- Check that ordinal and unsafeFromOrdinal are inverses.
 roundTrip = for i:(StringSetIx names2).
-  i == (unsafeFromOrdinal _ (ordinal i))
+  i == (unsafe_from_ordinal _ (ordinal i))
 :p all roundTrip
 > True
 
 -- Check that index to string and string to index are inverses.
 roundTrip2 = for i:(StringSetIx names2).
-  s = setIxToString i
-  ix = stringToSetIx s
-  i == fromJust ix
+  s = set_ix_to_string i
+  ix = string_to_set_ix s
+  i == from_just ix
 :p all roundTrip2
 > True
 
-setix : StringSetIx names2 = fromJust $ stringToSetIx "Bob"
+setix : StringSetIx names2 = from_just $ string_to_set_ix "Bob"
 :p setix
 > (MkSetIx 1)
 
-setix2 : StringSetIx names2 = fromJust $ stringToSetIx "Charlie"
+setix2 : StringSetIx names2 = from_just $ string_to_set_ix "Charlie"
 :p setix2
 > (MkSetIx 2)

--- a/tests/show-tests.dx
+++ b/tests/show-tests.dx
@@ -17,10 +17,10 @@
 
 -- Int64
 
-:p show (IToI64 1234: Int64)
+:p show (i_to_i64 1234: Int64)
 > (AsList 4 "1234")
 
-:p show (IToI64 (-1234): Int64)
+:p show (i_to_i64 (-1234): Int64)
 > (AsList 5 "-1234")
 
 -- Float32
@@ -53,26 +53,26 @@
 
 -- Float64
 
-:p show (FToF64 123.456789: Float64)
+:p show (f_to_f64 123.456789: Float64)
 > (AsList 16 "123.456787109375")
 
-:p show (FToF64 (pow 2. 16.): Float64)
+:p show (f_to_f64 (pow 2. 16.): Float64)
 > (AsList 5 "65536")
 
-:p show ((FToF64 nan): Float64)
+:p show ((f_to_f64 nan): Float64)
 > (AsList 3 "nan")
 
 -- Note: `show nan` (Dex runtime dtoa implementation) appears different from
 -- `:p nan` (Dex interpreter implementation).
-:p (FToF64 nan)
+:p (f_to_f64 nan)
 > NaN
 
-:p show ((FToF64 infinity): Float64)
+:p show ((f_to_f64 infinity): Float64)
 > (AsList 3 "inf")
 
 -- Note: `show infinity` (Dex runtime dtoa implementation) appears different from
 -- `:p nan` (Dex interpreter implementation).
-:p (FToF64 infinity)
+:p (f_to_f64 infinity)
 > Infinity
 
 -- Tuples

--- a/tests/sort-tests.dx
+++ b/tests/sort-tests.dx
@@ -1,8 +1,8 @@
 import sort
 
-:p isSorted $ sort []:((Fin 0)=>Int)
+:p is_sorted $ sort []:((Fin 0)=>Int)
 > True
-:p isSorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
+:p is_sorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
 > True
 
 
@@ -47,5 +47,5 @@ import sort
 :p "Thomas" > "Thompson"
 > False
 
-:p isSorted $ sort ["Charlie", "Alice", "Bob", "Aaron"]
+:p is_sorted $ sort ["Charlie", "Alice", "Bob", "Aaron"]
 > True

--- a/tests/trig-tests.dx
+++ b/tests/trig-tests.dx
@@ -60,5 +60,5 @@ angles = linspace (Fin 11) (-pi + 0.001) (pi)
 :p tanh 1.2 ~~ ((sinh 1.2) / (cosh 1.2))
 > True
 
-:p tanh (FToF64 1.2) ~~ divide (sinh (FToF64 1.2)) (cosh (FToF64 1.2))
+:p tanh (f_to_f64 1.2) ~~ divide (sinh (f_to_f64 1.2)) (cosh (f_to_f64 1.2))
 > True

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -63,7 +63,7 @@ help make the errors more local.
 :t
    x = iota (Fin 10)
    y = iota (Fin 3)
-   IToF (sum for i. x.i) + IToF (sum for j. y.j)
+   i_to_f (sum for i. x.i) + i_to_f (sum for j. y.j)
 > Float32
 
 :t
@@ -81,7 +81,7 @@ Narr = Fin 10
 
 arr  = iota Narr
 
-xr = map IToF arr
+xr = map i_to_f arr
 
 :t arr
 > ((Fin 10) => Int32)
@@ -322,19 +322,19 @@ bad_range : Int = (1@Fin 3)..(2@_)
 >                ^^^
 
 def getFst1 {n:Type} {b} (xs:n=>b) : b =
-  xs.(fromOrdinal n 0)
+  xs.(from_ordinal n 0)
 
 :p getFst1 [1,2,3]
 > 1
 
 def getFst2 {n b} (xs:n=>b) : b =
-  xs.(fromOrdinal n 0)
+  xs.(from_ordinal n 0)
 
 :p getFst2 [1,2,3]
 > 1
 
 def getFst3 {b:Type} {n:Type} (xs:n=>b) : b =
-  xs.(fromOrdinal n 0)
+  xs.(from_ordinal n 0)
 
 :p getFst3 [1,2,3]
 > 1
@@ -443,6 +443,6 @@ q 5
 :p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
 > True
 
-xbool : Bool = arb $ newKey 0
+xbool : Bool = arb $ new_key 0
 :p xbool
 > True

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -88,13 +88,13 @@ myPair = (1, 2.3)
 > 1
 
 :p
-   yieldState 2 \s.
+   yield_state 2 \s.
      x = get s
      s := x + 3
 > 5
 
 :p
-   yieldState 1 \s.
+   yield_state 1 \s.
      for i:(Fin 10).
        x = get s
        s := x + x
@@ -170,7 +170,7 @@ myPair = (1, 2.3)
 -- >    ^^^
 
 :p
-  yieldState [1,2,3] \xsRef.
+  yield_state [1,2,3] \xsRef.
     for i:(Fin 3).
       xsRef!i := ordinal i
 > [0, 1, 2]
@@ -178,13 +178,13 @@ myPair = (1, 2.3)
 def passthrough {a b} {eff:Effects} (f:(a -> {|eff} b)) (x:a) : {|eff} b = f x
 
 :p
-  yieldState 1 \ref.
+  yield_state 1 \ref.
     passthrough (\(). ref := 10) ()
 > 10
 
 :p
-  runState 0 \r1.
-    runState 0 \r2.
+  run_state 0 \r1.
+    run_state 0 \r2.
       r1 := 1
       r2 := 2
 > (((), 2), 1)


### PR DESCRIPTION
`make tests` and the Github actions pass, though I haven't done other testing.

This also touches a couple of places where the compiler and the `jax2dex` script look for or emit a specific Dex name, but I intentionally left %-primitives and foreign functions alone, because changing those would have to be coordinated across programming languages.

Changing local names is out of scope for this change---the footprint is large enough as it is. Local names should also be easier to update independently, because by construction any such change need not be coordinated across files.

This PR is completely programmatically generated, so I can easily accommodate requests to change a name to something other than what I chose here. Some items for consideration are mentioned on https://github.com/google-research/dex-lang/issues/786.

For reference, the program I used to generate this (such as that program is) can be perused on https://github.com/axch/dex-lang/tree/dex-auto-renamer.  My plan is to archive that program on a dead branch in this repo once I know I don't need to change it (i.e., once this change merges) but to not otherwise check the code in, lest it impose a needless maintenance burden.

Fixes https://github.com/google-research/dex-lang/issues/786.

For the record, these are the actual renamings:

Convert internalCast to internal_cast.
Convert F64ToF to f64_to_f.
Convert F32ToF to f32_to_f.
Convert FToF64 to f_to_f64.
Convert FToF32 to f_to_f32.
Convert I64ToI to i64_to_i.
Convert I32ToI to i32_to_i.
Convert W8ToI to w8_to_i.
Convert IToI64 to i_to_i64.
Convert IToI32 to i_to_i32.
Convert IToW8 to i_to_w8.
Convert IToW32 to i_to_w32.
Convert IToW64 to i_to_w64.
Convert W32ToW64 to w32_to_w64.
Convert IToF to i_to_f.
Convert I64ToRawPtr to i64_to_raw_ptr.
Convert RawPtrToI64 to raw_ptr_to_i64.
Convert fromInteger to from_integer.
Convert lowWord to low_word.
Convert highWord to high_word.
Convert getSize to get_size.
Convert unsafeFromOrdinal to unsafe_from_ordinal.
Convert clampNonnegPrim to clamp_nonneg_prim.
Convert scaleVec to scale_vec.
Convert BToW8 to b_to_w8.
Convert W8ToB to w8_to_b.
Convert BToI to b_to_i.
Convert BToF to b_to_f.
Convert OToW8 to o_to_w8.
Convert isNothing to is_nothing.
Convert isJust to is_just.
Convert fstRef to fst_ref.
Convert sndRef to snd_ref.
Convert runReader to run_reader.
Convert withReader to with_reader.
Convert runAccum to run_accum.
Convert withAccum to with_accum.
Convert runState to run_state.
Convert withState to with_state.
Convert yieldState to yield_state.
Convert unsafeIO to unsafe_io.
Convert castPtr to cast_ptr.
Convert storageSize to storage_size.
Convert storeTab to store_table.
Convert withAlloc to with_alloc.
Convert withTabPtr to with_table_ptr.
Convert tabFromPtr to table_from_ptr.
Convert applyN to apply_n.
Convert cumSum to cumsum.
Convert derivRev to deriv_rev.
Convert checkDerivBase to check_deriv_base.
Convert checkDeriv to check_deriv.
Convert unsafeCastTable to unsafe_cast_table.
Convert toList to to_list.
Convert argFilter to arg_filter.
Convert appIso to app_iso.
Convert flipIso to flip_iso.
Convert revIso to rev_iso.
Convert idIso to id_iso.
Convert getAt to get_at.
Convert popAt to pop_at.
Convert pushAt to push_at.
Convert setAt to set_at.
Convert matchWith to match_with.
Convert buildWith to build_with.
Convert swapPairIso to swap_pair_iso.
Convert exceptLens to except_lens.
Convert swapEitherIso to swap_either_iso.
Convert exceptPrism to except_prism.
Convert overLens to over_lens.
Convert splitR to split_r.
Convert overFields to over_fields.
Convert splitV to split_v.
Convert sliceFields to slice_fields.
Convert withDynamicBuffer to with_dynamic_buffer.
Convert maybeIncreaseBufferSize to maybe_increase_buffer_size.
Convert addAtIntPtr to add_at_int_ptr.
Convert extendDynBuffer to extend_dynamic_buffer.
Convert loadDynBuffer to load_dynamic_buffer.
Convert pushDynBuffer to push_dynamic_buffer.
Convert stringFromCharPtr to string_from_char_ptr.
Convert nullRawPtr to null_raw_ptr.
Convert fromNullableRawPtr to from_nullable_raw_ptr.
Convert cStringPtr to c_string_ptr.
Convert withCString to with_c_string.
Convert liftState to lift_state.
Convert boundedIter to bounded_iter.
Convert fromCString to from_c_string.
Convert getEnv to get_env.
Convert checkEnv to check_env.
Convert getOutputStream to get_output_stream.
Convert shellOut to shell_out.
Convert deleteFile to delete_file.
Convert withFile to with_file.
Convert writeFile to write_file.
Convert readFile to read_file.
Convert hasFile to has_file.
Convert newTempFile to new_temp_file.
Convert withTempFile to with_temp_file.
Convert withTempFiles to with_temp_files.
Convert fromOrdinal to from_ordinal.
Convert castTable to cast_table.
Convert threeFry2x32 to threefry_2x32.
Convert newKey to new_key.
Convert splitKey to split_key.
Convert randVec to rand_vec.
Convert randMat to rand_mat.
Convert randInt to rand_int.
Convert randnVec to randn_vec.
Convert randIdx to rand_idx.
Convert searchSorted to search_sorted.
Convert minBy to min_by.
Convert maxBy to max_by.
Convert minimumBy to minimum_by.
Convert maximumBy to maximum_by.
Convert lexicalOrder to lexical_order.
Convert padTo to pad_to.
Convert idivCeil to idiv_ceil.
Convert isOdd to is_odd.
Convert isEven to is_even.
Convert isPowerOf2 to is_power_of_2.
Convert generalIntegerPower to general_integer_power.
Convert fromJust to from_just.
Convert anySat to any_sat.
Convert seqMaybes to seq_maybes.
Convert linearSearch to linear_search.
Convert listLength to list_length.
Convert cumSumLow to cumsum_low.
Convert categoricalFromCDF to categorical_from_cdf.
Convert normalizePdf to normalize_pdf.
Convert cdfForCategorical to cdf_for_categorical.
Convert categoricalBatch to categorical_batch.
Convert defaultGeomStyle to default_geom_style.
Convert concatDiagrams to concat_diagrams.
Convert applyTransformation to apply_transformation.
Convert flipY to flip_y.
Convert moveXY to move_xy.
Convert singletonDefault to singleton_default.
Convert pointDiagram to point_diagram.
Convert updateGeom to update_geom.
Convert setFillColor to set_fill_color.
Convert setStrokeColor to set_stroke_color.
Convert setStrokeWidth to set_stroke_width.
Convert removeStroke to remove_stroke.
Convert removeFill to remove_fill.
Convert strCat to str_cat.
Convert strSpaceCatUncurried to str_space_cat_uncurried.
Convert selfClosingBrackets to self_closing_brackets.
Convert tagBrackets to tag_brackets.
Convert tagBracketsAttrUncurried to tag_brackets_attr_uncurried.
Convert tagBracketsAttr to tag_brackets_attr.
Convert htmlColor to html_color.
Convert optionalHtmlColor to optional_html_color.
Convert attrString to attr_string.
Convert renderGeom to render_geom.
Convert computeBounds to compute_bounds.
Convert renderSVG to render_svg.
Convert renderScaledSVG to render_scaled_svg.
Convert moveX to move_x.
Convert moveY to move_y.
Convert concentricDiagram to concentric_diagram.
Convert upperTriDiag to upper_tri_diag.
Convert lowerTriDiag to lower_tri_diag.
Convert transposeLowerToUpper to transpose_lower_to_upper.
Convert lowerTriMat to lower_tri_mat.
Convert upperTriMat to upper_tri_mat.
Convert swapInPlace to swap_in_place.
Convert permToTable to perm_to_table.
Convert permSign to perm_sign.
Convert fromOrdinalExc to from_ordinal_exc.
Convert indexList to index_list.
Convert runParserPartial to run_parser_partial.
Convert pChar to p_char.
Convert pEOF to p_eof.
Convert runParser to run_parser.
Convert parseAny to parse_any.
Convert parseDigit to parse_digit.
Convert parseMany to parse_many.
Convert parseUnsignedInt to parse_unsigned_int.
Convert parseInt to parse_int.
Convert applyScale to apply_scale.
Convert unitTypeScale to unit_type_scale.
Convert projectUnitInterval to project_unit_interval.
Convert unitIntervalScale to unit_interval_scale.
Convert mapScale to map_scale.
Convert floatScale to float_scale.
Convert getScaled to get_scaled.
Convert lowColor to low_color.
Convert highColor to high_color.
Convert makeRGBColor to make_rgb_color.
Convert colorScale to color_scale.
Convert plotToDiagram to plot_to_diagram.
Convert showPlot to show_plot.
Convert blankData to blank_data.
Convert blankPlot to blank_plot.
Convert autoScale to auto_scale.
Convert setXData to set_x_data.
Convert setYData to set_y_data.
Convert setCData to set_c_data.
Convert xyPlot to xy_plot.
Convert xycPlot to xyc_plot.
Convert yPlot to y_plot.
Convert encodingTable to encoding_table.
Convert decodingTable to decoding_table.
Convert getChunks to get_chunks.
Convert base64sToBytes to base64s_to_bytes.
Convert bytesToBase64s to bytes_to_base64s.
Convert base64ToAscii to base64_to_ascii.
Convert encodeChunk to encode_chunk.
Convert base64Encode to base64_encode.
Convert asciiToBase64 to ascii_to_base64.
Convert decodeChunk to decode_chunk.
Convert base64Decode to base64_decode.
Convert makePNG to make_png.
Convert pngsToGif to pngs_to_gif.
Convert imgToHtml to img_to_html.
Convert floatTo8Bit to float_to_8bit.
Convert imgToPng to img_to_png.
Convert allExceptLast to all_except_last.
Convert mergeUniqueSortedLists to merge_unique_sorted_lists.
Convert removeDuplicatesFromSorted to remove_duplicates_from_sorted.
Convert toSet to to_set.
Convert setSize to set_size.
Convert setUnion to set_union.
Convert setIntersect to set_intersect.
Convert stringToSetIx to string_to_set_ix.
Convert setIxToString to set_ix_to_string.
Convert concatTable to concat_table.
Convert mergeSortedTables to merge_sorted_tables.
Convert mergeSortedLists to merge_sorted_lists.
Convert isSorted to is_sorted.