### PR TITLE
Allow dex web to be used without a network connection

### DIFF
--- a/static/dynamic.html
+++ b/static/dynamic.html
@@ -5,12 +5,18 @@
   <title>Dex Output</title>
   <link rel="stylesheet" href="/style.css" type="text/css" />
   <!-- Plotly: charts and graphing library -->
-  <script src="https://cdn.plot.ly/plotly-1.2.0.min.js"></script>
+  <script defer src="https://cdn.plot.ly/plotly-1.2.0.min.js"></script>
   <!-- KaTeX: LaTeX rendering -->
   <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.css" integrity="sha384-AfEj0r4/OFrOo5t7NnNe46zW/tFgW6x/bCJG8FqQCEo3+Aro6EYUG4+cU+KJWu/X" crossorigin="anonymous">
   <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/katex.min.js" integrity="sha384-g7c+Jr9ZivxKLnZTDUhnkOnsh30B4H0rpLUpJ4jAIKs4fnJI+sEnkvrMWph2EDg4" crossorigin="anonymous"></script>
   <!-- Do dynamic webpage rendering on-load. -->
-  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js" integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa" onload="render(RENDER_MODE.DYNAMIC);" crossorigin="anonymous"></script>
+  <script defer src="https://cdn.jsdelivr.net/npm/katex@0.12.0/dist/contrib/auto-render.min.js"
+          integrity="sha384-mll67QQFJfxn0IYznZYonOWZ644AWYC+Pt2cHqMaRhXVrursRwvLnLaebdGIlYNa"
+          onload="render(RENDER_MODE.DYNAMIC);"
+          <!-- Render dynamically even if KaTeX fails to load (e.g., if running dex web locally with no network);
+               the latex will just remain unrendered. -->
+          onerror="render(RENDER_MODE.DYNAMIC);"
+          crossorigin="anonymous"></script>
 </head>
 
 <body>

--- a/static/index.js
+++ b/static/index.js
@@ -44,11 +44,13 @@ function lookup_address(cell, address) {
 }
 
 function renderLaTeX() {
-    // Render LaTeX equations in prose blocks via KaTeX.
-    var proseBlocks = document.querySelectorAll(".prose-block");
-    Array.from(proseBlocks).map((proseBlock) =>
-        renderMathInElement(proseBlock, katexOptions)
-    );
+    // Render LaTeX equations in prose blocks via KaTeX, if available.
+    if (typeof renderMathInElement != 'undefined') {
+        var proseBlocks = document.querySelectorAll(".prose-block");
+        Array.from(proseBlocks).map((proseBlock) =>
+            renderMathInElement(proseBlock, katexOptions)
+        );
+    }
 }
 
 /**

--- a/static/index.js
+++ b/static/index.js
@@ -45,7 +45,15 @@ function lookup_address(cell, address) {
 
 function renderLaTeX() {
     // Render LaTeX equations in prose blocks via KaTeX, if available.
-    if (typeof renderMathInElement != 'undefined') {
+    // Skip rendering if KaTeX is unavailable.
+    if (typeof renderMathInElement == 'undefined') {
+        return;
+    }
+    // Render LaTeX equations in prose blocks via KaTeX.
+    var proseBlocks = document.querySelectorAll(".prose-block");
+    Array.from(proseBlocks).map((proseBlock) =>
+        renderMathInElement(proseBlock, katexOptions)
+    );
         var proseBlocks = document.querySelectorAll(".prose-block");
         Array.from(proseBlocks).map((proseBlock) =>
             renderMathInElement(proseBlock, katexOptions)


### PR DESCRIPTION
The issue was that the dynamic content rendering loop was only started
after KaTeX was loaded, in the `onload` property.  But naturally
enough that trigger doesn't run if the load fails, as when there is no
network.  Added starting the same loop `onerror` as well, and tweaked
the Dex-specific Javascript to survive KaTeX being unavailable (by
just not rendering any LaTeX with it).

Fixes #610.