### PR TITLE
Speed up jax2dex

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test-script.cd
 .stack-work-opt
 .stack-work-dbg
 .stack-work-prof
+.stack-work-ffis
 garbage.hs
 *.lock
 *.pyc

--- a/makefile
+++ b/makefile
@@ -170,8 +170,8 @@ build-prof: dexrt-llvm
 
 # For some reason stack fails to detect modifications to foreign library files
 build-ffis: dexrt-llvm
-	$(STACK) build $(STACK_FLAGS) --force-dirty --flag dex:foreign
-	$(eval STACK_INSTALL_DIR=$(shell $(STACK) path --local-install-root))
+	$(STACK) build $(STACK_FLAGS) --work-dir .stack-work-ffis --force-dirty --flag dex:foreign --flag dex:optimized
+	$(eval STACK_INSTALL_DIR=$(shell $(STACK) path --work-dir .stack-work-ffis --local-install-root))
 	cp $(STACK_INSTALL_DIR)/lib/libDex.so python/dex/
 	cp $(STACK_INSTALL_DIR)/lib/libDex.so julia/deps/
 

--- a/python/dex/interop/jax/jax2dex.py
+++ b/python/dex/interop/jax/jax2dex.py
@@ -37,16 +37,17 @@ class Type:
 class Expr:
   pass
 
+i32 = np.dtype('int32')
+f32 = np.dtype('float32')
+f64 = np.dtype('float64')
 _dtypes = {
-  np.dtype('float32'): 'Float32',
-  np.dtype('float64'): 'Float64',
-  np.dtype('int32'): 'Int32',
+  f32: 'Float32',
+  f64: 'Float64',
+  i32: 'Int32',
   np.dtype('bool'): 'Bool',
 }
 
-_io_dtypes = {
-  np.dtype('float32'), np.dtype('float64'), np.dtype('int32'),
-}
+_io_dtypes = {f32, f64, i32}
 
 @dataclass
 class EType(Type):
@@ -62,7 +63,7 @@ class FinTabType(Type):
   size: int  # TODO Expr
   ty: Type
   def pprint(self) -> str:
-    return f'((Fin {self.size})=>{self.ty.pprint()})'
+    return f'((Fin (%monoLit {self.size}))=>{self.ty.pprint()})'
 
 @dataclass
 class FinType(Type):
@@ -80,8 +81,12 @@ class PairType(Type):
 @dataclass
 class Literal(Expr):
   val: Any
+  dtype: np.dtype
   def pprint(self) -> str:
-    return f'{self.val}'
+    if self.dtype in {f32, f64}:
+      return f'{self.val}'
+    elif self.dtype == i32:
+      return f'(%monoLit {self.val})'
 
 @dataclass
 class Var(Expr):
@@ -262,7 +267,7 @@ def dex_executable(jaxpr: core.Jaxpr) -> Callable:
 
   def read(x: core.Atom) -> Expr:
     if type(x) is core.Literal:
-      return Literal(x.val)
+      return Literal(x.val, core.get_aval(x.val).dtype)
     else:
       return env[x]
 
@@ -343,10 +348,13 @@ expr_makers[lax.cos_p] = lambda ctx, x: App(Var('cos'), x)
 expr_makers[lax.log_p] = lambda ctx, x: App(Var('log'), x)
 expr_makers[lax.exp_p] = lambda ctx, x: App(Var('exp'), x)
 
+IX_REP_DTYPE = np.dtype('int32')
+def IxRepLiteral(n): return Literal(n, IX_REP_DTYPE)
+
 def _broadcast_in_dim(ctx, x, *dyn_shape, shape, broadcast_dimensions):
   idx_names = [ctx.fresh('i') for _ in range(len(shape))]
   dyn = iter(dyn_shape)
-  tys = [FinType(next(dyn) if d is None else Literal(d)) for d in shape]
+  tys = [FinType(next(dyn) if d is None else IxRepLiteral(d)) for d in shape]
   idxs = [Var(idx_names[i]) for i in broadcast_dimensions]
   x_indexed = Idx(x, tuple(idxs)) if idxs else x
   return For(tuple(idx_names), tuple(tys), x_indexed)
@@ -357,7 +365,7 @@ def _broadcasting_binop(binop_expr: Expr, ctx, x, y):
   out_aval, = ctx.avals_out
   if not out_aval.shape:
     return App(App(binop_expr, x), y)
-  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(Literal(sz)))
+  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(IxRepLiteral(sz)))
                               for sz in out_aval.shape)
   x_expr = _make_bcast_expr(idx_names, out_aval.shape, x_aval.shape, x)
   y_expr = _make_bcast_expr(idx_names, out_aval.shape, y_aval.shape, y)
@@ -373,7 +381,8 @@ def _make_bcast_expr(idx_names, out_shape, in_shape, x):
           for idx_name, out_size, in_size
           in zip(idx_names[-ndim:], out_shape[-ndim:], in_shape)]
   return Idx(x, tuple(idxs))
-unitIdx = App(App(Var('unsafe_from_ordinal'), FinType(Literal(1))), Literal(0))
+unitIdx = App(App(Var('unsafe_from_ordinal'),
+              FinType(IxRepLiteral(1))), IxRepLiteral(0))
 
 expr_makers[lax.add_p] = partial(_broadcasting_binop, Var('add'))
 expr_makers[lax.sub_p] = partial(_broadcasting_binop, Var('sub'))
@@ -403,7 +412,7 @@ def _squeeze_lowering(ctx, x, dimensions):
   out_aval, = ctx.avals_out
   if not out_aval.shape:
     return Idx(x, (unitIdx,))
-  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(Literal(sz)))
+  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(IxRepLiteral(sz)))
                               for sz in out_aval.shape)
   idx_name = iter(idx_names)
   idxs = [unitIdx if dim in dimensions else Var(next(idx_name))
@@ -417,11 +426,11 @@ def _slice_lowering(ctx, x, start_indices, limit_indices, strides):
   in_aval, = ctx.avals_in
   out_aval, = ctx.avals_out
   assert len(start_indices) == len(limit_indices) == in_aval.ndim == out_aval.ndim
-  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(Literal(sz)))
+  idx_names, idx_tys = unzip2((ctx.fresh('i'), FinType(IxRepLiteral(sz)))
                               for sz in out_aval.shape)
   input_ixs = [Var(ix) if in_size == out_size else
-               App(App(Var('unsafe_from_ordinal'), FinType(Literal(in_size))),
-                   BinOp(Literal(start), '+', App(Var('ordinal'), Var(ix))))
+               App(App(Var('unsafe_from_ordinal'), FinType(IxRepLiteral(in_size))),
+                   BinOp(IxRepLiteral(start), '+', App(Var('ordinal'), Var(ix))))
                for ix, in_size, out_size, start
                in zip(idx_names, in_aval.shape, out_aval.shape, start_indices)]
   return For(tuple(idx_names), tuple(idx_tys), Idx(x, tuple(input_ixs)))
@@ -456,8 +465,8 @@ def _concatenate_lowering(ctx, *xs, dimension):
     xs_v = ctx.fresh('xs')
     return Block([
         Decl(xs_v, Table(tuple(xs)))
-      ], App(App(Var('unsafe_cast_table'), FinType(Literal(dim_size * len(xs)))),
-              For((i,), (PairType(FinType(Literal(len(xs))), FinType(Literal(dim_size))),),
+      ], App(App(Var('unsafe_cast_table'), FinType(IxRepLiteral(dim_size * len(xs)))),
+              For((i,), (PairType(FinType(IxRepLiteral(len(xs))), FinType(IxRepLiteral(dim_size))),),
                   TabApp(TabApp(Var(xs_v), App(Var('fst'), Var(i))), App(Var('snd'), Var(i))))))
   # Irregular concatenation
   # TODO: Generate specialized code
@@ -465,5 +474,5 @@ def _concatenate_lowering(ctx, *xs, dimension):
   return Block([
         Decl(ConPattern('AsList', (None, xs_v)),
              App(Var('concat'), Table(tuple(App(Var('to_list'), x) for x in xs)))),
-      ], App(App(Var('unsafe_cast_table'), FinType(Literal(out_aval.shape[0]))), Var(xs_v)))
+      ], App(App(Var('unsafe_cast_table'), FinType(IxRepLiteral(out_aval.shape[0]))), Var(xs_v)))
 expr_makers[lax.concatenate_p] = _concatenate_lowering

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -721,6 +721,7 @@ typeCheckPrimOp op = case op of
     methodTy <- getMethodType className i
     dropSubst $ checkApp methodTy params
   ExplicitApply _ _ -> error "shouldn't appear after inference"
+  MonoLiteral _ -> error "should't appear after inference"
 
 typeCheckPrimHof :: Typer m => PrimHof (Atom i) -> m i o (Type o)
 typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -30,7 +30,11 @@ exportFunctions = error "Not implemented"
 {-# SCC exportFunctions #-}
 
 prepareFunctionForExport :: (EnvReader m, Fallible1 m) => Atom n -> m n (ImpFunction n, ExportedSignature VoidS)
-prepareFunctionForExport f = do
+prepareFunctionForExport f = liftExcept =<< liftEnvReaderT (prepareFunctionForExport' f)
+{-# INLINE prepareFunctionForExport #-}
+
+prepareFunctionForExport' :: Atom n -> EnvReaderT Except n (ImpFunction n, ExportedSignature VoidS)
+prepareFunctionForExport' f = do
   naryPi <- getType f >>= asFirstOrderFunction >>= \case
     Nothing  -> throw TypeErr "Only first-order functions can be exported"
     Just npi -> return npi

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -911,6 +911,8 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
     ty' <- zonk =<< checkUType ty
     val' <- checkSigma val ty'
     matchRequirement val'
+  UPrimExpr (OpExpr (MonoLiteral (WithSrcE _ (UIntLit x)))) ->
+    matchRequirement $ Con $ Lit $ Int32Lit $ fromIntegral x
   UPrimExpr (OpExpr (ExplicitApply f x)) -> do
     f' <- inferFunNoInstantiation f
     x' <- inferRho x

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -1466,6 +1466,7 @@ builtinNames = M.fromList
   , ("projMethod2", OpExpr $ ProjMethod () 2)
   , ("explicitDict", ConExpr $ ExplicitDict () ())
   , ("explicitApply", OpExpr $ ExplicitApply () ())
+  , ("monoLit", OpExpr $ MonoLiteral ())
   ]
   where
     vbinOp op = OpExpr $ VectorBinOp op () ()

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -271,7 +271,7 @@ instance Fallible (TypeQueryM i o) where
   {-# INLINE throwErrs #-}
   addErrCtx = const id
   {-# INLINE addErrCtx #-}
-    
+
 class HasType (e::E) where
   getTypeE :: e i -> TypeQueryM i o (Type o)
 
@@ -623,6 +623,7 @@ getTypePrimOp op = case op of
     methodTy <- getMethodType className i
     dropSubst $ typeApp methodTy params
   ExplicitApply _ _ -> error "shouldn't appear after inference"
+  MonoLiteral _ -> error "shouldn't appear after inference"
 
 getTypeBaseType :: HasType e => e i -> TypeQueryM i o BaseType
 getTypeBaseType e =

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -258,6 +258,7 @@ transposeOp op ct = case op of
   OutputStreamPtr       -> notLinear
   ProjMethod _ _        -> notLinear
   ExplicitApply _ _     -> notLinear
+  MonoLiteral _         -> notLinear
   where notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
 
 transposeAtom :: HasCallStack => Emits o => Atom i -> Atom o -> TransposeM i o ()

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -143,6 +143,7 @@ data PrimOp e =
       | OutputStreamPtr
       | ProjMethod e Int  -- project a method from the dict
       | ExplicitApply e e
+      | MonoLiteral e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 traversePrimOp :: Applicative f => (e -> f e') -> PrimOp e -> f (PrimOp e')


### PR DESCRIPTION
JAX has lots of statically available information about the computation, but surface Dex is extremely polymorphic. Every integer literal, every instance of `add` and many other places required us to perform dictionary synthesis and have slowed down compile times significantly. Making them monomorphic helps a lot!