### PR TITLE
Generate fresh names instead of over-relying on refreshAbs

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -75,6 +75,7 @@ import {-# SOURCE #-} Interpreter
 import LabeledItems
 import Util (enumerate, restructure, transitiveClosureM, bindM2)
 import Err
+import Core
 
 -- === Ordinary (local) builder class ===
 
@@ -225,7 +226,7 @@ instance Fallible m => EnvReader (TopBuilderT m) where
 
 instance Fallible m => TopBuilder (TopBuilderT m) where
   emitBinding hint binding = do
-    Abs b v <- newNameM hint
+    Abs b v <- freshNameM hint
     let ab = Abs (b:>binding) v
     ab' <- liftEnvReaderM $ refreshAbs ab \b' v' -> do
       let envFrag = toEnvFrag b'
@@ -331,7 +332,7 @@ instance Fallible m => ScopableBuilder (BuilderT m) where
 instance Fallible m => Builder (BuilderT m) where
   emitDecl hint ann expr = do
     ty <- getType expr
-    Abs b v <- newNameM hint
+    Abs b v <- freshNameM hint
     let decl = Let b $ DeclBinding ann ty expr
     BuilderT $ extendInplaceT $ Abs (Nest decl Empty) v
   {-# INLINE emitDecl #-}

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -395,7 +395,7 @@ withFreshBinder
   -> (forall l. DExt n l => NameBinder c n l -> m l a)
   -> m n a
 withFreshBinder hint binding cont = do
-  Abs b v <- newNameM hint
+  Abs b v <- freshNameM hint
   refreshAbs (Abs (b:>binding) v) \(b':>_) _ -> cont b'
 
 withFreshBinders
@@ -670,3 +670,11 @@ trySelectBranch e = case e of
 
 freeAtomVarsList :: HoistableE e => e n -> [AtomName n]
 freeAtomVarsList = freeVarsList
+
+freshNameM :: (Color c, EnvReader m)
+           => NameHint -> m n (Abs (NameBinder c) (Name c) n)
+freshNameM hint = do
+  scope    <- toScope <$> unsafeGetEnv
+  Distinct <- getDistinct
+  return $ withFresh hint scope \b -> Abs b (binderName b)
+{-# INLINE freshNameM #-}

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -32,6 +32,7 @@ import Simplify
 import LabeledItems
 import qualified Algebra as A
 import Util (enumerate)
+import Core
 
 type AtomRecon = Abs (Nest (NameBinder AtomNameC)) Atom
 
@@ -625,7 +626,7 @@ getAllocInfo = DestM $ lift11 $ lift1 ask
 
 introduceNewPtr :: Mut n => NameHint -> PtrType -> Block n -> DestM n (AtomName n)
 introduceNewPtr hint ptrTy numel = do
-  Abs b v <- newNameM hint
+  Abs b v <- freshNameM hint
   let ptrInfo = DestPtrInfo ptrTy numel
   let emission = DestEmissions [ptrInfo] (Nest b Empty) Empty
   DestM $ StateT1 \s -> fmap (,s) $ extendInplaceT $ Abs emission v
@@ -729,7 +730,7 @@ instance EnvReader DestM where
 instance Builder DestM where
   emitDecl hint ann expr = do
     ty <- getType expr
-    Abs b v <- newNameM hint
+    Abs b v <- freshNameM hint
     let decl = Let b $ DeclBinding ann ty expr
     let emissions = DestEmissions [] Empty $ Nest decl Empty
     DestM $ StateT1 \s -> fmap (,s) $ extendInplaceT $ Abs emissions v

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -44,6 +44,7 @@ import Interpreter
 import LabeledItems
 import Err
 import Util
+import Core
 
 -- === Top-level interface ===
 
@@ -376,7 +377,7 @@ initInfOutMap bindings =
 
 emitInfererM :: Mut o => NameHint -> InfEmission o -> InfererM i o (AtomName o)
 emitInfererM hint emission = do
-  Abs b v <- newNameM hint
+  Abs b v <- freshNameM hint
   let frag = InfOutFrag (Nest (b :> emission) Empty) mempty emptySolverSubst
   InfererM $ SubstReaderT $ lift $ lift11 $ extendInplaceT $ Abs frag v
 
@@ -1830,7 +1831,7 @@ instance Solver SolverM where
     return $ zonkWithOutMap solverOutMap $ sink e
 
   emitSolver binding = do
-    Abs b v <- newNameM "?"
+    Abs b v <- freshNameM "?"
     let frag = SolverOutFrag (Nest (b:>binding) Empty) mempty emptySolverSubst
     SolverM $ extendInplaceT $ Abs frag v
 


### PR DESCRIPTION
refreshAbs is a very minimallistic approach to fresh names, but one that
comes at a cost if used improperly. So far we've been very lazy while
generating fresh names (and always ended up returning _the very same
name_) and relying on refreshAbs to update it. However, doing that often
means that we end up having to refresh other emitted expressions (e.g.
bindings) and that just ends up costing us unnecessarily. With this
patch we simply make sure to generate a fresh name right before the most
important Abs refreshments.

Overall this gives us an approximate 5% end-to-end speedup and saves us
~200MB of allocations on the kernel regression example.