### PR TITLE
Track the effects actually used by a Block

### DIFF
--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -103,7 +103,7 @@ prepareFunctionForExport f = do
         typeRecon :: EnvExtender m => ExportType n -> Atom n -> m n (IType, Block n)
         typeRecon ety v = case ety of
           ScalarType sbt ->
-            return (Scalar sbt, Block (BlockAnn $ BaseTy $ Scalar sbt) Empty v)
+            return (Scalar sbt, Block (BlockAnn (BaseTy $ Scalar sbt) Pure) Empty v)
           RectContArrayPtr sbt shape -> do
               block <- liftBuilder $ buildBlock $ tableAtom (sink v) (sink $ shapeToE shape) [] []
               return (PtrType (Heap CPU, Scalar sbt), block)

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -14,7 +14,6 @@ import Control.Monad
 import Name
 import Builder
 import Syntax
-import Type
 import PPrint
 
 import LabeledItems
@@ -106,13 +105,7 @@ instance GenericallyTraversableE Atom where
 
 instance GenericallyTraversableE Block where
   traverseGenericE (Block _ decls result) = do
-    Abs decls' (PairE ty result') <-
-      buildScoped $ traverseDeclNest decls do
-        result' <- traverseAtom result
-        resultTy <- getType result'
-        return $ PairE resultTy result'
-    ty' <- liftHoistExcept $ hoist decls' ty
-    return $ Block (BlockAnn ty') decls' result'
+    buildBlock $ traverseDeclNest decls $ traverseAtom result
 
 instance GenericallyTraversableE FieldRowElems where
   traverseGenericE elems = do

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -743,13 +743,7 @@ buildBlockDest
   :: Mut n
   => (forall l. (Emits l, DExt n l) => DestM l (Atom l))
   -> DestM n (Block n)
-buildBlockDest cont = do
-  Abs decls (PairE result ty) <- buildDeclsDest do
-    result <- cont
-    ty <- getType result
-    return $ result `PairE` ty
-  ty' <- liftHoistExcept $ hoist decls ty
-  return $ Block (BlockAnn ty') decls result
+buildBlockDest cont = buildDeclsDest (cont >>= withType) >>= computeAbsEffects >>= absToBlock
 {-# INLINE buildBlockDest #-}
 
 -- TODO: this is mostly copy-paste from Inference

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -35,7 +35,7 @@ import Name
 import Builder
 import Syntax hiding (State)
 import Type
-import PPrint (pprintCanonicalized)
+import PPrint (pprintCanonicalized, prettyBlock)
 import CheapReduction
 import GenericTraversal
 import MTL1
@@ -736,16 +736,16 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
           UPatBinder UIgnore ->
             buildPiInf noHint arr ann' \_ -> (,) <$> checkUEffRow effs <*> checkUType ty
           _ -> buildPiInf (getNameHint pat) arr ann' \v -> do
-            Abs decls piResult <- buildDeclsInf do
+            Abs decls result <- buildDeclsInf do
               v' <- sinkM v
               bindLamPat (WithSrcB pos' pat) v' do
                 effs' <- checkUEffRow effs
                 ty'   <- checkUType   ty
                 return $ PairE effs' ty'
-            cheapReduceWithDecls decls piResult >>= \case
+            cheapReduceWithDecls decls result >>= \case
               (Just (PairE effs' ty'), DictTypeHoistSuccess, []) -> return $ (effs', ty')
               _ -> throw TypeErr $ "Can't reduce type expression: " ++
-                     pprint (Block (BlockAnn TyKind) decls $ snd $ fromPairE piResult)
+                     docAsStr (prettyBlock decls $ snd $ fromPairE result)
     matchRequirement $ Pi piTy
   UTabPi (UTabPiExpr (UPatAnn (WithSrcB pos' pat) ann) ty) -> do
     ann' <- checkAnn ann
@@ -759,7 +759,7 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
         cheapReduceWithDecls decls piResult >>= \case
           (Just ty', DictTypeHoistSuccess, []) -> return ty'
           _ -> throw TypeErr $ "Can't reduce type expression: " ++
-                 pprint (Block (BlockAnn TyKind) decls piResult)
+                 docAsStr (prettyBlock decls piResult)
     checkIx pos' $ argType piTy
     matchRequirement $ TabPi piTy
   UDecl (UDeclExpr decl body) -> do
@@ -2453,13 +2453,7 @@ buildBlockInf
   :: (EmitsInf n, Solver m, InfBuilder m)
   => (forall l. (EmitsBoth l, Ext n l) => m l (Atom l))
   -> m n (Block n)
-buildBlockInf cont = do
-  Abs decls (PairE result ty) <- buildDeclsInf do
-    result <- cont
-    ty <- cheapNormalize =<< getType result
-    return $ result `PairE` ty
-  ty' <- liftHoistExcept $ hoist decls ty
-  return $ Block (BlockAnn ty') decls result
+buildBlockInf cont = buildDeclsInf (cont >>= withType) >>= computeAbsEffects >>= absToBlock
 
 buildLamInf
   :: (EmitsInf n, Solver m, InfBuilder m)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -10,7 +10,7 @@
 
 module PPrint (
   pprint, pprintCanonicalized, pprintList, asStr , atPrec, toJSONStr,
-  PrettyPrec(..), PrecedenceLevel (..), printLitBlock, printResult) where
+  PrettyPrec(..), PrecedenceLevel (..), prettyBlock, printLitBlock, printResult) where
 
 import Data.Aeson hiding (Result, Null, Value, Success)
 import GHC.Exts (Constraint)
@@ -100,8 +100,11 @@ pArg :: PrettyPrec a => a -> Doc ann
 pArg a = prettyPrec a ArgPrec
 
 instance Pretty (Block n) where
-  pretty (Block _ Empty expr) = group $ line <> pLowest expr
-  pretty (Block _ decls expr) = hardline <> prettyLines decls' <> pLowest expr
+  pretty (Block _ decls expr) = prettyBlock decls expr
+
+prettyBlock :: (PrettyPrec (e l)) => Nest Decl n l -> e l -> Doc ann
+prettyBlock Empty expr = group $ line <> pLowest expr
+prettyBlock decls expr = hardline <> prettyLines decls' <> pLowest expr
     where decls' = fromNest decls
 
 fromNest :: Nest b n l -> [b UnsafeS UnsafeS]

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -153,7 +153,7 @@ data Block n where
   Block :: BlockAnn n l -> Nest Decl n l -> Atom l -> Block n
 
 data BlockAnn n l where
-  BlockAnn :: Type n -> BlockAnn n l
+  BlockAnn :: Type n -> EffectRow n -> BlockAnn n l
   NoBlockAnn :: BlockAnn n n
 
 data LamBinding (n::S) = LamBinding Arrow (Type n)
@@ -1084,12 +1084,12 @@ instance SubstE AtomSubstVal (ExtLabeledItemsE Atom AtomName) where
     ExtLabeledItemsE $ prefixExtLabeledItems items' ext
 
 instance GenericE Block where
-  type RepE Block = PairE (MaybeE Type) (Abs (Nest Decl) Atom)
-  fromE (Block (BlockAnn ty) decls result) = PairE (JustE ty) (Abs decls result)
+  type RepE Block = PairE (MaybeE (PairE Type EffectRow)) (Abs (Nest Decl) Atom)
+  fromE (Block (BlockAnn ty effs) decls result) = PairE (JustE (PairE ty effs)) (Abs decls result)
   fromE (Block NoBlockAnn Empty result) = PairE NothingE (Abs Empty result)
   fromE _ = error "impossible"
   {-# INLINE fromE #-}
-  toE   (PairE (JustE ty) (Abs decls result)) = Block (BlockAnn ty) decls result
+  toE   (PairE (JustE (PairE ty effs)) (Abs decls result)) = Block (BlockAnn ty effs) decls result
   toE   (PairE NothingE (Abs Empty result)) = Block NoBlockAnn Empty result
   toE   _ = error "impossible"
   {-# INLINE toE #-}

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -308,6 +308,14 @@ def bug (n : Type) : Unit =
     for i:(w..). ()
   ()
 > Leaked local variables:[v#0]
+> Block:
+>   v#0:n = todo n
+>   w:n = v#0
+>   v#1:((v#0..) => Unit) = for i:(v#0..). ()
+>   v#2:(Ix (v#0..)) = synthesize (Ix (v#0..))
+>  v#1
+> Of type: ((v#0..) => Unit)
+> With effects: {}
 >
 >   for w':n.
 >   ^^^^


### PR DESCRIPTION
Specifically:
- Add a field to BlockAnn to record the effects the Block uses
- Add `computeAbsEffects` that computes effects in the decls by traversing them
- Add code to Block-building operations to hoist those effects and stash the result in the new BlockAnn field

Knock-on changes:
- Cleaned up the implementation of `exprEffects` to remove the `MonadFail1` constraint.
- Inlined the monadic `makeBlock` into its one use site and rename `makeBlockOfType` to `makeBlock`.

I expect no functional changes from this, because the new effects annotation is not meaningfully used (that's for the next PR).

The code comments contain several questions for the reviewer, but at this point I expect the effects of the answers to be fairly local.