### PR TITLE
Be lazy about computing leaked names during hoisting

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -863,7 +863,7 @@ buildDepDest idxs depVars hint ty cont =
 makeDestRec :: forall n. Emits n => DestIdxs n -> DepVars n -> Type n -> DestM n (Dest n)
 makeDestRec idxs depVars ty = case ty of
   TabTy (b:>iTy) bodyTy -> do
-    if depVars `areFreeIn` iTy
+    if depVars `anyFreeIn` iTy
       then do
         AbsPtrs absDest ptrsInfo <- buildLocalDest $ makeSingleDest [] $ sink ty
         ptrs <- forM ptrsInfo \(DestPtrInfo ptrTy size) -> do

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -70,7 +70,7 @@ module Name (
   newName, newNameM, newNames,
   unsafeCoerceE, unsafeCoerceB, ColorsEqual (..), eqColorRep,
   sinkR, fmapSubstFrag, catRecSubstFrags, extendRecSubst,
-  freeVarsList, isFreeIn, areFreeIn, todoSinkableProof,
+  freeVarsList, isFreeIn, anyFreeIn, todoSinkableProof,
   locallyMutableInplaceT, liftBetweenInplaceTs, toExtWitness,
   updateSubstFrag, nameSetToList, toNameSet, absurdExtEvidence,
   Mut, fabricateDistinctEvidence,
@@ -2592,10 +2592,12 @@ ignoreHoistFailure (HoistFailure _) = error "hoist failure"
 
 hoist :: (BindsNames b, HoistableE e) => b n l -> e l -> HoistExcept (e n)
 hoist b e =
-  case nameSetRawNames $ R.intersection (freeVarsE e) frag of
-    []          -> HoistSuccess $ unsafeCoerceE e
-    leakedNames -> HoistFailure leakedNames
-  where UnsafeMakeScopeFrag frag = toScopeFrag b
+  case R.disjoint fvs frag of
+    True  -> HoistSuccess $ unsafeCoerceE e
+    False -> HoistFailure $ nameSetRawNames $ R.intersection fvs frag
+  where
+    UnsafeMakeScopeFrag frag = toScopeFrag b
+    fvs = freeVarsE e
 
 hoistToTop :: HoistableE e => e n -> HoistExcept (e VoidS)
 hoistToTop e =
@@ -2626,19 +2628,21 @@ nameSetRawNames m = R.keys m
 isFreeIn :: HoistableE e => Name c n -> e n -> Bool
 isFreeIn v e = getRawName v `R.member` freeVarsE e
 
-areFreeIn :: HoistableE e => [Name c n] -> e n -> Bool
-areFreeIn vs e =
-  not $ null $ R.intersection (R.fromList $ map (\v -> (getRawName v, ())) vs)
-                              (freeVarsE e)
+anyFreeIn :: HoistableE e => [Name c n] -> e n -> Bool
+anyFreeIn vs e =
+  not $ R.disjoint (R.fromList $ map (\v -> (getRawName v, ())) vs)
+                   (freeVarsE e)
 
 exchangeBs :: (Distinct l, BindsNames b1, SinkableB b1, HoistableB b2)
               => PairB b1 b2 n l
               -> HoistExcept (PairB b2 b1 n l)
 exchangeBs (PairB b1 b2) =
-  case nameSetRawNames $ R.intersection (freeVarsB b2) frag  of
-    []          -> HoistSuccess $ PairB (unsafeCoerceB b2) (unsafeCoerceB b1)
-    leakedNames -> HoistFailure leakedNames
-  where UnsafeMakeScopeFrag frag = toScopeFrag b1
+  case R.disjoint fvs2 frag of
+    True  -> HoistSuccess $ PairB (unsafeCoerceB b2) (unsafeCoerceB b1)
+    False -> HoistFailure $ nameSetRawNames $ R.intersection fvs2 frag
+  where
+    UnsafeMakeScopeFrag frag = toScopeFrag b1
+    fvs2 = freeVarsB b2
 
 hoistNameSet :: BindsNames b => b n l -> NameSet l -> NameSet n
 hoistNameSet b nameSet =


### PR DESCRIPTION
We only really care about those in inference. In the rest of our code
we're generally only interested in whether the hoisting succeeds or not,
so it's better to use a faster `disjoint` predicate and only compute the
scope intersectio lazily.