### PR TITLE
Don't inline the error message in from_ordinal

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1535,7 +1535,9 @@ def get_output_stream (_:Unit) : {IO} Stream WriteMode =
   MkStream $ %ptrLoad %outputStreamPtr
 
 def print (s:String) : {IO} Unit =
-  fwrite (get_output_stream ()) (s <> "\n")
+  stream = get_output_stream ()
+  fwrite stream s
+  fwrite stream "\n"
 
 '### Shelling Out
 
@@ -1620,11 +1622,14 @@ def with_temp_files {n a} [Ix n] (action: (n=>FilePath) -> {IO} a) : {IO} a =
 
 '### Table operations
 
+@noinline
+def from_ordinal_error (i:Int) (upper:Int) : String =
+  "Ordinal index out of range:" <> show i <> " >= " <> show upper
+
 def from_ordinal (n:Type) [Ix n] (i:Int) : n =
   case (0 <= i) && (i < size n) of
     True  -> unsafe_from_ordinal _ i
-    False -> error $
-      "Ordinal index out of range:" <> show i <> " >= " <> show (size n)
+    False -> error $ from_ordinal_error i $ size n
 
 -- TODO: could make an `unsafeCastIndex` and this could avoid the runtime copy
 -- TODO: safe (runtime-checked) and unsafe versions


### PR DESCRIPTION
from_ordinal is used all over the place, but because it's polymorphic we
have no choice but to inline it into all use sites. (Well, we'd do that
even if it was monomorphic, but in principle that will change in the
future.) However, its body is large-ish, because it embeds sizable
string literals and inlines their concatenation code, which obviously
blows up the eventual code size.

This tiny change gives us a 15% end-to-end speedup and removes 27% of all
allocations on the kernel regression example! Seems like the changes
from the last month have shaken out most low hanging fruit from Haskell,
but we likely have plenty of those on the Dex side!