### PR TITLE
Convert transposeLinear to transpose_linear, yieldAccum to yield_accum

### DIFF
--- a/benchmarks/parboil/mriq.dx
+++ b/benchmarks/parboil/mriq.dx
@@ -16,7 +16,7 @@ def mriq
       : (cs=>Float & cs=>Float) =
   unzip $ for i.
     run_accum (AddMonoid Float) \qi.
-      yieldAccum (AddMonoid Float) \qr.
+      yield_accum (AddMonoid Float) \qr.
         for j.
           phiMag = phiR.j * phiR.j + phiI.j * phiI.j
           expArg = kx.j * x.i + ky.j * y.i + kz.j * z.i

--- a/benchmarks/rodinia/kmeans.dx
+++ b/benchmarks/rodinia/kmeans.dx
@@ -3,9 +3,9 @@ def dist (x : d=>Float) (y : d=>Float) : Float =
   sum $ for i. d.i * d.i
 
 def centroidsOf (points : n=>d=>Float) (membership : n=>k) : k=>d=>Float =
-  clusterSums = yieldAccum (AddMonoid Float) \clusterSums.
+  clusterSums = yield_accum (AddMonoid Float) \clusterSums.
     for i. clusterSums!(membership.i) += points.i
-  clusterSizes = yieldAccum (AddMonoid Float) \clusterSizes.
+  clusterSizes = yield_accum (AddMonoid Float) \clusterSizes.
     for i. clusterSizes!(membership.i) += 1.0
   for i. clusterSums.i / (max clusterSizes.i 1.0)
 

--- a/examples/manifold-gradients.dx
+++ b/examples/manifold-gradients.dx
@@ -87,7 +87,7 @@ def manifoldGrad
   [TangentSpace manifoldA tangentA, VSpace tangentA]
   (f: manifoldA -> Float) (x: manifoldA) : tangentA =
   linearized: (Float & (tangentA --o Float)) = manifoldLinearize f x
-  transposeLinear (snd linearized) 1.0
+  transpose_linear (snd linearized) 1.0
 
 
 ' ### Equivalence to standard differentiation

--- a/examples/raytrace.dx
+++ b/examples/raytrace.dx
@@ -214,7 +214,7 @@ def sampleLightRadiance {n}
   (surfNor, surf) = osurf
   (rayPos, _) = inRay
   (MkScene objs) = scene
-  yieldAccum (AddMonoid Float) \radiance.
+  yield_accum (AddMonoid Float) \radiance.
     for i. case objs.i of
       PassiveObject _ _ -> ()
       Light lightPos hw _ ->
@@ -229,7 +229,7 @@ def sampleLightRadiance {n}
 
 def trace {n} (params:Params) (scene:Scene n) (initRay:Ray) (k:Key) : Color =
   noFilter = [1.0, 1.0, 1.0]
-  yieldAccum (AddMonoid Float) \radiance.
+  yield_accum (AddMonoid Float) \radiance.
     run_state  noFilter \filter.
      run_state initRay  \ray.
       bounded_iter (get_at #maxBounces params) () \i.

--- a/examples/simplex.dx
+++ b/examples/simplex.dx
@@ -451,7 +451,7 @@ def constraints_satisfied (constraints: m=>Constraint n) (x: n=>Float) : Bool =
 
 def extractSolution (tableau: AbsTableau cons vars extra) : vars=>Float =
   (basics, _, table) = tableau
-  yieldAccum (AddMonoid Float) \varRef.
+  yield_accum (AddMonoid Float) \varRef.
     for v:cons.
       var = basics.v
       case var of  -- If this basic variable is an original variable, write it.

--- a/examples/tiled-matmul.dx
+++ b/examples/tiled-matmul.dx
@@ -19,7 +19,7 @@ def matmul
   vectorTile = Fin VectorWidth
   colTile = (colVectors & vectorTile)
   (tile2d (\nt:(Tile n rowTile). \mt:(Tile m colTile).
-             ct = yieldAccum (AddMonoid Float) \acc.
+             ct = yield_accum (AddMonoid Float) \acc.
                for l:k.
                  for i:rowTile.
                    ail = broadcastVector a.(nt +> i).l

--- a/lib/fft.dx
+++ b/lib/fft.dx
@@ -64,7 +64,7 @@ def power_of_2_fft {log2_n}
       ipow2 = get ipow2Ref
 
       log2_half_n = log2_n - 1
-      xRef := yieldAccum (AddMonoid Complex) \bufRef.
+      xRef := yield_accum (AddMonoid Complex) \bufRef.
         for j:((Fin log2_half_n)=>(Fin 2)).  -- Executes in parallel.
           (left_read_ix, right_read_ix,
            left_write_ix, right_write_ix) = butterfly_ixs j ipow2

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -539,7 +539,7 @@ def run_accum
     action' ref
   %runWriter empty combine explicitAction
 
-def yieldAccum
+def yield_accum
       {a b w eff}
       [mlift:MonoidLifter b w]
       (m:Monoid b)
@@ -692,7 +692,7 @@ instance Monoid Ordering
 
 instance {a n} [Eq a] Eq (n=>a)
   (==) = \xs ys.
-    yieldAccum AndMonoid \ref.
+    yield_accum AndMonoid \ref.
       for i. ref += xs.i == ys.i
 
 instance {a n} [Ord a] Ord (n=>a)
@@ -918,7 +918,7 @@ def reduce {a n} (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
 -- TODO: call this `scan` and call the current `scan` something else
 def scan' {a n} [Ix n] (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
-def fsum {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs.i
+def fsum {n} (xs:n=>Float) : Float = yield_accum (AddMonoid Float) \ref. for i. ref += xs.i
 def sum  {n v} [Add v] (xs:n=>v) : v = reduce zero (+) xs
 def prod {n v} [Mul v] (xs:n=>v) : v = reduce one  (*) xs
 def mean {n v} [VSpace v] (xs:n=>v) : v = sum xs / i_to_f (size n)
@@ -1139,14 +1139,14 @@ def append {a h} [AccumMonoid h (List a)]
     list += AsList 1 [x]
 
 def filter {a n} (condition:a->Bool) (xs:n=>a) : List a =
-  yieldAccum (ListMonoid a) \list.
+  yield_accum (ListMonoid a) \list.
     for i.
       if condition xs.i
         then append list xs.i
 
 def arg_filter {a n} (condition:a->Bool) (xs:n=>a) : List n =
   -- Returns all indices where the condition is true.
-  yieldAccum (ListMonoid n) \list.
+  yield_accum (ListMonoid n) \list.
     for i.
       if condition xs.i
         then append list i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -974,11 +974,11 @@ def cumsum {n} (xs: n=>Float) : n=>Float =
 -- TODO: add vector space constraints
 def linearize {a b} (f:a->b) (x:a) : (b & a --o b) = %linearize f x
 def jvp {a b} (f:a->b) (x:a) : a --o b = snd (linearize f x)
-def transposeLinear {a b} (f:a --o b) : b --o a = %linearTranspose f
+def transpose_linear {a b} (f:a --o b) : b --o a = %linearTranspose f
 
 def vjp {a b} (f:a->b) (x:a) : (b & b --o a) =
   (y, df) = linearize f x
-  (y, transposeLinear df)
+  (y, transpose_linear df)
 
 def grad {a} (f:a->Float) (x:a) : a = snd (vjp f x) 1.0
 

--- a/lib/sort.dx
+++ b/lib/sort.dx
@@ -2,7 +2,7 @@
 Warning: Very slow for now!!
 Because merging sorted lists is associative, we can expose the
 parallelism of merge sort to the Dex compiler by making a monoid
-and using reduce or yieldAccum.
+and using reduce or yield_accum.
 However, this approach puts a lot of pressure on the compiler.
 As noted on [StackOverflow](https://stackoverflow.com/questions/21877572/can-you-formulate-the-bubble-sort-as-a-monoid-or-semigroup),
 if the compiler does the reduction one element at a time,

--- a/python/dex/interop/jax/apply.py
+++ b/python/dex/interop/jax/apply.py
@@ -346,7 +346,7 @@ def dex_call_evaluate_linearized_transpose(cotangents, *args, func_atom):
   # parameter at index 1, the evaluated string should look like:
   # ```
   # \ x0 x1 x2 u1 ct.
-  #   transposeLinear (\(t0, t2). linearized x0 x1 x2 t0 u1 t2) ct
+  #   transpose_linear (\(t0, t2). linearized x0 x1 x2 t0 u1 t2) ct
   # ```
   # - The `x` variables are the (constant) inputs to the primal function. These
   #   should always be supplied by JAX.
@@ -373,9 +373,9 @@ def dex_call_evaluate_linearized_transpose(cotangents, *args, func_atom):
       arg_string("x", range(num_primals)) + " " + linearized_tangent_inputs)
 
   # \ x0 x1 x2 u1 ct.
-  #   transposeLinear (\(t0, t2). linearized x0 x1 x2 t0 u1 t2) ct
+  #   transpose_linear (\(t0, t2). linearized x0 x1 x2 t0 u1 t2) ct
   transposed = module.eval(
-      f"\\ {transposed_atom_params}. transposeLinear " +
+      f"\\ {transposed_atom_params}. transpose_linear " +
       f"(\ {linear_lambda_params}. {linearized_name} {linearized_inputs}) ct"
   )
 

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -1,6 +1,6 @@
 
 -- TODO: use prelude sum instead once we can differentiate state effect
-def sum' {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. ref += xs.i
+def sum' {n} (xs:n=>Float) : Float = yield_accum (AddMonoid Float) \ref. for i. ref += xs.i
 
 :p
    f : Float -> Float = \x. x
@@ -69,7 +69,7 @@ def sum' {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. r
 :p jvp sum' [1., 2.] [10.0, 20.0]
 > 30.
 
-f : Float -> Float = \x. yieldAccum (AddMonoid Float) \ref. ref += x
+f : Float -> Float = \x. yield_accum (AddMonoid Float) \ref. ref += x
 :p jvp f 1.0 1.0
 > 1.
 
@@ -167,7 +167,7 @@ tripleit : Float --o Float = \x. x + x + x
 > [2., 4.]
 
 myOtherSquare : Float -> Float =
-  \x. yieldAccum (AddMonoid Float) \w. w += x * x
+  \x. yield_accum (AddMonoid Float) \w. w += x * x
 
 :p check_deriv myOtherSquare 3.0
 > True
@@ -225,7 +225,7 @@ vec = [1.]
 :p
   f : Float -> Float = \x.
     y = x * 2.0
-    yieldAccum (AddMonoid Float) \a.
+    yield_accum (AddMonoid Float) \a.
       a += x * 2.0
       a += y
   grad f 1.0

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -24,27 +24,27 @@ def sum' {n} (xs:n=>Float) : Float = yieldAccum (AddMonoid Float) \ref. for i. r
 
 :p
    f : Float --o Float = \x. x
-   transposeLinear f 2.0
+   transpose_linear f 2.0
 > 2.
 
 :p
    f : Float --o Float = \x. x + x
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > 2.
 
 :p
    f : Float --o Float = \x. x + (x + x) * 2.0
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > 5.
 
 :p
    f : Float --o Float = \x. x * 2.0
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > 2.
 
 :p
    f : Float --o Float = \x. 2.0 * x
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > 2.
 
 :p grad (\x. x * x) 1.0
@@ -85,12 +85,12 @@ f : Float -> Float = \x. yieldAccum (AddMonoid Float) \ref. ref += x
 
 :p
    f : Float --o (Float & Float) = \x. (x, 2.0 * x)
-   transposeLinear f (1.0, 3.0)
+   transpose_linear f (1.0, 3.0)
 > 7.
 
 :p
    f : (Float & Float) --o Float = \(x,y). x + 2.0 * y
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > (1., 2.)
 
 :p deriv cos 0.0
@@ -148,22 +148,22 @@ tripleit : Float --o Float = \x. x + x + x
 :p tripleit 1.0
 > 3.
 
-:p transposeLinear tripleit 1.0
+:p transpose_linear tripleit 1.0
 > 3.
 
-:p transposeLinear (transposeLinear tripleit) 1.0
+:p transpose_linear (transpose_linear tripleit) 1.0
 > 3.
 
 :p
   f : n:Type ?-> Ix n ?=> Float --o n=>Float = \x. for i. x
 
-  transposeLinear f [1.0, 2.0]
+  transpose_linear f [1.0, 2.0]
 > 3.
 
 :p
   f : n:Type ?-> n=>Float --o n=>Float = \x. for i. x.i * 2.0
 
-  transposeLinear f [1.0, 2.0]
+  transpose_linear f [1.0, 2.0]
 > [2., 4.]
 
 myOtherSquare : Float -> Float =

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -102,7 +102,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 > Runtime error
 
 :p
-  yieldAccum (AddMonoid Float) \ref.
+  yield_accum (AddMonoid Float) \ref.
     for i. case myTab.i of
       MyLeft tmp -> ()
       MyRight val -> ref += 1.0 + val
@@ -110,7 +110,7 @@ myTab = [MyLeft 1, MyRight 3.5, MyLeft 123, MyLeft 456]
 
 :p
   -- check that the order of the case alternatives doesn't matter
-  yieldAccum (AddMonoid Float) \ref.
+  yield_accum (AddMonoid Float) \ref.
     for i. case myTab.i of
       MyRight val -> ref += 1.0 + val
       MyLeft tmp -> ()
@@ -128,7 +128,7 @@ threeCaseTab : (Fin 4)=>ThreeCases =
 > [(TheIntCase 3), TheEmptyCase, (ThePairCase 2 0.1), TheEmptyCase]
 
 :p
-  yieldAccum (AddMonoid Float) \ref.
+  yield_accum (AddMonoid Float) \ref.
     for i. case threeCaseTab.i of
       TheEmptyCase    -> ref += 1000.0
       ThePairCase x y -> ref +=  100.0 + y + i_to_f x

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -709,7 +709,7 @@ def newtonSolve (tol:Float) (f : Float -> Float) (x0:Float) : Float =
 --   x = for i:(Fin 3). for j:(Fin 200). 1.0
 --   -- Last dimension split to allow for vector loads
 --   y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). IToF $ (iota _).(i,j,h)
---   z = yieldAccum \acc.
+--   z = yield_accum \acc.
 --         for l.
 --           for i.
 --             xil = (broadcastVector x.i.l)

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -154,19 +154,19 @@ symmetrizeInPlace [[1.,2.],[3.,4.]]
 :p with_reader 5 \r. ()
 > ()
 
-:p yieldAccum (AddMonoid Float) \w.
+:p yield_accum (AddMonoid Float) \w.
   for i:(Fin 2).
     w += 1.0
     w += 1.0
 > 4.
 
-:p yieldAccum (AddMonoid Float) \w.
+:p yield_accum (AddMonoid Float) \w.
   for i:(Fin 2).
     w += 1.0
   w += 1.0
 > 3.
 
-:p yieldAccum (AddMonoid Float) \ref.
+:p yield_accum (AddMonoid Float) \ref.
      ref += [1.,2.,3.]
      ref += [2.,4.,5.]
 > [3., 6., 8.]
@@ -196,7 +196,7 @@ def effectsAtZero {eff:Effects} (f: Int ->{|eff} Unit) : {|eff} Unit =
 
 -- Test custom list monoid with accum
 def adjacencyMatrixToEdgeList {n} (mat: n=>n=>Bool) : List (n & n) =
-  yieldAccum (ListMonoid (n & n)) \list.
+  yield_accum (ListMonoid (n & n)) \list.
     for (i, j).
       if mat.i.j then
         append list (i, j)

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -84,7 +84,7 @@ def myInt2 : {State Int} Int = 1
 > Nullary def can't have effects
 
 :p
-  yieldAccum (AddMonoid Float) \ref.
+  yield_accum (AddMonoid Float) \ref.
     x = if True then 1. else 3.
     if True then ref += x
 

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -227,19 +227,19 @@ def myOtherFst {a b} ((x, _):(a&b)) : a = x
 :p
    f : Float --o Float =
      \x. 2.0 * (x + x)
-   transposeLinear f 1.0
+   transpose_linear f 1.0
 > 4.
 
 -- FIXME: This fails due to shadowing!
 --def transpose' (x:n=>m=>Float) --o : m=>n=>Float = for i j. x.j.i
 --
---:p transposeLinear transpose' [[1.0, 2.0, 3.0]]
+--:p transpose_linear transpose' [[1.0, 2.0, 3.0]]
 --> [[1.0], [2.0], [3.0]]
 
 :p
    f : Float --o (Fin 3=>Float) =
      \x. for i. x * 2.0
-   transposeLinear f [1.0, 2.0, 3.0]
+   transpose_linear f [1.0, 2.0, 3.0]
 > 12.
 
 id'' : b:Type ?-> b -> b = id


### PR DESCRIPTION
This PR converts the two prelude-exported names `transposeLinear` and `yieldAccum` to snake_case (to match e.g. `yield_state`) in line with #786, as follow-up to PR #814.