### PR TITLE
Bring superclasses into scope in the method types of interface definitions

### DIFF
--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -1356,15 +1356,40 @@ inferClassDef
   :: SourceName -> [SourceName] -> Nest (UAnnBinder AtomNameC) i i'
   -> [UType i'] -> [UMethodType i']
   -> InfererM i o (ClassDef o)
-inferClassDef className methodNames paramBs superclasses methods = solveLocal do
+inferClassDef className methodNames paramBs superclassTys methods = solveLocal do
   ab <- withNestedUBinders paramBs id \_ -> do
-    superclasses' <- mapM checkUType superclasses
-    methodsTys'   <- forM methods \(UMethodType (Right explicits) ty) -> do
-      ty' <- checkUType ty
-      return $ MethodType explicits ty'
-    return $ PairE (ListE superclasses') (ListE methodsTys')
-  Abs bs (PairE (ListE scs) (ListE mtys)) <- return ab
+    superclassTys' <- mapM checkUType superclassTys
+    withSuperclassBinders superclassTys' do
+      ListE <$> forM methods \(UMethodType (Right explicits) ty) -> do
+        ty' <- checkUType ty
+        return $ MethodType explicits ty'
+  Abs bs (Abs scs (ListE mtys)) <- return ab
   return $ ClassDef className methodNames bs scs mtys
+
+withSuperclassBinders
+  :: (SinkableE e, SubstE Name e, HoistableE e, EmitsInf o)
+  => [Type o]
+  -> (forall o'. (EmitsInf o', DExt o o') => InfererM i o' (e o'))
+  -> InfererM i o (Abs SuperclassBinders e o)
+withSuperclassBinders tys cont = do
+  Abs bs e <- withSuperclassBindersRec tys cont
+  return $ Abs (SuperclassBinders bs tys) e
+
+withSuperclassBindersRec
+  :: (SinkableE e, SubstE Name e, HoistableE e, EmitsInf o)
+  => [Type o]
+  -> (forall o'. (EmitsInf o', DExt o o') => InfererM i o' (e o'))
+  -> InfererM i o (Abs (Nest AtomNameBinder) e o)
+withSuperclassBindersRec [] cont = do
+  Distinct <- getDistinct
+  result <- cont
+  return $ Abs Empty result
+withSuperclassBindersRec (ty:rest) cont = do
+  let binding = PiBinding ClassArrow ty
+  Abs (b:>_) (Abs bs e) <- buildAbsInf noHint binding \_ -> do
+    ListE rest' <- sinkM $ ListE rest
+    withSuperclassBindersRec rest' cont
+  return $ Abs (Nest b bs) e
 
 withNestedUBinders
   :: (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e, ToBinding binding AtomNameC)
@@ -1470,13 +1495,15 @@ checkInstanceBody :: EmitsInf o
                   -> InfererM i o (InstanceBody o)
 checkInstanceBody className params methods = do
   def@(ClassDef _ methodNames _ _ _ ) <- getClassDef className
-  (superclassTys, methodTys) <- checkedApplyClassParams def params
+  Abs superclassBs methodTys <- checkedApplyClassParams def params
+  SuperclassBinders bs superclassTys <- return superclassBs
   superclassDicts <- mapM trySynthTerm superclassTys
-  methodsChecked <- mapM (checkMethodDef className methodTys) methods
+  ListE methodTys' <- applySubst (bs @@> map SubstVal superclassDicts) methodTys
+  methodsChecked <- mapM (checkMethodDef className methodTys') methods
   let (idxs, methods') = unzip $ sortOn fst $ methodsChecked
   forM_ (repeated idxs) \i ->
     throw TypeErr $ "Duplicate method: " ++ pprint (methodNames!!i)
-  forM_ ([0..(length methodTys - 1)] `listDiff` idxs) \i ->
+  forM_ ([0..(length methodTys' - 1)] `listDiff` idxs) \i ->
     throw TypeErr $ "Missing method: " ++ pprint (methodNames!!i)
   return $ InstanceBody superclassDicts methods'
 
@@ -2449,7 +2476,7 @@ getSuperclassClosurePure env givens newGivens =
       superclasses <- case synthTy of
         SynthPiType _ -> return []
         SynthDictType (DictType _ className _) -> do
-          ClassDef _ _ _ superclasses _ <- lookupClassDef className
+          ClassDef _ _ _ (SuperclassBinders _ superclasses) _ <- lookupClassDef className
           return $ void superclasses
       return $ enumerate superclasses <&> \(i, _) -> DictCon $ SuperclassProj synthExpr i
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -483,7 +483,7 @@ instance Pretty (ClassDef n) where
     "Class:" <+> pretty classSourceName <+> pretty methodNames
     <> indented (
          line <> "parameter biners:" <+> pretty params <>
-         line <> "superclasses:" <+> pretty superclasses <>
+         line <> "superclasses:" <+> pretty (superclassTypes superclasses) <>
          line <> "methods:" <+> pretty methodTys)
 
 instance Pretty (InstanceDef n) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -3,13 +3,13 @@ module QueryType (
   getEffects, getEffectsSubst,
   computeAbsEffects, declNestEffects,
   caseAltsBinderTys, depPairLeftTy, extendEffect,
-  getAppType, getTabAppType, getMethodType, getBaseMonoidType, getReferentTy,
+  getAppType, getTabAppType, getBaseMonoidType, getReferentTy,
   getMethodIndex,
   instantiateDataDef, instantiateDepPairTy, instantiatePi, instantiateTabPi,
   litType, lamExprTy,
   numNaryPiArgs, naryLamExprType,
   oneEffect, projectLength, sourceNameType, typeAsBinderNest, typeBinOp, typeUnOp,
-  isSingletonType, singletonTypeVal, ixDictType
+  isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts
   ) where
 
 import Control.Category ((>>>))
@@ -87,19 +87,6 @@ getTabAppType f xs = case nonEmpty xs of
   Nothing -> getType f
   Just xs' -> liftTypeQueryM idSubst $ typeTabApp f xs'
 {-# INLINE getTabAppType #-}
-
-getMethodType :: EnvReader m => ClassName n -> Int -> m n (Type n)
-getMethodType className i = do
-  ClassDef _ _ bs _ methodTys <- lookupClassDef className
-  let MethodType explicits methodTy = methodTys !! i
-  return $ addParamBinders explicits bs methodTy
-  where
-    addParamBinders :: [Bool] -> Nest Binder n l -> Type l -> Type n
-    addParamBinders [] Empty ty = ty
-    addParamBinders (explicit:explicits) (Nest (b:>argTy) bs) ty =
-      Pi $ PiType (PiBinder b argTy arr) Pure $ addParamBinders explicits bs ty
-      where arr = if explicit then PlainArrow else ImplicitArrow
-    addParamBinders _ _ _ = error "arg/binder mismatch"
 
 getBaseMonoidType :: Fallible1 m => ScopeReader m => Type n -> m n (Type n)
 getBaseMonoidType ty = case ty of
@@ -427,7 +414,8 @@ dictExprType e = case e of
   SuperclassProj d i -> do
     DictTy (DictType _ className params) <- getTypeE d
     ClassDef _ _ bs superclasses _ <- lookupClassDef className
-    DictTy dTy <- applyNaryAbs (Abs bs (superclasses !! i)) $ map SubstVal params
+    DictTy dTy <- applySubst (bs @@> map SubstVal params) $
+                    superclassTypes superclasses !! i
     return dTy
   IxFin n -> do
     n' <- substM n
@@ -623,10 +611,18 @@ getTypePrimOp op = case op of
     where hostPtrTy ty = PtrType (Heap CPU, ty)
   ProjMethod dict i -> do
     DictTy (DictType _ className params) <- getTypeE dict
-    methodTy <- getMethodType className i
-    dropSubst $ typeApp methodTy params
+    def@(ClassDef _ _ paramBs classBs methodTys) <- lookupClassDef className
+    let MethodType _ methodTy = methodTys !! i
+    superclassDicts <- getSuperclassDicts def <$> substM dict
+    let subst = (    paramBs @@> map SubstVal params
+                 <.> classBs @@> map SubstVal superclassDicts)
+    applySubst subst methodTy
   ExplicitApply _ _ -> error "shouldn't appear after inference"
   MonoLiteral _ -> error "shouldn't appear after inference"
+
+getSuperclassDicts :: ClassDef n -> Atom n -> [Atom n]
+getSuperclassDicts (ClassDef _ _ _ (SuperclassBinders classBs _) _) dict =
+  for [0 .. nestLength classBs - 1] \i -> DictCon $ SuperclassProj dict i
 
 getTypeBaseType :: HasType e => e i -> TypeQueryM i o BaseType
 getTypeBaseType e =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -34,7 +34,7 @@ module Syntax (
     PiBinding (..), PiBinder (..),
     PiType (..), DepPairType (..), LetAnn (..),
     BinOp (..), UnOp (..), CmpOp (..), SourceMap (..), SourceNameDef (..), LitProg,
-    ForAnn (..), Val, Op, Con, Hof, TC,
+    ForAnn (..), Val, Op, Con, Hof, TC, SuperclassBinders (..),
     ClassDef (..), InstanceDef (..), InstanceBody (..), MethodType (..),
     SynthCandidates (..), Env (..), TopEnv (..), ModuleEnv (..),
     ImportStatus (..), emptyModuleEnv,


### PR DESCRIPTION
This was intended to fix the `Basis` example in #323 and it does get rid of the
"couldn't synthesize a class dictionary" failure. But the example now just fails
for a different reason, which is that we can't have method projection appearing
in types.