### PR TITLE
Change default RTS options to tune GC flags

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -230,6 +230,7 @@ executable dex
   ghc-options:         -threaded
                        -optP-Wno-nonportable-include-path
                        -rtsopts
+                       "-with-rtsopts=-I0 -A16m"
   default-extensions:  CPP
                      , DeriveGeneric
                      , LambdaCase

--- a/src/Dex/Foreign/rts.c
+++ b/src/Dex/Foreign/rts.c
@@ -4,8 +4,8 @@
 #include "HsFFI.h"
 
 void dexInit() {
-  int argc = 0;
-  char *argv[] = { NULL };
+  int argc = 4;
+  char *argv[] = { "+RTS", "-I0", "-A16m", "-RTS", NULL };
   char **pargv = argv;
 
   hs_init(&argc, &pargv);


### PR DESCRIPTION
I noticed that lowering the LLVM optimization level had a surprising
effect on the GC stats: it has significantly lowered the amount of bytes
copied! This is counter-intuitive, since no Haskell code is executed in
that path, and the GHC profiler reports no allocations in that code
path. And turns out that this is precisely what the problem was! When
building with the threaded runtime (which we do), GHC RTS enables _idle
garbage collection_ by default! That is, whenever we'd end up spending
300ms without running any Haskell operations (because we were busy
optimizing the LLVM program or running the native executable), it would
trigger a major GC! And those are expensive!

This change turns off idle GC using the `-I0` flag and slightly bumps
the default size of allocation area to 16MB. This should still have good
caching behavior and lets us promote even fewer values from the nursery.

In short, we used to do over 20 major GCs while running the kernel
regression example, and now we only run 4 (with negligible impact on
peak memory usage)!