### PR TITLE
Fix bug 841, linearization of triangular table.

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1398,7 +1398,7 @@ localVarsAndTypeVars b e =
     varsViaType :: AtomName l -> m l [AtomName l]
     varsViaType v = do
       ty <- getType $ Var v
-      return $ nameSetToList $ freeVarsE ty
+      return $ localVars b ty
 
 localVars :: (Color c, BindsNames b, HoistableE e)
           => b n l -> e l -> [Name c l]

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -313,3 +313,12 @@ vec = [1.]
 
   check_deriv f 1.0
 > True
+
+-- Regression test for bug #841, linearization through triangular table
+func = \x:Float.
+  table = for i:(Fin 2). for j:(..i). x
+  tmp = (0 @ (Fin 2))
+  sum table.tmp
+
+snd (linearize func 1.0) 2.0
+> 2.


### PR DESCRIPTION
Defunctionalization is supposed to only capture local variables.  We
used to also be capturing all variables in the types of those local
variables, but we should only capture _local_ variables in the types
of local variables.

Not sure why exactly this come up during linearization of a function
with a local triangular table (such as the LU decomposition), but it
did.

Co-authored-by: @dougalm <dougalm@google.com>