### PR TITLE
Don't use unhelpful name hints

### DIFF
--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -70,7 +70,7 @@ dexInsert ctxPtr namePtr atomPtr = do
   AtomEx atom <- fromStablePtr atomPtr
   (_, finalEnv) <- runTopperM evalConfig initEnv do
     -- TODO: Check if atom is compatible with context! Use module name?
-    name <- emitTopLet (fromString sourceName) PlainLet $ Atom $ unsafeCoerceE atom
+    name <- emitTopLet (getNameHint @String sourceName) PlainLet $ Atom $ unsafeCoerceE atom
     emitSourceMap $ SourceMap $ M.singleton sourceName [ModuleVar Main $ Just $ UAtomVar name]
   toStablePtr $ Context evalConfig finalEnv
 

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -480,14 +480,14 @@ buildNullaryLam :: ScopableBuilder m
                 => EffectRow n
                 -> (forall l. (Emits l, DExt n l) => m l (Atom l))
                 -> m n (Atom n)
-buildNullaryLam effs cont = buildLam "ignore" PlainArrow UnitTy effs \_ -> cont
+buildNullaryLam effs cont = buildLam noHint PlainArrow UnitTy effs \_ -> cont
 
 buildNullaryPi :: Builder m
                => EffectRow n
                -> (forall l. DExt n l => m l (Type l))
                -> m n (Type n)
 buildNullaryPi effs cont =
-  Pi <$> buildPi "ignore" PlainArrow UnitTy \_ -> do
+  Pi <$> buildPi noHint PlainArrow UnitTy \_ -> do
     resultTy <- cont
     return (sink effs, resultTy)
 
@@ -738,7 +738,7 @@ buildEffLam
   -> m n (Atom n)
 buildEffLam rws hint ty body = do
   eff <- getAllowedEffects
-  buildLam "h" PlainArrow TyKind Pure \h -> do
+  buildLam noHint PlainArrow TyKind Pure \h -> do
     let eff' = extendEffect (RWSEffect rws (Just h)) (sink eff)
     buildLam hint PlainArrow (RefTy (Var h) (sink ty)) eff' \ref ->
       body (sink h) ref
@@ -763,9 +763,9 @@ buildFor hint dir ty body = buildForAnn hint (RegularFor dir) ty body
 unzipTab :: (Emits n, Builder m) => Atom n -> m n (Atom n, Atom n)
 unzipTab tab = do
   TabTy b _ <- getType tab
-  fsts <- liftEmitBuilder $ buildTabLam "i" (binderType b) \i ->
+  fsts <- liftEmitBuilder $ buildTabLam noHint (binderType b) \i ->
             liftM fst $ tabApp (sink tab) (Var i) >>= fromPair
-  snds <- liftEmitBuilder $ buildTabLam "i" (binderType b) \i ->
+  snds <- liftEmitBuilder $ buildTabLam noHint (binderType b) \i ->
             liftM snd $ tabApp (sink tab) (Var i) >>= fromPair
   return (fsts, snds)
 
@@ -856,7 +856,7 @@ maybeTangentType ty = case ty of
 tangentBaseMonoidFor :: Builder m => Type n -> m n (BaseMonoid n)
 tangentBaseMonoidFor ty = do
   zero <- zeroAt ty
-  adder <- liftEmitBuilder $ buildLam "t" PlainArrow ty Pure \v -> updateAddAt $ Var v
+  adder <- liftEmitBuilder $ buildLam noHint PlainArrow ty Pure \v -> updateAddAt $ Var v
   return $ BaseMonoid zero adder
 
 addTangent :: (Emits n, Builder m) => Atom n -> Atom n -> m n (Atom n)
@@ -881,13 +881,13 @@ addTangent x y = do
 updateAddAt :: (Emits n, Builder m) => Atom n -> m n (Atom n)
 updateAddAt x = liftEmitBuilder do
   ty <- getType x
-  buildLam "t" PlainArrow ty Pure \v -> addTangent (sink x) (Var v)
+  buildLam noHint PlainArrow ty Pure \v -> addTangent (sink x) (Var v)
 
 -- === builder versions of common top-level emissions ===
 
 litValToPointerlessAtom :: (Mut n, TopBuilder m) => LitVal -> m n (Atom n)
 litValToPointerlessAtom litval = case litval of
-  PtrLit val -> Var <$> emitPtrLit "ptr" val
+  PtrLit val -> Var <$> emitPtrLit (getNameHint @String "ptr") val
   VecLit _ -> error "not implemented"
   _ -> return $ Con $ Lit litval
 
@@ -937,7 +937,7 @@ makeMethodGetter classDefName explicit methodIdx = liftBuilder do
   let arrows = explicit <&> \case True -> PlainArrow; False -> ImplicitArrow
   buildPureNaryLam (EmptyAbs $ zipPiBinders arrows paramBs) \params -> do
     defName' <- sinkM defName
-    buildPureLam "dict" ClassArrow (TypeCon sourceName defName' (map Var params)) \dict ->
+    buildPureLam noHint ClassArrow (TypeCon sourceName defName' (map Var params)) \dict ->
       return $ getProjection [methodIdx] $ getProjection [1, 0] $ Var dict
 
 emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> Atom n -> m n (Name TyConNameC n)
@@ -1091,7 +1091,7 @@ ptrOffset x i = emitOp $ PtrOffset x i
 
 unsafePtrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 unsafePtrLoad x = do
-  lam <- liftEmitBuilder $ buildLam "_ign" PlainArrow UnitTy (oneEffect IOEffect) \_ ->
+  lam <- liftEmitBuilder $ buildLam noHint PlainArrow UnitTy (oneEffect IOEffect) \_ ->
     ptrLoad =<< sinkM x
   liftM Var $ emit $ Hof $ RunIO $ lam
 
@@ -1106,7 +1106,7 @@ liftMonoidEmpty accTy x = do
     True -> return x
     False -> case accTy of
       TabTy b eltTy -> do
-        liftEmitBuilder $ buildTabLam "i" (binderType b) \i -> do
+        liftEmitBuilder $ buildTabLam noHint (binderType b) \i -> do
           x' <- sinkM x
           ab <- sinkM $ Abs b eltTy
           eltTy' <- applyAbs ab i
@@ -1124,7 +1124,7 @@ liftMonoidCombine accTy bc x y = do
     True -> naryApp bc [x, y]
     False -> case accTy of
       TabTy b eltTy -> do
-        liftEmitBuilder $ buildFor "i" Fwd (binderType b) \i -> do
+        liftEmitBuilder $ buildFor noHint Fwd (binderType b) \i -> do
           xElt <- tabApp (sink x) (Var i)
           yElt <- tabApp (sink y) (Var i)
           eltTy' <- applySubst (b@>i) eltTy
@@ -1217,16 +1217,16 @@ reduceE :: (Emits n, Builder m) => BaseMonoid n -> Atom n -> m n (Atom n)
 reduceE monoid xs = liftEmitBuilder do
   TabTy n a <- getType xs
   a' <- return $ ignoreHoistFailure $ hoist n a
-  getSnd =<< emitRunWriter "ref" a' monoid \_ ref ->
-    buildFor "i" Fwd (sink $ binderType n) \i -> do
+  getSnd =<< emitRunWriter noHint a' monoid \_ ref ->
+    buildFor noHint Fwd (sink $ binderType n) \i -> do
       x <- tabApp (sink xs) (Var i)
       emitOp $ PrimEffect (sink $ Var ref) $ MExtend (fmap sink monoid) x
 
 andMonoid :: EnvReader m => m n (BaseMonoid n)
 andMonoid =  liftM (BaseMonoid TrueAtom) do
   liftBuilder $
-    buildLam "_" PlainArrow BoolTy Pure \x ->
-      buildLam "_" PlainArrow BoolTy Pure \y -> do
+    buildLam noHint PlainArrow BoolTy Pure \x ->
+      buildLam noHint PlainArrow BoolTy Pure \y -> do
         emitOp $ ScalarBinOp BAnd (sink $ Var x) (Var y)
 
 -- (a-> {|eff} b) -> n=>a -> {|eff} (n=>b)
@@ -1276,7 +1276,7 @@ runMaybeWhile :: (Emits n, ScopableBuilder m)
               => (forall l. (Emits l, DExt n l) => m l (Atom l))
               -> m n (Atom n)
 runMaybeWhile body = do
-  hadError <- getSnd =<< emitRunState "ref" FalseAtom \_ ref -> do
+  hadError <- getSnd =<< emitRunState noHint FalseAtom \_ ref -> do
     emitWhile do
       ans <- body
       emitMaybeCase ans Word8Ty

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -56,7 +56,7 @@ toImpStandaloneFunction' :: NaryLamExpr o -> SubstImpM i o (ImpFunction o)
 toImpStandaloneFunction' lam@(NaryLamExpr bs Pure body) = do
   ty <- naryLamExprType lam
   AbsPtrs (Abs ptrBinders argResultDest) ptrsInfo <- makeNaryLamDest ty
-  let ptrHintTys = [("ptr"::NameHint, PtrType baseTy) | DestPtrInfo baseTy _ <- ptrsInfo]
+  let ptrHintTys = [(noHint, PtrType baseTy) | DestPtrInfo baseTy _ <- ptrsInfo]
   dropSubst $ buildImpFunction CInternalFun ptrHintTys \vs -> do
     argResultDest' <- applySubst (ptrBinders@@>vs) argResultDest
     (args, resultDest) <- loadArgDests argResultDest'
@@ -80,7 +80,7 @@ toImpExportedFunction lam@(NaryLamExpr (NonEmptyNest fb tb) effs body) (Abs base
     -- In particular, every array has to be backend by a single pointer and pairs
     -- should be traversed left-to-right.
     AbsPtrs (Abs ptrBs' resDest') ptrInfo <- makeDest (LLVM, CPU, Unmanaged) resTy'
-    let ptrFormals = ptrInfo <&> \(DestPtrInfo bt _) -> ("res"::NameHint, PtrType bt)
+    let ptrFormals = ptrInfo <&> \(DestPtrInfo bt _) -> (noHint, PtrType bt)
     return (Abs tbs' (Abs ptrBs' resDest'), ptrFormals)
   let argFormals = nestToList ((noHint,) . iBinderType) baseArgBs
   dropSubst $ buildImpFunction CEntryFun (argFormals ++ ptrFormals) \argsAndPtrs -> do
@@ -869,7 +869,7 @@ makeDestRec idxs depVars ty = case ty of
       else do
         Distinct <- getDistinct
         idxsTy <- extendIdxsTy idxs iTy
-        Con <$> TabRef <$> buildTabLamDest "i" iTy \v -> do
+        Con <$> TabRef <$> buildTabLamDest noHint iTy \v -> do
           let newIdxVals = map sink (snd idxs) <> [v]
           bodyTy' <- applyAbs (sink $ Abs b bodyTy) v
           makeDestRec (sink idxsTy, newIdxVals) (map sink depVars) bodyTy'
@@ -939,7 +939,7 @@ makeBaseTypePtr (idxsTy, idxs) ty = do
   allocInfo <- getAllocInfo
   let addrSpace = chooseAddrSpace allocInfo numel
   let ptrTy = (addrSpace, ty)
-  ptr <- Var <$> introduceNewPtr "ptr" ptrTy numel
+  ptr <- Var <$> introduceNewPtr (getNameHint @String "ptr") ptrTy numel
   ptrOffset ptr offset
 
 copyAtom :: Emits n => Dest n -> Atom n -> SubstImpM i n ()
@@ -1011,7 +1011,7 @@ copyAtom topDest topSrc = copyRec topDest topSrc
       checkAlphaEq (binderType b) (binderType b')
       let idxTy = binderType b
       n <- indexSetSizeImp idxTy
-      emitLoop "i" Fwd n \i -> do
+      emitLoop noHint Fwd n \i -> do
         idx <- intToIndexImp (sink idxTy) i
         destIndexed <- destGet (sink dest) idx
         srcIndexed  <- dropSubst $ translateExpr Nothing (TabApp (sink src) (idx:|[]))

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -544,7 +544,7 @@ linearizeHof hof = case hof of
   RunIO (Lam (LamExpr b@(LamBinder _ _ _ effs) body)) -> do
     effs' <- substM $ ignoreHoistFailure $ hoist b effs
     -- TODO: consider the possibility of other effects here besides IO
-    ioLam <- buildLam "_" PlainArrow UnitTy effs' \v -> do
+    ioLam <- buildLam noHint PlainArrow UnitTy effs' \v -> do
       WithTangent primalResult tangentFun <- extendSubst (b@>v) $ linearizeBlock body
       lam <- tangentFunAsLambda tangentFun
       return $ PairVal primalResult lam

--- a/src/lib/RawName.hs
+++ b/src/lib/RawName.hs
@@ -23,7 +23,6 @@ import Data.Char
 import Data.Bits
 import Data.Coerce
 import Data.Store
-import Data.String
 import Data.Text.Prettyprint.Doc  hiding (nest)
 import GHC.Generics (Generic)
 
@@ -149,23 +148,23 @@ instance HasNameHint RawName where
   getNameHint (RawName name) = NameHint name
 
 instance HasNameHint String where
-  getNameHint = fromString
+  getNameHint = hintFromString
 
-instance IsString NameHint where
-  fromString s = NameHint $ goFromString (nameRepBits - 8) zeroBits s'
-    where
-      s' = case s of [] -> "v"; _ -> s
+hintFromString :: String -> NameHint
+hintFromString s = NameHint $ goFromString (nameRepBits - 8) zeroBits s'
+  where
+    s' = case s of [] -> "v"; _ -> s
 
-      goFromString :: Int -> NameRep -> String -> NameRep
-      goFromString !shft !hint str = case shft > 0 of
-        False -> hint
-        True  -> goFromString (shft - 8) hint' str'
-          where
-            (hBits, str') = case str of
-              []    -> (zeroBits, str)
-              (h:t) -> (fromEnum (if isNiceAscii h then h else '_') .|. 0x80, t)
-            hint' = hint .|. (hBits `shiftL` shft)
-            isNiceAscii h = isAsciiLower h || isAsciiUpper h || isDigit h
+    goFromString :: Int -> NameRep -> String -> NameRep
+    goFromString !shft !hint str = case shft > 0 of
+      False -> hint
+      True  -> goFromString (shft - 8) hint' str'
+        where
+          (hBits, str') = case str of
+            []    -> (zeroBits, str)
+            (h:t) -> (fromEnum (if isNiceAscii h then h else '_') .|. 0x80, t)
+          hint' = hint .|. (hBits `shiftL` shft)
+          isNiceAscii h = isAsciiLower h || isAsciiUpper h || isDigit h
 
 instance HasNameHint a => HasNameHint (Maybe a) where
   getNameHint (Just x) = getNameHint x

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -537,7 +537,7 @@ simplifyHof hof = case hof of
     case recon of
       IdentityRecon -> return ans
       LamRecon reconAbs ->
-        buildTabLam "i" ixTy \i' -> do
+        buildTabLam noHint ixTy \i' -> do
           elt <- tabApp (sink ans) $ Var i'
           -- TODO Avoid substituting the body of `recon` twice (once
           -- for `applySubst` and once for `applyReconAbs`).  Maybe
@@ -632,7 +632,7 @@ exceptToMaybeExpr expr = case expr of
   Hof (RunState s lam) -> do
     s' <- substM s
     Lam (BinaryLamExpr h ref body) <- return lam
-    result  <- emitRunState "ref" s' \h' ref' ->
+    result  <- emitRunState noHint s' \h' ref' ->
       extendSubst (h @> Rename h' <.> ref @> Rename ref') do
         exceptToMaybeBlock body
     (maybeAns, newState) <- fromPair result
@@ -645,7 +645,7 @@ exceptToMaybeExpr expr = case expr of
   Hof (RunWriter monoid (Lam (BinaryLamExpr h ref body))) -> do
     monoid' <- mapM substM monoid
     accumTy <- substM =<< (getReferentTy $ EmptyAbs $ PairB h ref)
-    result <- emitRunWriter "ref" accumTy monoid' \h' ref' ->
+    result <- emitRunWriter noHint accumTy monoid' \h' ref' ->
       extendSubst (h @> Rename h' <.> ref @> Rename ref') $
         exceptToMaybeBlock body
     (maybeAns, accumResult) <- fromPair result

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -403,17 +403,17 @@ instance HasNameHint (b n l) => HasNameHint (WithSrcB b n l) where
 
 instance HasNameHint (UPat' n l) where
   getNameHint (UPatBinder b) = getNameHint b
-  getNameHint _ = "pat"
+  getNameHint _ = noHint
 
 instance HasNameHint ModuleSourceName where
   getNameHint (OrdinaryModule name) = getNameHint name
-  getNameHint Prelude = "prelude"
-  getNameHint Main = "main"
+  getNameHint Prelude = getNameHint @String "prelude"
+  getNameHint Main = getNameHint @String "main"
 
 instance Color c => HasNameHint (UBinder c n l) where
   getNameHint b = case b of
     UBindSource v -> getNameHint v
-    UIgnore       -> fromString "_ign"
+    UIgnore       -> noHint
     UBind v _     -> getNameHint v
 
 instance Color c => BindsNames (UBinder c) where

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -216,7 +216,7 @@ def catLists {a} (xs:List a) (ys:List a) : List a =
 def listToTable {a} ((AsList n xs): List a) : (Fin n)=>a = xs
 
 :t listToTable
-> ((a:Type) ?-> (pat:(List a)) -> (Fin (ProjectElt [0] pat)) => a)
+> ((a:Type) ?-> (v#0:(List a)) -> (Fin (ProjectElt [0] v#0)) => a)
 
 :p
   l = AsList _ [1, 2, 3]

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -373,7 +373,7 @@ def weakerInferenceReduction {n} (l : i:n=>(..i)=>Float) (j:n): Unit =
 val = for i:(Fin 2). \(x:Float). for j:(..i). 1
 
 :t val
-> ((i:(Fin 2)) => Float32 -> (..i) => Int32)
+> ((v#0:(Fin 2)) => Float32 -> (..v#0) => Int32)
 
 -- Tests for table
 
@@ -409,9 +409,9 @@ def mkEmpty (a:Type) : (Fin 0)=>a = []
 > ((Fin 1 & Fin 2) => Float32)
 
 :t [[0.0], [1.0, 2.0]] : i:(Fin 2)=>(..i)=>Float
-> ((i:(Fin 2)) => (..i) => Float32)
+> ((v#0:(Fin 2)) => (..v#0) => Float32)
 :t [[[0.0, 1.0]], [[2.0, 3.0], [4.0, 5.0]]] : i:(Fin 2)=>(..i)=>(Fin 2)=>Float
-> ((i:(Fin 2)) => (..i) => (Fin 2) => Float32)
+> ((v#0:(Fin 2)) => (..v#0) => (Fin 2) => Float32)
 
 def uncurryTable {a} (x : ((Fin 2) & (Fin 2))=>a) : (Fin 2)=>(Fin 2)=>a =
   for i j. x.(i, j)


### PR DESCRIPTION
Stringy name hints are useful when trying to preserve some association
of iternal names to source names, but we often ended up creating names
from strings such as `"_ign"`. String names are slightly slower than
integer names, so this change removes all such occurrences.