### PR TITLE
Add another order of analytic sums to Algebra.hs.

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -99,10 +99,13 @@ sumMonoC lim (Abs b (ClampMonomial clamps m)) =
 sumMono :: PolyName n -> Abs PolyBinder Monomial n -> Polynomial n
 sumMono lim (Abs b (Monomial m)) = case lookup (binderName b) m of
   -- TODO: Implement the formula for arbitrary order polynomials
-  Nothing -> poly [(1, Monomial $ insert lim 1 c)]
-  Just 0  -> error "Each variable appearing in a monomial should have a positive power"
-  Just 1  -> poly [(1/2, Monomial $ insert lim 2 c), (-1/2, Monomial $ insert lim 1 c)]
-  _       -> error "Not implemented yet!"
+  Nothing  -> poly [(1, Monomial $ insert lim 1 c)]
+  Just 0   -> error "Each variable appearing in a monomial should have a positive power"
+  -- Summing exclusive of `lim`: Sum_{i=1}^{n-1} i = (n-1)n/2 = 1/2 n^2 - 1/2 n
+  Just 1   -> poly [(1/2, Monomial $ insert lim 2 c), (-1/2, Monomial $ insert lim 1 c)]
+  -- Summing exclusive of `lim`: Sum_{i=1}^{n-1} i^2 = (n-1)n(2n-1)/6 = 1/3 n^3 - 1/2 n^2 + 1/6 n
+  Just 2   -> poly [(1/3, Monomial $ insert lim 3 c), (-1/2, Monomial $ insert lim 2 c), (1/6, Monomial $ insert lim 1 c)]
+  (Just n) -> error $ "Triangular arrays of order " ++ show n ++ " not implemented yet!"
   where
     c = fromMonomial $ ignoreHoistFailure $ hoist b $  -- failure impossible
           Monomial $ delete (binderName b) m

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -27,3 +27,8 @@ v = [1., 2., 3., 4.]
 
 :p trace mat == (11. + 5. + 18. + 1.)
 > True
+
+-- Check that we can differentiate through LU decomposition
+-- This is a regression test for Issue #842.
+snd (linearize (\x. snd $ sign_and_log_determinant [[x]]) 1.0) 2.0
+> 2.


### PR DESCRIPTION
Also improve the error message, since it is (kind of) user-facing.

Fixes #842.

Co-authored-by: @dougalm <dougalm@google.com>