### PR TITLE
Make InplaceT more efficient by threading out updated bindings

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -307,6 +307,7 @@ liftBuilder :: EnvReader m => BuilderM n a -> m n a
 liftBuilder cont = liftM runHardFail $ liftBuilderT cont
 {-# INLINE liftBuilder #-}
 
+-- TODO: This should not fabricate Emits evidence!!
 -- XXX: this uses unsafe functions in its implementations. It should be safe to
 -- use, but be careful changing it.
 liftEmitBuilder :: (Builder m, SinkableE e, SubstE Name e)
@@ -314,7 +315,7 @@ liftEmitBuilder :: (Builder m, SinkableE e, SubstE Name e)
 liftEmitBuilder cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
-  let (result, decls) = runHardFail $ unsafeRunInplaceT (runBuilderT' cont) env
+  let (result, decls, _) = runHardFail $ unsafeRunInplaceT (runBuilderT' cont) env
   Emits <- fabricateEmitsEvidenceM
   emitDecls (unsafeCoerceB decls) result
 

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -242,7 +242,9 @@ instance (Monad m, ExtOutMap Env decls)
   refreshAbs ab cont = UnsafeMakeInplaceT \env ->
     refreshAbsPure (toScope env) ab \_ b e -> do
       let env' = extendOutMap env $ toEnvFrag b
-      unsafeRunInplaceT (cont b e) env'
+      (ans, decls, _) <- unsafeRunInplaceT (cont b e) env'
+      case fabricateDistinctEvidence @UnsafeS of
+        Distinct -> return (ans, decls, extendOutMap (unsafeCoerceE env) decls)
   {-# INLINE refreshAbs #-}
 
 -- === Typeclasses for syntax ===

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -2515,7 +2515,9 @@ instance (Monad m, ExtOutMap InfOutMap decls)
   refreshAbs ab cont = UnsafeMakeInplaceT \env ->
     refreshAbsPure (toScope env) ab \_ b e -> do
       let env' = extendOutMap env $ toEnvFrag b
-      unsafeRunInplaceT (cont b e) env'
+      (ans, decls, _) <- unsafeRunInplaceT (cont b e) env'
+      case fabricateDistinctEvidence @UnsafeS of
+        Distinct -> return (ans, decls, extendOutMap (unsafeCoerceE env) decls)
 
 instance BindsEnv InfOutFrag where
   toEnvFrag (InfOutFrag frag _ _) = toEnvFrag frag


### PR DESCRIPTION
InplaceT is a reader in bindings/environment and a writer in decls. When
two monadic actions are sequenced, the environment that is a result of
the first one can be computed by applying `extendOutMap` to the input
env and the decls of the first action. However, if that first action is
a long chain of binds, it might have already materialized the extended
env inside only to throw it out! This changes InplaceT so that every
action returns both the decls and an environment obtained from extending
the input env by the emitted decls.

In terms of performance, the benchmarks are a bit noisy but it does seem
to make a difference of ~5% end-to-end in run time, but it also lets us
save on 8% of all allocations during a single run!