### PR TITLE
Make sure GenericE methods are inlined

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -320,7 +320,9 @@ emitPolyName v = do
 instance GenericE Monomial where
   type RepE Monomial = ListE (PairE PolyName (LiftE Int))
   fromE (Monomial m) = ListE $ toList m <&> \(v, n) -> PairE v (LiftE n)
+  {-# INLINE fromE #-}
   toE (ListE pairs) = Monomial $ fromList $ pairs <&> \(PairE v (LiftE n)) -> (v, n)
+  {-# INLINE toE #-}
 
 instance SinkableE  Monomial
 instance HoistableE Monomial
@@ -329,7 +331,9 @@ instance AlphaEqE   Monomial
 instance GenericE ClampMonomial where
   type RepE ClampMonomial = PairE (ListE Clamp) Monomial
   fromE (ClampMonomial clamps m) = PairE (ListE clamps) m
+  {-# INLINE fromE #-}
   toE   (PairE (ListE clamps) m) = ClampMonomial clamps m
+  {-# INLINE toE #-}
 
 instance SinkableE  ClampMonomial
 instance HoistableE ClampMonomial
@@ -338,7 +342,9 @@ instance AlphaEqE   ClampMonomial
 instance OrdE mono => GenericE (PolynomialP mono) where
   type RepE (PolynomialP mono) = ListE (PairE mono (LiftE Constant))
   fromE (Polynomial m) = ListE $ toList m <&> \(x, n) -> PairE x (LiftE n)
+  {-# INLINE fromE #-}
   toE (ListE pairs) = Polynomial $ fromList $ pairs <&> \(PairE x (LiftE n)) -> (x, n)
+  {-# INLINE toE #-}
 
 instance (OrdE mono, SinkableE  mono) => SinkableE  (PolynomialP mono)
 instance (OrdE mono, HoistableE mono) => HoistableE (PolynomialP mono)

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1136,10 +1136,14 @@ clampPositive x = do
   select isNegative (IdxRepVal 0) x
 
 data IxImpl n = IxImpl { ixSize :: Atom n, toOrdinal :: Atom n, unsafeFromOrdinal :: Atom n }
+
 instance GenericE IxImpl where
   type RepE IxImpl = Atom `PairE` Atom `PairE` Atom
   fromE IxImpl{..} = ixSize `PairE` toOrdinal `PairE` unsafeFromOrdinal
+  {-# INLINE fromE #-}
   toE (ixSize `PairE` toOrdinal `PairE` unsafeFromOrdinal) = IxImpl{..}
+  {-# INLINE toE #-}
+
 instance SinkableE IxImpl
 
 getIxImpl :: (Builder m, Emits n) => Type n -> m n (IxImpl n)

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -170,9 +170,11 @@ instance GenericE ExportType where
   fromE = \case
     ScalarType sbt   -> LeftE $ LiftE sbt
     RectContArrayPtr sbt shape -> RightE $ LiftE sbt `PairE` shapeToE shape
+  {-# INLINE fromE #-}
   toE = \case
     LeftE (LiftE sbt) -> ScalarType sbt
     RightE (LiftE sbt `PairE` shape) -> RectContArrayPtr sbt (shapeFromE shape)
+  {-# INLINE toE #-}
 instance SubstE    Name ExportType
 instance SinkableE      ExportType
 

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -115,7 +115,9 @@ data ImpFunctionWithRecon n = ImpFunctionWithRecon (ImpFunction n) (AtomRecon n)
 instance GenericE ImpFunctionWithRecon where
   type RepE ImpFunctionWithRecon = PairE ImpFunction AtomRecon
   fromE (ImpFunctionWithRecon fun recon) = PairE fun recon
+  {-# INLINE fromE #-}
   toE   (PairE fun recon) = ImpFunctionWithRecon fun recon
+  {-# INLINE toE #-}
 
 instance SinkableE ImpFunctionWithRecon
 instance SubstE Name ImpFunctionWithRecon

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -219,7 +219,9 @@ newtype Defaults (n::S) = Defaults [(Atom n, Atom VoidS)]
 instance GenericE Defaults where
   type RepE Defaults = ListE (PairE Atom (LiftE (Atom VoidS)))
   fromE (Defaults xys) = ListE [PairE x (LiftE y) | (x, y) <- xys]
+  {-# INLINE fromE #-}
   toE (ListE xys) = Defaults [(x, y) | PairE x (LiftE y) <- xys]
+  {-# INLINE toE #-}
 
 instance SinkableE         Defaults
 instance SubstE Name         Defaults
@@ -331,10 +333,12 @@ instance GenericE RequiredIfaces where
   fromE = \case
     FailIfRequired    -> NothingE
     GatherRequired ds -> JustE ds
+  {-# INLINE fromE #-}
   toE = \case
     NothingE  -> FailIfRequired
     JustE ds  -> GatherRequired ds
     _ -> error "unreachable"
+  {-# INLINE toE #-}
 instance SinkableE RequiredIfaces
 instance SubstE Name RequiredIfaces
 instance HoistableE  RequiredIfaces
@@ -1914,7 +1918,9 @@ instance GenericE SolverSubst where
   -- XXX: this is a bit sketchy because it's not actually bijective...
   type RepE SolverSubst = ListE (PairE AtomName Type)
   fromE (SolverSubst m) = ListE $ map (uncurry PairE) $ M.toList m
+  {-# INLINE fromE #-}
   toE (ListE pairs) = SolverSubst $ M.fromList $ map fromPairE pairs
+  {-# INLINE toE #-}
 
 instance SinkableE SolverSubst where
 instance SubstE Name SolverSubst where
@@ -2333,9 +2339,11 @@ instantiateDictParamsRec monoTy polyTy = case polyTy of
     return ([], [])
 
 instance GenericE Givens where
-  type RepE Givens = ListE (PairE (EKey Type) Given)
-  fromE (Givens m) = ListE $ map (uncurry PairE) $ HM.toList m
-  toE   (ListE pairs) = Givens $ HM.fromList $ map fromPairE pairs
+  type RepE Givens = HashMapE (EKey Type) Given
+  fromE (Givens m) = HashMapE m
+  {-# INLINE fromE #-}
+  toE (HashMapE m) = Givens m
+  {-# INLINE toE #-}
 
 instance SinkableE Givens where
 

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -592,7 +592,9 @@ notImplemented = error "Not implemented"
 instance GenericE ActivePrimals where
   type RepE ActivePrimals = PairE (ListE AtomName) EffectRow
   fromE (ActivePrimals vs effs) = ListE vs `PairE` effs
+  {-# INLINE fromE #-}
   toE   (ListE vs `PairE` effs) = ActivePrimals vs effs
+  {-# INLINE toE #-}
 
 instance SinkableE   ActivePrimals
 instance HoistableE  ActivePrimals
@@ -602,7 +604,9 @@ instance SubstE Name ActivePrimals
 instance GenericE TangentArgs where
   type RepE TangentArgs = ListE AtomName
   fromE (TangentArgs vs) = ListE vs
+  {-# INLINE fromE #-}
   toE   (ListE vs) = TangentArgs vs
+  {-# INLINE toE #-}
 
 instance SinkableE   TangentArgs
 instance HoistableE  TangentArgs

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1212,7 +1212,9 @@ newtype EKey (e::E) (n::S) = EKey { fromEKey :: e n }
 instance GenericE (EKey e) where
   type RepE (EKey e) = e
   fromE (EKey e) = e
+  {-# INLINE fromE #-}
   toE e = EKey e
+  {-# INLINE toE #-}
 
 -- We can do alpha-invariant equality checking without a scope at hand. It's
 -- slower (because we have to query the free vars of both expressions) and its
@@ -1272,7 +1274,9 @@ instance (AlphaEqE k, AlphaHashableE k, HoistableE k)
          => GenericE (EMap k v) where
   type RepE (EMap k v) = ListE (PairE k v)
   fromE m = ListE $ map (uncurry PairE) $ eMapToList m
+  {-# INLINE fromE #-}
   toE (ListE pairs) = eMapFromList $ map fromPairE pairs
+  {-# INLINE toE #-}
 
 instance (AlphaEqE   k, AlphaHashableE k, HoistableE k, SubstE sv k, SubstE sv v) => SubstE sv (EMap k v)
 instance (AlphaEqE   k, AlphaHashableE k, HoistableE k, SinkableE  k, SinkableE  v) => SinkableE  (EMap k v)
@@ -2022,7 +2026,9 @@ instance Semigroup (ListE e n) where
 instance (EqE k, HashableE k) => GenericE (HashMapE k v) where
   type RepE (HashMapE k v) = ListE (PairE k v)
   fromE (HashMapE m) = ListE $ map (uncurry PairE) $ HM.toList m
+  {-# INLINE fromE #-}
   toE   (ListE pairs) = HashMapE $ HM.fromList $ map fromPairE pairs
+  {-# INLINE toE #-}
 instance (EqE k, HashableE k, SinkableE k  , SinkableE   v) => SinkableE   (HashMapE k v)
 instance (EqE k, HashableE k, HoistableE k , HoistableE  v) => HoistableE  (HashMapE k v)
 instance (EqE k, HashableE k, SubstE Name k, SubstE Name v) => SubstE Name (HashMapE k v)

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -88,7 +88,9 @@ simplifyTopFunction ty f = liftSimplifyM $
 instance GenericE SimplifiedBlock where
   type RepE SimplifiedBlock = PairE Block ReconstructAtom
   fromE (SimplifiedBlock block recon) = PairE block recon
+  {-# INLINE fromE #-}
   toE   (PairE block recon) = SimplifiedBlock block recon
+  {-# INLINE toE #-}
 
 instance SinkableE SimplifiedBlock
 instance SubstE Name SimplifiedBlock
@@ -685,7 +687,9 @@ instance GenericE SimpleIxInstance where
                                  (PairE (Abs (Nest Decl) LamExpr)
                                         (Abs (Nest Decl) LamExpr)))
   fromE (SimpleIxInstance a b c) = PairE a (PairE b c)
+  {-# INLINE fromE #-}
   toE (PairE a (PairE b c)) = SimpleIxInstance a b c
+  {-# INLINE toE #-}
 
 instance SubstE Name SimpleIxInstance
 instance SinkableE SimpleIxInstance

--- a/src/lib/Types/Imp.hs
+++ b/src/lib/Types/Imp.hs
@@ -148,6 +148,7 @@ instance GenericE ImpInstr where
 
     ICastOp idt ix -> Case3 $ Case0 $ LiftE idt `PairE` ix
     IPrimOp op     -> Case3 $ Case1 $ ComposeE op
+  {-# INLINE fromE #-}
 
   toE instr = case instr of
     Case0 instr' -> case instr' of
@@ -177,6 +178,7 @@ instance GenericE ImpInstr where
       _ -> error "impossible"
 
     _ -> error "impossible"
+  {-# INLINE toE #-}
 
 instance SinkableE ImpInstr
 instance HoistableE  ImpInstr
@@ -187,7 +189,9 @@ instance SubstE Name ImpInstr
 instance GenericE ImpBlock where
   type RepE ImpBlock = Abs (Nest ImpDecl) (ListE IExpr)
   fromE (ImpBlock decls results) = Abs decls (ListE results)
+  {-# INLINE fromE #-}
   toE   (Abs decls (ListE results)) = ImpBlock decls results
+  {-# INLINE toE #-}
 
 instance SinkableE ImpBlock
 instance HoistableE  ImpBlock
@@ -202,11 +206,13 @@ instance GenericE IExpr where
   fromE iexpr = case iexpr of
     ILit x -> Case0 (LiftE x)
     IVar v ty -> Case1 (v `PairE` LiftE ty)
+  {-# INLINE fromE #-}
 
   toE rep = case rep of
     Case0 (LiftE x) -> ILit x
     Case1 (v `PairE` LiftE ty) -> IVar v ty
     _ -> error "impossible"
+  {-# INLINE toE #-}
 
 instance SinkableE IExpr
 instance HoistableE  IExpr
@@ -257,11 +263,13 @@ instance GenericE ImpFunction where
   fromE f = case f of
     ImpFunction ty ab   -> Case0 $ LiftE ty `PairE` ab
     FFIFunction ty name -> Case1 $ LiftE (ty, name)
+  {-# INLINE fromE #-}
 
   toE f = case f of
     Case0 (LiftE ty `PairE` ab) -> ImpFunction ty ab
     Case1 (LiftE (ty, name))    -> FFIFunction ty name
     _ -> error "impossible"
+  {-# INLINE toE #-}
 
 instance SinkableE ImpFunction
 instance HoistableE  ImpFunction

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -334,10 +334,12 @@ instance GenericE (EffectP name) where
     RWSEffect rws name -> LeftE  (PairE (LiftE rws) $ toMaybeE name)
     ExceptionEffect -> RightE (LiftE (Left  ()))
     IOEffect        -> RightE (LiftE (Right ()))
+  {-# INLINE fromE #-}
   toE = \case
     LeftE  (PairE (LiftE rws) name) -> RWSEffect rws $ fromMaybeE name
     RightE (LiftE (Left  ())) -> ExceptionEffect
     RightE (LiftE (Right ())) -> IOEffect
+  {-# INLINE toE #-}
 
 instance Color c => SinkableE      (EffectP (Name c))
 instance Color c => HoistableE     (EffectP (Name c))
@@ -350,10 +352,12 @@ instance OrdE name => GenericE (EffectRowP name) where
   fromE (EffectRow effs ext) = ListE (S.toList effs) `PairE` ext'
     where ext' = case ext of Just v  -> JustE v
                              Nothing -> NothingE
+  {-# INLINE fromE #-}
   toE (ListE effs `PairE` ext) = EffectRow (S.fromList effs) ext'
     where ext' = case ext of JustE v  -> Just v
                              NothingE -> Nothing
                              _ -> error "impossible"
+  {-# INLINE toE #-}
 
 instance Color c => SinkableE         (EffectRowP (Name c))
 instance Color c => HoistableE        (EffectRowP (Name c))

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -327,8 +327,10 @@ instance GenericE SourceNameDef where
   type RepE SourceNameDef = EitherE UVar (LiftE ModuleSourceName `PairE` MaybeE UVar)
   fromE (LocalVar v) = LeftE v
   fromE (ModuleVar name maybeUVar) = RightE (PairE (LiftE name) (toMaybeE maybeUVar))
+  {-# INLINE fromE #-}
   toE (LeftE v) = LocalVar v
   toE (RightE (PairE (LiftE name) maybeUVar)) = ModuleVar name (fromMaybeE maybeUVar)
+  {-# INLINE toE #-}
 
 instance SinkableE      SourceNameDef
 instance HoistableE     SourceNameDef
@@ -339,7 +341,9 @@ instance SubstE Name    SourceNameDef
 instance GenericE SourceMap where
   type RepE SourceMap = ListE (PairE (LiftE SourceName) (ListE SourceNameDef))
   fromE (SourceMap m) = ListE [PairE (LiftE v) (ListE defs) | (v, defs) <- M.toList m]
+  {-# INLINE fromE #-}
   toE   (ListE pairs) = SourceMap $ M.fromList [(v, defs) | (PairE (LiftE v) (ListE defs)) <- pairs]
+  {-# INLINE toE #-}
 
 deriving via WrapE SourceMap n instance Generic (SourceMap n)
 
@@ -374,6 +378,7 @@ instance GenericE UVar where
     UDataConVar v -> Case2 v
     UClassVar   v -> Case3 v
     UMethodVar  v -> Case4 v
+  {-# INLINE fromE #-}
 
   toE name = case name of
     Case0 v -> UAtomVar    v
@@ -382,6 +387,7 @@ instance GenericE UVar where
     Case3 v -> UClassVar   v
     Case4 v -> UMethodVar  v
     _ -> error "impossible"
+  {-# INLINE toE #-}
 
 instance Pretty (UVar n) where
   pretty name = case name of


### PR DESCRIPTION
As outlined in [Optimizing generics is easy!](https://dl.acm.org/doi/10.1145/1706356.1706366)
inlining of generic conversions seems to be the crucial factor enabling
(or inhibiting, when it fails!) GHC to optimize generic instances. Since
`fromE`/`toE` methods like to get big for some of our ADTs, GHC was very
conservative about inlining, forcing us to regularly go through the
generic representation.

With this commit we save on 10% of all allocations made while running
the kernel regression example.