### PR TITLE
Use rewrite rules to elide unnecessary Env extensions

### DIFF
--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -75,7 +75,7 @@ module Syntax (
     naryNonDepPiType, naryNonDepTabPiType, nonDepPiType, nonDepTabPiType,
     fromNonDepPiType, fromNaryNonDepPiType, fromNaryNonDepTabType,
     considerNonDepPiType, trySelectBranch,
-    fromNonDepTabType, nonDepDataConTys, binderType, bindersTypes,
+    fromNonDepTabType, nonDepDataConTys, bindersTypes,
     atomBindingType, getProjection,
     HasArgType (..), extendEffRow,
     bindingsFragToSynthCandidates,


### PR DESCRIPTION
There are many monadic actions that don't emit any decls, and GHC can
even sometimes realize that statically. However, GHC was unaware that
extending a `Nest` with an `Empty` (on either side) is a no-op, and
similarly for an `Env` extension with an `EnvFrag` derived from an `Empty`.
In the end it doesn't seem to be making a huge difference
performance-wise, but it does at least end up giving us tidier Core
dumps, so I would treat that as a win.