### PR TITLE
Fix #833 with Dougal.

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -57,7 +57,7 @@ import qualified Data.Set        as S
 import qualified Data.Map.Strict as M
 import Data.Functor ((<&>))
 import Data.Graph (graphFromEdges, topSort)
-import Data.Text.Prettyprint.Doc (Pretty (..))
+import Data.Text.Prettyprint.Doc (Pretty (..), line, (<+>))
 import GHC.Stack
 
 import qualified Unsafe.Coerce as TrulyUnsafe
@@ -426,7 +426,10 @@ buildBlock cont = do
     ty <- {-# SCC blockTypeNormalization #-} cheapNormalize =<< getType result
     return $ result `PairE` ty
   let (result `PairE` ty) = results
-  ty' <- liftHoistExcept $ hoist decls ty
+  let msg = "Decls:" <+> line <> pretty decls <> line
+            <> "Result:" <+> line <> pretty result <> line
+            <> "Of type:" <+> line <> pretty ty
+  ty' <- liftHoistExcept' (docAsStr msg) $ hoist decls ty
   Abs decls' result' <- return $ inlineLastDecl decls $ Atom result
   return $ Block (BlockAnn ty') decls' result'
 
@@ -1404,8 +1407,10 @@ localVars b e = nameSetToList $
 
 instance GenericE ReconstructAtom where
   type RepE ReconstructAtom = EitherE UnitE (NaryAbs AtomNameC Atom)
-  toE = undefined
-  fromE = undefined
+  fromE IdentityRecon = LeftE UnitE
+  fromE (LamRecon recon) = RightE recon
+  toE (LeftE _) = IdentityRecon
+  toE (RightE recon) = LamRecon recon
 
 instance SinkableE   ReconstructAtom
 instance HoistableE  ReconstructAtom

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -62,7 +62,7 @@ module Name (
   InFrag (..), InMap (..), OutFrag (..), OutMap (..), ExtOutMap (..),
   toSubstPairs, fromSubstPairs, SubstPair (..),
   hoist, hoistToTop, sinkFromTop, fromConstAbs, exchangeBs, HoistableE (..),
-  HoistExcept (..), liftHoistExcept, abstractFreeVars, abstractFreeVar,
+  HoistExcept (..), liftHoistExcept', liftHoistExcept, abstractFreeVars, abstractFreeVar,
   abstractFreeVarsNoAnn,
   WithRenamer (..), ignoreHoistFailure,
   HoistableB (..), HoistableV, withScopeFromFreeVars, canonicalizeForPrinting,
@@ -2536,6 +2536,11 @@ canonicalizeForPrinting e cont =
 liftHoistExcept :: Fallible m => HoistExcept a -> m a
 liftHoistExcept (HoistSuccess x) = return x
 liftHoistExcept (HoistFailure vs) = throw EscapedNameErr (pprint vs)
+
+liftHoistExcept' :: Fallible m => String -> HoistExcept a -> m a
+liftHoistExcept' _ (HoistSuccess x) = return x
+liftHoistExcept' msg (HoistFailure vs) =
+  throw EscapedNameErr $ (pprint vs) ++ "\n" ++ msg
 
 ignoreHoistFailure :: HasCallStack => HoistExcept a -> a
 ignoreHoistFailure (HoistSuccess x) = x

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -75,7 +75,7 @@ data SimplifiedBlock n = SimplifiedBlock (Block n) (ReconstructAtom n)
 -- accessible as nullary functions)
 simplifyTopBlock :: EnvReader m => Block n -> m n (SimplifiedBlock n)
 simplifyTopBlock block = liftSimplifyM do
-  (Abs UnitB block', recon) <- simplifyAbs $ Abs UnitB block
+  (Abs UnitB block', Abs UnitB recon) <- simplifyAbs $ Abs UnitB block
   return $ SimplifiedBlock block' recon
 {-# SCC simplifyTopBlock #-}
 
@@ -294,7 +294,7 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
     -- TODO(subst): Use EnvReaderI to getType before subst
     substM atom >>= getType >>= isData >>= \case
       True -> do
-        (Abs b' body', IdentityRecon) <- simplifyAbs $ Abs b body
+        (Abs b' body', IdentityReconAbs) <- simplifyAbs $ Abs b body
         return $ TabLam $ TabLamExpr b' body'
       False -> substM atom
   -- We don't simplify body of lam because we'll beta-reduce it soon.
@@ -359,26 +359,31 @@ simplifyVar v = do
         LetBound (DeclBinding _ _ (Atom x)) -> dropSubst $ simplifyAtom x
         _ -> return $ Var v'
 
-simplifyLam :: Atom i -> SimplifyM i o (Atom o, ReconstructAtom o)
+simplifyLam :: Atom i -> SimplifyM i o (Atom o, Abs LamBinder ReconstructAtom o)
 simplifyLam atom = case atom of
   Lam (LamExpr b body) -> doSimpLam b body
   _ -> substM atom >>= \case
     Lam (LamExpr b body) -> dropSubst $ doSimpLam b body
     _ -> error "Not a lambda expression"
   where
-    doSimpLam :: LamBinder i i' -> Block i' -> SimplifyM i o (Atom o, ReconstructAtom o)
+    doSimpLam :: LamBinder i i' -> Block i'
+      -> SimplifyM i o (Atom o, Abs LamBinder ReconstructAtom o)
     doSimpLam b body = do
       (Abs b' body', recon) <- simplifyAbs $ Abs b body
       return $! (Lam $ LamExpr b' body', recon)
 
-simplifyBinaryLam :: Emits o => Atom i -> SimplifyM i o (Atom o, ReconstructAtom o)
+type BinaryLamBinder = (PairB LamBinder LamBinder)
+
+simplifyBinaryLam :: Emits o => Atom i
+  -> SimplifyM i o (Atom o, Abs BinaryLamBinder ReconstructAtom o)
 simplifyBinaryLam atom = case atom of
   Lam (LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))) -> doSimpBinaryLam b1 b2 body
   _ -> substM atom >>= \case
     Lam (LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))) -> dropSubst $ doSimpBinaryLam b1 b2 body
     _ -> error "Not a binary lambda expression"
   where
-    doSimpBinaryLam :: LamBinder i i' -> LamBinder i' i'' -> Block i'' -> SimplifyM i o (Atom o, ReconstructAtom o)
+    doSimpBinaryLam :: LamBinder i i' -> LamBinder i' i'' -> Block i''
+      -> SimplifyM i o (Atom o, Abs BinaryLamBinder ReconstructAtom o)
     doSimpBinaryLam b1 b2 body = do
       (Abs (b1' `PairB` b2') body', recon) <- simplifyAbs $ Abs (b1 `PairB` b2) body
       let binaryLam' = Lam $ LamExpr b1' $ AtomicBlock $ Lam $ LamExpr b2' body'
@@ -422,7 +427,7 @@ splitDataComponents = \case
 
 simplifyAbs
   :: (BindsEnv b, SubstB Name b, SubstB AtomSubstVal b)
-  => Abs b Block i -> SimplifyM i o (Abs b Block o, ReconstructAtom o)
+  => Abs b Block i -> SimplifyM i o (Abs b Block o, Abs b ReconstructAtom o)
 simplifyAbs (Abs bs body) = fromPairE <$> do
   substBinders bs \bs' -> do
     ab <- buildScoped $ simplifyBlock body
@@ -430,15 +435,12 @@ simplifyAbs (Abs bs body) = fromPairE <$> do
       getType result >>= isData >>= \case
         True -> do
           block <- makeBlock decls $ Atom result
-          return $ PairE (Abs bs' block) IdentityRecon
+          return $ PairE (Abs bs' block) (Abs bs' IdentityRecon)
         False -> do
-          let locals = toScopeFrag bs' >>> toScopeFrag decls
-          -- TODO: this might be too cautious. The type only needs to be hoistable
-          -- above the delcs. In principle it can still mention vars from the lambda
-          -- binders.
+          let locals = toScopeFrag decls
           (newResult, newResultTy, reconAbs) <- telescopicCapture locals result
           let block = Block (BlockAnn $ sink newResultTy) decls (Atom newResult)
-          return $ PairE (Abs bs' block) (LamRecon reconAbs)
+          return $ PairE (Abs bs' block) (Abs bs' (LamRecon reconAbs))
 
 -- TODO: come up with a coherent strategy for ordering these various reductions
 simplifyOp :: Emits o => Op o -> SimplifyM i o (Atom o)
@@ -523,53 +525,64 @@ simplifyOp op = case op of
   Select c x y -> select c x y
   _ -> emitOp op
 
+pattern IdentityReconAbs :: Abs binder ReconstructAtom n
+pattern IdentityReconAbs <- Abs _ IdentityRecon
+
 simplifyHof :: Emits o => Hof i -> SimplifyM i o (Atom o)
 simplifyHof hof = case hof of
   For d lam@(Lam lamExpr) -> do
     ixTy <- substM $ argType lamExpr
-    (lam', recon) <- simplifyLam lam
+    (lam', Abs b recon) <- simplifyLam lam
     ans <- liftM Var $ emit $ Hof $ For d lam'
     case recon of
       IdentityRecon -> return ans
       LamRecon reconAbs ->
         buildTabLam "i" ixTy \i' -> do
           elt <- tabApp (sink ans) $ Var i'
-          applyReconAbs (sink reconAbs) elt
+          -- TODO Avoid substituting the body of `recon` twice (once
+          -- for `applySubst` and once for `applyReconAbs`).  Maybe
+          -- by making `applyReconAbs` run in a `SubstReader`?
+          reconAbs' <- applySubst (b @> i') reconAbs
+          applyReconAbs reconAbs' elt
   While body -> do
-    (lam', IdentityRecon) <- simplifyLam body
+    (lam', IdentityReconAbs) <- simplifyLam body
     liftM Var $ emit $ Hof $ While lam'
   RunReader r lam -> do
     r' <- simplifyAtom r
-    (lam', recon) <- simplifyBinaryLam lam
+    (lam', Abs b recon) <- simplifyBinaryLam lam
     ans <- emit $ Hof $ RunReader r' lam'
-    applyRecon recon $ Var ans
+    let recon' = ignoreHoistFailure $ hoist b recon
+    applyRecon recon' $ Var ans
   RunWriter (BaseMonoid e combine) lam -> do
     e' <- simplifyAtom e
-    (combine', IdentityRecon) <- simplifyBinaryLam combine
-    (lam', recon) <- simplifyBinaryLam lam
+    (combine', IdentityReconAbs) <- simplifyBinaryLam combine
+    (lam', Abs b recon) <- simplifyBinaryLam lam
     let hof' = Hof $ RunWriter (BaseMonoid e' combine') lam'
     (ans, w) <- fromPair =<< liftM Var (emit hof')
-    ans' <- applyRecon recon ans
+    let recon' = ignoreHoistFailure $ hoist b recon
+    ans' <- applyRecon recon' ans
     return $ PairVal ans' w
   RunState s lam -> do
     s' <- simplifyAtom s
-    (lam', recon) <- simplifyBinaryLam lam
+    (lam', Abs b recon) <- simplifyBinaryLam lam
     resultPair <- emit $ Hof $ RunState s' lam'
     (ans, sOut) <- fromPair $ Var resultPair
-    ans' <- applyRecon recon ans
+    let recon' = ignoreHoistFailure $ hoist b recon
+    ans' <- applyRecon recon' ans
     return $ PairVal ans' sOut
   RunIO lam -> do
-    (lam', recon) <- simplifyLam lam
+    (lam', Abs b recon) <- simplifyLam lam
     ans <- emit $ Hof $ RunIO lam'
-    applyRecon recon $ Var ans
+    let recon' = ignoreHoistFailure $ hoist b recon
+    applyRecon recon' $ Var ans
   Linearize lam -> do
-    (lam', IdentityRecon) <- simplifyLam lam
+    (lam', IdentityReconAbs) <- simplifyLam lam
     linearize lam'
   Transpose lam -> do
-    (lam', IdentityRecon) <- simplifyLam lam
+    (lam', IdentityReconAbs) <- simplifyLam lam
     transpose lam'
   CatchException lam -> do
-    (Lam (LamExpr b body), IdentityRecon) <- simplifyLam lam
+    (Lam (LamExpr b body), IdentityReconAbs) <- simplifyLam lam
     dropSubst $ extendSubst (b@>SubstVal UnitVal) $ exceptToMaybeBlock $ body
   _ -> error $ "not implemented: " ++ pprint hof
 
@@ -705,9 +718,9 @@ simplifiedIxInstance ty = do
     simplifyInstance = liftSimplifyM do
       Abs decls inst <- liftBuilder $ buildScoped $ getIxImpl $ sink ty
       simpAbs <- buildScoped $ simplifyDecls decls do
-        (s , IdentityRecon) <- simplifyLam $ ixSize inst
-        (to, IdentityRecon) <- simplifyLam $ toOrdinal inst
-        (fo, IdentityRecon) <- simplifyLam $ unsafeFromOrdinal inst
+        (s , IdentityReconAbs) <- simplifyLam $ ixSize inst
+        (to, IdentityReconAbs) <- simplifyLam $ toOrdinal inst
+        (fo, IdentityReconAbs) <- simplifyLam $ unsafeFromOrdinal inst
         return $! IxImpl{ ixSize = s, toOrdinal = to, unsafeFromOrdinal = fo }
       return $! case simpAbs of
         Abs simpDecls IxImpl{..} ->

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -366,6 +366,15 @@ def weakerInferenceReduction {n} (l : i:n=>(..i)=>Float) (j:n): Unit =
     ()
   ()
 
+-- Regression test for
+-- https://github.com/google-research/dex-lang/issues/833,
+-- simplification of a table of functions whose type mentions
+-- the table index.
+val = for i:(Fin 2). \(x:Float). for j:(..i). 1
+
+:t val
+> ((i:(Fin 2)) => Float32 -> (..i) => Int32)
+
 -- Tests for table
 
 a = [0, 1]


### PR DESCRIPTION
The root of the problem is that Dex used to capture lambda-bound
variables during defunctionalization; but that's actually too
conservative, because the argument (unlike anything from the enclosing
environment) will actually be available when the lambda is
reconstructed.

This change avoids doing that, so the return type of the lambda need
no longer be hoisted past its binder, and thereby doesn't trigger the
observed leak error.

Co-authored-by: @dougalm <d.maclaurin@gmail.com>