### PR TITLE
Use a CPS-style writer for dest accumulation in InplaceT

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -314,7 +314,7 @@ liftEmitBuilder :: (Builder m, SinkableE e, SubstE Name e)
 liftEmitBuilder cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
-  let (result, decls, _) = runHardFail $ unsafeRunInplaceT (runBuilderT' cont) env
+  let (result, decls, _) = runHardFail $ unsafeRunInplaceT (runBuilderT' cont) env emptyOutFrag
   Emits <- fabricateEmitsEvidenceM
   emitDecls (unsafeCoerceB decls) result
 

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -2499,12 +2499,14 @@ instance (Monad m, ExtOutMap InfOutMap decls)
 
 instance (Monad m, ExtOutMap InfOutMap decls)
          => EnvExtender (InplaceT InfOutMap decls m) where
-  refreshAbs ab cont = UnsafeMakeInplaceT \env ->
+  refreshAbs ab cont = UnsafeMakeInplaceT \env decls ->
     refreshAbsPure (toScope env) ab \_ b e -> do
-      let env' = extendOutMap env $ toEnvFrag b
-      (ans, decls, _) <- unsafeRunInplaceT (cont b e) env'
+      let subenv = extendOutMap env $ toEnvFrag b
+      (ans, d, _) <- unsafeRunInplaceT (cont b e) subenv emptyOutFrag
       case fabricateDistinctEvidence @UnsafeS of
-        Distinct -> return (ans, decls, extendOutMap (unsafeCoerceE env) decls)
+        Distinct -> do
+          let env' = extendOutMap (unsafeCoerceE env) d
+          return (ans, catOutFrags (toScope env') decls d, env')
 
 instance BindsEnv InfOutFrag where
   toEnvFrag (InfOutFrag frag _ _) = toEnvFrag frag


### PR DESCRIPTION
Writer-style accumulation turns out to be really annoying. It produces
weird associations of mconcat and any trivial monadic action causes the
bind to extend with mempty (which is obviously a no-op). This changes
InplaceT --- one of our most fundamental monads --- to use a CPS-style:
instead of being a writer in decls (`env -> (a, decls, env)`) it is now a
stateful operation in decls (`env -> decls -> (a, decls, env)`).

This does not have a dramatic effect on the run-time (~3%?), but it does
reduce the number of total allocations by 10%.