### PR TITLE
Patch the unifier to recognize records with the same tail variable.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -249,6 +249,7 @@ executable dex
   hs-source-dirs:      src
   ghc-options:         -threaded
                        -optP-Wno-nonportable-include-path
+                       -rtsopts
   default-extensions:  CPP
                      , DeriveGeneric
                      , LambdaCase

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -816,6 +816,7 @@ deriving instance Generic (DataConRefBinding n l)
 newtype ExtLabeledItemsE (e1::E) (e2::E) (n::S) =
   ExtLabeledItemsE
    { fromExtLabeledItemsE :: ExtLabeledItems (e1 n) (e2 n) }
+   deriving Show
 
 instance GenericE Atom where
   type RepE Atom =

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -316,3 +316,15 @@ data MySum2 =
 >           , ((Just [0, 0, 0]), (Just [0, 0, 0]))
 >           , ((Just [0, 0, 0]), (Just [0, 0, 0]))
 >           , ((Just [0, 0, 0]), (Just [0, 0, 0])) ])
+
+-- bug #818.  Yes, get_at is backwards.  That was what it took to
+-- tickle the bug at the time.
+def fadd (x: Float) (y: Float) : Float = x + y
+:t (\p. fadd (get_at p #foo) (get_at p #bar))
+> Type error:
+> Expected: (Iso {foo: a & ...b} (a & {&...b}))
+>   Actual: (Iso {bar: c & ...d} (c & {&...d}))
+> (Solving for: [a, b, c, d])
+>
+> :t (\p. fadd (get_at p #foo) (get_at p #bar))
+>                                        ^^^^


### PR DESCRIPTION
Fixes #818, which see for the explanation of the bug.