### PR TITLE
Separate `stack test` work space from `stack build` work space

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -45,6 +45,7 @@ jobs:
         path: |
           ~/.stack
           $GITHUB_WORKSPACE/.stack-work
+          $GITHUB_WORKSPACE/.stack-work-test
           $GITHUB_WORKSPACE/examples/t10k-images-idx3-ubyte
           $GITHUB_WORKSPACE/examples/t10k-labels-idx1-ubyte
 

--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ test-script.cd
 .stack-work-opt
 .stack-work-dbg
 .stack-work-prof
+.stack-work-test
 .stack-work-ffis
 garbage.hs
 *.lock

--- a/makefile
+++ b/makefile
@@ -221,8 +221,10 @@ doc-lib-names = $(lib-names:%=doc/lib/%.html)
 
 tests: unit-tests quine-tests repl-test module-tests
 
+# Keep the unit tests in their own working directory too, due to
+# https://github.com/commercialhaskell/stack/issues/4977
 unit-tests:
-	$(STACK) test $(STACK_FLAGS)
+	$(STACK) test --work-dir .stack-work-test $(STACK_FLAGS)
 
 quine-tests: $(quine-test-targets)
 


### PR DESCRIPTION
because they evict each other's caches.