### PR TITLE
Optimize Imp

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1096,6 +1096,7 @@ naryIndexRef ref is = foldM indexRef ref is
 ptrOffset :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
 ptrOffset x (IdxRepVal 0) = return x
 ptrOffset x i = emitOp $ PtrOffset x i
+{-# INLINE ptrOffset #-}
 
 unsafePtrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 unsafePtrLoad x = do

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -239,12 +239,12 @@ instance (SinkableV v, ScopeReader m, EnvExtender m)
       cont' subst'
   {-# INLINE refreshAbs #-}
 
-instance (Monad m, ExtOutMap Env decls)
-         => EnvReader   (InplaceT Env decls m) where
+instance (Monad m, ExtOutMap Env decls, OutFrag decls)
+         => EnvReader (InplaceT Env decls m) where
   unsafeGetEnv = getOutMapInplaceT
   {-# INLINE unsafeGetEnv #-}
 
-instance (Monad m, ExtOutMap Env decls)
+instance (Monad m, ExtOutMap Env decls, OutFrag decls)
          => EnvExtender (InplaceT Env decls m) where
   refreshAbs ab cont = UnsafeMakeInplaceT \env decls ->
     refreshAbsPure (toScope env) ab \_ b e -> do

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -2576,13 +2576,13 @@ instance (SubstE Name e, CheckableE e) => CheckableE (UDeclInferenceResult e) wh
     return $ UDeclResultWorkRemaining block'
                 (error "TODO: implement substitution for UDecl")
 
-instance (Monad m, ExtOutMap InfOutMap decls)
+instance (Monad m, ExtOutMap InfOutMap decls, OutFrag decls)
         => EnvReader (InplaceT InfOutMap decls m) where
   unsafeGetEnv = do
     InfOutMap env _ _ _ <- getOutMapInplaceT
     return env
 
-instance (Monad m, ExtOutMap InfOutMap decls)
+instance (Monad m, ExtOutMap InfOutMap decls, OutFrag decls)
          => EnvExtender (InplaceT InfOutMap decls m) where
   refreshAbs ab cont = UnsafeMakeInplaceT \env decls ->
     refreshAbsPure (toScope env) ab \_ b e -> do

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1880,12 +1880,17 @@ instance SinkableE e => SinkableB (LiftB e) where
 instance ProvesExt (LiftB e) where
 instance BindsNames (LiftB e) where
   toScopeFrag (LiftB _) = id
+  {-# INLINE toScopeFrag #-}
 
 instance HoistableE e => HoistableB (LiftB e) where
   freeVarsB (LiftB e) = freeVarsE e
+  {-# INLINE freeVarsB #-}
 
 instance (SinkableE e, SubstE v e) => SubstB v (LiftB e) where
-  substB env (LiftB e) cont = cont env $ LiftB $ substE env e
+  substB env@(_, subst) (LiftB e) cont = case tryApplyIdentitySubst subst e of
+    Just e' -> cont env $ LiftB e'
+    Nothing -> cont env $ LiftB $ substE env e
+  {-# INLINE substB #-}
 
 instance (BindsNames b1, BindsNames b2) => ProvesExt  (EitherB b1 b2) where
 instance (BindsNames b1, BindsNames b2) => BindsNames (EitherB b1 b2) where


### PR DESCRIPTION
A bunch of performance fixes, mostly to Imp. Overall they get rid of over 10% allocations and give us a reliable 2-4% end-to-end speedup on the kernel regression example.

**Add a concept of "sub fragment" and use it to optimize Imp's Dest emissions**

DestEmissions are a very rich structure that is a bit complicated to
extend. At the same time in most places we emit only a tiny component of
the whole emissions, which means that we still have to pay for no-op
extensions of the other parts.

In this change I add a concept of "sub fragment" that effectively
represents a specialized update to the inplace environment and
emissions. Thanks to inlining and specialization GHC is able to elide
the unnecessary extensions and make the code both faster and have a much
less noisy Core representation.

**Add a method that fuses fresh name generation with InplaceT emissions**

While the non-distinct paths weren't causing any noticeable performance
problems, they make GHC Core incredibly branchy. After all, every single
extension, might cause a branch for possible refreshment, only to
converge in a common join-point. Reading join-points is a pain, because
they are displayed reversed compared to code execution.

**Optimize Imp**

Use some more tricks to optimize Imp. A non-exhaustive list as follows:
- Apply assorted inlining hints and demands
- Use reverse nests in the Dest monad
- Apply extra `confuseGHC` calls
- Cache free vars in IxCache for more efficient hoisting

**Use the new InplaceT tricks to speed up Builder**