### PR TITLE
Avoid unintentional haddock comments

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1108,8 +1108,8 @@ instance (AlphaEqE e1, AlphaEqE e2) => AlphaEqE (EitherE e1 e2) where
 type HashVal = Int
 data NamePreHash (c::C) (n::S) =
    HashFreeName RawName
-    -- XXX: convention is the opposite of de Bruijn order, `0` means the
-    -- *outermost* binder
+    -- XXX: convention is the opposite of de Bruijn order, `0` means
+    -- the *outermost* binder
  | HashBoundName Int
  deriving (Eq, Generic)
 

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -134,12 +134,13 @@ data Result = Result
               deriving (Show, Eq)
 
 type BenchStats = (Int, Double) -- number of runs, total benchmarking time
-data Output = TextOut String
-            | HtmlOut String
-            | PassInfo PassName String
-            | EvalTime  Double (Maybe BenchStats)
-            | TotalTime Double
-            | BenchResult String Double Double (Maybe BenchStats) -- name, compile time, eval time
-            | MiscLog String
-            -- | ExportedFun String Atom
-              deriving (Show, Eq, Generic)
+data Output =
+    TextOut String
+  | HtmlOut String
+  | PassInfo PassName String
+  | EvalTime  Double (Maybe BenchStats)
+  | TotalTime Double
+  | BenchResult String Double Double (Maybe BenchStats) -- name, compile time, eval time
+  | MiscLog String
+  -- Used to have | ExportedFun String Atom
+    deriving (Show, Eq, Generic)


### PR DESCRIPTION
This allows haddock to parse the Dex sources, which in turn allows `stack hoogle` to work.  Example invocation: `stack hoogle -- server --local`.