### PR TITLE
Optimize dictionary synthesis and solver

### DIFF
--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -137,6 +137,8 @@ instance MonadIO m => MonadIO (EnvReaderT m n) where
   liftIO m = EnvReaderT $ lift $ liftIO m
   {-# INLINE liftIO #-}
 
+deriving instance (Monad m, MonadState s m) => MonadState s (EnvReaderT m o)
+
 -- === EnvReaderI monad ===
 
 newtype EnvReaderIT (m::MonadKind1) (i::S) (o::S) (a:: *) =
@@ -498,14 +500,17 @@ getLambdaDicts :: EnvReader m => m n [AtomName n]
 getLambdaDicts = do
   env <- withEnv moduleEnv
   return $ lambdaDicts $ envSynthCandidates env
+{-# INLINE getLambdaDicts #-}
 
 getInstanceDicts :: EnvReader m => ClassName n -> m n [InstanceName n]
 getInstanceDicts name = do
   env <- withEnv moduleEnv
   return $ M.findWithDefault [] name $ instanceDicts $ envSynthCandidates env
+{-# INLINE getInstanceDicts #-}
 
 getAllowedEffects :: EnvReader m => m n (EffectRow n)
 getAllowedEffects = withEnv $ allowedEffects . moduleEnv
+{-# INLINE getAllowedEffects #-}
 
 nonDepPiType :: ScopeReader m
              => Arrow -> Type n -> EffectRow n -> Type n -> m n (PiType n)

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -10,7 +10,7 @@ module Err (Err (..), Errs (..), ErrType (..), Except (..), ErrCtx (..),
             FallibleM (..), HardFailM (..), CtxReader (..),
             runFallibleM, runHardFail, throw, throwErr,
             addContext, addSrcContext, addSrcTextContext,
-            catchIOExcept, liftExcept,
+            catchIOExcept, liftExcept, liftExceptAlt,
             assertEq, ignoreExcept,
             pprint, docAsStr,
             FallibleApplicativeWrapper, traverseMergingErrs,
@@ -274,6 +274,12 @@ liftExcept :: Fallible m => Except a -> m a
 liftExcept (Failure errs) = throwErrs errs
 liftExcept (Success ans) = return ans
 {-# INLINE liftExcept #-}
+
+liftExceptAlt :: Alternative m => Except a -> m a
+liftExceptAlt = \case
+  Success a -> pure a
+  Failure _ -> empty
+{-# INLINE liftExceptAlt #-}
 
 ignoreExcept :: HasCallStack => Except a -> a
 ignoreExcept (Failure e) = error $ pprint e

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -99,6 +99,7 @@ newtype FallibleM a =
 instance Fallible FallibleM where
   throwErrs (Errs errs) = FallibleM $ ReaderT \ambientCtx ->
     throwErrs $ Errs [Err errTy (ambientCtx <> ctx) s | Err errTy ctx s <- errs]
+  {-# INLINE throwErrs #-}
   addErrCtx ctx (FallibleM m) = FallibleM $ local (<> ctx) m
   {-# INLINE addErrCtx #-}
 
@@ -118,6 +119,7 @@ instance CtxReader FallibleM where
 
 instance Fallible IO where
   throwErrs errs = throwIO errs
+  {-# INLINE throwErrs #-}
   addErrCtx ctx m = do
     result <- catchIOExcept m
     liftExcept $ addErrCtx ctx result
@@ -220,6 +222,7 @@ instance MonadFail HardFailM where
 
 instance Fallible HardFailM where
   throwErrs errs = error $ pprint errs
+  {-# INLINE throwErrs #-}
   addErrCtx _ cont = cont
   {-# INLINE addErrCtx #-}
 
@@ -230,9 +233,11 @@ instance FallibleApplicative HardFailM where
 
 throw :: Fallible m => ErrType -> String -> m a
 throw errTy s = throwErrs $ Errs [addCompilerStackCtx $ Err errTy mempty s]
+{-# INLINE throw #-}
 
 throwErr :: Fallible m => Err -> m a
 throwErr err = throwErrs $ Errs [addCompilerStackCtx err]
+{-# INLINE throwErr #-}
 
 addCompilerStackCtx :: Err -> Err
 addCompilerStackCtx (Err ty ctx msg) = Err ty ctx{stackCtx = compilerStack} msg
@@ -307,6 +312,7 @@ instance MonadFail SearcherM where
 
 instance Fallible SearcherM where
   throwErrs e = SearcherM $ lift $ throwErrs e
+  {-# INLINE throwErrs #-}
   addErrCtx ctx (SearcherM (MaybeT m)) = SearcherM $ MaybeT $
     addErrCtx ctx $ m
   {-# INLINE addErrCtx #-}
@@ -337,6 +343,7 @@ instance (Monoid w, Searcher m) => Searcher (WriterT w m) where
 
 instance (Monoid w, Fallible m) => Fallible (WriterT w m) where
   throwErrs errs = lift $ throwErrs errs
+  {-# INLINE throwErrs #-}
   addErrCtx ctx (WriterT m) = WriterT $ addErrCtx ctx m
   {-# INLINE addErrCtx #-}
 
@@ -383,6 +390,7 @@ instance MonadFail FallibleM where
 
 instance Fallible Except where
   throwErrs errs = Failure errs
+  {-# INLINE throwErrs #-}
 
   addErrCtx _ (Success ans) = Success ans
   addErrCtx ctx (Failure (Errs errs)) =
@@ -463,6 +471,7 @@ instance Pretty ErrType where
 
 instance Fallible m => Fallible (ReaderT r m) where
   throwErrs errs = lift $ throwErrs errs
+  {-# INLINE throwErrs #-}
   addErrCtx ctx (ReaderT f) = ReaderT \r -> addErrCtx ctx $ f r
   {-# INLINE addErrCtx #-}
 
@@ -484,6 +493,7 @@ instance Pretty Errs where
 
 instance Fallible m => Fallible (StateT s m) where
   throwErrs errs = lift $ throwErrs errs
+  {-# INLINE throwErrs #-}
   addErrCtx ctx (StateT f) = StateT \s -> addErrCtx ctx $ f s
   {-# INLINE addErrCtx #-}
 


### PR DESCRIPTION
Dictionary synthesis can be a huge bottleneck for large programs and this patch tries to make it a bit faster. There were clearly many low hanging fruit, as all of those changes lower the end-to-end runtime on one example I'm using as a benchmark (derived from a jax2dex output) 3x!