### PR TITLE
Replace local instances with explicit dictionary projection/creation/application

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -492,19 +492,21 @@ def (:=) {h s} (ref:Ref h s) (x:s) : {State h} Unit = %put  ref x
 
 def ask  {h r} (ref:Ref h r)       : {Read  h} r    = %ask  ref
 
-data AccumMonoid h w =
-  UnsafeMkAccumMonoid b:Type (Monoid b)
+data AccumMonoidData h w =
+  UnsafeMkAccumMonoidData b:Type (Monoid b)
 
-@instance
-def tableAccumMonoid {n h w} [Ix n] [am : AccumMonoid h w] : AccumMonoid h (n=>w) =
-  (UnsafeMkAccumMonoid b bm) = am
-  UnsafeMkAccumMonoid b bm
+interface AccumMonoid h w
+  getAccumMonoidData : AccumMonoidData h w
+
+instance {n h w} [Ix n] [am : AccumMonoid h w] AccumMonoid h (n=>w)
+  getAccumMonoidData =
+    (UnsafeMkAccumMonoidData b bm) = %projMethod am ##getAccumMonoidData
+    UnsafeMkAccumMonoidData b bm
 
 def (+=) {h w} [am:AccumMonoid h w] (ref:Ref h w) (x:w) : {Accum h} Unit =
-  (UnsafeMkAccumMonoid b bm) = am
-  %instance bmHint = bm
-  empty : b = mempty
-  combine : b -> b -> b = mcombine
+  (UnsafeMkAccumMonoidData b bm) = %projMethod am ##getAccumMonoidData
+  empty = %projMethod bm ##mempty
+  combine = %projMethod bm ##mcombine
   %mextend ref empty combine x
 
 def (!) {h n a} (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
@@ -534,15 +536,15 @@ def run_accum
       (bm:Monoid b)
       (action: (h:Type ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} (a & w) =
-    -- Normally, only the ?=> lambda binders participate in dictionary synthesis,
-    -- so we need to explicitly declare `m` as a hint.
-    %instance bmHint = bm
-    empty : b = mempty
-    combine : b -> b -> b = mcombine
-    def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a =
-      %instance accumBaseMonoidHint : AccumMonoid h' b = UnsafeMkAccumMonoid b bm
-      action ref
-    %runWriter empty combine explicitAction
+  empty = %projMethod bm ##mempty
+  combine = %projMethod bm ##mcombine
+  def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a =
+    accumMonoidData : (AccumMonoidData h' w) = UnsafeMkAccumMonoidData b bm
+    accumBaseMonoid = %explicitDict (AccumMonoid h' b) accumMonoidData
+    accumBaseMonoidLifted = %explicitApply (%explicitApply mlift h') accumBaseMonoid
+    action' = %explicitApply (%explicitApply action h') accumBaseMonoidLifted
+    action' ref
+  %runWriter empty combine explicitAction
 
 def yieldAccum
       {a b w eff}

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -1434,6 +1434,9 @@ builtinNames = M.fromList
   , ("dataConTag", OpExpr $ DataConTag ())
   , ("toEnum"    , OpExpr $ ToEnum () ())
   , ("outputStreamPtr", OpExpr $ OutputStreamPtr)
+  , ("projMethod", OpExpr $ ProjMethod () ())
+  , ("explicitDict", OpExpr $ ExplicitDict () ())
+  , ("explicitApply", OpExpr $ ExplicitApply () ())
   ]
   where
     vbinOp op = OpExpr $ VectorBinOp op () ()

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -521,6 +521,16 @@ simplifyOp op = case op of
   ScalarBinOp (ICmp Less ) x y -> ilt x y
   ScalarBinOp (ICmp Equal) x y -> ieq x y
   Select c x y -> select c x y
+  ProjMethod dict methodName -> do
+    Con (LabelCon methodName') <- return methodName
+    lookupSourceMap methodName' >>= \case
+      Just (UMethodVar  v') -> lookupEnv v' >>= \case
+        MethodBinding _ i _ -> do
+          return $ getProjection [i,1,0] dict
+      _ -> throw TypeErr "Not a method name"
+  ExplicitDict dictTy method -> do
+    TypeCon sourceName name params <- return dictTy
+    return $ DataCon sourceName name params 0 [PairVal (ProdVal []) (ProdVal [method])]
   _ -> emitOp op
 
 simplifyHof :: Emits o => Hof i -> SimplifyM i o (Atom o)

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -230,6 +230,9 @@ transposeOp op ct = case op of
   ThrowException _      -> notLinear
   OutputStreamPtr       -> notLinear
   SynthesizeDict _ _    -> notLinear
+  ProjMethod _ _        -> notLinear
+  ExplicitDict _ _      -> notLinear
+  ExplicitApply _ _     -> notLinear
   where notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
 
 transposeAtom :: HasCallStack => Emits o => Atom i -> Atom o -> TransposeM i o ()

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -140,6 +140,10 @@ data PrimOp e =
       -- Pointer to the stdout-like output stream
       | OutputStreamPtr
       | SynthesizeDict SrcPosCtx e  -- Only used during type inference
+      | ProjMethod e e  -- project a method, by source name, from the dict
+      -- Used in prelude for `run_accum`. Only works for single-method classes.
+      | ExplicitDict e e  -- dict type, dict method
+      | ExplicitApply e e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 traversePrimOp :: Applicative f => (e -> f e') -> PrimOp e -> f (PrimOp e')


### PR DESCRIPTION
We only used local instances in `run_accum`, where we're playing tricky rank-2
games with `AccumMonoid`. We can do the same thing with some privileged
primitives for working with dictionaries directly.