### PR TITLE
Simplify non-lambda atom instead of substituting

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -364,7 +364,7 @@ simplifyVar v = do
 simplifyLam :: Atom i -> SimplifyM i o (Atom o, Abs LamBinder ReconstructAtom o)
 simplifyLam atom = case atom of
   Lam (LamExpr b body) -> doSimpLam b body
-  _ -> substM atom >>= \case
+  _ -> simplifyAtom atom >>= \case
     Lam (LamExpr b body) -> dropSubst $ doSimpLam b body
     _ -> error "Not a lambda expression"
   where
@@ -380,7 +380,7 @@ simplifyBinaryLam :: Emits o => Atom i
   -> SimplifyM i o (Atom o, Abs BinaryLamBinder ReconstructAtom o)
 simplifyBinaryLam atom = case atom of
   Lam (LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))) -> doSimpBinaryLam b1 b2 body
-  _ -> substM atom >>= \case
+  _ -> simplifyAtom atom >>= \case
     Lam (LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))) -> dropSubst $ doSimpBinaryLam b1 b2 body
     _ -> error "Not a binary lambda expression"
   where

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -205,3 +205,21 @@ data MyData a5       = MkMyData (MyPairOfXs a5)
 >                                  ^^^^^^^^^^^^^
 
 data MyDataBetter a [X a] = MkMyDataBetter (MyPairOfXs a)
+
+-------------------- User-defined Ix --------------------
+
+data TwoPoints =
+  FirstPoint
+  SecondPoint
+
+instance Ix TwoPoints
+  get_size = \(). 2
+  ordinal = \b. case b of
+    FirstPoint  -> 0
+    SecondPoint -> 1
+  unsafe_from_ordinal = \i. case i == 0 of
+    True  -> FirstPoint
+    False -> SecondPoint
+
+:p for i:TwoPoints. i
+> [FirstPoint, SecondPoint]@TwoPoints


### PR DESCRIPTION
If the atom passed to `simplifyLam` doesn't come from the currently
simplified program (and e.g. refers to the top-level functions instead),
substituting it will not inline the lambda body as we'd expect.

Fixes #869.