### PR TITLE
Add a `Post n` index set to represent the fenceposts of n

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2144,6 +2144,41 @@ def concat {n a} (lists:n=>(List a)) : List a =
         eltIdx := eltIdxVal + 1
         xs.(eltIdxVal@_)
 
+def cat_maybes {a n} (xs:n=>Maybe a) : List a =
+  (num_res, res_inds) = yield_state (0:Int, for i:n. Nothing) \ref.
+    for i. case xs.i of
+      Just _ ->
+        ix = get $ fst_ref ref
+        (snd_ref ref) ! (unsafe_from_ordinal _ ix) := Just i
+        fst_ref ref := ix + 1
+      Nothing -> ()
+  to_list $ for i:(Fin num_res).
+    case res_inds.(unsafe_from_ordinal _ $ ordinal i) of
+      Just j -> case xs.j of
+        Just x -> x
+        Nothing -> todo -- Impossible
+      Nothing -> todo -- Impossible
+
+def prev_ix {n} [Ix n] (i:n) : Maybe n =
+  ord = ordinal i
+  if ord == 0
+    then Nothing
+    else Just $ (ord - 1) @ n
+
+def lines (source:String) : List String =
+  (AsList _ s) = source
+  (AsList num_lines newline_ixs) = cat_maybes for i_char.
+    if s.i_char == '\n'
+      then Just i_char
+      else Nothing
+  to_list for i_line:(Fin num_lines).
+    start = case prev_ix i_line of
+      Nothing -> first_ix
+      Just i -> right_post newline_ixs.i
+    end = left_post newline_ixs.i_line
+    post_slice s start end
+
+
 '## Probability
 
 def cumsum_low {n} (xs: n=>Float) : n=>Float =

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -298,6 +298,29 @@ instance Ix Unit
 
 def iota (n:Type) [Ix n] : n=>Int = view i. ordinal i
 
+'## Fencepost index sets
+
+data Post segment:Type = UnsafeMkPost Int
+
+instance {segment} [Ix segment] Ix (Post segment)
+  get_size = \(). size segment + 1
+  ordinal = \(UnsafeMkPost i). i
+  unsafe_from_ordinal = \i. UnsafeMkPost i
+
+def left_post {n} [Ix n] (i:n) : Post n =
+  unsafe_from_ordinal (Post n) (ordinal i)
+
+def right_post {n} [Ix n] (i:n) : Post n =
+  unsafe_from_ordinal (Post n) (ordinal i + 1)
+
+interface [Ix n] NonEmpty n
+  first_ix : n
+
+def last_ix {n} [NonEmpty n] : n = unsafe_from_ordinal _ (size n - 1)
+
+instance {n} [Ix n] NonEmpty (Post n)
+  first_ix = unsafe_from_ordinal (Post n) 0
+
 '## Arithmetic instances for table types
 
 instance {a n} [Add a] Add (n=>a)
@@ -1242,6 +1265,12 @@ def split_v {a} : Iso a ({|} | a) =
 
 def slice_fields {a b c v} [Ix b] (iso: Iso ({|} | a) (b | c)) (tab: a=>v) : b=>v =
   reindex (build_with $ split_v &>> iso) tab
+
+-- TODO: replace `slice` with this?
+def post_slice {a n} (xs:n=>a) (start:Post n) (end:Post n) : List a =
+  slice_size = ordinal end - ordinal start
+  to_list for i:(Fin slice_size).
+    xs.(unsafe_from_ordinal n (ordinal i + ordinal start))
 
 '## Dynamic buffer
 


### PR DESCRIPTION
This gives a neat way to handle "fencepost" problems, where you have two sets of
entities whose sizes differ by one, e.g. a sequence of states and the
transitions between those states, or the characters in a string and the set of
prefixes of the string. Usually, in a world where indices are integers, you have
to decide on a convention for how to map the "post" indices to the "segment"
indices and it's a common source of off-by-one errors. In Dex, we can just use
separate index sets for the posts and the segments, with functions that map
between them. Each segment has a previous post and a next post. Each post
*might* have a previous or next segment.

This also introduces the `NonEmpty` constraint on index sets, but for now the
only instance is for `Post n`.