### PR TITLE
Optimize SubstFrag values

### DIFF
--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -228,9 +228,8 @@ runEnvQuery query = do
     DumpSubst -> logTop $ TextOut $ pprint $ env
     InternalNameInfo name ->
       case lookupSubstFragRaw (fromRecSubst $ envDefs $ topEnv env) name of
-        Nothing -> throw UnboundVarErr $ pprint name
-        Just (WithColor binding) ->
-          logTop $ TextOut $ pprint binding
+        Nothing      -> throw UnboundVarErr $ pprint name
+        Just binding -> logTop $ TextOut $ pprint binding
     SourceNameInfo name -> do
       lookupSourceMap name >>= \case
         Nothing -> throw UnboundVarErr $ pprint name


### PR DESCRIPTION
Previously every element in a substitution or a scope was a list of
`WithColor` objects that existentially hid the color of the substitution
element. While it worked fine, it meant that putting a new value into scope
required us to allocate at least two extra constructors (`[]`+`WithColor`)
and every lookup required us to perform the extra pointer chasing to unpack
them all.

This change adds a `SubstItem` that we always use as a value in
`RawNameMap`s. It packs together an unboxed integer that encodes the
color of the `v` and whether the name for which this entry is present
has been shadowed in the scope fragment it represents.

Overall the effect on total allocations is not very dramatic (given how
unoptimized many paths still are), but it does result in a noisy, but
noticeable performance improvement.