### PR TITLE
Added table index sets, and used them to make fft types enforce power…

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -131,15 +131,13 @@ labels = for i:position. randIdxNoZero Vocab (new_key (ordinal i))
 -- semantics of the marginal likelihood being computed, and whether
 -- e.g. the summed-over labels should include blanks.
 
+0.141468 ~~ sum for i:Vocab. exp $ ctc blank logits [i]
+> True
 
-:p sum for i:Vocab.
-  exp $ ctc blank logits [i]
-> 0.141468
+-- (Fin N)=>Vocab is all combinations of N tokens.
+0.709123 ~~ sum for i:((Fin 2)=>Vocab). exp $ ctc blank logits i
+> True
 
-:p sum for (i, j):(Vocab & Vocab).
-  exp $ ctc blank logits [i, j]
-> 0.709123
+0.925101 ~~ sum for i:((Fin 3)=>Vocab). exp $ ctc blank logits i
+> True
 
-:p sum for (i, j, k):(Vocab & Vocab & Vocab).
-  exp $ ctc blank logits [i, j, k]
-> 0.925101

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -51,7 +51,7 @@ def power_of_2_fft {log2_n}
   (direction: FTDirection)
   (x: ((Fin log2_n)=>(Fin 2))=>Complex) :
       ((Fin log2_n)=>(Fin 2))=>Complex =
-  -- (Fin log2_n)=>(Fin 2) has 2^n elements.
+  -- (Fin n)=>(Fin 2) has 2^n elements, so (Fin log2_n)=>(Fin n) has exactly n.
 
   dir_const = case direction of
     ForwardFT -> -pi

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -90,13 +90,19 @@ def pad_to_power_of_2 {a n} (log2_m:Int) (pad_val:a) (xs:n=>a) :
   
 def convolve_complex {n m} (u:n=>Complex) (v:m=>Complex) : ((n|m)=>Complex) =
   -- Convolve by pointwise multiplication in the Fourier domain.
-  convolved_size = (size n) + (size m) - 1
-  log_working_size = nextpow2 convolved_size
+
+  -- Pad and convert to Fourier domain.
+  min_convolve_size = (size n) + (size m) - 1
+  log_working_size = nextpow2 min_convolve_size
   u_padded = pad_to_power_of_2 log_working_size zero u
   v_padded = pad_to_power_of_2 log_working_size zero v
   spectral_u = power_of_2_fft ForwardFT u_padded
   spectral_v = power_of_2_fft ForwardFT v_padded
+  
+  -- Pointwise multiply.
   spectral_conv = for i. spectral_u.i * spectral_v.i
+
+  -- Convert back to primal domain and undo padding.
   padded_conv = power_of_2_fft InverseFT spectral_conv
   slice padded_conv 0 (n | m)
 
@@ -107,6 +113,23 @@ def convolve {n m} (u:n=>Float) (v:m=>Float) : ((n|m)=>Float) =
   for i.
     (MkComplex real imag) = ans.i
     real
+
+def bluestein {n} (x: n=>Complex): n=>Complex =
+  -- Bluestein's algorithm.
+  -- Converts the general FFT into a convolution,
+  -- which is then solved with calls to a power-of-2 FFT.
+  im = MkComplex 0.0 1.0
+  wks = for i.
+    i_squared = i_to_f $ sq $ ordinal i
+    exp $ (-im) * (MkComplex (pi * i_squared / (i_to_f (size n))) 0.0)
+
+  (AsList _ tailTable) = tail wks 1
+  back_and_forth = odd_sized_palindrome (head wks) tailTable
+  xq = for i. x.i * wks.i
+  back_and_forth_conj = for i. complex_conj back_and_forth.i
+  convolution = convolve_complex xq back_and_forth_conj
+  convslice = slice convolution (size n - 1) n
+  for i. wks.i * convslice.i
 
 
 '## FFT Interface
@@ -119,21 +142,7 @@ def fft {n} (x: n=>Complex): n=>Complex =
       ret = power_of_2_fft ForwardFT castx
       unsafe_cast_table n ret
     else
-      -- Bluestein's algorithm.
-      -- Converts the general FFT into a convolution,
-      -- which is then solved with calls to a power-of-2 FFT.
-      im = MkComplex 0.0 1.0
-      wks = for i.
-        i_squared = i_to_f $ sq $ ordinal i
-        exp $ (-im) * (MkComplex (pi * i_squared / (i_to_f (size n))) 0.0)
-
-      (AsList _ tailTable) = tail wks 1
-      back_and_forth = odd_sized_palindrome (head wks) tailTable
-      xq = for i. x.i * wks.i
-      back_and_forth_conj = for i. complex_conj back_and_forth.i
-      convolution = convolve_complex xq back_and_forth_conj
-      convslice = slice convolution (size n - 1) n
-      for i. wks.i * convslice.i
+      bluestein x
 
 def ifft {n} (xs: n=>Complex): n=>Complex =
   if is_power_of_2 (size n)

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -8,6 +8,7 @@ This demo also uses types to enforce internally that the array sizes are powers 
 which calls the power-of-2 FFT as a subroutine.
 
 
+
 '### Helper functions
 
 def odd_sized_palindrome {a n} (mid:a) (seq:n=>a) : ((n|Unit|n)=>a) =
@@ -19,15 +20,11 @@ def odd_sized_palindrome {a n} (mid:a) (seq:n=>a) : ((n|Unit|n)=>a) =
         Right () -> mid
       Right i -> seq.i
 
---def cast_to_power_of_2 {n a log_m} (xs:n=>a) : Maybe (((log_m)=>2)=>a) =
---  if is_power_of_2 (size n)
---    then Just $ unsafe_cast_table (intlog2 (size n)) xs
---    else Nothing
-
 def nextpow2 (x:Int) : Int =
   case is_power_of_2 x of
-    True -> x
+    True -> intlog2 x
     False -> 1 + intlog2 x
+
 
 '## Inner FFT functions
 
@@ -54,18 +51,19 @@ def power_of_2_fft {log2_n}
   (direction: FTDirection)
   (x: ((Fin log2_n)=>(Fin 2))=>Complex) :
       ((Fin log2_n)=>(Fin 2))=>Complex =
+  -- (Fin log2_n)=>(Fin 2) has 2^n elements.
 
   dir_const = case direction of
     ForwardFT -> -pi
     InverseFT -> pi
   
-  log2_half_n = log2_n - 1
-
   (n, ans) = yield_state (1, x) \combRef.
     for i:(Fin log2_n).
       ipow2Ref = fst_ref combRef
       xRef = snd_ref combRef
       ipow2 = get ipow2Ref
+
+      log2_half_n = log2_n - 1
       xRef := yieldAccum (AddMonoid Complex) \bufRef.
         for j:((Fin log2_half_n)=>(Fin 2)).  -- Executes in parallel.
           (left_read_ix, right_read_ix,
@@ -84,25 +82,23 @@ def power_of_2_fft {log2_n}
     ForwardFT -> ans
     InverseFT -> ans / (i_to_f n)
 
-def pad_to_power_of_2 {log2_m a n}
-    (pad_val:a) (xs:n=>a) :
+def pad_to_power_of_2 {a n} (log2_m:Int) (pad_val:a) (xs:n=>a) :
     ((Fin log2_m)=>(Fin 2))=>a =
   flatsize = intpow2 log2_m
   padded_flat = pad_to (Fin flatsize) pad_val xs
   unsafe_cast_table ((Fin log2_m)=>(Fin 2)) padded_flat
   
-def convolve_complex {n m} (u:n=>Complex) (v:m=>Complex) :
-  ((n|m)=>Complex) =  -- Alphabetical order matters here.
+def convolve_complex {n m} (u:n=>Complex) (v:m=>Complex) : ((n|m)=>Complex) =
   -- Convolve by pointwise multiplication in the Fourier domain.
   convolved_size = (size n) + (size m) - 1
   log_working_size = nextpow2 convolved_size
-  u_padded : ((Fin log_working_size)=>(Fin 2))=>Complex = pad_to_power_of_2 zero u
-  v_padded : ((Fin log_working_size)=>(Fin 2))=>Complex = pad_to_power_of_2 zero v
+  u_padded = pad_to_power_of_2 log_working_size zero u
+  v_padded = pad_to_power_of_2 log_working_size zero v
   spectral_u = power_of_2_fft ForwardFT u_padded
   spectral_v = power_of_2_fft ForwardFT v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
   padded_conv = power_of_2_fft InverseFT spectral_conv
-  slice padded_conv 0 (n | m )
+  slice padded_conv 0 (n | m)
 
 def convolve {n m} (u:n=>Float) (v:m=>Float) : ((n|m)=>Float) =
   u' = for i. MkComplex u.i 0.0
@@ -165,6 +161,10 @@ def  fft2_real {n m} (x: n=>m=>Float): n=>m=>Complex =  fft2 for i j. MkComplex 
 def ifft2_real {n m} (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex x.i.j 0.0
 
 -------- Tests --------
+
+:p map nextpow2 [-1, 0, 1, 2, 3, 4, 7, 8, 9, 1023, 1024, 1025]
+> [0, 0, 0, 1, 2, 2, 3, 3, 4, 10, 10, 11]
+
 
 a : (Fin 4)=>Complex = arb $ new_key 0
 :p a ~~ (ifft $ fft a)

--- a/examples/fft.dx
+++ b/examples/fft.dx
@@ -1,7 +1,9 @@
 '# Fast Fourier Transform
 For arrays whose size is a power of 2, we use a radix-2 algorithm based
 on the [Fhutark demo](https://github.com/diku-dk/fft/blob/master/lib/github.com/diku-dk/fft/stockham-radix-2.fut#L30).
-For non-power-of-2 sized arrays, it uses
+This demo also uses types to enforce internally that the array sizes are powers of 2.
+
+'For non-power-of-2 sized arrays, it uses
 [Bluestein's Algorithm](https://en.wikipedia.org/wiki/Chirp_Z-transform),
 which calls the power-of-2 FFT as a subroutine.
 
@@ -17,6 +19,15 @@ def odd_sized_palindrome {a n} (mid:a) (seq:n=>a) : ((n|Unit|n)=>a) =
         Right () -> mid
       Right i -> seq.i
 
+--def cast_to_power_of_2 {n a log_m} (xs:n=>a) : Maybe (((log_m)=>2)=>a) =
+--  if is_power_of_2 (size n)
+--    then Just $ unsafe_cast_table (intlog2 (size n)) xs
+--    else Nothing
+
+def nextpow2 (x:Int) : Int =
+  case is_power_of_2 x of
+    True -> x
+    False -> 1 + intlog2 x
 
 '## Inner FFT functions
 
@@ -39,22 +50,24 @@ def butterfly_ixs {halfn n} [Ix halfn, Ix n] (j':halfn) (pow2:Int)
   right_read_ix = unsafe_from_ordinal n (j + size halfn)
   (left_read_ix, right_read_ix, left_write_ix, right_write_ix)
 
-def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
-  -- Input size must be a power of 2.
-  -- Can enforce this with tables-as-index-sets like:
-  -- (x: (log2n=>(Fin 2))=>Complex)) once that's supported.
+def power_of_2_fft {log2_n}
+  (direction: FTDirection)
+  (x: ((Fin log2_n)=>(Fin 2))=>Complex) :
+      ((Fin log2_n)=>(Fin 2))=>Complex =
+
   dir_const = case direction of
     ForwardFT -> -pi
     InverseFT -> pi
-
-  log2n = intlog2 (size n)
-  halfn = idiv (size n) 2
   
-  ans = yield_state x \xRef.
-    for i:(Fin log2n).
-      ipow2 = intpow 2 (ordinal i)
+  log2_half_n = log2_n - 1
+
+  (n, ans) = yield_state (1, x) \combRef.
+    for i:(Fin log2_n).
+      ipow2Ref = fst_ref combRef
+      xRef = snd_ref combRef
+      ipow2 = get ipow2Ref
       xRef := yieldAccum (AddMonoid Complex) \bufRef.
-        for j:(Fin halfn).  -- Executes in parallel.
+        for j:((Fin log2_half_n)=>(Fin 2)).  -- Executes in parallel.
           (left_read_ix, right_read_ix,
            left_write_ix, right_write_ix) = butterfly_ixs j ipow2
 
@@ -65,18 +78,26 @@ def power_of_2_fft {n} (direction: FTDirection) (x: n=>Complex) : n=>Complex =
           -- Add and subtract it to the relevant places in the new buffer.
           bufRef!left_write_ix  += (get (xRef!left_read_ix)) + v
           bufRef!right_write_ix += (get (xRef!left_read_ix)) - v
+      ipow2Ref := ipow2 * 2
 
   case direction of
     ForwardFT -> ans
-    InverseFT -> ans / (i_to_f (size n))
+    InverseFT -> ans / (i_to_f n)
 
+def pad_to_power_of_2 {log2_m a n}
+    (pad_val:a) (xs:n=>a) :
+    ((Fin log2_m)=>(Fin 2))=>a =
+  flatsize = intpow2 log2_m
+  padded_flat = pad_to (Fin flatsize) pad_val xs
+  unsafe_cast_table ((Fin log2_m)=>(Fin 2)) padded_flat
+  
 def convolve_complex {n m} (u:n=>Complex) (v:m=>Complex) :
   ((n|m)=>Complex) =  -- Alphabetical order matters here.
   -- Convolve by pointwise multiplication in the Fourier domain.
   convolved_size = (size n) + (size m) - 1
-  working_size = nextpow2 convolved_size
-  u_padded = pad_to (Fin working_size) zero u
-  v_padded = pad_to (Fin working_size) zero v
+  log_working_size = nextpow2 convolved_size
+  u_padded : ((Fin log_working_size)=>(Fin 2))=>Complex = pad_to_power_of_2 zero u
+  v_padded : ((Fin log_working_size)=>(Fin 2))=>Complex = pad_to_power_of_2 zero v
   spectral_u = power_of_2_fft ForwardFT u_padded
   spectral_v = power_of_2_fft ForwardFT v_padded
   spectral_conv = for i. spectral_u.i * spectral_v.i
@@ -96,7 +117,11 @@ def convolve {n m} (u:n=>Float) (v:m=>Float) : ((n|m)=>Float) =
 
 def fft {n} (x: n=>Complex): n=>Complex =
   if is_power_of_2 (size n)
-    then power_of_2_fft ForwardFT x
+    then
+      newsize = intlog2 (size n)
+      castx = unsafe_cast_table ((Fin newsize)=>(Fin 2)) x
+      ret = power_of_2_fft ForwardFT castx
+      unsafe_cast_table n ret
     else
       -- Bluestein's algorithm.
       -- Converts the general FFT into a convolution,
@@ -116,7 +141,11 @@ def fft {n} (x: n=>Complex): n=>Complex =
 
 def ifft {n} (xs: n=>Complex): n=>Complex =
   if is_power_of_2 (size n)
-    then power_of_2_fft InverseFT xs
+    then
+      newsize = intlog2 (size n)
+      castx = unsafe_cast_table ((Fin newsize)=>(Fin 2)) xs
+      ret = power_of_2_fft InverseFT castx
+      unsafe_cast_table n ret
     else
       unscaled_fft = fft (for i. complex_conj xs.i)
       for i. (complex_conj unscaled_fft.i) / (i_to_f (size n))
@@ -137,14 +166,13 @@ def ifft2_real {n m} (x: n=>m=>Float): n=>m=>Complex = ifft2 for i j. MkComplex 
 
 -------- Tests --------
 
-a = for i. MkComplex [10.1, -2.2, 8.3, 4.5, 9.3].i 0.0
-b = for i:(Fin 20) j:(Fin 70).
-  MkComplex (randn $ ixkey2 (new_key 0) i j) 0.0
-
+a : (Fin 4)=>Complex = arb $ new_key 0
 :p a ~~ (ifft $ fft a)
 > True
 :p a ~~ (fft $ ifft a)
 > True
+
+b : (Fin 20)=>(Fin 70)=>Complex = arb $ new_key 0
 :p b ~~ (ifft2 $ fft2 b)
 > True
 :p b ~~ (fft2 $ ifft2 b)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -397,7 +397,6 @@ def select {a} (p:Bool) (x:a) (y:a) : a = case p of
 def b_to_i (x:Bool) : Int  = w8_to_i $ b_to_w8 x
 def b_to_f (x:Bool) : Float = i_to_f (b_to_i x)
 
-
 '## Ordering
 TODO: move this down to with `Ord`?
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -397,6 +397,7 @@ def select {a} (p:Bool) (x:a) (y:a) : a = case p of
 def b_to_i (x:Bool) : Int  = w8_to_i $ b_to_w8 x
 def b_to_f (x:Bool) : Float = i_to_f (b_to_i x)
 
+
 '## Ordering
 TODO: move this down to with `Ord`?
 
@@ -705,6 +706,13 @@ instance {a n} [Ord a] Ord (n=>a)
     f: Ordering =
         fold EQ $ \i c. c <> (compare xs.i ys.i)
     f == LT
+
+instance Ix Bool
+  get_size = \(). 2
+  ordinal = \b. case b of
+    False -> 0
+    True -> 1
+  unsafe_from_ordinal = \i. i > 0
 
 '## Elementary/Special Functions
 This is more or less the standard [LibM fare](https://en.wikipedia.org/wiki/C_mathematical_functions).
@@ -1910,6 +1918,9 @@ instance Mul Complex
 instance VSpace Complex
   scale_vec = \a:Float (MkComplex c d):Complex. MkComplex (a * c) (a * d)
 
+instance Arbitrary Complex
+  arb = \key. (MkComplex (randn key) (randn key))
+
 -- Todo: Hook up to (/) operator.  Might require two-parameter VSpace.
 def complex_division (MkComplex a b:Complex) (MkComplex c d:Complex): Complex =
   MkComplex ((a * c + b * d) / (c * c + d * d)) ((b * c - a * d) / (c * c + d * d))
@@ -2045,10 +2056,6 @@ def intlog2 (x:Int) : Int =
             True
           else
             False
-
-def nextpow2 (x:Int) : Int = case is_power_of_2 x of
-  True -> x
-  False -> intpow2 (1 + intlog2 x)
 
 def general_integer_power {a} (times:a->a->a) (one:a) (base:a) (power:Int) : a =
   -- Implements exponentiation by squaring.
@@ -2190,3 +2197,24 @@ def assert (b:Bool) : {Except} Unit =
 --   if ordinal i == 0
 --     then Left (toList [1,2,3])
 --     else Right 1
+
+'### Index set for tables
+
+def int_to_reversed_digits {a b} [Ix a, Ix b] (k:Int) : a=>b =
+  base = size b
+  snd $ scan k \_ cur_k.
+    next_k = idiv cur_k base
+    digit  = mod  cur_k base
+    (next_k, unsafe_from_ordinal b digit)
+
+def reversed_digits_to_int {a b} [Ix a, Ix b] (digits: a=>b) : Int =
+  base = size b
+  fst $ fold (0, 1) \j (cur_k, cur_base).
+    next_k = cur_k + ordinal digits.j * cur_base
+    next_base = cur_base * base
+    (next_k, next_base)
+
+instance {a b} [Ix a, Ix b] Ix (a=>b)
+  get_size = \(). intpow (size b) (size a)
+  ordinal             = reversed_digits_to_int
+  unsafe_from_ordinal = int_to_reversed_digits

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2214,6 +2214,8 @@ def reversed_digits_to_int {a b} [Ix a, Ix b] (digits: a=>b) : Int =
     (next_k, next_base)
 
 instance {a b} [Ix a, Ix b] Ix (a=>b)
+  -- 0@a is the least significant digit,
+  -- while (size a - 1)@a is the most significant digit.
   get_size = \(). intpow (size b) (size a)
   ordinal             = reversed_digits_to_int
   unsafe_from_ordinal = int_to_reversed_digits

--- a/makefile
+++ b/makefile
@@ -189,7 +189,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 regression brownian_motion particle-swarm-optimizer \
                 ode-integrator mcmc ctc raytrace particle-filter \
                 isomorphisms ode-integrator fluidsim \
-                sgd psd kernelregression \
+                sgd psd kernelregression fft \
                 quaternions manifold-gradients schrodinger tutorial \
                 latex
 # TODO: re-enable

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -914,10 +914,6 @@ def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 :p map intlog2 [-1, 0, 1, 2, 3, 4, 5, 1023, 1024, 1025]
 > [-1, -1, 0, 1, 1, 2, 2, 9, 10, 10]
 
-:p map nextpow2 [-1, 0, 1, 2, 3, 4, 7, 8, 9, 1023, 1024, 1025]
-> [1, 1, 1, 2, 4, 4, 8, 8, 16, 1024, 1024, 2048]
-
-
 interface AssociatedInt a
   value a : Int
 
@@ -988,3 +984,18 @@ interface AssociatedPermutedParams a c
 
 4.0e4
 > 40000.
+
+'### Misc. index sets
+
+all for x:(Bool & Bool).
+  x == (unsafe_from_ordinal _ (ordinal x))
+> True
+
+all for x:((Bool & Bool)=>(Fin 3)).
+  x == (unsafe_from_ordinal _ (ordinal x))
+> True
+
+all for x:((Bool & Fin 3)=>(Fin 4)).
+  x == (unsafe_from_ordinal _ (ordinal x))
+> True
+


### PR DESCRIPTION
…s-of-2 sizes.

This was very satisfying.  Now we can programmatically iterate over tables of arbitrary dimension, which let me clean up the CTC and FFT examples.

The FFT inner loop also now avoids some unnecessary discrete math.  The FFT code now typechecks and passes tests again, thanks to [#877](https://github.com/google-research/dex-lang/pull/877)!

There are further enhancements that can be made to the FFT example once we can handle incrementing and decrementing `Nat`s at the type level.