### PR TITLE
Fix LaTeX example.

### DIFF
--- a/examples/latex.dx
+++ b/examples/latex.dx
@@ -30,14 +30,22 @@
 
 '## No LaTeX rendering in non-prose-blocks
 
-'LaTeX rendering should not occur in code blocks, not in error output cells.
+'LaTeX rendering should not occur in code blocks, nor in error output cells.
 
-def arraySum (x:a=>Int32) : Int32 =
-  initAcc = 0
+def array_sum {a} (x:a=>Int32) : Int32 =
   -- Note: the following line has `$ ... $`, but it should not trigger KaTeX.
-  snd $ with_state initAcc $ \acc.
+  -- Note: the incorrect usage of `with_state` below is intentional to verify
+  --       that `$ ... $` is not rendered as LaTeX in error output cells.
+  snd $ with_state 0 $ \acc.
     for i.
       acc := (get acc) + x.i
+> Type error:
+> Expected: (a.1 & b)
+>   Actual: (a => Unit)
+> (Solving for: [a.1, b])
+>
+>   snd $ with_state 0 $ \acc.
+>         ^^^^^^^^^^^^^^^^^^^^^
 
 '## [Layout annotation](https://katex.org/docs/supported.html#annotation)
 

--- a/makefile
+++ b/makefile
@@ -190,7 +190,8 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 ode-integrator mcmc ctc raytrace particle-filter \
                 isomorphisms ode-integrator fluidsim \
                 sgd psd kernelregression \
-                quaternions manifold-gradients schrodinger tutorial
+                quaternions manifold-gradients schrodinger tutorial \
+                latex
 # TODO: re-enable
 # fft vega-plotting
 


### PR DESCRIPTION
Fix `def arraySum` after language syntax changes.
Rename `arraySum` to `array_sum` following naming convention (https://github.com/google-research/dex-lang/pull/814).
Clarify purpose of example in a comment: the error output cell is intentional.

---

Before:

<img width="660" alt="Screen Shot 2022-04-11 at 11 20 42 AM" src="https://user-images.githubusercontent.com/5590046/162804344-60fc2487-a2f7-41d8-a425-ce710773fb17.png">

After:

<img width="661" alt="Screen Shot 2022-04-11 at 11 42 10 AM" src="https://user-images.githubusercontent.com/5590046/162807659-de8ebf4a-94a1-4497-bf47-a73a290b68ca.png">

Low impact because `examples/latex.dx` isn't exported to GitHub Pages ([list here](https://github.com/google-research/dex-lang/blob/e878fc66641b0c17ed211e7546e6f6577fe9ab55/makefile#L188-L193)).
