### PR TITLE
Add more non-overlapping Dex compilation modes.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,8 @@ test-script.cd
 *.so
 *.egg-info
 .stack-work
+.stack-work-opt
+.stack-work-dbg
 .stack-work-prof
 garbage.hs
 *.lock


### PR DESCRIPTION
We already had two development make targets: one for the default build, and one for turning on the Haskell profiler.  This change renames the "Haskell profiler" build to "dbg", and adds two more: an "opt" build for building a development version of Dex with GHC optimizations on, and a new "prof" build tuned for profiling the Dex compiler.

We keep the builds from stepping on each other's compilation caches by keeping them in different .stack-work* directories.  This should make it relatively painless to switch between them.

It may be necessary to delete your ~/.stack/snapshots/ directory once after syncing past this change (axch@ was getting weird linking errors from stack until doing that).