### PR TITLE
Refactor Blocks to terminate in Atoms rather than Exprs

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -193,7 +193,7 @@ type CPolySubstVal = SubstVal AtomNameC (MaybeE ClampPolynomial)
 
 blockAsCPoly :: (EnvExtender m, EnvReader m) => Block n -> m n (Maybe (ClampPolynomial n))
 blockAsCPoly (Block _ decls' result') =
-  runMaybeT1 $ runSubstReaderT idSubst $ go $ Abs decls' result'
+  runMaybeT1 $ runSubstReaderT idSubst $ go $ Abs decls' $ Atom result'
   where
     go :: (EnvExtender2 m, EnvReader2 m, SubstReader CPolySubstVal m, Alternative2 m)
        => Abs (Nest Decl) Expr o -> m o o (ClampPolynomial o)

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -226,7 +226,7 @@ instance CheaplyReducibleE DictExpr Atom where
 instance (CheaplyReducibleE e e', NiceE e') => CheaplyReducibleE (Abs (Nest Decl) e) e' where
   cheapReduceE (Abs decls result) = cheapReduceWithDeclsB decls $ cheapReduceE result
 
-instance (CheaplyReducibleE Expr e', NiceE e') => CheaplyReducibleE Block e' where
+instance (CheaplyReducibleE Atom e', NiceE e') => CheaplyReducibleE Block e' where
   cheapReduceE (Block _ decls result) = cheapReduceE $ Abs decls result
 
 instance CheaplyReducibleE Expr Atom where

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -103,7 +103,7 @@ prepareFunctionForExport f = do
         typeRecon :: EnvExtender m => ExportType n -> Atom n -> m n (IType, Block n)
         typeRecon ety v = case ety of
           ScalarType sbt ->
-            return (Scalar sbt, Block (BlockAnn $ BaseTy $ Scalar sbt) Empty $ Atom v)
+            return (Scalar sbt, Block (BlockAnn $ BaseTy $ Scalar sbt) Empty v)
           RectContArrayPtr sbt shape -> do
               block <- liftBuilder $ buildBlock $ tableAtom (sink v) (sink $ shapeToE shape) [] []
               return (PtrType (Heap CPU, Scalar sbt), block)

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -108,7 +108,7 @@ instance GenericallyTraversableE Block where
   traverseGenericE (Block _ decls result) = do
     Abs decls' (PairE ty result') <-
       buildScoped $ traverseDeclNest decls do
-        result' <- traverseExpr result
+        result' <- traverseAtom result
         resultTy <- getType result'
         return $ PairE resultTy result'
     ty' <- liftHoistExcept $ hoist decls' ty

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -268,7 +268,7 @@ buildRecon b x = do
 
 translateBlock :: forall i o. Emits o
                => MaybeDest o -> Block i -> SubstImpM i o (Atom o)
-translateBlock dest (Block _ decls result) = translateDeclNest decls $ translateExpr dest result
+translateBlock dest (Block _ decls result) = translateDeclNest decls $ translateExpr dest $ Atom result
 
 translateDeclNestSubst :: Emits o => Subst AtomSubstVal l o -> Nest Decl l i' -> SubstImpM i o (Subst AtomSubstVal i' o)
 translateDeclNestSubst !s = \case
@@ -749,7 +749,7 @@ buildBlockDest cont = do
     ty <- getType result
     return $ result `PairE` ty
   ty' <- liftHoistExcept $ hoist decls ty
-  return $ Block (BlockAnn ty') decls $ Atom result
+  return $ Block (BlockAnn ty') decls result
 {-# INLINE buildBlockDest #-}
 
 -- TODO: this is mostly copy-paste from Inference
@@ -1292,7 +1292,7 @@ chooseAddrSpace (backend, curDev, allocTy) numel = case allocTy of
 
     isSmall :: Bool
     isSmall = case numel of
-      Block _ Empty (Atom (Con (Lit l))) | getIntLit l <= 256 -> True
+      Block _ Empty (Con (Lit l)) | getIntLit l <= 256 -> True
       _ -> False
 {-# NOINLINE chooseAddrSpace #-}
 

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -745,7 +745,7 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
             cheapReduceWithDecls decls piResult >>= \case
               (Just (PairE effs' ty'), DictTypeHoistSuccess, []) -> return $ (effs', ty')
               _ -> throw TypeErr $ "Can't reduce type expression: " ++
-                     pprint (Block (BlockAnn TyKind) decls $ Atom $ snd $ fromPairE piResult)
+                     pprint (Block (BlockAnn TyKind) decls $ snd $ fromPairE piResult)
     matchRequirement $ Pi piTy
   UTabPi (UTabPiExpr (UPatAnn (WithSrcB pos' pat) ann) ty) -> do
     ann' <- checkAnn ann
@@ -759,7 +759,7 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
         cheapReduceWithDecls decls piResult >>= \case
           (Just ty', DictTypeHoistSuccess, []) -> return ty'
           _ -> throw TypeErr $ "Can't reduce type expression: " ++
-                 pprint (Block (BlockAnn TyKind) decls $ Atom piResult)
+                 pprint (Block (BlockAnn TyKind) decls piResult)
     checkIx pos' $ argType piTy
     matchRequirement $ TabPi piTy
   UDecl (UDeclExpr decl body) -> do
@@ -2459,7 +2459,7 @@ buildBlockInf cont = do
     ty <- cheapNormalize =<< getType result
     return $ result `PairE` ty
   ty' <- liftHoistExcept $ hoist decls ty
-  return $ Block (BlockAnn ty') decls $ Atom result
+  return $ Block (BlockAnn ty') decls result
 
 buildLamInf
   :: (EmitsInf n, Solver m, InfBuilder m)

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -51,7 +51,7 @@ liftInterpM cont = do
 {-# INLINE liftInterpM #-}
 
 evalBlock :: Interp m => Block i -> m i o (Atom o)
-evalBlock (Block _ decls result) = evalDecls decls $ evalExpr result
+evalBlock (Block _ decls result) = evalDecls decls $ evalAtom result
 
 evalDecls :: Interp m => Nest Decl i i' -> m i' o a -> m i o a
 evalDecls Empty cont = cont

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -290,7 +290,7 @@ linearizeAtom atom = case atom of
 
 linearizeBlock :: Emits o => Block i -> LinM i o Atom Atom
 linearizeBlock (Block _ decls result) =
-  linearizeDecls decls $ linearizeExpr result
+  linearizeDecls decls $ linearizeAtom result
 
 linearizeDecls :: Emits o => Nest Decl i i' -> LinM i' o e1 e2 -> LinM i  o e1 e2
 linearizeDecls Empty cont = cont

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -93,8 +93,8 @@ extendLinRegions v cont = local (\(ListE vs) -> ListE (v:vs)) cont
 transposeBlock :: Emits o => Block i -> Atom o -> TransposeM i o ()
 transposeBlock (Block _ decls result) ct = transposeWithDecls decls result ct
 
-transposeWithDecls :: Emits o => Nest Decl i i' -> Expr i' -> Atom o -> TransposeM i o ()
-transposeWithDecls Empty expr ct = transposeExpr expr ct
+transposeWithDecls :: Emits o => Nest Decl i i' -> Atom i' -> Atom o -> TransposeM i o ()
+transposeWithDecls Empty atom ct = transposeAtom atom ct
 transposeWithDecls (Nest (Let b (DeclBinding _ ty expr)) rest) result ct =
   substExprIfNonlin expr >>= \case
     Nothing  -> do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -150,7 +150,7 @@ data DataConDef n =
 -- cheaply query the result, and, more importantly, there's no risk of having a
 -- type that mentions local variables.
 data Block n where
-  Block :: BlockAnn n l -> Nest Decl n l -> Expr l -> Block n
+  Block :: BlockAnn n l -> Nest Decl n l -> Atom l -> Block n
 
 data BlockAnn n l where
   BlockAnn :: Type n -> BlockAnn n l
@@ -668,8 +668,8 @@ pattern BinaryFunTy :: PiBinder n l1 -> PiBinder l1 l2 -> EffectRow l2 -> Type l
 pattern BinaryFunTy b1 b2 eff ty <- Pi (PiType b1 Pure (Pi (PiType b2 eff ty)))
 
 pattern AtomicBlock :: Atom n -> Block n
-pattern AtomicBlock atom <- Block _ Empty (Atom atom)
-  where AtomicBlock atom = Block NoBlockAnn Empty (Atom atom)
+pattern AtomicBlock atom <- Block _ Empty atom
+  where AtomicBlock atom = Block NoBlockAnn Empty atom
 
 pattern BinaryLamExpr :: LamBinder n l1 -> LamBinder l1 l2 -> Block l2 -> LamExpr n
 pattern BinaryLamExpr b1 b2 body = LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))
@@ -1084,7 +1084,7 @@ instance SubstE AtomSubstVal (ExtLabeledItemsE Atom AtomName) where
     ExtLabeledItemsE $ prefixExtLabeledItems items' ext
 
 instance GenericE Block where
-  type RepE Block = PairE (MaybeE Type) (Abs (Nest Decl) Expr)
+  type RepE Block = PairE (MaybeE Type) (Abs (Nest Decl) Atom)
   fromE (Block (BlockAnn ty) decls result) = PairE (JustE ty) (Abs decls result)
   fromE (Block NoBlockAnn Empty result) = PairE NothingE (Abs Empty result)
   fromE _ = error "impossible"


### PR DESCRIPTION
It turns out that this was already the case, except for the consequences of `inlineLastDecl`.  Moved that out of Builder and into
the two consumers that seem to depend upon it, namely PPrint.hs (of a chain of for expressions?) and Serialize.hs (which has a fast path guarded by pattern-matching for trivial string tables).