### PR TITLE
Example of general linear maps.

### DIFF
--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -89,8 +89,11 @@ instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
   solve' = backward_substitute
 
 -- Skew symmetric maps.
+
 -- For now it's just a wrapper around lower triangular matrices with no diagonal
 -- elements, but that might be a bit presumptuous.
+def SkewSymmetricMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..<i)=>v
+
 def transpose_lower_to_upper' {n v}
     (lower:i:n=>(..<i)=>v) :
            i:n=>(i<..)=>v =
@@ -115,39 +118,69 @@ instance {n v} [Mul v, VSpace v] LinearEndo (i:n=>(..<i)=>Float) (n=>v)
 -- Todo: sparse matrices.
 
 
-'## Determinant typeclass
+'## Determinant and miscellaneous typeclass
 This should probably be part of the `LinearEndo` typeclass,
 once associated types work.
 
 interface HasDeterminant m
   determinant': m -> Float
+  transpose': m -> m
+  identity': m
 
 instance HasDeterminant Float
   determinant' = id
+  transpose' = id
+  identity' = 1.0
 
 -- Diagonal matrices
 instance {n} HasDeterminant (n=>Float)
   determinant' = prod
+  transpose' = id
+  identity' = one
 
 -- Full-rank matrices
 instance {n} HasDeterminant (n=>n=>Float)
   determinant' = determinant
+  transpose' = transpose
+  identity' = eye
 
 -- Lower-triangular matrices
 instance {n} HasDeterminant (LowerTriMat n Float)
   determinant' = \x. prod $ lower_tri_diag x
+  transpose' = id  -- A transpose in the linear map sense.
+  identity' = for i j. select (ordinal i == ordinal j) one zero
 
 -- Upper-triangular matrices
 instance {n} HasDeterminant (UpperTriMat n Float)
   determinant' = \x. prod $ upper_tri_diag x
+  transpose' = id  -- A transpose in the linear map sense.
+  identity' = for i j. select (0 == ordinal j) one zero
 
 instance {n} HasDeterminant (i:n=>(..<i)=>Float)
   determinant' = case is_odd (size n) of
     True -> zero
     False -> todo  -- Pfaffian
+  transpose' = \x. -x
+  identity' = error "Skew symmetric matrices can't represent the identity map."
+
+
+i : (LowerTriMat (Fin 4) Float) = identity'
+i
+
+vec: (Fin 4)=>Float = (arb $ new_key 0)
+vec
+
+apply i vec
+
+i2 : (UpperTriMat (Fin 4) Float) = identity'
+i2
+
+apply i2 vec
 
 
 '## Tests
+
+inner_prod ((apply (transpose mat) vec) vec) ~~ inner_prod ((apply mat) vec) vec)
 
 -- Check inverse of skew-symmetric matrices.
 skew_mat : i:(Fin 4)=>(..<i)=>Float = arb $ new_key 0
@@ -199,11 +232,12 @@ def gaussianlogpdf {m v}
     [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
     (mean:v) (covroot:m) (x:v) : Float =
   dim = get_VSpace_dim x
-  squarepart = inner_prod (x - mean) (solve' covroot (solve' covroot (x - mean)))
+  squarepart = inner_prod (x - mean) (solve' (transpose' covroot) (solve' covroot (x - mean)))
   const = dim * log (2.0 * pi) + log (sq (determinant' covroot))
   -0.5 * (squarepart + const)
 
--- Tests
+
+'## Tests
 
 solve [[3.0]] [2.0]
 solve' 3.0 2.0
@@ -222,16 +256,34 @@ mat = (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float)
 vec = (arb $ new_key 0):(Fin 4)=>Float
 gaussianlogpdf vec mat (arb $ new_key 0)
 
+sizen = Fin 200
+span = 10.0
+
 -- Check that it sums to 1
-xs = linspace (Fin 100) (-3.0) 3.0
-6.0 * mean for i:(Fin 100).
+xs = linspace sizen (-span) span
+2.0 * span* mean for i:sizen.
   exp $ gaussianlogpdf (-0.1) 0.07 xs.i
 
 
 -- Check that it sums to 1
 covroot = (arb $ new_key 0):((Fin 2)=>(Fin 2)=>Float)
-36.0 * mean for (i, j):((Fin 100) & (Fin 100)).
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
   exp $ gaussianlogpdf (arb $ new_key 0) covroot [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot2 = (arb $ new_key 2):(LowerTriMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot2 [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot4 = (arb $ new_key 2):(UpperTriMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot4 [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot3 = (arb $ new_key 2):(SkewSymmetricMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot3 [xs.i, xs.j]
 
 
 '## Application 2: SDEs
@@ -250,15 +302,17 @@ def radonNikodym {m s} [Mul s, VSpace s, LinearEndo m s]
 
 -- Drift and diffusion product.
 -- DiffusionProd takes state and noise and returns dstate/dtime
-def Drift {v} [VSpace v] (v:Type) : Type = v->Time->v
-def Diffusion {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = v->Time->(LinearEndo m v)
-def SDE {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = (Drift v & Diffusion m v )
+def Drift (v:Type) [VSpace v]: Type = v->Time->v
+def Diffusion (m:Type) (v:Type) [VSpace m, VSpace v] : Type = v->Time->(LinearEndo m v)
+def DiffusionProd (v:Type) : Type = v->Time->v->v
+def SDE (m:Type) (v:Type) [VSpace m, VSpace v] : Type = ((Drift v) & (DiffusionProd v))
 
 def SkewSymmetricProd (v:Type) : Type = v->Time->v->v
+
 def NegEnergyFunc (v:Type) : Type = v->Time->Float
 def StationarySDE (v:Type) : Type = (NegEnergyFunc v & SkewSymmetricProd v & DiffusionProd v)
 
-def stationary_SDE_to_SDE {v} [Mul v, VSpace v] (sta:StationarySDE v) : SDE v =
+def stationary_SDE_to_SDE {m v} [Mul v, VSpace v, VSpace m] (sta:StationarySDE v) : (SDE m v) =
   -- From Section 2.1 of "A Complete Recipe for Stochastic Gradient MCMC"
   -- https://arxiv.org/pdf/1506.04696.pdf
   (negEnergyFunc, skewSymmetricProd, diffusionProd) = sta

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -38,12 +38,20 @@ instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
   arb = \x. for i. arb $ new_key (ordinal i)
 
 
+'Todo: factor out a more general linear map typeclass, and make this one inherit from it.
+-- interface [VSpace m, VSpace in, VSpace out] LinearMap m in out
+  -- apply: m -> in -> out
+  -- transpose': m -> m
+
 '## Linear Endomorphisms
 a.k.a. linear maps from a space back to that same space.
+
 
 interface [VSpace m, VSpace v] LinearEndo m v
   apply: m -> v -> v
   -- determinant': m -> Float
+  -- transpose': m -> m
+  -- identity': m
   diag: m -> v
   solve': m -> v -> v
 
@@ -88,10 +96,11 @@ instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
   diag = \x. for i. x.i.(0@_) .* one
   solve' = backward_substitute
 
--- Skew symmetric maps.
+
+'### Skew symmetric maps.
 
 -- For now it's just a wrapper around lower triangular matrices with no diagonal
--- elements, but that might be a bit presumptuous.
+-- elements, but that might be confusing.
 def SkewSymmetricMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..<i)=>v
 
 def transpose_lower_to_upper' {n v}
@@ -115,7 +124,9 @@ instance {n v} [Mul v, VSpace v] LinearEndo (i:n=>(..<i)=>Float) (n=>v)
     dense_rep = skewSymmetricProd a eye  -- Fall back to naive algorithm
     solve dense_rep y
 
--- Todo: sparse matrices.
+'### Sparse matrices.
+def SparseMatrix (n:Type) (m:Type) [Ix n, Ix m] (v:Type) : Type = todo
+def SquareSparseMatrix (n:Type) [Ix n] (v:Type) : Type = SparseMatrix n n v
 
 
 '## Determinant and miscellaneous typeclass
@@ -160,34 +171,8 @@ instance {n} HasDeterminant (i:n=>(..<i)=>Float)
   determinant' = case is_odd (size n) of
     True -> zero
     False -> todo  -- Pfaffian
-  transpose' = \x. -x
+  transpose' = \x. x
   identity' = error "Skew symmetric matrices can't represent the identity map."
-
-
-i : (LowerTriMat (Fin 4) Float) = identity'
-i
-
-vec: (Fin 4)=>Float = (arb $ new_key 0)
-vec
-
-apply i vec
-
-i2 : (UpperTriMat (Fin 4) Float) = identity'
-i2
-
-apply i2 vec
-
-
-'## Tests
-
-inner_prod ((apply (transpose mat) vec) vec) ~~ inner_prod ((apply mat) vec) vec)
-
--- Check inverse of skew-symmetric matrices.
-skew_mat : i:(Fin 4)=>(..<i)=>Float = arb $ new_key 0
-si : (Fin 4)=>(Fin 4)=>Float = solve' skew_mat eye
-sf : (Fin 4)=>(Fin 4)=>Float = apply skew_mat eye
-apply si sf ~~ eye
-> True
 
 
 '## Application 1: Gaussians
@@ -225,9 +210,11 @@ def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
   asdf : v = one
   inner_prod asdf asdf
 
--- This single definition of a Gaussian log pdf should work
--- efficiently for any type of covariance matrix for which
--- an efficient solve and determinant is known.
+'## Generic log pdf of a multivariate Gaussian
+This single definition of a Gaussian log pdf should work
+efficiently for any type of covariance matrix for which
+an efficient solve and determinant is known.
+
 def gaussianlogpdf {m v}
     [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
     (mean:v) (covroot:m) (x:v) : Float =
@@ -235,55 +222,6 @@ def gaussianlogpdf {m v}
   squarepart = inner_prod (x - mean) (solve' (transpose' covroot) (solve' covroot (x - mean)))
   const = dim * log (2.0 * pi) + log (sq (determinant' covroot))
   -0.5 * (squarepart + const)
-
-
-'## Tests
-
-solve [[3.0]] [2.0]
-solve' 3.0 2.0
-
-gaussianlogpdf 1.0 2.0 (arb $ new_key 0)
-
-exp (gaussianlogpdf 0.2 (sqrt 2.0) 0.1)
-exp (gaussianlogpdf [0.2] ([[sqrt 2.0]]) [0.1])
-
-def mld (mean:Float) (var:Float) (v:Float): Float =
-  -0.5 * (sq (v - mean)) / var - 0.5 * log (2.0 * pi * var)
-
-exp $ mld 0.2 2.0 0.1
-
-mat = (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float)
-vec = (arb $ new_key 0):(Fin 4)=>Float
-gaussianlogpdf vec mat (arb $ new_key 0)
-
-sizen = Fin 200
-span = 10.0
-
--- Check that it sums to 1
-xs = linspace sizen (-span) span
-2.0 * span* mean for i:sizen.
-  exp $ gaussianlogpdf (-0.1) 0.07 xs.i
-
-
--- Check that it sums to 1
-covroot = (arb $ new_key 0):((Fin 2)=>(Fin 2)=>Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot [xs.i, xs.j]
-
--- Check that it sums to 1
-covroot2 = (arb $ new_key 2):(LowerTriMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot2 [xs.i, xs.j]
-
--- Check that it sums to 1
-covroot4 = (arb $ new_key 2):(UpperTriMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot4 [xs.i, xs.j]
-
--- Check that it sums to 1
-covroot3 = (arb $ new_key 2):(SkewSymmetricMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot3 [xs.i, xs.j]
 
 
 '## Application 2: SDEs
@@ -326,3 +264,126 @@ def stationary_SDE_to_SDE {m v} [Mul v, VSpace v, VSpace m] (sta:StationarySDE v
     t3 = jvp gammapart state one
     t1 + t3
   (drift, diffusionProd)
+
+
+'## Tests
+
+
+vec_len = (Fin 4)
+full_mat_type = (vec_len=>vec_len=>Float)
+
+'### Check application of the identity is a no-op.
+
+def check_identity (m:Type) (v:Type)
+    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v,
+     VSpace v, HasAllClose v, HasDefaultTolerance v] : Bool =
+  i : m = identity'
+  vec : v = (arb $ new_key 0)
+  vec ~~ apply i vec
+
+check_identity (LowerTriMat vec_len Float) (vec_len=>Float)
+> True
+check_identity (UpperTriMat vec_len Float) (vec_len=>Float)
+> True
+check_identity (vec_len=>vec_len=>Float) (vec_len=>Float)
+> True
+check_identity (vec_len=>Float) (vec_len=>Float)
+> True
+check_identity (Float) (vec_len=>Float)
+> True
+
+def check_inverse (m:Type) (v:Type)
+    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v, LinearEndo m full_mat_type,
+     VSpace v, HasAllClose v, HasDefaultTolerance v] : Bool =
+  a : m   = (arb $ new_key 0)
+  vec : v = (arb $ new_key 0)
+  inv : full_mat_type = solve' a eye
+  full : full_mat_type = apply a eye
+  apply inv full ~~ eye
+
+check_inverse (SkewSymmetricMat vec_len Float) (vec_len=>Float)
+> True
+check_inverse (LowerTriMat vec_len Float) (vec_len=>Float)
+> True
+check_inverse (UpperTriMat vec_len Float) (vec_len=>Float)
+> True
+check_inverse (vec_len=>vec_len=>Float) (vec_len=>Float)
+> True
+check_inverse (vec_len=>Float) (vec_len=>Float)
+> True
+check_inverse (Float) (vec_len=>Float)
+> True
+
+def check_transpose (m:Type) (v:Type)
+    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v, LinearEndo m full_mat_type,
+     VSpace v, HasAllClose v, HasDefaultTolerance v, InnerProd v] : Bool =
+  a : m   = (arb $ new_key 0)
+  vec1 : v = (arb $ new_key 0)
+  vec2 : v = (arb $ new_key 0)
+  
+  hitright = inner_prod (apply (transpose' a) vec1) vec2
+  hitleft = inner_prod (apply a vec1) vec2
+  hitleft ~~ hitright
+
+check_transpose (SkewSymmetricMat vec_len Float) (vec_len=>Float)
+> True
+check_transpose (LowerTriMat vec_len Float) (vec_len=>Float)
+> True
+check_transpose (UpperTriMat vec_len Float) (vec_len=>Float)
+> True
+check_transpose (vec_len=>vec_len=>Float) (vec_len=>Float)
+> True
+check_transpose (vec_len=>Float) (vec_len=>Float)
+> True
+check_transpose (Float) (vec_len=>Float)
+> True
+
+
+
+
+
+
+
+'## Tests
+
+
+
+def mld (mean:Float) (var:Float) (v:Float): Float =
+  -0.5 * (sq (v - mean)) / var - 0.5 * log (2.0 * pi * var)
+
+exp $ mld 0.2 2.0 0.1
+
+mat = (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float)
+vec = (arb $ new_key 0):(Fin 4)=>Float
+gaussianlogpdf vec mat (arb $ new_key 0)
+
+sizen = Fin 200
+span = 10.0
+
+-- Check that it sums to 1
+xs = linspace sizen (-span) span
+2.0 * span* mean for i:sizen.
+  exp $ gaussianlogpdf (-0.1) 0.07 xs.i
+
+
+-- Check that it sums to 1
+covroot = (arb $ new_key 0):((Fin 2)=>(Fin 2)=>Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot2 = (arb $ new_key 2):(LowerTriMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot2 [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot4 = (arb $ new_key 2):(UpperTriMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot4 [xs.i, xs.j]
+
+-- Check that it sums to 1
+covroot3 = (arb $ new_key 2):(SkewSymmetricMat (Fin 2) Float)
+(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot3 [xs.i, xs.j]
+
+

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -38,6 +38,15 @@ instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
   arb = \x. for i. arb $ new_key (ordinal i)
 
 
+t = (i:(Fin 2)=> (..i) => Float32)
+x : t = arb $ new_key 0
+
+def f (g:t) : t =
+  g
+
+f x
+
+
 'Todo: factor out a more general linear map typeclass, and make this one inherit from it.
 -- interface [VSpace m, VSpace in, VSpace out] LinearMap m in out
   -- apply: m -> in -> out
@@ -50,7 +59,8 @@ a.k.a. linear maps from a space back to that same space.
 interface [VSpace m, VSpace v] LinearEndo m v
   apply: m -> v -> v
   -- determinant': m -> Float
-  -- transpose': m -> m
+  -- transposeType: Type
+  -- transpose': m -> transposeType
   -- identity': m
   diag: m -> v
   solve': m -> v -> v
@@ -64,43 +74,39 @@ because `v` is always ambiguous at its usage site.
 
 instance {v} [Mul v, VSpace v] LinearEndo (Float) v
   apply = (.*)
-  -- determinant' = id
   diag = \a. a .* one
   solve' = \a b. b / a
 
 -- Diagonal matrices
 instance {n v} [Mul v, VSpace v] LinearEndo (n=>Float) (n=>v)
   apply = \x y. for i. x.i .* y.i
-  -- determinant' = prod
   diag = \a. for i. a.i .* one
   solve' = \a b. for i. b.i / a.i
 
 -- Full-rank matrices
 instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
   apply = \x y. for i. sum for j. x.i.j .* y.j
-  -- determinant' = determinant
   diag = \x. for i. x.i.i .* one
   solve' = solve
 
 -- Lower-triangular matrices
 instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMat n Float) (n=>v)
   apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
-  -- determinant' = \x. prod $ lower_tri_diag x
   diag = \x. for i. x.i.(cast i) .* one
   solve' = forward_substitute
 
 -- Upper-triangular matrices
 instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
   apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
-  -- determinant' = \x. prod $ upper_tri_diag x
   diag = \x. for i. x.i.(0@_) .* one
   solve' = backward_substitute
 
 
-'### Skew symmetric maps.
+'### Skew symmetric matrices.
+For now it's just a wrapper around lower triangular matrices with no diagonal
+elements, but the danger is that something accidentally gets treated as a
+skew-symmetric matrix. 
 
--- For now it's just a wrapper around lower triangular matrices with no diagonal
--- elements, but that might be confusing.
 def SkewSymmetricMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..<i)=>v
 
 def transpose_lower_to_upper' {n v}
@@ -135,44 +141,65 @@ once associated types work.
 
 interface HasDeterminant m
   determinant': m -> Float
-  transpose': m -> m
+  transposeType m : Type  -- unused for now
+  transpose': m -> m   -- In future: m -> transposeType
   identity': m
 
 instance HasDeterminant Float
   determinant' = id
+  transposeType = Float
   transpose' = id
   identity' = 1.0
 
 -- Diagonal matrices
 instance {n} HasDeterminant (n=>Float)
   determinant' = prod
+  transposeType = n=>Float
   transpose' = id
   identity' = one
 
 -- Full-rank matrices
 instance {n} HasDeterminant (n=>n=>Float)
   determinant' = determinant
+  transposeType = n=>n=>Float
   transpose' = transpose
   identity' = eye
 
 -- Lower-triangular matrices
 instance {n} HasDeterminant (LowerTriMat n Float)
   determinant' = \x. prod $ lower_tri_diag x
-  transpose' = id  -- A transpose in the linear map sense.
+  transposeType = UpperTriMat n Float
+  transpose' = error "Can't transpose to different types yet."
   identity' = for i j. select (ordinal i == ordinal j) one zero
 
 -- Upper-triangular matrices
 instance {n} HasDeterminant (UpperTriMat n Float)
   determinant' = \x. prod $ upper_tri_diag x
-  transpose' = id  -- A transpose in the linear map sense.
+  transposeType = LowerTriMat n Float
+  transpose' = error "Can't transpose to different types yet."
   identity' = for i j. select (0 == ordinal j) one zero
 
 instance {n} HasDeterminant (i:n=>(..<i)=>Float)
   determinant' = case is_odd (size n) of
     True -> zero
-    False -> todo  -- Pfaffian
-  transpose' = \x. x
+    False -> \a.
+      dense_rep = skewSymmetricProd a eye
+      determinant dense_rep  -- Naive algorithm, could be done with Pfaffian
+  transposeType = i:n=>(..<i)=>Float
+  transpose' = \x. -x
   identity' = error "Skew symmetric matrices can't represent the identity map."
+
+
+'## Inner product typeclass
+
+interface [VSpace v] InnerProd v
+  inner_prod : v->v->Float
+
+instance InnerProd Float
+  inner_prod = \x y. x * y
+
+instance {a n} [InnerProd a] InnerProd (n=>a)
+  inner_prod = \x y. sum for i. inner_prod x.i y.i
 
 
 '## Application 1: Gaussians
@@ -194,26 +221,15 @@ def gaussianSample {v m} [VSpace v, VSpace m, LinearEndo m v, HasStandardNormal 
 
 :p gaussianSample (1.0, 2.0) (new_key 0)
 
-
-interface [VSpace v] InnerProd v
-  inner_prod : v->v->Float
-
-instance InnerProd Float
-  inner_prod = \x y. x * y
-
-instance {a n} [InnerProd a] InnerProd (n=>a)
-  inner_prod = \x y. sum for i. inner_prod x.i y.i
-
-
--- This is a hack until the basis typeclass works.
-def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
-  asdf : v = one
-  inner_prod asdf asdf
-
 '## Generic log pdf of a multivariate Gaussian
 This single definition of a Gaussian log pdf should work
 efficiently for any type of covariance matrix for which
 an efficient solve and determinant is known.
+
+-- This helper will be osbolete once the basis typeclass works.
+def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
+  asdf : v = one
+  inner_prod asdf asdf
 
 def gaussianlogpdf {m v}
     [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
@@ -314,23 +330,23 @@ check_inverse (vec_len=>Float) (vec_len=>Float)
 check_inverse (Float) (vec_len=>Float)
 > True
 
+
 def check_transpose (m:Type) (v:Type)
-    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v, LinearEndo m full_mat_type,
+    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v,
      VSpace v, HasAllClose v, HasDefaultTolerance v, InnerProd v] : Bool =
-  a : m   = (arb $ new_key 0)
-  vec1 : v = (arb $ new_key 0)
-  vec2 : v = (arb $ new_key 0)
+  a : m                  = arb $ new_key 0
+  (vec1, vec2) : (v & v) = arb $ new_key 1
   
-  hitright = inner_prod (apply (transpose' a) vec1) vec2
   hitleft = inner_prod (apply a vec1) vec2
+  hitright = inner_prod (apply (transpose' a) vec2) vec1
   hitleft ~~ hitright
 
 check_transpose (SkewSymmetricMat vec_len Float) (vec_len=>Float)
 > True
-check_transpose (LowerTriMat vec_len Float) (vec_len=>Float)
-> True
-check_transpose (UpperTriMat vec_len Float) (vec_len=>Float)
-> True
+-- check_transpose (LowerTriMat vec_len Float) (vec_len=>Float)
+-- > True
+-- check_transpose (UpperTriMat vec_len Float) (vec_len=>Float)
+-- > True
 check_transpose (vec_len=>vec_len=>Float) (vec_len=>Float)
 > True
 check_transpose (vec_len=>Float) (vec_len=>Float)
@@ -338,52 +354,38 @@ check_transpose (vec_len=>Float) (vec_len=>Float)
 check_transpose (Float) (vec_len=>Float)
 > True
 
-
-
-
-
-
-
-'## Tests
-
-
-
-def mld (mean:Float) (var:Float) (v:Float): Float =
-  -0.5 * (sq (v - mean)) / var - 0.5 * log (2.0 * pi * var)
-
-exp $ mld 0.2 2.0 0.1
-
-mat = (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float)
-vec = (arb $ new_key 0):(Fin 4)=>Float
-gaussianlogpdf vec mat (arb $ new_key 0)
-
-sizen = Fin 200
+-- Check that 1D Gaussian sums to 1
+sizen = Fin 2000
 span = 10.0
-
--- Check that it sums to 1
 xs = linspace sizen (-span) span
-2.0 * span* mean for i:sizen.
+integral = 2.0 * span * mean for i.
   exp $ gaussianlogpdf (-0.1) 0.07 xs.i
+integral ~~ 1.0
 
+def check_2D_Gaussian_normalizes (m:Type)
+    [LinearEndo m ((Fin 2) => Float32), HasDeterminant m, Arbitrary m] : Bool =
 
--- Check that it sums to 1
-covroot = (arb $ new_key 0):((Fin 2)=>(Fin 2)=>Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot [xs.i, xs.j]
+  sizen = Fin 200
+  span = 10.0
+  xs = linspace sizen (-span) span
 
--- Check that it sums to 1
-covroot2 = (arb $ new_key 2):(LowerTriMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot2 [xs.i, xs.j]
+  covroot : m = arb $ new_key 0
+  meanvec : ((Fin 2) => Float32) = arb $ new_key 1
+  integral = (sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+    x = [xs.i, xs.j]
+    exp $ gaussianlogpdf meanvec covroot x
+  integral ~~ 1.0
 
--- Check that it sums to 1
-covroot4 = (arb $ new_key 2):(UpperTriMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot4 [xs.i, xs.j]
+check_2D_Gaussian_normalizes (SkewSymmetricMat (Fin 2) Float)
+> True
+-- check_2D_Gaussian_normalizes (LowerTriMat (Fin 2) Float)
+-- > True
+-- check_2D_Gaussian_normalizes (UpperTriMat (Fin 2) Float)
+-- > True
+check_2D_Gaussian_normalizes ((Fin 2)=>(Fin 2)=>Float)
+> True
+check_2D_Gaussian_normalizes ((Fin 2)=>Float)
+> True
 
--- Check that it sums to 1
-covroot3 = (arb $ new_key 2):(SkewSymmetricMat (Fin 2) Float)
-(sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-  exp $ gaussianlogpdf (arb $ new_key 0) covroot3 [xs.i, xs.j]
-
-
+-- check_2D_Gaussian_normalizes (Float)  -- How does this even typecheck?
+-- > True

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -1,4 +1,4 @@
-'# General Linear Maps
+'# Polymorphic Operations on Linear Maps
 Often when writing numerical code, there are efficient specializations for
 e.g. diagonal matrices, lower-triangular, or sparse matrices.
 I'd like to be able to write just one version of this code without having to
@@ -145,7 +145,7 @@ instance {n} HasDeterminant (SkewSymmetricMap n)
     False -> \(MkSkewSymMap a).
       dense_rep = skew_symmetric_prod a eye
       determinant dense_rep  -- Naive algorithm, could be done with Pfaffian
-  transposeType = i:n=>(..<i)=>Float
+  transposeType = i:n=>(..<i)=>Float  -- 
   transpose' = \(MkSkewSymMap x). MkSkewSymMap (-x)
   identity' = error "Skew symmetric matrices can't represent the identity map."
 
@@ -177,13 +177,13 @@ instance {a n} [HasStandardNormal a] HasStandardNormal (n=>a)
     for i. randNormal (ixkey key i)
 
 
-def gaussianSample {v m} [VSpace v, LinearEndo m v, HasStandardNormal v]
-                   ((mean, covroot) : (v & m)) (key:Key) : v =
+def multivariate_gaussian_sample {v m} [LinearEndo m v, HasStandardNormal v]
+                   (mean:v) (covroot:m) (key:Key) : v =
   noise = randNormal key
   mean + apply covroot noise
 
-:p gaussianSample (1.0, (MkScalarMap 2.0)) (new_key 0)
-
+:t multivariate_gaussian_sample 1.0 (MkScalarMap 2.0) (new_key 0)
+> Float32
 
 '### Generic log pdf of a multivariate Gaussian
 This single definition of a Gaussian log pdf should work
@@ -195,8 +195,8 @@ def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
   one' : v = one
   inner_prod one' one'
 
-def gaussianlogpdf {m v}
-    [VSpace v, Mul v, InnerProd v, LinearEndo m v]
+def gaussian_log_pdf {m v}
+    [Mul v, InnerProd v, LinearEndo m v]
     (mean:v) (covroot:m) (x:v) : Float =
   dim = get_VSpace_dim x
   squarepart = inner_prod (x - mean) (solve' (transpose' covroot)
@@ -206,13 +206,12 @@ def gaussianlogpdf {m v}
 
 
 
-
 '## Tests
-
 
 vec_len = (Fin 4)
 full_mat_type = (vec_len=>vec_len=>Float)
 v = vec_len=>Float
+
 
 '### Check application of the identity is a no-op.
 
@@ -265,6 +264,7 @@ def check_transpose (m:Type)
 
 check_transpose $ SkewSymmetricMap vec_len
 > True
+-- Disabled until associated types are implemented.
 -- check_transpose $ LowerTriMap vec_len
 -- > True
 -- check_transpose $ UpperTriMap vec_len
@@ -281,7 +281,7 @@ sizen = Fin 2000
 span = 10.0
 xs = linspace sizen (-span) span
 integral = 2.0 * span * mean for i.
-  exp $ gaussianlogpdf (-0.1) (MkScalarMap 0.07) xs.i
+  exp $ gaussian_log_pdf (-0.1) (MkScalarMap 0.07) xs.i
 integral ~~ 1.0
 > True
 
@@ -296,11 +296,12 @@ def check_2D_Gaussian_normalizes (m:Type)
   meanvec : ((Fin 2) => Float32) = arb $ new_key 1
   integral = (sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
     x = [xs.i, xs.j]
-    exp $ gaussianlogpdf meanvec covroot x
+    exp $ gaussian_log_pdf meanvec covroot x
   integral ~~ 1.0
 
 check_2D_Gaussian_normalizes (SkewSymmetricMap (Fin 2))
 > True
+-- Disabled until associated types are implemented.
 -- check_2D_Gaussian_normalizes (LowerTriMat (Fin 2) Float)
 -- > True
 -- check_2D_Gaussian_normalizes (UpperTriMat (Fin 2) Float)
@@ -313,45 +314,72 @@ check_2D_Gaussian_normalizes $ DiagMap (Fin 2)
 
 '## Application 2: SDEs
 
-Time = Float
-def radonNikodym {m s} [InnerProd s, VSpace s, LinearEndo m s]
-                 (drift1: s->Time->s)
-                 (drift2: s->Time->s)
-                 (diffusion: s->Time->m)
-                 (state: s) (t: Time) : Float =
-  -- Dynamics of simple Monte Carlo estimatr of KL divergence between
-  -- two SDEs that share a diffusion function. (If not, divergence is infinite)
+data Time = MkTime Float
+
+def Drift (v:Type) [VSpace v] : Type = v->Time->v
+def Diffusion (m:Type) (v:Type) [LinearEndo m v] : Type =
+  v->Time->m
+def SDE (m:Type) (v:Type) [LinearEndo m v] : Type =
+  (Drift v & Diffusion m v)
+
+def radon_nikodym {m s} [InnerProd s, LinearEndo m s]
+  (drift1:Drift s)
+  (drift2:Drift s)
+  (diffusion:Diffusion m s)
+  (state:s) (t:Time) : Float =
+  -- By Girsanov's theorem, this gives a simple Monte Carlo estimator
+  -- of the (loosely speaking) instantaneous KL divergence between
+  -- two SDEs that share a diffusion function.
   difference = (drift1 state t) - (drift2 state t)
   cur_diffusion = diffusion state t
   a = solve' cur_diffusion difference
   0.5 * inner_prod a a
 
 
--- Drift and diffusion product.
--- DiffusionProd takes state and noise and returns dstate/dtime
-def Drift (v:Type) [VSpace v]: Type = v->Time->v
-def Diffusion (m:Type) (v:Type) [VSpace m, VSpace v] : Type = v->Time->(LinearEndo m v)
-def DiffusionProd (v:Type) : Type = v->Time->v->v
-def SDE (m:Type) (v:Type) [VSpace m, VSpace v] : Type = ((Drift v) & (DiffusionProd v))
+'### Stationary SDEs
+From Equation 3, Section 2.1 of ["A Complete Recipe for Stochastic Gradient
+MCMC"](https://arxiv.org/pdf/1506.04696.pdf):
+Every SDE with a stationary distribution can be parameterized
+by:
+ 1. A state-dependent energy function
+ 2. A state-dependent skew-symmetric matrix
+ 3. A state-dependent diffusion matrix
 
-def SkewSymmetricProd (v:Type) : Type = v->Time->v->v
+'The function below converts these matrices into the drift and diffusion which,
+if followed, will converge to a stationary distribution whose marginal
+  log-density is equal to the negative energy function (plus a constant).
 
-def NegEnergyFunc (v:Type) : Type = v->Time->Float
-def StationarySDE (v:Type) : Type = (NegEnergyFunc v & SkewSymmetricProd v & DiffusionProd v)
+def StationaryDiffusion (m:Type) (v:Type) [LinearEndo m v] : Type = v->m
+def NegEnergyFunc (v:Type) : Type = v->Float
+def SkewSymmetricFunc (n:Type) (v:Type) [Ix n] : Type =
+  v->(i:n=>(..<i)=>Float)
+def StationarySDEParts (n:Type) (v:Type)
+    [Ix n, LinearEndo n v, VSpace v] : Type =
+  (NegEnergyFunc v & SkewSymmetricFunc n v & StationaryDiffusion n v)
 
-def stationary_SDE_to_SDE {m v} [Mul v, VSpace v, VSpace m] (sta:StationarySDE v) : (SDE m v) =
-  -- From Section 2.1 of "A Complete Recipe for Stochastic Gradient MCMC"
-  -- https://arxiv.org/pdf/1506.04696.pdf
-  (negEnergyFunc, skewSymmetricProd, diffusionProd) = sta
-  varProd = \state time vec.
-    0.5 .* (diffusionProd state time $ diffusionProd state time vec)
+def stationary_SDE_parts_to_SDE {n v}
+  [Ix n, VSpace v, Mul v, LinearEndo n (n=>v)]
+  ((neg_energy_func, skew_symm_map, diffusion_func):StationarySDEParts n (n=>v)) :
+    (SDE n (n=>v)) =
   drift = \state time.
-    curNE = \state. negEnergyFunc state time
-    negenergygrad = (grad curNE) state
-    t1 = (skewSymmetricProd + varProd) state time negenergygrad
-    gammapart = \state. (skewSymmetricProd + varProd) state time one
-    t3 = jvp gammapart state one
-    t1 + t3
-  (drift, diffusionProd)
+
+    diffusion_prod = \vec.  -- Square the root of the covariance matrix
+      cur_diffusion_root = diffusion_func state
+      0.5 .* (apply cur_diffusion_root (apply cur_diffusion_root vec))
+  
+    neg_energy_grad = (grad neg_energy_func) state
+
+    skew_term = skew_symmetric_prod (skew_symm_map state) neg_energy_grad
+    diff_term = diffusion_prod neg_energy_grad
+
+    gammapart = \state.
+      skew_term' = skew_symmetric_prod (skew_symm_map state) one
+      diff_term' = diffusion_prod one
+      skew_term' + diff_term'
+    gamma_term = jvp gammapart state one
+    
+    skew_term + diff_term + gamma_term
+  diffusion = \state time. diffusion_func state
+  (drift, diffusion)
 
 -- Todo: tests for SDE functions.

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -1,53 +1,16 @@
+'# General Linear Maps
+Often when writing numerical code, there are efficient specializations for
+e.g. diagonal matrices, lower-triangular, or sparse matrices.
+I'd like to be able to write just one version of this code without having to
+fall back to casting everything to full-rank unstructured matrices.
+This example is for brainstorming how the typeclass system might support
+efficient polymorphism for linear algebra over different types of
+structured maps.
+
 import linalg
 
-'## Instances for triangular tables
-How to avoid these repetitive instances?
-
-instance {a n} [Add a] Add (i:n => (..<i) => a)
-  add = \xs ys. for i. xs.i + ys.i
-  sub = \xs ys. for i. xs.i - ys.i
-  zero = for _. zero
-
-instance {a n} [Add a] Add (i:n => (i<..) => a)
-  add = \xs ys. for i. xs.i + ys.i
-  sub = \xs ys. for i. xs.i - ys.i
-  zero = for _. zero
-
-instance {a n} [VSpace a] VSpace (i:n => (..i) => a)
-  scale_vec = \s xs. for i. s .* xs.i
-
-instance {a n} [VSpace a] VSpace (i:n => (i..) => a)
-  scale_vec = \s xs. for i. s .* xs.i
-
-instance {a n} [VSpace a] VSpace (i:n => (..<i) => a)
-  scale_vec = \s xs. for i. s .* xs.i
-
-instance {a n} [VSpace a] VSpace (i:n => (i<..) => a)
-  scale_vec = \s xs. for i. s .* xs.i
-
-instance {n a} [Arbitrary a] Arbitrary (i:n=>(..<i) => a)
-  arb = \x. for i. arb $ new_key (ordinal i)
-
-instance {n a} [Arbitrary a] Arbitrary (i:n=>(..i) => a)
-  arb = \x. for i. arb $ new_key (ordinal i)
-
-instance {n a} [Arbitrary a] Arbitrary (i:n=>(i..) => a)
-  arb = \x. for i. arb $ new_key (ordinal i)
-
-instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
-  arb = \x. for i. arb $ new_key (ordinal i)
-
-
-t = (i:(Fin 2)=> (..i) => Float32)
-x : t = arb $ new_key 0
-
-def f (g:t) : t =
-  g
-
-f x
-
-
 'Todo: factor out a more general linear map typeclass, and make this one inherit from it.
+
 -- interface [VSpace m, VSpace in, VSpace out] LinearMap m in out
   -- apply: m -> in -> out
   -- transpose': m -> m
@@ -55,151 +18,150 @@ f x
 '## Linear Endomorphisms
 a.k.a. linear maps from a space back to that same space.
 
-
-interface [VSpace m, VSpace v] LinearEndo m v
-  apply: m -> v -> v
-  -- determinant': m -> Float
-  -- transposeType: Type
-  -- transpose': m -> transposeType
-  -- identity': m
-  diag: m -> v
-  solve': m -> v -> v
-
-'We'd like to remove `v` from the above interface,
-and instead use associated types to specify a `v` for each `m`.
-But for now, fields in typeclasses can't refer to one another.
-This means that `determinant'` can't be part of this typeclass yet,
-because `v` is always ambiguous at its usage site.
-
-
-instance {v} [Mul v, VSpace v] LinearEndo (Float) v
-  apply = (.*)
-  diag = \a. a .* one
-  solve' = \a b. b / a
-
--- Diagonal matrices
-instance {n v} [Mul v, VSpace v] LinearEndo (n=>Float) (n=>v)
-  apply = \x y. for i. x.i .* y.i
-  diag = \a. for i. a.i .* one
-  solve' = \a b. for i. b.i / a.i
-
--- Full-rank matrices
-instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
-  apply = \x y. for i. sum for j. x.i.j .* y.j
-  diag = \x. for i. x.i.i .* one
-  solve' = solve
-
--- Lower-triangular matrices
-instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMat n Float) (n=>v)
-  apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
-  diag = \x. for i. x.i.(cast i) .* one
-  solve' = forward_substitute
-
--- Upper-triangular matrices
-instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
-  apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
-  diag = \x. for i. x.i.(0@_) .* one
-  solve' = backward_substitute
-
-
-'### Skew symmetric matrices.
-For now it's just a wrapper around lower triangular matrices with no diagonal
-elements, but the danger is that something accidentally gets treated as a
-skew-symmetric matrix. 
-
-def SkewSymmetricMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..<i)=>v
-
-def transpose_lower_to_upper' {n v}
-    (lower:i:n=>(..<i)=>v) :
-           i:n=>(i<..)=>v =
-  for i j.
-    j' = %inject j
-    lower.j'.(unsafe_from_ordinal _ (ordinal i))
-
-def skewSymmetricProd {v n} [VSpace v]
-    (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
-  lower_prod = for i. sum for j. lower.i.j .* (y.(%inject j))
-  upper = transpose_lower_to_upper' lower
-  upper_prod = for i. sum for j. upper.i.j .* (y.(%inject j))
-  lower_prod - upper_prod
-
-instance {n v} [Mul v, VSpace v] LinearEndo (i:n=>(..<i)=>Float) (n=>v)
-  apply = skewSymmetricProd
-  diag = \x. zero
-  solve' = \a y.
-    dense_rep = skewSymmetricProd a eye  -- Fall back to naive algorithm
-    solve dense_rep y
-
-'### Sparse matrices.
-def SparseMatrix (n:Type) (m:Type) [Ix n, Ix m] (v:Type) : Type = todo
-def SquareSparseMatrix (n:Type) [Ix n] (v:Type) : Type = SparseMatrix n n v
-
-
-'## Determinant and miscellaneous typeclass
-This should probably be part of the `LinearEndo` typeclass,
-once associated types work.
-
 interface HasDeterminant m
   determinant': m -> Float
   transposeType m : Type  -- unused for now
-  transpose': m -> m   -- In future: m -> transposeType
+  transpose': m -> m      -- In future: m -> transposeType m
   identity': m
 
-instance HasDeterminant Float
-  determinant' = id
+interface [VSpace v, HasDeterminant m] LinearEndo m v
+  apply: m -> v -> v
+  diag: m -> v
+  solve': m -> v -> v
+
+'We'd like to remove `v` from the `LinearEndo` interface,
+and instead use associated types to specify a `v` for each `m`.
+This would let use combine it with `HasDeterminant`.
+But for now, fields in typeclasses can't refer to one another.
+This means that `determinant'` and other operations can't be part
+of this typeclass yet, because `v` is always ambiguous at its usage site.
+
+
+'## Instances
+
+'### Scalar maps
+
+data ScalarMap =
+  MkScalarMap Float
+
+instance HasDeterminant ScalarMap
+  determinant' = \(MkScalarMap a). a
   transposeType = Float
   transpose' = id
-  identity' = 1.0
+  identity' = MkScalarMap 1.0
 
--- Diagonal matrices
-instance {n} HasDeterminant (n=>Float)
-  determinant' = prod
+instance {v} [Mul v, VSpace v] LinearEndo ScalarMap v
+  apply =  \(MkScalarMap a) b. a .* b
+  diag =   \(MkScalarMap a).   a .* one
+  solve' = \(MkScalarMap a) b. b / a
+
+instance Arbitrary ScalarMap
+  arb = \k. MkScalarMap $ arb k
+
+
+'### Diagonal maps
+
+data DiagMap n [Ix n] =
+  MkDiagMap (i:n=>Float)
+
+instance {n} HasDeterminant (DiagMap n)
+  determinant' = \(MkDiagMap x). prod x
   transposeType = n=>Float
   transpose' = id
-  identity' = one
+  identity' = MkDiagMap one
 
--- Full-rank matrices
+instance {n v} [Mul v, VSpace v] LinearEndo (DiagMap n) (n=>v)
+  apply =  \(MkDiagMap x) y. for i. x.i .* y.i
+  diag =   \(MkDiagMap a).   for i. a.i .* one
+  solve' = \(MkDiagMap a) b. for i. b.i / a.i
+
+instance {n} Arbitrary (DiagMap n)
+  arb = \k. MkDiagMap $ arb k
+
+
+'### Full-rank matrices.
+I didn't use a newtype for these, but I'm not sure if that's the right call.
+
 instance {n} HasDeterminant (n=>n=>Float)
   determinant' = determinant
   transposeType = n=>n=>Float
   transpose' = transpose
   identity' = eye
 
--- Lower-triangular matrices
-instance {n} HasDeterminant (LowerTriMat n Float)
-  determinant' = \x. prod $ lower_tri_diag x
+instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
+  apply = \x y. for i. sum for j. x.i.j .* y.j
+  diag = \x. for i. x.i.i .* one
+  solve' = solve
+
+
+'### Lower-triangular maps
+
+data LowerTriMap n [Ix n] =
+  MkLowerTriMap (i:n=>(..i)=>Float)
+
+instance {n} HasDeterminant (LowerTriMap n)
+  determinant' = \(MkLowerTriMap x). prod $ lower_tri_diag x
   transposeType = UpperTriMat n Float
   transpose' = error "Can't transpose to different types yet."
-  identity' = for i j. select (ordinal i == ordinal j) one zero
+  identity' = MkLowerTriMap for i j. select (ordinal i == ordinal j) one zero
 
--- Upper-triangular matrices
-instance {n} HasDeterminant (UpperTriMat n Float)
-  determinant' = \x. prod $ upper_tri_diag x
+instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMap n) (n=>v)
+  apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(%inject j)
+  diag   = \(MkLowerTriMap x).   for i. x.i.(cast i) .* one
+  solve' = \(MkLowerTriMap x).   forward_substitute x
+
+instance {n} Arbitrary (LowerTriMap n)
+  arb = \k. MkLowerTriMap $ arb k
+
+
+'### Upper-triangular maps
+
+data UpperTriMap n [Ix n] =
+  MkUpperTriMap (i:n=>(i..)=>Float)
+
+instance {n} HasDeterminant (UpperTriMap n)
+  determinant' = \(MkUpperTriMap x). prod $ upper_tri_diag x
   transposeType = LowerTriMat n Float
   transpose' = error "Can't transpose to different types yet."
-  identity' = for i j. select (0 == ordinal j) one zero
+  identity' = MkUpperTriMap for i j. select (0 == ordinal j) one zero
 
-instance {n} HasDeterminant (i:n=>(..<i)=>Float)
+instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMap n) (n=>v)
+  apply  = \(MkUpperTriMap x) y. for i. sum for j. x.i.j .* y.(%inject j)
+  diag   = \(MkUpperTriMap x).   for i. x.i.(0@_) .* one
+  solve' = \(MkUpperTriMap x).   backward_substitute x
+
+instance {n} Arbitrary (UpperTriMap n)
+  arb = \k. MkUpperTriMap $ arb k
+
+
+'### Skew-symmetric maps
+
+data SkewSymmetricMap n [Ix n] =
+  MkSkewSymMap (i:n=>(..<i)=>Float)
+
+instance {n} HasDeterminant (SkewSymmetricMap n)
   determinant' = case is_odd (size n) of
     True -> zero
-    False -> \a.
-      dense_rep = skewSymmetricProd a eye
+    False -> \(MkSkewSymMap a).
+      dense_rep = skew_symmetric_prod a eye
       determinant dense_rep  -- Naive algorithm, could be done with Pfaffian
   transposeType = i:n=>(..<i)=>Float
-  transpose' = \x. -x
+  transpose' = \(MkSkewSymMap x). MkSkewSymMap (-x)
   identity' = error "Skew symmetric matrices can't represent the identity map."
 
+instance {n v} [Mul v, VSpace v] LinearEndo (SkewSymmetricMap n) (n=>v)
+  apply  = \(MkSkewSymMap x) y. skew_symmetric_prod x y
+  diag   = \(MkSkewSymMap x).   zero
+  solve' = \(MkSkewSymMap x) y.
+    dense_rep = skew_symmetric_prod x eye  -- Fall back to naive algorithm
+    solve dense_rep y
 
-'## Inner product typeclass
+instance {n} Arbitrary (SkewSymmetricMap n)
+  arb = \k. MkSkewSymMap $ arb k
 
-interface [VSpace v] InnerProd v
-  inner_prod : v->v->Float
 
-instance InnerProd Float
-  inner_prod = \x y. x * y
+-- Todo: Sparse matrices. Need hashmaps for these to be practical.
 
-instance {a n} [InnerProd a] InnerProd (n=>a)
-  inner_prod = \x y. sum for i. inner_prod x.i y.i
 
 
 '## Application 1: Gaussians
@@ -214,44 +176,155 @@ instance {a n} [HasStandardNormal a] HasStandardNormal (n=>a)
   randNormal = \key.
     for i. randNormal (ixkey key i)
 
-def gaussianSample {v m} [VSpace v, VSpace m, LinearEndo m v, HasStandardNormal v]
+
+def gaussianSample {v m} [VSpace v, LinearEndo m v, HasStandardNormal v]
                    ((mean, covroot) : (v & m)) (key:Key) : v =
   noise = randNormal key
   mean + apply covroot noise
 
-:p gaussianSample (1.0, 2.0) (new_key 0)
+:p gaussianSample (1.0, (MkScalarMap 2.0)) (new_key 0)
 
-'## Generic log pdf of a multivariate Gaussian
+
+'### Generic log pdf of a multivariate Gaussian
 This single definition of a Gaussian log pdf should work
 efficiently for any type of covariance matrix for which
 an efficient solve and determinant is known.
 
 -- This helper will be osbolete once the basis typeclass works.
 def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
-  asdf : v = one
-  inner_prod asdf asdf
+  one' : v = one
+  inner_prod one' one'
 
 def gaussianlogpdf {m v}
-    [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
+    [VSpace v, Mul v, InnerProd v, LinearEndo m v]
     (mean:v) (covroot:m) (x:v) : Float =
   dim = get_VSpace_dim x
-  squarepart = inner_prod (x - mean) (solve' (transpose' covroot) (solve' covroot (x - mean)))
+  squarepart = inner_prod (x - mean) (solve' (transpose' covroot)
+                                     (solve'             covroot (x - mean)))
   const = dim * log (2.0 * pi) + log (sq (determinant' covroot))
   -0.5 * (squarepart + const)
+
+
+
+
+'## Tests
+
+
+vec_len = (Fin 4)
+full_mat_type = (vec_len=>vec_len=>Float)
+v = vec_len=>Float
+
+'### Check application of the identity is a no-op.
+
+def check_identity (m:Type)
+    [LinearEndo m v, HasDeterminant m, Arbitrary m] : Bool =
+  i : m = identity'
+  vec : v = (arb $ new_key 0)
+  vec ~~ apply i vec
+
+check_identity $ LowerTriMap vec_len
+> True
+check_identity $ UpperTriMap vec_len
+> True
+check_identity $ vec_len=>vec_len=>Float
+> True
+check_identity $ DiagMap vec_len
+> True
+check_identity $ ScalarMap
+> True
+
+def check_inverse (m:Type) [LinearEndo m v, Arbitrary m, LinearEndo m full_mat_type] : Bool =
+  a : m   = arb $ new_key 0
+  vec : v = arb $ new_key 0
+  inv  : full_mat_type = solve' a eye
+  full : full_mat_type = apply  a eye
+  apply inv full ~~ eye
+
+check_inverse $ SkewSymmetricMap vec_len
+> True
+check_inverse $ LowerTriMap vec_len
+> True
+check_inverse $ UpperTriMap vec_len
+> True
+check_inverse $ vec_len=>vec_len=>Float
+> True
+check_inverse $ DiagMap vec_len
+> True
+check_inverse ScalarMap
+> True
+
+
+def check_transpose (m:Type)
+    [LinearEndo m v, HasDeterminant m, Arbitrary m] : Bool =
+  a : m                  = arb $ new_key 0
+  (vec1, vec2) : (v & v) = arb $ new_key 1
+  
+  hitleft  = inner_prod (apply a vec1) vec2
+  hitright = inner_prod (apply (transpose' a) vec2) vec1
+  hitleft ~~ hitright
+
+check_transpose $ SkewSymmetricMap vec_len
+> True
+-- check_transpose $ LowerTriMap vec_len
+-- > True
+-- check_transpose $ UpperTriMap vec_len
+-- > True
+check_transpose $ vec_len=>vec_len=>Float
+> True
+check_transpose $ DiagMap vec_len
+> True
+check_transpose ScalarMap
+> True
+
+-- Check that 1D Gaussian sums to 1
+sizen = Fin 2000
+span = 10.0
+xs = linspace sizen (-span) span
+integral = 2.0 * span * mean for i.
+  exp $ gaussianlogpdf (-0.1) (MkScalarMap 0.07) xs.i
+integral ~~ 1.0
+> True
+
+def check_2D_Gaussian_normalizes (m:Type)
+    [LinearEndo m ((Fin 2) => Float32), Arbitrary m] : Bool =
+
+  sizen = Fin 200
+  span = 10.0
+  xs = linspace sizen (-span) span
+
+  covroot : m = arb $ new_key 0
+  meanvec : ((Fin 2) => Float32) = arb $ new_key 1
+  integral = (sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
+    x = [xs.i, xs.j]
+    exp $ gaussianlogpdf meanvec covroot x
+  integral ~~ 1.0
+
+check_2D_Gaussian_normalizes (SkewSymmetricMap (Fin 2))
+> True
+-- check_2D_Gaussian_normalizes (LowerTriMat (Fin 2) Float)
+-- > True
+-- check_2D_Gaussian_normalizes (UpperTriMat (Fin 2) Float)
+-- > True
+check_2D_Gaussian_normalizes $ (Fin 2)=>(Fin 2)=>Float
+> True
+check_2D_Gaussian_normalizes $ DiagMap (Fin 2)
+> True
 
 
 '## Application 2: SDEs
 
 Time = Float
-def radonNikodym {m s} [Mul s, VSpace s, LinearEndo m s]
+def radonNikodym {m s} [InnerProd s, VSpace s, LinearEndo m s]
                  (drift1: s->Time->s)
                  (drift2: s->Time->s)
                  (diffusion: s->Time->m)
-                 (state: s) (t: Time) : s =
+                 (state: s) (t: Time) : Float =
   -- Dynamics of simple Monte Carlo estimatr of KL divergence between
   -- two SDEs that share a diffusion function. (If not, divergence is infinite)
-  sqd = sq ((drift1 state t) - (drift2 state t))
-  solve' (diffusion state t) sqd
+  difference = (drift1 state t) - (drift2 state t)
+  cur_diffusion = diffusion state t
+  a = solve' cur_diffusion difference
+  0.5 * inner_prod a a
 
 
 -- Drift and diffusion product.
@@ -281,111 +354,4 @@ def stationary_SDE_to_SDE {m v} [Mul v, VSpace v, VSpace m] (sta:StationarySDE v
     t1 + t3
   (drift, diffusionProd)
 
-
-'## Tests
-
-
-vec_len = (Fin 4)
-full_mat_type = (vec_len=>vec_len=>Float)
-
-'### Check application of the identity is a no-op.
-
-def check_identity (m:Type) (v:Type)
-    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v,
-     VSpace v, HasAllClose v, HasDefaultTolerance v] : Bool =
-  i : m = identity'
-  vec : v = (arb $ new_key 0)
-  vec ~~ apply i vec
-
-check_identity (LowerTriMat vec_len Float) (vec_len=>Float)
-> True
-check_identity (UpperTriMat vec_len Float) (vec_len=>Float)
-> True
-check_identity (vec_len=>vec_len=>Float) (vec_len=>Float)
-> True
-check_identity (vec_len=>Float) (vec_len=>Float)
-> True
-check_identity (Float) (vec_len=>Float)
-> True
-
-def check_inverse (m:Type) (v:Type)
-    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v, LinearEndo m full_mat_type,
-     VSpace v, HasAllClose v, HasDefaultTolerance v] : Bool =
-  a : m   = (arb $ new_key 0)
-  vec : v = (arb $ new_key 0)
-  inv : full_mat_type = solve' a eye
-  full : full_mat_type = apply a eye
-  apply inv full ~~ eye
-
-check_inverse (SkewSymmetricMat vec_len Float) (vec_len=>Float)
-> True
-check_inverse (LowerTriMat vec_len Float) (vec_len=>Float)
-> True
-check_inverse (UpperTriMat vec_len Float) (vec_len=>Float)
-> True
-check_inverse (vec_len=>vec_len=>Float) (vec_len=>Float)
-> True
-check_inverse (vec_len=>Float) (vec_len=>Float)
-> True
-check_inverse (Float) (vec_len=>Float)
-> True
-
-
-def check_transpose (m:Type) (v:Type)
-    [LinearEndo m v, HasDeterminant m, Arbitrary m, Arbitrary v,
-     VSpace v, HasAllClose v, HasDefaultTolerance v, InnerProd v] : Bool =
-  a : m                  = arb $ new_key 0
-  (vec1, vec2) : (v & v) = arb $ new_key 1
-  
-  hitleft = inner_prod (apply a vec1) vec2
-  hitright = inner_prod (apply (transpose' a) vec2) vec1
-  hitleft ~~ hitright
-
-check_transpose (SkewSymmetricMat vec_len Float) (vec_len=>Float)
-> True
--- check_transpose (LowerTriMat vec_len Float) (vec_len=>Float)
--- > True
--- check_transpose (UpperTriMat vec_len Float) (vec_len=>Float)
--- > True
-check_transpose (vec_len=>vec_len=>Float) (vec_len=>Float)
-> True
-check_transpose (vec_len=>Float) (vec_len=>Float)
-> True
-check_transpose (Float) (vec_len=>Float)
-> True
-
--- Check that 1D Gaussian sums to 1
-sizen = Fin 2000
-span = 10.0
-xs = linspace sizen (-span) span
-integral = 2.0 * span * mean for i.
-  exp $ gaussianlogpdf (-0.1) 0.07 xs.i
-integral ~~ 1.0
-
-def check_2D_Gaussian_normalizes (m:Type)
-    [LinearEndo m ((Fin 2) => Float32), HasDeterminant m, Arbitrary m] : Bool =
-
-  sizen = Fin 200
-  span = 10.0
-  xs = linspace sizen (-span) span
-
-  covroot : m = arb $ new_key 0
-  meanvec : ((Fin 2) => Float32) = arb $ new_key 1
-  integral = (sq (2.0 * span)) * mean for (i, j):(sizen & sizen).
-    x = [xs.i, xs.j]
-    exp $ gaussianlogpdf meanvec covroot x
-  integral ~~ 1.0
-
-check_2D_Gaussian_normalizes (SkewSymmetricMat (Fin 2) Float)
-> True
--- check_2D_Gaussian_normalizes (LowerTriMat (Fin 2) Float)
--- > True
--- check_2D_Gaussian_normalizes (UpperTriMat (Fin 2) Float)
--- > True
-check_2D_Gaussian_normalizes ((Fin 2)=>(Fin 2)=>Float)
-> True
-check_2D_Gaussian_normalizes ((Fin 2)=>Float)
-> True
-
--- check_2D_Gaussian_normalizes (Float)  -- How does this even typecheck?
--- > True
+-- Todo: tests for SDE functions.

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -38,7 +38,7 @@ instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
   arb = \x. for i. arb $ new_key (ordinal i)
 
 
-'## Linear Enomorphisms
+'## Linear Endomorphisms
 a.k.a. linear maps from a space back to that same space.
 
 interface [VSpace m, VSpace v] LinearEndo m v
@@ -88,7 +88,9 @@ instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
   diag = \x. for i. x.i.(0@_) .* one
   solve' = backward_substitute
 
--- Skew symmetric maps
+-- Skew symmetric maps.
+-- For now it's just a wrapper around lower triangular matrices with no diagonal
+-- elements, but that might be a bit presumptuous.
 def transpose_lower_to_upper' {n v}
     (lower:i:n=>(..<i)=>v) :
            i:n=>(i<..)=>v =
@@ -110,6 +112,7 @@ instance {n v} [Mul v, VSpace v] LinearEndo (i:n=>(..<i)=>Float) (n=>v)
     dense_rep = skewSymmetricProd a eye  -- Fall back to naive algorithm
     solve dense_rep y
 
+-- Todo: sparse matrices.
 
 
 '## Determinant typeclass
@@ -194,18 +197,41 @@ def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
 -- an efficient solve and determinant is known.
 def gaussianlogpdf {m v}
     [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
-    ((mean, covroot) : (v & m)) (x:v) : Float =
+    (mean:v) (covroot:m) (x:v) : Float =
   dim = get_VSpace_dim x
-  alpha = solve' covroot (solve' covroot x)
-  covpart = -0.5 * inner_prod (x - mean) alpha 
-  normpart = log (determinant' covroot)  -- need a square?
-  constpart = 0.5 * dim * log (2.0 * pi)
-  covpart - normpart - constpart
+  squarepart = inner_prod (x - mean) (solve' covroot (solve' covroot (x - mean)))
+  const = dim * log (2.0 * pi) + log (sq (determinant' covroot))
+  -0.5 * (squarepart + const)
 
-gaussianlogpdf (1.0, 2.0) (arb $ new_key 0)
+-- Tests
 
-gaussianlogpdf ((arb $ new_key 0):(Fin 4)=>Float,
-                (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float) ) (arb $ new_key 0)
+solve [[3.0]] [2.0]
+solve' 3.0 2.0
+
+gaussianlogpdf 1.0 2.0 (arb $ new_key 0)
+
+exp (gaussianlogpdf 0.2 (sqrt 2.0) 0.1)
+exp (gaussianlogpdf [0.2] ([[sqrt 2.0]]) [0.1])
+
+def mld (mean:Float) (var:Float) (v:Float): Float =
+  -0.5 * (sq (v - mean)) / var - 0.5 * log (2.0 * pi * var)
+
+exp $ mld 0.2 2.0 0.1
+
+mat = (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float)
+vec = (arb $ new_key 0):(Fin 4)=>Float
+gaussianlogpdf vec mat (arb $ new_key 0)
+
+-- Check that it sums to 1
+xs = linspace (Fin 100) (-3.0) 3.0
+6.0 * mean for i:(Fin 100).
+  exp $ gaussianlogpdf (-0.1) 0.07 xs.i
+
+
+-- Check that it sums to 1
+covroot = (arb $ new_key 0):((Fin 2)=>(Fin 2)=>Float)
+36.0 * mean for (i, j):((Fin 100) & (Fin 100)).
+  exp $ gaussianlogpdf (arb $ new_key 0) covroot [xs.i, xs.j]
 
 
 '## Application 2: SDEs
@@ -228,7 +254,7 @@ def Drift {v} [VSpace v] (v:Type) : Type = v->Time->v
 def Diffusion {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = v->Time->(LinearEndo m v)
 def SDE {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = (Drift v & Diffusion m v )
 
-def SkewSymmetricProd (v:Type) : Type = v->Time->v->v  -- How to express matrix?
+def SkewSymmetricProd (v:Type) : Type = v->Time->v->v
 def NegEnergyFunc (v:Type) : Type = v->Time->Float
 def StationarySDE (v:Type) : Type = (NegEnergyFunc v & SkewSymmetricProd v & DiffusionProd v)
 

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -1,0 +1,248 @@
+import linalg
+
+'## Instances for triangular tables
+How to avoid these repetitive instances?
+
+instance {a n} [Add a] Add (i:n => (..<i) => a)
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [Add a] Add (i:n => (i<..) => a)
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [VSpace a] VSpace (i:n => (..i) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (i..) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (..<i) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (i<..) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(..<i) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(..i) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(i..) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+
+'## Linear Enomorphisms
+a.k.a. linear maps from a space back to that same space.
+
+interface [VSpace m, VSpace v] LinearEndo m v
+  apply: m -> v -> v
+  -- determinant': m -> Float
+  diag: m -> v
+  solve': m -> v -> v
+
+'We'd like to remove `v` from the above interface,
+and instead use associated types to specify a `v` for each `m`.
+But for now, fields in typeclasses can't refer to one another.
+This means that `determinant'` can't be part of this typeclass yet,
+because `v` is always ambiguous at its usage site.
+
+
+instance {v} [Mul v, VSpace v] LinearEndo (Float) v
+  apply = (.*)
+  -- determinant' = id
+  diag = \a. a .* one
+  solve' = \a b. b / a
+
+-- Diagonal matrices
+instance {n v} [Mul v, VSpace v] LinearEndo (n=>Float) (n=>v)
+  apply = \x y. for i. x.i .* y.i
+  -- determinant' = prod
+  diag = \a. for i. a.i .* one
+  solve' = \a b. for i. b.i / a.i
+
+-- Full-rank matrices
+instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
+  apply = \x y. for i. sum for j. x.i.j .* y.j
+  -- determinant' = determinant
+  diag = \x. for i. x.i.i .* one
+  solve' = solve
+
+-- Lower-triangular matrices
+instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMat n Float) (n=>v)
+  apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
+  -- determinant' = \x. prod $ lower_tri_diag x
+  diag = \x. for i. x.i.(cast i) .* one
+  solve' = forward_substitute
+
+-- Upper-triangular matrices
+instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMat n Float) (n=>v)
+  apply = \x y. for i. sum for j. x.i.j .* y.(%inject j)
+  -- determinant' = \x. prod $ upper_tri_diag x
+  diag = \x. for i. x.i.(0@_) .* one
+  solve' = backward_substitute
+
+-- Skew symmetric maps
+def transpose_lower_to_upper' {n v}
+    (lower:i:n=>(..<i)=>v) :
+           i:n=>(i<..)=>v =
+  for i j.
+    j' = %inject j
+    lower.j'.(unsafe_from_ordinal _ (ordinal i))
+
+def skewSymmetricProd {v n} [VSpace v]
+    (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
+  lower_prod = for i. sum for j. lower.i.j .* (y.(%inject j))
+  upper = transpose_lower_to_upper' lower
+  upper_prod = for i. sum for j. upper.i.j .* (y.(%inject j))
+  lower_prod - upper_prod
+
+instance {n v} [Mul v, VSpace v] LinearEndo (i:n=>(..<i)=>Float) (n=>v)
+  apply = skewSymmetricProd
+  diag = \x. zero
+  solve' = \a y.
+    dense_rep = skewSymmetricProd a eye  -- Fall back to naive algorithm
+    solve dense_rep y
+
+
+
+'## Determinant typeclass
+This should probably be part of the `LinearEndo` typeclass,
+once associated types work.
+
+interface HasDeterminant m
+  determinant': m -> Float
+
+instance HasDeterminant Float
+  determinant' = id
+
+-- Diagonal matrices
+instance {n} HasDeterminant (n=>Float)
+  determinant' = prod
+
+-- Full-rank matrices
+instance {n} HasDeterminant (n=>n=>Float)
+  determinant' = determinant
+
+-- Lower-triangular matrices
+instance {n} HasDeterminant (LowerTriMat n Float)
+  determinant' = \x. prod $ lower_tri_diag x
+
+-- Upper-triangular matrices
+instance {n} HasDeterminant (UpperTriMat n Float)
+  determinant' = \x. prod $ upper_tri_diag x
+
+instance {n} HasDeterminant (i:n=>(..<i)=>Float)
+  determinant' = case is_odd (size n) of
+    True -> zero
+    False -> todo  -- Pfaffian
+
+
+'## Tests
+
+-- Check inverse of skew-symmetric matrices.
+skew_mat : i:(Fin 4)=>(..<i)=>Float = arb $ new_key 0
+si : (Fin 4)=>(Fin 4)=>Float = solve' skew_mat eye
+sf : (Fin 4)=>(Fin 4)=>Float = apply skew_mat eye
+apply si sf ~~ eye
+> True
+
+
+'## Application 1: Gaussians
+
+-- This typeclass will be obsolete once the `Basis` typeclass can be written.
+interface HasStandardNormal a:Type
+  randNormal : Key -> a
+
+instance HasStandardNormal Float32
+  randNormal = randn
+instance {a n} [HasStandardNormal a] HasStandardNormal (n=>a)
+  randNormal = \key.
+    for i. randNormal (ixkey key i)
+
+def gaussianSample {v m} [VSpace v, VSpace m, LinearEndo m v, HasStandardNormal v]
+                   ((mean, covroot) : (v & m)) (key:Key) : v =
+  noise = randNormal key
+  mean + apply covroot noise
+
+:p gaussianSample (1.0, 2.0) (new_key 0)
+
+
+interface [VSpace v] InnerProd v
+  inner_prod : v->v->Float
+
+instance InnerProd Float
+  inner_prod = \x y. x * y
+
+instance {a n} [InnerProd a] InnerProd (n=>a)
+  inner_prod = \x y. sum for i. inner_prod x.i y.i
+
+
+-- This is a hack until the basis typeclass works.
+def get_VSpace_dim {v} [InnerProd v, Mul v, VSpace v] (x:v) : Float =
+  asdf : v = one
+  inner_prod asdf asdf
+
+-- This single definition of a Gaussian log pdf should work
+-- efficiently for any type of covariance matrix for which
+-- an efficient solve and determinant is known.
+def gaussianlogpdf {m v}
+    [HasDeterminant m, VSpace m, Mul v, VSpace v, InnerProd v, LinearEndo m v]
+    ((mean, covroot) : (v & m)) (x:v) : Float =
+  dim = get_VSpace_dim x
+  alpha = solve' covroot (solve' covroot x)
+  covpart = -0.5 * inner_prod (x - mean) alpha 
+  normpart = log (determinant' covroot)  -- need a square?
+  constpart = 0.5 * dim * log (2.0 * pi)
+  covpart - normpart - constpart
+
+gaussianlogpdf (1.0, 2.0) (arb $ new_key 0)
+
+gaussianlogpdf ((arb $ new_key 0):(Fin 4)=>Float,
+                (arb $ new_key 0):((Fin 4)=>(Fin 4)=>Float) ) (arb $ new_key 0)
+
+
+'## Application 2: SDEs
+
+Time = Float
+def radonNikodym {m s} [Mul s, VSpace s, LinearEndo m s]
+                 (drift1: s->Time->s)
+                 (drift2: s->Time->s)
+                 (diffusion: s->Time->m)
+                 (state: s) (t: Time) : s =
+  -- Dynamics of simple Monte Carlo estimatr of KL divergence between
+  -- two SDEs that share a diffusion function. (If not, divergence is infinite)
+  sqd = sq ((drift1 state t) - (drift2 state t))
+  solve' (diffusion state t) sqd
+
+
+-- Drift and diffusion product.
+-- DiffusionProd takes state and noise and returns dstate/dtime
+def Drift {v} [VSpace v] (v:Type) : Type = v->Time->v
+def Diffusion {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = v->Time->(LinearEndo m v)
+def SDE {m v} [VSpace m, VSpace v] (m:Type) (v:Type) : Type = (Drift v & Diffusion m v )
+
+def SkewSymmetricProd (v:Type) : Type = v->Time->v->v  -- How to express matrix?
+def NegEnergyFunc (v:Type) : Type = v->Time->Float
+def StationarySDE (v:Type) : Type = (NegEnergyFunc v & SkewSymmetricProd v & DiffusionProd v)
+
+def stationary_SDE_to_SDE {v} [Mul v, VSpace v] (sta:StationarySDE v) : SDE v =
+  -- From Section 2.1 of "A Complete Recipe for Stochastic Gradient MCMC"
+  -- https://arxiv.org/pdf/1506.04696.pdf
+  (negEnergyFunc, skewSymmetricProd, diffusionProd) = sta
+  varProd = \state time vec.
+    0.5 .* (diffusionProd state time $ diffusionProd state time vec)
+  drift = \state time.
+    curNE = \state. negEnergyFunc state time
+    negenergygrad = (grad curNE) state
+    t1 = (skewSymmetricProd + varProd) state time negenergygrad
+    gammapart = \state. (skewSymmetricProd + varProd) state time one
+    t3 = jvp gammapart state one
+    t1 + t3
+  (drift, diffusionProd)

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -19,6 +19,21 @@ def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
     j = %inject j'
     lower.j.(cast i)
 
+def transpose_lower_to_upper_no_diag {n v}
+    (lower:i:n=>(..<i)=>v) :
+           i:n=>(i<..)=>v =
+  for i j.
+    j' = %inject j
+    lower.j'.(unsafe_from_ordinal _ (ordinal i))
+
+def skew_symmetric_prod {v n} [VSpace v]
+    (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
+  -- We could probably fuse these two for loops.
+  lower_prod = for i. sum for j. lower.i.j .* (y.(%inject j))
+  upper = transpose_lower_to_upper_no_diag lower
+  upper_prod = for i. sum for j. upper.i.j .* (y.(%inject j))
+  lower_prod - upper_prod
+
 def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v =
   -- Solves lower triangular linear system (inverse a) **. b
   yield_state zero \sRef.

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -338,6 +338,16 @@ instance {a n} [Add a] Add (i:n => (..i) => a)  -- Lower triangular tables
   sub = \xs ys. for i. xs.i - ys.i
   zero = for _. zero
 
+instance {a n} [Add a] Add (i:n => (..<i) => a)
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
+instance {a n} [Add a] Add (i:n => (i<..) => a)
+  add = \xs ys. for i. xs.i + ys.i
+  sub = \xs ys. for i. xs.i - ys.i
+  zero = for _. zero
+
 instance {a n} [Mul a] Mul (n=>a)
   mul = \xs ys. for i. xs.i * ys.i
   one = for _. one
@@ -378,6 +388,18 @@ instance VSpace Float
   scale_vec = \x y. x * y
 
 instance {a n} [VSpace a] VSpace (n=>a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (..i) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (i..) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (..<i) => a)
+  scale_vec = \s xs. for i. s .* xs.i
+
+instance {a n} [VSpace a] VSpace (i:n => (i<..) => a)
   scale_vec = \s xs. for i. s .* xs.i
 
 instance {a n} [VSpace a] VSpace (n->a)
@@ -1749,6 +1771,19 @@ def rand_idx {n} [Ix n] (k:Key) : n =
   unif = rand k
   from_ordinal n $ FToI $ floor $ unif * i_to_f (size n)
 
+
+'## Inner product typeclass
+
+interface [VSpace v] InnerProd v
+  inner_prod : v->v->Float
+
+instance InnerProd Float
+  inner_prod = \x y. x * y
+
+instance {a n} [InnerProd a] InnerProd (n=>a)
+  inner_prod = \x y. sum for i. inner_prod x.i y.i
+
+
 '## Arbitrary
 Type class for generating example values
 
@@ -1766,6 +1801,18 @@ instance Arbitrary Int32
 
 instance {n a} [Arbitrary a] Arbitrary (n=>a)
   arb = \key. for i. arb $ ixkey key i
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(..<i) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(..i) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(i..) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
+
+instance {n a} [Arbitrary a] Arbitrary (i:n=>(i<..) => a)
+  arb = \x. for i. arb $ new_key (ordinal i)
 
 instance {a b} [Arbitrary a, Arbitrary b] Arbitrary (a & b)
   arb = \key.

--- a/makefile
+++ b/makefile
@@ -196,7 +196,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
                 isomorphisms ode-integrator fluidsim \
                 sgd psd kernelregression \
                 quaternions manifold-gradients schrodinger tutorial \
-                latex
+                latex linear-maps
 # TODO: re-enable
 # fft vega-plotting
 


### PR DESCRIPTION
Often when writing numerical code, there are efficient specializations for e.g. diagonal matrices, lower-triangular, or sparse matrices.  I'd like to be able to write just one version of this code without having to fall back to casting everything to full-rank unstructured matrices.  This example is for brainstorming how the typeclass system might support efficient polymorphism for linear algebra over different types of structured maps.

I'm pretty pleased that it seems like one can finally write a generic Gaussian sampler and log pdf in any vector space now.  And some of the necessary math for variational inference in stochastic differential equations works.

One thing holding back this direction is the lack of a `Basis` typeclass, currently waiting on #323.

Comments and suggestions are welcome.

I think this is ready for review now.