### PR TITLE
Don't carry around Scope in TopEnv

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -2086,9 +2086,14 @@ instance ( Store   (b1 UnsafeS UnsafeS), Store   (b2 UnsafeS UnsafeS)
          , Generic (b1 UnsafeS UnsafeS), Generic (b2 UnsafeS UnsafeS) )
          => Store (PairB b1 b2 n l)
 
+instance HasScope (RecSubst v) where
+  toScope = Scope . toScopeFrag . RecSubstFrag . fromRecSubst
+  {-# INLINE toScope #-}
+
 instance ProvesExt  (RecSubstFrag v) where
 instance BindsNames (RecSubstFrag v) where
   toScopeFrag env = substFragAsScope $ fromRecSubstFrag env
+  {-# INLINE toScopeFrag #-}
 instance HoistableV v => HoistableB (RecSubstFrag v) where
   freeVarsB (RecSubstFrag env) = freeVarsE (Abs (substFragAsScope env) env)
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -412,7 +412,7 @@ instance Pretty (ClassDef n) where
 deriving instance (forall c n. Pretty (v c n)) => Pretty (RecSubst v o)
 
 instance Pretty (TopEnv n) where
-  pretty (TopEnv _ defs cache ms) =
+  pretty (TopEnv defs cache ms) =
     prettyRecord [ ("Defs"          , p defs)
                  , ("Cache"         , p cache)
                  , ("Loaded modules", p ms)]

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -594,10 +594,9 @@ clearCache = liftIO do
 -- TODO: real garbage collection (maybe leave it till after we have a
 -- database-backed cache and we can do it incrementally)
 stripEnvForSerialization :: TopStateEx -> TopStateEx
-stripEnvForSerialization (TopStateEx (Env (TopEnv _ (RecSubst defs) cache _) _)) =
-  collectGarbage (RecSubstFrag defs) cache \d@(RecSubstFrag defs') cache' -> do
-    let scope = Scope $ toScopeFrag d
-    TopStateEx $ Env (TopEnv scope (RecSubst defs') cache' mempty) emptyModuleEnv
+stripEnvForSerialization (TopStateEx (Env (TopEnv (RecSubst defs) cache _) _)) =
+  collectGarbage (RecSubstFrag defs) cache \(RecSubstFrag defs') cache' -> do
+    TopStateEx $ Env (TopEnv (RecSubst defs') cache' mempty) emptyModuleEnv
 
 snapshotPtrs :: MonadIO m => TopStateEx -> m TopStateEx
 snapshotPtrs s = traverseBindingsTopStateEx s \case


### PR DESCRIPTION
Scope can be derived from the definitions, which used to be expensive,
but is now an O(1) operation.