### PR TITLE
Perform incremental outputs in all but HTML mode

### DIFF
--- a/makefile
+++ b/makefile
@@ -225,9 +225,9 @@ run-%: export DEX_ALLOW_CONTRACTIONS=0
 run-%: export DEX_TEST_MODE=t
 
 run-tests/%: tests/%.dx just-build
-	misc/check-quine $< $(dex) script --allow-errors
+	misc/check-quine $< $(dex) script
 run-examples/%: examples/%.dx just-build
-	misc/check-quine $< $(dex) script --allow-errors
+	misc/check-quine $< $(dex) script
 
 update-%: export DEX_ALLOW_CONTRACTIONS=0
 update-%: export DEX_TEST_MODE=t
@@ -235,20 +235,20 @@ update-%: export DEX_TEST_MODE=t
 update-all: $(update-test-targets) $(update-example-targets)
 
 update-tests/%: tests/%.dx just-build
-	$(dex) script --allow-errors $< > $<.tmp
+	$(dex) script $< > $<.tmp
 	mv $<.tmp $<
 
 update-examples/%: examples/%.dx just-build
-	$(dex) script --allow-errors $< > $<.tmp
+	$(dex) script $< > $<.tmp
 	mv $<.tmp $<
 
 run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
 run-gpu-tests: tests/gpu-tests.dx just-build
-	misc/check-quine $< $(dex) --backend llvm-cuda script --allow-errors
+	misc/check-quine $< $(dex) --backend llvm-cuda script
 
 update-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0
 update-gpu-tests: tests/gpu-tests.dx just-build
-	$(dex) --backend llvm-cuda script --allow-errors $< > $<.tmp
+	$(dex) --backend llvm-cuda script $< > $<.tmp
 	mv $<.tmp $<
 
 repl-test: just-build
@@ -258,7 +258,7 @@ repl-test: just-build
 
 module-tests: just-build
 	misc/check-quine tests/module-tests.dx \
-    $(dex) --prelude lib/prelude.dx --lib-path tests script --allow-errors
+    $(dex) --prelude lib/prelude.dx --lib-path tests script
 
 # --- running and querying benchmarks ---
 

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -57,7 +57,7 @@ dexEval :: Ptr Context -> CString -> IO (Ptr Context)
 dexEval ctxPtr sourcePtr = do
   Context evalConfig initEnv <- fromStablePtr ctxPtr
   source <- peekCString sourcePtr
-  (results, finalEnv) <- runTopperM evalConfig initEnv $ evalSourceText source
+  (results, finalEnv) <- runTopperM evalConfig initEnv $ evalSourceText source (const $ return ()) (const $ return True)
   let anyError = asum $ fmap (\case (_, Result _ (Failure err)) -> Just err; _ -> Nothing) results
   case anyError of
     Nothing  -> toStablePtr $ Context evalConfig finalEnv

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -10,7 +10,7 @@
 
 module PPrint (
   pprint, pprintCanonicalized, pprintList, asStr , atPrec, toJSONStr,
-  PrettyPrec(..), PrecedenceLevel (..), printLitBlock) where
+  PrettyPrec(..), PrecedenceLevel (..), printLitBlock, printResult) where
 
 import Data.Aeson hiding (Result, Null, Value, Success)
 import GHC.Exts (Constraint)
@@ -884,15 +884,16 @@ instance Pretty RWS where
     State  -> "State"
 
 printLitBlock :: Pretty block => Bool -> block -> Result -> String
-printLitBlock isatty block (Result outs result) =
-  pprint block ++ concat (map (printOutput isatty) outs) ++ printResult isatty result
+printLitBlock isatty block result = pprint block ++ printResult isatty result
 
-printOutput :: Bool -> Output -> String
-printOutput isatty out = addPrefix (addColor isatty Cyan ">") $ pprint $ out
-
-printResult :: Bool -> Except () -> String
-printResult _ (Success ()) = ""
-printResult isatty (Failure err) = addColor isatty Red $ addPrefix ">" $ pprint err
+printResult :: Bool -> Result -> String
+printResult isatty (Result outs errs) =
+  concat (map printOutput outs) ++ case errs of
+    Success ()  -> ""
+    Failure err -> addColor isatty Red $ addPrefix ">" $ pprint err
+  where
+    printOutput :: Output -> String
+    printOutput out = addPrefix (addColor isatty Cyan ">") $ pprint $ out
 
 addPrefix :: String -> String -> String
 addPrefix prefix str = unlines $ map prefixLine $ lines str

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -9,7 +9,7 @@
 module TopLevel (
   EvalConfig (..), Topper, runTopperM,
   evalSourceBlock, evalSourceBlockRepl,
-  evalFile, evalSourceText, initTopState, TopStateEx (..),
+  evalSourceText, initTopState, TopStateEx (..),
   evalSourceBlockIO, loadCache, storeCache, clearCache) where
 
 import Data.Maybe
@@ -119,12 +119,20 @@ evalSourceBlockIO :: EvalConfig -> TopStateEx -> SourceBlock -> IO (Result, TopS
 evalSourceBlockIO opts env block = runTopperM opts env $ evalSourceBlockRepl block
 
 -- Used for the top-level source file (rather than imported modules)
-evalSourceText :: (Topper m, Mut n) => String -> m n [(SourceBlock, Result)]
-evalSourceText source = do
+evalSourceText :: (Topper m, Mut n) => String -> (SourceBlock -> IO ()) -> (Result -> IO Bool) -> m n [(SourceBlock, Result)]
+evalSourceText source beginCallback endCallback = do
   let (UModule mname deps sourceBlocks) = parseUModule Main source
   mapM_ ensureModuleLoaded deps
-  results <- mapM (evalSourceBlock mname) sourceBlocks
-  return $ zip sourceBlocks results
+  evalSourceBlocks mname sourceBlocks
+  where
+    evalSourceBlocks mname = \case
+      [] -> return []
+      (sb:rest) -> do
+        liftIO $ beginCallback sb
+        result <- evalSourceBlock mname sb
+        liftIO (endCallback result) >>= \case
+          False -> return [(sb, result)]
+          True  -> ((sb, result):) <$> evalSourceBlocks mname rest
 
 catchLogsAndErrs :: (Topper m, Mut n) => m n a -> m n (Except a, [Output])
 catchLogsAndErrs m = do
@@ -348,9 +356,6 @@ importModule name = do
       let importStatus = ImportStatus (S.singleton name') (S.singleton name' <> transImports')
       emitLocalModuleEnv $ mempty { envImportStatus = importStatus }
 {-# SCC importModule #-}
-
-evalFile :: (Topper m, Mut n) => FilePath -> m n [(SourceBlock, Result)]
-evalFile fname = evalSourceText =<< (liftIO $ readFile fname)
 
 passLogFilter :: LogLevel -> PassName -> Bool
 passLogFilter = \case


### PR DESCRIPTION
Right now we wait until a script is fully evaluated before we even
attempt to produce any output. It's confusing and bad UX, because it
almost looks like a hang until a wall of text appears at the very end.
This reorganizes the executable and top level so that we print the
evaluated source blocks interactively, making Dex seem much more
responsive.

Also, restore support for aborting on errors (with the new flag enabling
the aborts and the default being to continue until the end of the script).