### PR TITLE
Make EitherE6 faster

### DIFF
--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -933,7 +933,6 @@ instance GenericE Atom where
       Case3 (ListE ptrsAndSizes `PairE` ab) -> BoxedRef (map fromPairE ptrsAndSizes) ab
       Case4 (lhs `PairE` rhs `PairE` ty) -> DepPairRef lhs rhs ty
       _ -> error "impossible"
-    _ -> error "impossible"
 
 instance SinkableE   Atom
 instance HoistableE  Atom
@@ -944,7 +943,7 @@ instance SubstE Name Atom
 -- TODO: special handling of ACase too
 instance SubstE AtomSubstVal Atom where
   substE (scope, env) atom = case fromE atom of
-    LeftE specialCase -> case specialCase of
+    Case0 specialCase -> case specialCase of
       -- Var
       Case0 v -> do
         case env ! v of
@@ -957,7 +956,11 @@ instance SubstE AtomSubstVal Atom where
                    Rename v''  -> Var v''
         getProjection (NE.toList idxs) v'
       _ -> error "impossible"
-    RightE rest -> (toE . RightE) $ substE (scope, env) rest
+    Case1 rest -> (toE . Case1) $ substE (scope, env) rest
+    Case2 rest -> (toE . Case2) $ substE (scope, env) rest
+    Case3 rest -> (toE . Case3) $ substE (scope, env) rest
+    Case4 rest -> (toE . Case4) $ substE (scope, env) rest
+    Case5 rest -> (toE . Case5) $ substE (scope, env) rest
 
 getProjection :: HasCallStack => [Int] -> Atom n -> Atom n
 getProjection [] a = a
@@ -1004,7 +1007,6 @@ instance GenericE Expr where
     Case3 (x)                               -> Atom x
     Case4 (ComposeE op)                     -> Op op
     Case5 (ComposeE hof)                    -> Hof hof
-    _ -> error "impossible"
 
 instance SinkableE Expr
 instance HoistableE  Expr


### PR DESCRIPTION
We use it all over the place in GenericE instances, but instead of being
a flat ADT it's actually a nest of binary sum types! To inject the last
case into the generic representation one has to allocate 6 extra
constructors, and that obviously adds up. Especially given that GHC is
currently unwilling to optimize out toE/fromE. And even when I try hard
to get it to simplify those away, GHC becomes very shy about inlining
things into very deep case statements.

So, overall it's a win all accross the board. If we simplify away
GenericE our code will be faster. And if we don't... it will still be
faster! With this change, we allocate On the kernel regression example we
allocate 15% less data overall, letting us save on 15% of gen-0 garbage
collections. It doesn't seem to translate to huge performance
improvements, but it does seem to let us get a percent or two
end-to-end.