### PR TITLE
Make WriterT1 use HoistableState instead of FallibleMonoid.

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -77,8 +77,11 @@ instance Semigroup (FailedDictTypes n) where
   _ <> _ = FailedDictTypes $ NothingE
 instance Monoid (FailedDictTypes n) where
   mempty = FailedDictTypes $ JustE mempty
-instance FallibleMonoid1 FailedDictTypes where
-  mfail = FailedDictTypes $ NothingE
+
+instance Monad1 m => HoistableState FailedDictTypes m where
+  hoistState _ b d = case hoist b d of
+    HoistSuccess d' -> return d'
+    HoistFailure _  -> return $ FailedDictTypes NothingE
 
 class ( Alternative2 m, SubstReader AtomSubstVal m
       , EnvReader2 m, EnvExtender2 m) => CheapReducer m where


### PR DESCRIPTION
With FallibleMonoid, hoisting the written state was all or nothing. With
HoistableState, the implementor of the state type gets to choose how hoisting
should happen. We need this in CheapReduction, where we want to hoist those
dict types that are possible to hoist even if there are others that can't be
hoisted.