### PR TITLE
Fix typo and move around SCC pragmas

### DIFF
--- a/makefile
+++ b/makefile
@@ -90,7 +90,7 @@ STACK_FLAGS := --ghc-options="-j +RTS -A256m -n2m -RTS"
 
 # CUDA
 ifneq (,$(wildcard /usr/local/cuda/include/cuda.h))
-STACK_FLAGS = $(STACK_FLAGS) --flag dex:cuda
+STACK_FLAGS := $(STACK_FLAGS) --flag dex:cuda
 CFLAGS := $(CFLAGS) -I/usr/local/cuda/include -DDEX_CUDA
 endif
 

--- a/src/lib/CUDA.hs
+++ b/src/lib/CUDA.hs
@@ -30,9 +30,11 @@ cuMemcpyDToH = error "Dex built without CUDA support"
 
 synchronizeCUDA :: IO ()
 synchronizeCUDA = return ()
+{-# SCC synchronizeCUDA #-}
 
 ensureHasCUDAContext :: IO ()
 ensureHasCUDAContext = return ()
+{-# SCC ensureHasCUDAContext #-}
 
 getCudaArchitecture :: Int -> IO String
 getCudaArchitecture _ = error "Dex built without CUDA support"
@@ -42,7 +44,4 @@ loadCUDAArray :: Ptr () -> Ptr () -> Int -> IO ()
 loadCUDAArray hostPtr devicePtr bytes = do
   ensureHasCUDAContext
   cuMemcpyDToH (fromIntegral bytes) devicePtr hostPtr
-
-{-# SCC synchronizeCUDA #-}
-{-# SCC ensureHasCUDAContext #-}
 {-# SCC loadCUDAArray #-}


### PR DESCRIPTION
These two errors occurred from `make install`:

> makefile:93: *** Recursive variable 'STACK_FLAGS' references itself (eventually).  Stop.

and

> .../dex-lang/src/lib/CUDA.hs:46:9: error:
    The SCC pragma for ‘synchronizeCUDA’ lacks an accompanying binding
      (The SCC pragma must be given where ‘synchronizeCUDA’ is declared)
   |                 
46 | {-# SCC synchronizeCUDA #-}