### PR TITLE
Get superclasses from the given dict's type rather than trying all projections

### DIFF
--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -455,11 +455,6 @@ getLambdaDicts = do
   env <- withEnv moduleEnv
   return $ lambdaDicts $ envSynthCandidates env
 
-getSuperclassProjs :: EnvReader m => m n [Atom n]
-getSuperclassProjs = do
-  env <- withEnv moduleEnv
-  return $ superclassGetters $ envSynthCandidates env
-
 getInstanceDicts :: EnvReader m => DataDefName n -> m n [Atom n]
 getInstanceDicts name = do
   env <- withEnv moduleEnv

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -665,8 +665,7 @@ instance Pretty (Cache n) where
 
 instance Pretty (SynthCandidates n) where
   pretty scs =
-       "lambda dicts:"   <+> p (lambdaDicts       scs) <> hardline
-    <> "superclasses:"   <+> p (superclassGetters scs) <> hardline
+       "lambda dicts:"   <+> p (lambdaDicts scs) <> hardline
     <> "instance dicts:" <+> p (M.toList $ instanceDicts scs)
 
 instance Pretty (LoadedModules n) where

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -79,7 +79,7 @@ module Syntax (
     atomBindingType, getProjection,
     HasArgType (..), extendEffRow,
     bindingsFragToSynthCandidates,
-    getLambdaDicts, getSuperclassProjs, getInstanceDicts,
+    getLambdaDicts, getInstanceDicts,
     getAllowedEffects, withAllowedEffects, todoSinkableProof,
     freeAtomVarsList,
     IExpr (..), IBinder (..), IPrimOp, IVal, IType, Size, IFunType (..),

--- a/src/lib/Type.hs
+++ b/src/lib/Type.hs
@@ -261,10 +261,9 @@ instance CheckableE SourceMap where
   checkE sourceMap = substM sourceMap
 
 instance CheckableE SynthCandidates where
-  checkE (SynthCandidates xs ys zs) =
+  checkE (SynthCandidates xs ys) =
     SynthCandidates <$> mapM checkE xs
-                    <*> mapM checkE ys
-                    <*> (M.fromList <$> forM (M.toList zs) \(k, vs) ->
+                    <*> (M.fromList <$> forM (M.toList ys) \(k, vs) ->
                           (,) <$> substM k <*> mapM checkE vs)
 
 instance CheckableB (RecSubstFrag Binding) where


### PR DESCRIPTION
We were doing a very silly thing in dictionary synthesis. When we first
implemented type classes we wrote superclass projections by hand. To obtain the
superclasses for a particular given, we would try to apply every superclass
projection available, almost all of which would fail to type check. Maybe that
made sense at the time, but it's completely ridiculous now. A dictionary's
superclasses are now plainly described in the dictionary's type.

This speeds up prelude evaluation by 25%.

I had to special-case the `AccumMonoid` dictionary because we still define that
one by hand, so its representation isn't like the others.