### PR TITLE
Python integration improvements

### DIFF
--- a/python/dex/__init__.py
+++ b/python/dex/__init__.py
@@ -66,6 +66,11 @@ class Prelude(Module):
 prelude = Prelude()
 eval = prelude.eval
 
+_calling_conventions = {
+  'flat': api.FlatCC,
+  'xla': api.XLACC,
+}
+
 
 class Atom:
   __slots__ = ('__weakref__', '_as_parameter_', 'module', 'name')
@@ -132,7 +137,8 @@ class Atom:
       api.destroyContext(old_env)
     return eval(" ".join(f"python_arg{i}" for i in range(len(args) + 1)), module=self.module, _env=env)
 
-  def compile(self):
-    func_ptr = api.compile(api.jit, self.module, self)
+  def compile(self, calling_convention='flat'):
+    cc = _calling_conventions[calling_convention]
+    func_ptr = api.compile(api.jit, cc, self.module, self)
     if not func_ptr: api.raise_from_dex()
-    return NativeFunction(api.jit, func_ptr)
+    return NativeFunction(api.jit, func_ptr, cc)

--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -98,6 +98,8 @@ unload     = dex_func('dexUnload',     HsJITPtr, NativeFunction, None)
 getFunctionSignature  = dex_func('dexGetFunctionSignature', HsJITPtr, NativeFunction, NativeFunctionSignaturePtr)
 freeFunctionSignature = dex_func('dexFreeFunctionSignature', NativeFunctionSignaturePtr, None)
 
+xlaCpuTrampoline = lib.dexXLACPUTrampoline
+
 init()
 jit = createJIT()
 nofree = False

--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -49,6 +49,16 @@ class NativeFunctionSignature(ctypes.Structure):
               ("res", ctypes.c_char_p),
               ("ccall", ctypes.c_char_p)]
 
+class ExportCC:
+  def __init__(self, value):
+    self._as_parameter_ = ctypes.c_int32(value)
+
+  @classmethod
+  def from_param(cls, p):
+    return p._as_parameter_
+FlatCC = ExportCC(0)
+XLACC = ExportCC(1)
+
 
 HsAtomPtr = ctypes.POINTER(HsAtom)
 HsContextPtr = ctypes.POINTER(HsContext)
@@ -82,7 +92,7 @@ fromCAtom = dex_func('dexFromCAtom', CAtomPtr,                HsAtomPtr)
 
 createJIT  = dex_func('dexCreateJIT',  HsJITPtr)
 destroyJIT = dex_func('dexDestroyJIT', HsJITPtr, None)
-compile    = dex_func('dexCompile',    HsJITPtr, HsContextPtr, HsAtomPtr, NativeFunction)
+compile    = dex_func('dexCompile',    HsJITPtr, ExportCC, HsContextPtr, HsAtomPtr, NativeFunction)
 unload     = dex_func('dexUnload',     HsJITPtr, NativeFunction, None)
 
 getFunctionSignature  = dex_func('dexGetFunctionSignature', HsJITPtr, NativeFunction, NativeFunctionSignaturePtr)

--- a/src/Dex/Foreign/API.hs
+++ b/src/Dex/Foreign/API.hs
@@ -37,7 +37,7 @@ foreign export ccall "dexFromCAtom" dexFromCAtom  :: Ptr CAtom                  
 -- JIT
 foreign export ccall "dexCreateJIT"  dexCreateJIT  :: IO (Ptr JIT)
 foreign export ccall "dexDestroyJIT" dexDestroyJIT :: Ptr JIT -> IO ()
-foreign export ccall "dexCompile"    dexCompile    :: Ptr JIT -> Ptr Context -> Ptr AtomEx -> IO (Ptr NativeFunction)
+foreign export ccall "dexCompile"    dexCompile    :: Ptr JIT -> CInt -> Ptr Context -> Ptr AtomEx -> IO (Ptr NativeFunction)
 foreign export ccall "dexUnload"     dexUnload     :: Ptr JIT -> Ptr NativeFunction -> IO ()
 foreign export ccall "dexGetFunctionSignature"  dexGetFunctionSignature  :: Ptr JIT -> Ptr NativeFunction -> IO (Ptr ClosedExportedSignature)
 foreign export ccall "dexFreeFunctionSignature" dexFreeFunctionSignature :: Ptr ClosedExportedSignature -> IO ()

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -17,6 +17,7 @@ import Control.Monad.State.Strict
 
 import Foreign.Ptr
 import Foreign.C.String
+import Foreign.C.Types
 import Foreign.Storable
 import Foreign.Marshal.Alloc
 
@@ -80,14 +81,20 @@ dexDestroyJIT jitPtr = do
   LLVM.JIT.destroyJIT jit
   LLVM.Shims.disposeTargetMachine jitTargetMachine
 
-dexCompile :: Ptr JIT -> Ptr Context -> Ptr AtomEx -> IO NativeFunctionAddr
-dexCompile jitPtr ctxPtr funcAtomPtr = catchErrors $ do
+intAsCC :: CInt -> ExportCC
+intAsCC 0 = FlatExportCC
+intAsCC 1 = XLAExportCC
+intAsCC _ = error "Unregognized calling convention"
+
+dexCompile :: Ptr JIT -> CInt -> Ptr Context -> Ptr AtomEx -> IO NativeFunctionAddr
+dexCompile jitPtr ccInt ctxPtr funcAtomPtr = catchErrors $ do
   ForeignJIT{..} <- fromStablePtr jitPtr
   Context evalConfig initEnv <- fromStablePtr ctxPtr
   AtomEx funcAtom <- fromStablePtr funcAtomPtr
+  let cc = intAsCC ccInt
   fst <$> runTopperM evalConfig initEnv do
     -- TODO: Check if atom is compatible with context! Use module name?
-    (impFunc, nativeSignature) <- prepareFunctionForExport (unsafeCoerceE funcAtom)
+    (impFunc, nativeSignature) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
     filteredLogger <- FilteredLogger (const False) <$> getLogger
     (_, llvmAST) <- impToLLVM filteredLogger "userFunc" impFunc
     objFileNames <- getAllRequiredObjectFiles

--- a/src/Dex/Foreign/rts.c
+++ b/src/Dex/Foreign/rts.c
@@ -26,3 +26,9 @@ void _internal_dexSetError(char* new_err, int64_t len) {
   memcpy(dex_err_storage, new_err, len);
   dex_err_storage[2047] = 0;
 }
+
+typedef int64_t (*dex_xla_f)(void*, void**);
+void dexXLACPUTrampoline(void* out, void** in) {
+  dex_xla_f f = *((dex_xla_f*)(*in));
+  f(out, in + 1);
+}


### PR DESCRIPTION
#### Add support for the XLA:CPU calling convention in export

Dispatch times of Dex computations launched from JAX is pretty high,
because at the moment we use a Python-based trampoline that adjusts the
calling conventions to match. In this patch I add support for the
XLA calling convention to our codegen, which lets us eliminate the
Python indirection and have a fully native jump.

#### Use the new MLIR-based APIs to implement dex_apply lowering

#### Add a universal C trampoline for XLA-Dex calls

This lets us avoid generating a custom call per compiled Dex program,
and solves the problem of slightly mismatched return types. Also, use
the new "keepalive" mechanism of MLIR lowering instead of the global
dict.

#### Add support for jaxjitting dexjit'ed functions
