### PR TITLE
Break out of joinNest immediately if rhs is empty

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -767,14 +767,18 @@ splitNestAt n (Nest b rest) =
     PairB xs ys -> PairB (Nest b xs) ys
 
 joinNest :: Nest b n m -> Nest b m l -> Nest b n l
-joinNest l r = case l of
-  Empty     -> r
-  Nest b lt -> Nest b $ joinNest lt r
+joinNest l Empty = l
+joinNest l r     = doJoinNest l r
 {-# NOINLINE [1] joinNest #-}
 {-# RULES
       "joinNest Empty *"    forall n. joinNest Empty n = n;
       "joinNest * Empty"    forall n. joinNest n Empty = n;
   #-}
+
+doJoinNest :: Nest b n m -> Nest b m l -> Nest b n l
+doJoinNest l r = case l of
+  Empty     -> r
+  Nest b lt -> Nest b $ doJoinNest lt r
 
 binderAnn :: BinderP c ann n l -> ann n
 binderAnn (_:>ann) = ann


### PR DESCRIPTION
This adds a run-time check for the `joinNest * Empty` rewrite rule I
added recently. GHC can catch many instances of `Empty` on the RHS statically,
but not all of them, and the current implementation would unnecessarily
rebuild the left nest when that happens.

This saves us 4% of allocations over the run on the kernel regression
example.