### PR TITLE
Optimize GenericTraversal and add trivial loop unrolling

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -67,6 +67,7 @@ library
                      , Logging
                      , MTL1
                      , Name
+                     , Optimize
                      , PPrint
                      , Parser
                      , RawName

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -78,9 +78,9 @@ newtype FailedDictTypes (n::S) = FailedDictTypes (ESet (MaybeE Type) n)
         deriving (SinkableE, HoistableE, Semigroup, Monoid)
 data DictTypeHoistStatus = DictTypeHoistFailure | DictTypeHoistSuccess
 
-instance Monad1 m => HoistableState FailedDictTypes m where
+instance HoistableState FailedDictTypes where
   hoistState _ b (FailedDictTypes ds) =
-    return $ FailedDictTypes $ eSetFromList $
+    FailedDictTypes $ eSetFromList $
       for (eSetToList ds) \d -> case hoist b d of
         HoistSuccess d' -> d'
         HoistFailure _  -> NothingE

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -1,237 +1,63 @@
--- Copyright 2020 Google LLC
+-- Copyright 2022 Google LLC
 --
 -- Use of this source code is governed by a BSD-style
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Optimize (optimizeModule, dceModule, inlineModule) where
+module Optimize (earlyOptimize) where
 
-import Control.Monad.State.Strict
-import Data.Foldable
-import Data.Maybe
+import Control.Monad
 
-import Syntax
+import Types.Core
+import Types.Primitives
+import MTL1
+import Name
+import Core
+import GenericTraversal
 import Builder
-import Cat
-import Subst
-import Type
+import QueryType
 
-optimizeModule :: Module -> Module
-optimizeModule = dceModule . inlineModule . narrowEffects . dceModule
+earlyOptimize :: EnvReader m => Block n -> m n (Block n)
+earlyOptimize = unrollTrivialLoops
 
--- === DCE ===
+-- === Trivial loop unrolling ===
+-- This pass unrolls loops that use Fin 0 or Fin 1 as an index set.
 
-type DceM = State Scope
+data UTLS n = UTLS
+type UTLM = GenericTraverserM UTLS
+instance SinkableE UTLS where
+  sinkingProofE _ UTLS = UTLS
+instance HoistableState UTLS where
+  hoistState _ _ _ = UTLS
+  {-# INLINE hoistState #-}
 
-dceModule :: Module -> Module
-dceModule (Module ir decls result) = flip evalState mempty $ do
-  let EvaluatedModule bindings scs sourceMap = result
-  bindings' <- traverse dceBinding bindings
-  let result' = EvaluatedModule bindings' scs sourceMap
-  modify (<> freeVars result')
-  newDecls <- dceDecls decls
-  return $ Module ir newDecls result'
-  where
-    dceBinding (AtomBinderInfo ty (LetBound ann expr)) =
-      AtomBinderInfo ty . LetBound ann <$> dceExpr expr
-    dceBinding b = return b
+data IndexSetKind n
+  = EmptyIxSet
+  | SingletonIxSet (Atom n)
+  | UnknownIxSet
 
-dceBlock :: Block -> DceM Block
-dceBlock (Block decls result) = do
-  newResult <- dceExpr result
-  modify (<> freeVars newResult)
-  newDecls <- dceDecls decls
-  return $ Block newDecls newResult
+isTrivialIndex :: Type i -> UTLM i o (IndexSetKind o)
+isTrivialIndex = \case
+  TC (Fin     (IdxRepVal n)) | n <= 0 -> return EmptyIxSet
+  TC (Fin  nv@(IdxRepVal n)) | n == 1 ->
+    liftM (SingletonIxSet . Con) $ FinVal <$> substM nv <*> pure (IdxRepVal 0)
+  _ -> return UnknownIxSet
 
-dceDecls :: Nest Decl -> DceM (Nest Decl)
-dceDecls decls = do
-  let revDecls = reverse $ toList decls
-  revNewDecls <- catMaybes <$> mapM dceDecl revDecls
-  return $ toNest $ reverse $ revNewDecls
+instance GenericTraverser UTLS where
+  traverseExpr expr = case expr of
+    Hof (For _ (IxTy ixTy) (Lam (LamExpr b body@(Block _ decls a)))) -> do
+      isTrivialIndex (binderType b) >>= \case
+        UnknownIxSet     -> traverseExprDefault expr
+        SingletonIxSet i -> do
+          ixTy' <- substM ixTy
+          ans <- extendSubst (b @> SubstVal i) $ traverseDeclNest decls $ traverseAtom a
+          liftM Atom $ buildTabLam noHint ixTy' $ const $ return $ sink ans
+        EmptyIxSet -> do
+          ixTy' <- substM ixTy
+          liftM Atom $ buildTabLam noHint ixTy' \i -> do
+            resTy' <- extendSubst (b @> Rename i) $ getTypeSubst body
+            emitOp $ ThrowError (sink resTy')
+    _ -> traverseExprDefault expr
 
-dceDecl :: Decl -> DceM (Maybe Decl)
-dceDecl decl = do
-  newDecl <- case decl of
-    Let ann b expr -> go [b] expr $ Let ann b
-  modify (<> freeVars newDecl)
-  return newDecl
-  where
-    go bs expr mkDecl = do
-      varsNeeded <- get
-      forM_ bs $ modify . envDelete
-      if any (`isin` varsNeeded) bs || (not $ isPure expr)
-        then Just . mkDecl <$> dceExpr expr
-        else return Nothing
-
-dceExpr :: Expr -> DceM Expr
-dceExpr expr = case expr of
-  App g x        -> App  <$> dceAtom g <*> dceAtom x
-  Atom x         -> Atom <$> dceAtom x
-  Op  op         -> Op   <$> traverse dceAtom op
-  Hof hof        -> Hof  <$> traverse dceAtom hof
-  Case e alts ty -> Case <$> dceAtom e <*> mapM dceAlt alts <*> dceAtom ty
-
-dceAlt :: Alt -> DceM Alt
-dceAlt (Abs bs block) = Abs <$> traverse dceAbsBinder bs <*> dceBlock block
-
-dceAbsBinder :: Binder -> DceM Binder
-dceAbsBinder b = modify (envDelete b) >> return b
-
-dceAtom :: Atom -> DceM Atom
-dceAtom atom = case atom of
-  Lam (Abs b (arr, block)) -> Lam <$> (Abs <$> dceAbsBinder b <*> ((arr,) <$> dceBlock block))
-  _ -> return atom
-
--- === For inlining ===
-
-type InlineM = SubstBuilder
-
-inlineTraversalDef :: TraversalDef InlineM
-inlineTraversalDef = (inlineTraverseDecl, inlineTraverseExpr, traverseAtom inlineTraversalDef)
-
-inlineModule :: Module -> Module
-inlineModule m = transformModuleAsBlock inlineBlock (computeInlineHints m)
-  where
-    inlineBlock block = fst $ runSubstBuilder mempty mempty (traverseBlock inlineTraversalDef block)
-
-inlineTraverseDecl :: Decl -> InlineM SubstSubst
-inlineTraverseDecl decl = case decl of
-  Let _ b@(BindWithHint CanInline _) expr@(Hof (For _ body)) | isPure expr -> do
-    ~(LamVal ib block) <- traverseAtom inlineTraversalDef body
-    return $ b @> SubstVal (TabVal ib block)
-  -- If `f` turns out to be an inlined table lambda, we expand its block and
-  -- call ourselves recursively on the block's result expression. This makes
-  -- it possible for us to e.g. discover that the result is a `for` loop, and
-  -- match the case above, to continue the inlining process.
-  Let letAnn letBinder (App f' x') -> do
-    f <- traverseAtom inlineTraversalDef f'
-    x <- traverseAtom inlineTraversalDef x'
-    case f of
-      TabVal b (Block body result) -> do
-        dropSub $ extendR (b@>SubstVal x) $ do
-          blockSubst <- traverseDeclsOpen substTraversalDef body
-          extendR blockSubst $ inlineTraverseDecl $ Let letAnn letBinder result
-      _ -> ((letBinder@>) . SubstVal )<$> withNameHint letBinder (emitAnn letAnn (App f x))
-  _ -> traverseDecl inlineTraversalDef decl
-
--- TODO: This is a bit overeager. We should count under how many loops are we.
---       Even if the array is accessed in an sinkive fashion, the accesses might
---       be happen in a deeply nested loop and we might not want to repeat the
---       compute over and over.
-inlineTraverseExpr :: Expr -> InlineM Expr
-inlineTraverseExpr expr = case expr of
-  Hof (For d body) -> do
-    newBody <- traverseAtom inlineTraversalDef body
-    case newBody of
-      -- XXX: The trivial body might be a table lambda, and those could technically
-      --      get quite expensive. But I think this should never be the case in practice.
-      -- Trivial bodies
-      LamVal ib block@(Block Empty (Atom _)) -> return $ Atom $ TabVal ib block
-      -- Pure broadcasts
-      LamVal ib@(Ignore _) block | blockEffs block == Pure -> do
-        result <- dropSub $ evalBlockE inlineTraversalDef block
-        Atom <$> buildLam ib TabArrow (\_ -> return $ result)
-      _ -> return $ Hof $ For d newBody
-  App f' x' -> do
-    f <- traverseAtom inlineTraversalDef f'
-    x <- traverseAtom inlineTraversalDef x'
-    case f of
-      TabVal b body -> Atom <$> (dropSub $ extendR (b@>SubstVal x) $ evalBlockE inlineTraversalDef body)
-      _ -> return $ App f x
-  _ -> nope
-  where nope = traverseExpr inlineTraversalDef expr
-
-type InlineHintM = State (Subst InlineHint)
-
-computeInlineHints :: Module -> Module
-computeInlineHints m@(Module _ _ bindings) =
-    transformModuleAsBlock (flip evalState bindingsNoInline . hintBlock) m
-  where
-    usedInBindings = bindingsAsVars $ freeVars bindings
-    bindingsNoInline = newSubst usedInBindings (repeat NoInline)
-
-    hintBlock (Block decls result) = do
-      result' <- hintExpr result  -- Traverse result before decls!
-      Block <$> hintDecls decls <*> pure result'
-
-    hintDecls decls = do
-      let revDecls = reverse $ toList decls
-      revNewDecls <- mapM hintDecl revDecls
-      return $ toNest $ reverse $ revNewDecls
-
-    hintDecl decl = case decl of
-      Let ann b expr -> go [b] expr $ Let ann . head
-      where
-        go bs expr mkDecl = do
-          void $ noInlineFree bs
-          bs' <- traverse hintBinder bs
-          forM_ bs $ modify . envDelete
-          mkDecl bs' <$> hintExpr expr
-
-    hintExpr :: Expr -> InlineHintM Expr
-    hintExpr expr = case expr of
-      App (Var v) x  -> App  <$> (Var v <$ use v) <*> hintAtom x
-      App g x        -> App  <$> hintAtom g       <*> hintAtom x
-      Atom x         -> Atom <$> hintAtom x
-      Op  op         -> Op   <$> traverse hintAtom op
-      Hof hof        -> Hof  <$> traverse hintAtom hof
-      Case e alts ty -> Case <$> hintAtom e <*> traverse hintAlt alts <*> hintAtom ty
-
-    hintAlt (Abs bs block) = Abs <$> traverse hintAbsBinder bs <*> hintBlock block
-
-    hintAtom :: Atom -> InlineHintM Atom
-    hintAtom atom = case atom of
-      -- TODO: Is it always ok to inline e.g. into a table lambda? Even if the
-      --       lambda indicates that the access pattern would be sinkive, its
-      --       body can still get instantiated multiple times!
-      Lam (Abs b (arr, block)) -> Lam <$> (Abs <$> hintAbsBinder b <*> ((arr,) <$> hintBlock block))
-      _ -> noInlineFree atom
-
-    use n = do
-      maybeHint <- gets $ (`envLookup` n)
-      let newHint = case maybeHint of
-                      Nothing -> CanInline
-                      Just _  -> NoInline
-      modify (<> (n @> newHint))
-
-    hintBinder :: Binder -> InlineHintM Binder
-    hintBinder b = do
-      maybeHint <- gets $ (`envLookup` b)
-      case (b, maybeHint) of
-        (Bind v  , Just hint) -> return $ BindWithHint hint   v
-        (Bind v  , Nothing  ) -> return $ BindWithHint NoHint v -- TODO: Change to Ignore?
-        (Ignore _, Nothing  ) -> return b
-        (Ignore _, Just _   ) -> error "Ignore binder is not supposed to have any uses"
-
-    hintAbsBinder :: Binder -> InlineHintM Binder
-    hintAbsBinder b = modify (envDelete b) >> traverse hintAtom b
-
-    noInlineFree :: HasVars a => a -> InlineHintM a
-    noInlineFree a = modify (<> (fmap (const NoInline) (freeVars a))) >> return a
-
--- === effect narrowing ===
--- We often annotate lambdas with way more effects than they really induce
--- and this makes those annotations much more precise (but only on `for` expressions).
-
-narrowEffects :: Module -> Module
-narrowEffects m = transformModuleAsBlock narrowBlock m
-  where
-    narrowBlock block = fst $ runSubstBuilder mempty mempty (traverseBlock narrowingTraversalDef block)
-
-    narrowingTraversalDef :: TraversalDef SubstBuilder
-    narrowingTraversalDef = ( traverseDecl narrowingTraversalDef
-                            , traverseExpr narrowingTraversalDef
-                            , narrowAtom )
-
-    narrowAtom :: Atom -> SubstBuilder Atom
-    narrowAtom atom = case atom of
-      Lam (Abs b (arr, body)) -> do
-          b' <- mapM (traverseAtom narrowingTraversalDef) b
-          ~lam@(Lam (Abs b'' (_, body''))) <-
-            buildDepEffLam b'
-              (\x -> extendR (b'@>SubstVal x) (substBuilderR arr))
-              (\x -> extendR (b'@>SubstVal x) (evalBlockE narrowingTraversalDef body))
-          return $ case arr of
-            PlainArrow _ -> Lam $ Abs b'' (PlainArrow (blockEffs body''), body'')
-            _            -> lam
-      _ -> traverseAtom narrowingTraversalDef atom
+unrollTrivialLoops :: EnvReader m => Block n -> m n (Block n)
+unrollTrivialLoops b = liftM fst $ liftGenericTraverserM UTLS $ traverseGenericE b

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -51,6 +51,7 @@ import Inference
 import Simplify
 import Imp
 import JIT
+import Optimize
 import QueryType
 
 -- === top-level monad ===
@@ -418,7 +419,8 @@ evalUExpr expr = do
 
 evalBlock :: (Topper m, Mut n) => Block n -> m n (Atom n)
 evalBlock typed = do
-  synthed <- checkPass SynthPass $ synthTopBlock typed
+  opt <- checkPass EarlyOptPass $ earlyOptimize typed
+  synthed <- checkPass SynthPass $ synthTopBlock opt
   SimplifiedBlock simp recon <- checkPass SimpPass $ simplifyTopBlock synthed
   result <- evalBackend simp
   applyRecon recon result

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -299,7 +299,7 @@ data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
 
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
               | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval
-              | ResultPass | JaxprAndHLO | OptimPass
+              | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass
                 deriving (Ord, Eq, Bounded, Enum, Generic)
 
 instance Show PassName where
@@ -309,7 +309,8 @@ instance Show PassName where
     SimpPass -> "simp"  ; ImpPass  -> "imp"     ; JitPass   -> "llvm"
     LLVMOpt  -> "llvmopt" ; AsmPass   -> "asm"
     JAXPass  -> "jax"   ; JAXSimpPass -> "jsimp"; ResultPass -> "result"
-    LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo"; OptimPass -> "optimized"
+    LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo";
+    EarlyOptPass -> "early-opt"; OptPass -> "opt"
 
 data EnvQuery =
    DumpSubst


### PR DESCRIPTION
#### Refactor and optimize generic traversals

Soon enough we'll need to start adding optimization passes, and those
will have to be implemented on top of generic traversals. I glanced over
the current implementation, and while it was nice conceptually, it
didn't expose too many optimization opportunities for GHC.

In this commit, I make the generic traversal monad concrete, and only
allow the different traversals to customize the type of state carried by
the monad. Of course each traversal can also customize both
`traverseExpr` and `traverseAtom`, with type of the monadic state acting
as a selector for the appropriate typeclass methods. While this loses
flexibility compared to the old approach (which could run with an
arbitrary stack), it should help us avoid unnecessary slowdowns in the
compiler.

Finally, I also use other tricks like the tail-recursive decl traversal
or monad eta-expansion that we already implement in Simplification.

#### Add an early optimization pass that unrolls trivial loops

This adds a transform that eliminates loops that use `Fin 0` and `Fin 1`
as their index set. In the future we can extend it to user-defined index
sets as well, by looking up the `size` in the `Ix` dictionary. But since
those are still undergoing some changes, I decided to hard-code the
builtin types for now.

Note that it only runs _before simplification_, meaning that it's
complexity is proportional to the source program size. Since those are
generally small, it should be very cheap to apply. It misses some
opportunities for further optimizations that might get exposed once
polymorphic functions get instantiated, but we can always repeat this
pass in a later optimization pipeline.
