### PR TITLE
Remove built-in index ranges and reimplement them in user space.

### DIFF
--- a/examples/fluidsim.dx
+++ b/examples/fluidsim.dx
@@ -41,8 +41,8 @@ def add_neighbours_2d {n m a} [Add a] (x:n=>m=>a) : (n=>m=>a) =
   ax2 = apply_along_axis2 add_neighbours x
   ax1 + ax2
 
-def project {n m a} [VSpace a] (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
-  -- Project the velocity field to be approximately mass-conserving,
+def project_vel {n m a} [VSpace a] (v: n=>m=>(Fin 2)=>a) : n=>m=>(Fin 2)=>a =
+  -- Project_vel the velocity field to be approximately mass-conserving,
   -- using a few iterations of Gauss-Seidel.
   h = 1.0 / n_to_f (size n)
 
@@ -102,7 +102,7 @@ def fluidsim {n m a} [VSpace a] (num_steps: Nat) (color_init: n=>m=>a)
     for i:(Fin num_steps).
       (color, v) = get state
       v = advect v v          -- Move velocities
-      v = project v           -- Project to be volume-preserving
+      v = project_vel v       -- Project to be volume-preserving
       color' = advect color v -- Move color
       state := (color', v)
       color

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -106,7 +106,7 @@ instance {n} HasDeterminant (LowerTriMap n)
   identity' = MkLowerTriMap for i j. select (ordinal i == ordinal j) one zero
 
 instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMap n) (n=>v)
-  apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(%inject j)
+  apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
   diag   = \(MkLowerTriMap x).   for i. x.i.(cast i) .* one
   solve' = \(MkLowerTriMap x).   forward_substitute x
 
@@ -126,7 +126,7 @@ instance {n} HasDeterminant (UpperTriMap n)
   identity' = MkUpperTriMap for i j. select (0 == ordinal j) one zero
 
 instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMap n) (n=>v)
-  apply  = \(MkUpperTriMap x) y. for i. sum for j. x.i.j .* y.(%inject j)
+  apply  = \(MkUpperTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
   diag   = \(MkUpperTriMap x).   for i. x.i.(0@_) .* one
   solve' = \(MkUpperTriMap x).   backward_substitute x
 

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -16,22 +16,22 @@ def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = for i. l.i.(cast i)
 
 def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
   for i:n. for j':(i..).
-    j = %inject j'
+    j = inject n j'
     lower.j.(cast i)
 
 def transpose_lower_to_upper_no_diag {n v}
     (lower:i:n=>(..<i)=>v) :
            i:n=>(i<..)=>v =
   for i j.
-    j' = %inject j
+    j' = inject n j
     lower.j'.(unsafe_from_ordinal _ (ordinal i))
 
 def skew_symmetric_prod {v n} [VSpace v]
     (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
   -- We could probably fuse these two for loops.
-  lower_prod = for i. sum for j. lower.i.j .* (y.(%inject j))
+  lower_prod = for i. sum for j. lower.i.j .* (y.(inject n j))
   upper = transpose_lower_to_upper_no_diag lower
-  upper_prod = for i. sum for j. upper.i.j .* (y.(%inject j))
+  upper_prod = for i. sum for j. upper.i.j .* (y.(inject n j))
   lower_prod - upper_prod
 
 def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v =
@@ -39,7 +39,7 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
   yield_state zero \sRef.
     for i:n.
       s = sum for k:(..<i).  -- dot product
-        a.i.(cast k) .* get sRef!(%inject k)
+        a.i.(cast k) .* get sRef!(inject n k)
       sRef!i := (b.i - s) / a.i.(cast i)
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =
@@ -47,7 +47,7 @@ def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v
   yield_state zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
-        a.i.(cast k) .* get sRef!(%inject k)
+        a.i.(cast k) .* get sRef!(inject n k)
       sRef!i := (b.i - s) / a.i.(0@_) -- 0 is the diagonal index
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
@@ -64,7 +64,7 @@ def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
   yield_state zero \buf.
     mat = lower_tri_mat buf
     for i:n. for j':(..i).
-      j = %inject j'
+      j = inject n j'
       row  = for k:(..<j). get $ mat i (cast k)
       row' = for k:(..<j). get $ mat j (cast k)
       a = x.i.j - vdot row row'
@@ -106,10 +106,10 @@ def pivotize {n} (a:n=>n=>Float) : Permutation n =
   -- Gives a row permutation that makes Gaussian elimination more stable.
   yield_state identity_permutation \permRef.
     for j:n.
-      row_with_largest = argmin for i:(j..). (-(abs a.(%inject i).j))
+      row_with_largest = argmin for i:(j..). (-(abs a.(inject n i).j))
       case ordinal j == ordinal row_with_largest of
         True -> ()
-        False -> swap_in_place permRef j (%inject row_with_largest)
+        False -> swap_in_place permRef j (inject n row_with_largest)
 
 def lu {n} (a: n=>n=>Float) :
        (LowerTriMat n Float & UpperTriMat n Float & Permutation n) =
@@ -119,7 +119,7 @@ def lu {n} (a: n=>n=>Float) :
   a = apply_permutation permutation a
 
   init_lower = for i:n. for j':(..i).
-    select (ordinal i == (ordinal (%inject j'))) 1.0 0.0
+    select (ordinal i == (ordinal (inject n j'))) 1.0 0.0
   init_upper = zero
 
   (lower, upper) = yield_state (init_lower, init_upper) \stateRef.
@@ -130,16 +130,16 @@ def lu {n} (a: n=>n=>Float) :
   -- without dependent tables (i.e. with standard flat matrices):
   --  for j:n.
   --    for i:(..j).
-  --      i = %inject i
+  --      i = inject _ i
   --      s = sum for k':(..i).
-  --        k = %inject k'
+  --        k = inject _ k'
   --        (get uRef!k!j) * (get lRef!i!k)
   --      uRef!i!j := a.i.j - s
 
   --    for i':(j<..).
-  --      i = %inject i'
+  --      i = inject _ i'
   --      s = sum for k':(..j).
-  --        k = %inject k'
+  --        k = inject _ k'
   --        (get uRef!k!j) * (get lRef!i!k)
   --      lRef!i!j := (a.i.j - s) / (get uRef!j!j)
   --    for i:n. ()
@@ -148,21 +148,22 @@ def lu {n} (a: n=>n=>Float) :
     umat = upper_tri_mat uRef
     for j:n.
       for i:(..j).
-        i' = %inject i
+        i' = inject n i
         s = sum for k:(..i).
-          k'' = %inject k
-          k' = %inject k''
+          -- TODO: get transitivity of Subset working so we can do a single injection
+          k'' = inject (..j) k
+          k' = inject n k''
           ukj = get $ umat k' ((unsafe_nat_diff (ordinal j) (ordinal k))@_)
           lik = get $ lmat i' (cast k)
           ukj * lik
 
         uijRef = umat i' ((unsafe_nat_diff (ordinal j) (ordinal i))@_)
-        uijRef := a.(%inject i).j - s
+        uijRef := a.(inject _ i).j - s
 
       for i:(j<..).
-        i' = %inject i
+        i' = inject _ i
         s = sum for k:(..j).
-          k' = %inject k
+          k' = inject _ k
           i'' = ((unsafe_nat_diff (ordinal j) (ordinal k))@_)
           ukj = get $ umat k' i''
           lik = get $ lmat i' (cast k)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -300,45 +300,37 @@ def (-|) (x: Nat) (y:Nat) : Nat =
 
 def unsafe_nat_diff (x:Nat) (y:Nat) : Nat = %isub x y
 
-instance {q:Type} {i:q} [Ix q] Ix (i..)
+-- `(i..)` parses as `RangeFrom _ i`
+data RangeFrom q:Type i:q = UnsafeMkRangeFrom Nat
+
+-- `(i<..)` parses as `RangeFromExc _ i`
+data RangeFromExc q:Type i:q = UnsafeMkRangeFromExc Nat
+
+-- `(..i)` parses as `RangeTo _ i`
+data RangeTo q:Type i:q = UnsafeMkRangeTo Nat
+
+-- `(..<i)` parses as `RangeToExc _ i`
+data RangeToExc q:Type i:q = UnsafeMkRangeToExc Nat
+
+instance {q:Type} {i:q} [Ix q] Ix (RangeFrom q i)
   size = unsafe_nat_diff (size q) (ordinal i)
-  ordinal = \j. %cast Nat j
-  unsafe_from_ordinal = \j. %cast (i..) j
+  ordinal = \(UnsafeMkRangeFrom j). j
+  unsafe_from_ordinal = \j. UnsafeMkRangeFrom j
 
-instance {q:Type} {i:q} [Ix q] Ix (i<..)
+instance {q:Type} {i:q} [Ix q] Ix (RangeFromExc q i)
   size = unsafe_nat_diff (size q) (ordinal i + 1)
-  ordinal = \j. %cast Nat j
-  unsafe_from_ordinal = \j. %cast (i<..) j
+  ordinal = \(UnsafeMkRangeFromExc j). j
+  unsafe_from_ordinal = \j. UnsafeMkRangeFromExc j
 
-instance {q:Type} {i:q} [Ix q] Ix (..i)
+instance {q:Type} {i:q} [Ix q] Ix (RangeTo q i)
   size = ordinal i + 1
-  ordinal = \j. %cast Nat j
-  unsafe_from_ordinal = \j. %cast (..i) j
+  ordinal = \(UnsafeMkRangeTo j). j
+  unsafe_from_ordinal = \j. UnsafeMkRangeTo j
 
-instance {q:Type} {i:q} [Ix q] Ix (..<i)
+instance {q:Type} {i:q} [Ix q] Ix (RangeToExc q i)
   size = ordinal i
-  ordinal = \j. %cast Nat j
-  unsafe_from_ordinal = \j. %cast (..<i) j
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..i)
-  size = (ordinal i + 1) -| ordinal j
-  ordinal = \k. %cast Nat k
-  unsafe_from_ordinal = \k. %cast (j..i) k
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j..<i)
-  size = ordinal i -| ordinal j
-  ordinal = \k. %cast Nat k
-  unsafe_from_ordinal = \k. %cast (j..<i) k
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..i)
-  size = ordinal i -| ordinal j
-  ordinal = \k. %cast Nat k
-  unsafe_from_ordinal = \k. %cast (j<..i) k
-
-instance {q:Type} {i:q} {j:q} [Ix q] Ix (j<..<i)
-  size = ordinal i -| (ordinal j + 1)
-  ordinal = \k. %cast Nat k
-  unsafe_from_ordinal = \k. %cast (j<..<i) k
+  ordinal = \(UnsafeMkRangeToExc j). j
+  unsafe_from_ordinal = \j. UnsafeMkRangeToExc j
 
 instance Ix Unit
   size = 1
@@ -558,10 +550,6 @@ def last_ix {n} [NonEmpty n] : n =
 
 instance {n} [Ix n] NonEmpty (Post n)
   first_ix = unsafe_from_ordinal (Post n) 0
-
-
-
-
 
 '### Monoid
 A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.
@@ -845,6 +833,73 @@ instance Ix Bool
     False -> 0
     True -> 1
   unsafe_from_ordinal = \i. i > 0
+
+'## Subset class
+
+interface Subset a_sub a
+  inject' : a_sub -> a
+  project' : a -> Maybe a_sub
+
+def project {a} (a_sub:Type) [Subset a_sub a] (x:a) : Maybe a_sub =
+  project' x
+
+def inject {a_sub} (a:Type) [Subset a_sub a] (x:a_sub) : a =
+  inject' x
+
+instance {a b c} [Subset a b, Subset b c] Subset a c
+  inject' = \x. inject c $ inject b x
+  project' = \x. case project b x of
+    Nothing -> Nothing
+    Just y -> project a y
+
+-- TODO: figure out how to have an instance like this without producing an
+-- infinite number of apparent synthesis paths.
+-- instance {a} Subset a a
+--   inject' = \x. x
+--   inject' = \x. inject c $ inject b x
+
+-- TODO?: Subset (Fin n) Nat
+-- TODO?: Subset Nat Int
+-- TODO?: Subset Int Float
+
+instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
+  inject' = \(UnsafeMkRangeFrom j).
+    unsafe_from_ordinal _ $ j + ordinal i
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' < i'
+      then Nothing
+      else Just $ UnsafeMkRangeFrom $ unsafe_nat_diff j' i'
+
+instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
+  inject' = \(UnsafeMkRangeFromExc j).
+    unsafe_from_ordinal _ $ j + ordinal i + 1
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' <= i'
+      then Nothing
+      else Just $ UnsafeMkRangeFromExc $ unsafe_nat_diff j' (i' + 1)
+
+instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
+  inject' = \(UnsafeMkRangeTo j). unsafe_from_ordinal _ j
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' > i'
+      then Nothing
+      else Just $ UnsafeMkRangeTo j'
+
+instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
+  inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' >= i'
+      then Nothing
+      else Just $ UnsafeMkRangeToExc j'
+
 
 '## Elementary/Special Functions
 This is more or less the standard [LibM fare](https://en.wikipedia.org/wiki/C_mathematical_functions).

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -852,16 +852,6 @@ instance {a b c} [Subset a b, Subset b c] Subset a c
     Nothing -> Nothing
     Just y -> project a y
 
--- TODO: figure out how to have an instance like this without producing an
--- infinite number of apparent synthesis paths.
--- instance {a} Subset a a
---   inject' = \x. x
---   inject' = \x. inject c $ inject b x
-
--- TODO?: Subset (Fin n) Nat
--- TODO?: Subset Nat Int
--- TODO?: Subset Int Float
-
 instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
   inject' = \(UnsafeMkRangeFrom j).
     unsafe_from_ordinal _ $ j + ordinal i

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -249,9 +249,15 @@ blockAsCPoly (Block _ decls' result') =
                 => Atom i -> m i o (ClampPolynomial o)
     intAsCPoly = \case
       Var v       -> varAsCPoly v
+      -- XXX: this case is needed to handle the Nat-wrapper types, RangeFrom,
+      -- RangeFromExc, RangeTo, and RangeToExc. But user-defined index sets
+      -- won't always just be wrappers around `Nat`! So we need Algebra to be
+      -- aware of their definitions.
+      ProjectElt (0:|[]) v -> varAsCPoly v
       IdxRepVal x -> return $ fromInt x
       _ -> empty
-      where fromInt i = liftC $ poly [((fromIntegral i) % 1, mono [])]
+      where
+        fromInt i = liftC $ poly [((fromIntegral i) % 1, mono [])]
 
     varAsCPoly :: (SubstReader CPolySubstVal m, Alternative2 m)
                => AtomName i -> m i o (ClampPolynomial o)

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -243,7 +243,6 @@ blockAsCPoly (Block _ decls' result') =
     indexAsCPoly = \case
       Var v                       -> varAsCPoly v
       Con (FinVal _ i)            -> intAsCPoly i
-      Con (IndexRangeVal _ _ _ i) -> intAsCPoly i
       _                           -> empty
 
     intAsCPoly :: (SubstReader CPolySubstVal m, Alternative2 m)

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -23,7 +23,7 @@ module Builder (
   buildLam, buildTabLam, buildLamGeneral,
   buildAbs, buildNaryAbs, buildNaryLam, buildNullaryLam, buildNaryLamExpr,
   buildAlt, buildUnaryAlt, buildUnaryAtomAlt,
-  buildNewtype, fromNewtype,
+  buildNewtype,
   emitDataDef, emitClassDef, emitInstanceDef, emitDataConName, emitTyConName,
   buildCase, emitMaybeCase, buildSplitCase,
   emitBlock, emitDecls, BuilderEmissions, emitAtomToName,
@@ -703,11 +703,6 @@ buildNewtype name paramBs body = do
     singletonBinderNest noHint ty
   return $ DataDef name (DataDefBinders paramBs' Empty) [DataConDef ("mk" <> name) argBs]
 
-fromNewtype :: [DataConDef n]
-            -> Maybe (Type n)
-fromNewtype [DataConDef _ (EmptyAbs (Nest (_:>ty) Empty))] = Just ty
-fromNewtype _ = Nothing
-
 -- TODO: consider a version with nonempty list of alternatives where we figure
 -- out the result type from one of the alts rather than providing it explicitly
 buildCase :: (Emits n, ScopableBuilder m)
@@ -861,7 +856,6 @@ maybeTangentType ty = case ty of
     BaseType (Scalar Float32Type) -> return $ TC con
     BaseType   _                  -> return $ UnitTy
     Fin _                         -> return $ UnitTy
-    IndexRange _ _ _              -> return $ UnitTy
     ProdType   tys                -> ProdTy <$> traverse maybeTangentType tys
     _ -> Nothing
   _ -> Nothing

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -927,12 +927,6 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
     scrut'' <- zonk scrut'
     buildSortedCase scrut'' alts' reqTy'
   UTabCon xs -> inferTabCon xs reqTy >>= matchRequirement
-  UIndexRange low high -> do
-    n <- freshType TyKind
-    low'  <- mapM (flip checkRho n) low
-    high' <- mapM (flip checkRho n) high
-    ixTy <- asIxType n
-    matchRequirement $ TC $ IndexRange (IxTy ixTy) low' high'
   UHole -> case reqTy of
     Infer -> throw MiscErr "Can't infer type of hole"
     Check ty -> freshType ty

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -214,10 +214,6 @@ evalOp expr = mapM evalAtom expr >>= \case
       (TC (Fin _), IdxRepTy) -> do
         let Con (FinVal _ ord) = x
         return ord
-      (IdxRepTy, TC (IndexRange t l h)) -> return $ Con $ IndexRangeVal t l h x
-      (TC (IndexRange _ _ _), IdxRepTy) -> do
-        let Con (IndexRangeVal _ _ _ ord) = x
-        return ord
       (BaseTy (Scalar sb), BaseTy (Scalar db)) -> case (sb, db) of
         (Int64Type, Int32Type) -> do
           let Con (Lit (Int64Lit v)) = x

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -365,7 +365,6 @@ linearizeOp op = case op of
   PtrOffset _ _          -> emitZeroT
   IOAlloc _ _            -> emitZeroT
   IOFree _               -> emitZeroT
-  Inject _               -> emitZeroT
   ThrowError _           -> emitZeroT
   DataConTag _           -> emitZeroT
   ToEnum _ _             -> emitZeroT
@@ -486,7 +485,6 @@ linearizePrimCon con = case con of
                   forM elemsWithT' \(WithTangent _ t) -> t
       return $ Con $ SumAsProd (sink ty') (sink tg') elemsT
   FinVal _ _            -> emitZeroT
-  IndexRangeVal _ _ _ _ -> emitZeroT
   LabelCon _     -> error "Unexpected label"
   BaseTypeRef _  -> error "Unexpected ref"
   TabRef _       -> error "Unexpected ref"

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -1074,33 +1074,19 @@ joinPos (Just (l, h)) (Just (l', h')) = Just (min l l', max h h')
 
 indexRangeOps :: [Operator Parser (UExpr VoidS)]
 indexRangeOps =
-  [ Prefix    $ symPos ".."   <&> \pos h   -> range pos  Unlimited       (InclusiveLim h)
-  , inpostfix $ symPos ".."   <&> \pos l h -> range pos (InclusiveLim l) (limFromMaybe h)
-  , inpostfix $ symPos "<.."  <&> \pos l h -> range pos (ExclusiveLim l) (limFromMaybe h)
-  , Prefix    $ symPos "..<"  <&> \pos h   -> range pos  Unlimited       (ExclusiveLim h)
-  , InfixL    $ symPos "..<"  <&> \pos l h -> range pos (InclusiveLim l) (ExclusiveLim h)
-  , InfixL    $ symPos "<..<" <&> \pos l h -> range pos (ExclusiveLim l) (ExclusiveLim h) ]
+  [ Prefix  $ symPos ".."  <&> \pos l -> range "RangeTo"      pos l
+  , Prefix  $ symPos "..<" <&> \pos l -> range "RangeToExc"   pos l
+  , Postfix $ symPos ".."  <&> \pos l -> range "RangeFrom"    pos l
+  , Postfix $ symPos "<.." <&> \pos l -> range "RangeFromExc" pos l ]
   where
-    range pos l h = WithSrcE (Just pos) $ UIndexRange l h
     symPos s = snd <$> withPos (sym s)
 
-limFromMaybe :: Maybe a -> Limit a
-limFromMaybe Nothing = Unlimited
-limFromMaybe (Just x) = InclusiveLim x
+    range :: SourceName -> SrcPos -> UExpr VoidS -> UExpr VoidS
+    range rangeName pos lim = binApp rangeName pos (ns UHole) lim
 
 annotatedExpr :: Operator Parser (UExpr VoidS)
 annotatedExpr = InfixL $ opWithSrc $
   sym ":" $> (\pos v ty -> WithSrcE (Just pos) $ UTypeAnn v ty)
-
-inpostfix :: Parser (UExpr VoidS -> Maybe (UExpr VoidS) -> UExpr VoidS)
-          -> Operator Parser (UExpr VoidS)
-inpostfix = inpostfix' expr
-
-inpostfix' :: Parser a -> Parser (a -> Maybe a -> a) -> Operator Parser a
-inpostfix' p op = Postfix $ do
-  f <- op
-  rest <- optional p
-  return \x -> f x rest
 
 -- === lexemes ===
 
@@ -1423,7 +1409,6 @@ builtinNames = M.fromList
   , ("get"        , OpExpr $ PrimEffect () $ MGet)
   , ("put"        , OpExpr $ PrimEffect () $ MPut  ())
   , ("indexRef"   , OpExpr $ IndexRef () ())
-  , ("inject"     , OpExpr $ Inject ())
   , ("select"     , OpExpr $ Select () () ())
   , ("while"           , HofExpr $ While ())
   , ("linearize"       , HofExpr $ Linearize ())

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -199,8 +199,6 @@ instance SourceRenamableE UExpr' where
     UIndexType ty -> UIndexType <$> sourceRenameE ty
     UTypeAnn e ty -> UTypeAnn <$> sourceRenameE e <*> sourceRenameE ty
     UTabCon xs -> UTabCon <$> mapM sourceRenameE xs
-    UIndexRange low high ->
-      UIndexRange <$> mapM sourceRenameE low <*> mapM sourceRenameE high
     UPrimExpr e -> UPrimExpr <$> mapM sourceRenameE e
     ULabel name -> return $ ULabel name
     URecord elems -> URecord <$> mapM sourceRenameE elems

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -43,7 +43,7 @@ module Syntax (
     DataConRefBinding (..), AltP, Alt, AtomBinding (..), SolverBinding (..),
     SubstE (..), SubstB (..), Ptr, PtrType,
     AddressSpace (..), Device (..),
-    Direction (..), Limit (..), DataDefParams (..), DataDefBinders (..),
+    Direction (..), DataDefParams (..), DataDefBinders (..),
     DataDef (..), DataConDef (..), Nest (..),
     mkConsList, mkConsListTy, fromConsList, fromConsListTy, fromLeftLeaningConsListTy,
     mkBundle, mkBundleTy, BundleDesc,

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -242,7 +242,6 @@ transposeOp op ct = case op of
   PtrOffset _ _         -> notLinear
   IOAlloc _ _           -> notLinear
   IOFree _              -> notLinear
-  Inject       _        -> notLinear
   ThrowError   _        -> notLinear
   DataConTag _          -> notLinear
   ToEnum _ _            -> notLinear
@@ -345,7 +344,6 @@ transposeCon con ct = case con of
   SumCon _ _ _      -> notImplemented
   SumAsProd _ _ _   -> notImplemented
   FinVal _ _        -> notTangent
-  IndexRangeVal _ _ _ _ -> notTangent
   LabelCon _     -> notTangent
   BaseTypeRef _  -> notTangent
   TabRef _       -> notTangent

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -49,7 +49,6 @@ data PrimTC e =
       | ProdType [e]
       | SumType [e]
       | Fin e
-      | IndexRange e (Limit e) (Limit e)  -- TODO: Define IndexRange in prelude
       | RefType (Maybe e) e
       | TypeKind
       | EffectRowKind
@@ -69,7 +68,6 @@ data PrimCon e =
       | SumAsProd e e   [[e]] -- type, tag, payload
       | LabelCon String
       | FinVal e e
-      | IndexRangeVal e (Limit e) (Limit e) e
       -- References
       | BaseTypeRef e
       | TabRef e
@@ -102,7 +100,6 @@ data PrimOp e =
       -- References
       | IndexRef e e
       | ProjRef Int e
-      | Inject e
       -- Low-level memory operations
       | IOAlloc BaseType e
       | IOFree e
@@ -182,11 +179,6 @@ data CmpOp = Less | Greater | Equal | LessEqual | GreaterEqual
 data Direction = Fwd | Rev  deriving (Show, Eq, Generic)
 data ForAnn = RegularFor Direction | ParallelFor
                 deriving (Show, Eq, Generic)
-
-data Limit a = InclusiveLim a
-             | ExclusiveLim a
-             | Unlimited
-               deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data RWS = Reader | Writer | State  deriving (Show, Eq, Ord, Generic)
 
@@ -378,7 +370,6 @@ instance Store a => Store (PrimOp  a)
 instance Store a => Store (PrimCon a)
 instance Store a => Store (PrimTC  a)
 instance Store a => Store (PrimHof a)
-instance Store a => Store (Limit a)
 instance Store a => Store (PrimEffect a)
 instance Store a => Store (BaseMonoidP a)
 
@@ -402,6 +393,5 @@ instance Hashable a => Hashable (PrimOp  a)
 instance Hashable a => Hashable (PrimCon a)
 instance Hashable a => Hashable (PrimTC  a)
 instance Hashable a => Hashable (PrimHof a)
-instance Hashable a => Hashable (Limit a)
 instance Hashable a => Hashable (PrimEffect a)
 instance Hashable a => Hashable (BaseMonoidP a)

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -87,7 +87,6 @@ data UExpr' (n::S) =
  | UIndexType (UExpr n)
  | UTypeAnn (UExpr n) (UExpr n)
  | UTabCon [UExpr n]
- | UIndexRange (Limit (UExpr n)) (Limit (UExpr n))
  | UPrimExpr (PrimExpr (UExpr n))
  | ULabel String
  | URecord (UFieldRowElems n)                        -- {@v=x, a=y, b=z, ...rest}

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -447,31 +447,6 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 > 4.
 
 :p
-  one = from_ordinal (Fin 4) 1
-  for i:(Fin 4). sum for j:(one..i). 1.0
-> [0., 1., 2., 3.]
-
-:p
-  one = from_ordinal (Fin 4) 1
-  for i:(Fin 4). sum for j:(one<..i). 1.0
-> [0., 0., 1., 2.]
-
-:p
-  one = from_ordinal (Fin 4) 1
-  for i:(Fin 4). sum for j:(one<..i). 1.0
-> [0., 0., 1., 2.]
-
-:p
-  one = from_ordinal (Fin 4) 1
-  for i:(Fin 4). sum for j:(one..<i). 1.0
-> [0., 0., 1., 2.]
-
-:p
-  one = from_ordinal (Fin 4) 1
-  for i:(Fin 4). sum for j:(one<..<i). 1.0
-> [0., 0., 0., 1.]
-
-:p
   for i:(Fin 4). sum for j:(..i). 1.0
 > [1., 2., 3., 4.]
 

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -98,7 +98,7 @@ Syntax for records, variants, and their types.
 > 94 | :p {a:Int & b:Float | c:Int }
 >    |                     ^
 > unexpected '|'
-> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', ':', '}', arrow, backquoted name, expression, or infix operator
+> expecting "..", "<..", "=>", "{|", '$', '&', '.', ':', '}', arrow, backquoted name, expression, or infix operator
 
 :p {a:Int,}
 
@@ -107,7 +107,7 @@ Syntax for records, variants, and their types.
 > 103 | :p {a:Int,}
 >     |          ^
 > unexpected ','
-> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', ':', '?', '|', '}', arrow, backquoted name, expression, or infix operator
+> expecting "..", "<..", "=>", "{|", '$', '&', '.', ':', '?', '|', '}', arrow, backquoted name, expression, or infix operator
 
 :p {|3}
 

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -275,17 +275,6 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 -- :p fst $ fromNewPair newPair
 -- > 1
 
-good_range : Type = (1@Fin 3)..(2@_)
-
-bad_range : Int = (1@Fin 3)..(2@_)
-> Type error:
-> Expected: Int32
->   Actual: Type
->
-> bad_range : Int = (1@Fin 3)..(2@_)
->                            ^^
-
-
 -- Tests for the Unit index set
 
 () == ()
@@ -360,7 +349,7 @@ id (for i:(Fin 2). for j:(..i). 1.0)
 
 def weakerInferenceReduction {n} (l : i:n=>(..i)=>Float) (j:n): Unit =
   for i:(..j).
-    i' = %inject i
+    i' = inject n i
     for k:(..i').
       l.i'.k
     ()


### PR DESCRIPTION
This makes `inject` a user-defined function too. It's based on a new
user-defined `Subset` class, with a total `inject` method and a partial
`project` method. It ought to be transitive and reflexive, but that isn't
captured yet because of limitations in dict synthesis.

I also removed ranges with both upper and lower bounds. They're complicated,
they have strange semantics when the lower bound is higher than the upper
bound, and we haven't found a need for them in practice. You can always
simulate them using two one-sided slices, and that has the additional benefit
that it forces you to handle the case where the bounds cross.

I added a hack in `intAsCPoly` to recognize the new newtype wrappers, RangeFrom,
RangeTo, etc., as the ordinals they represent. But this isn't valid in general.
We need to make `Algebra` aware of the `ordinal`/`unsafe_from_ordinal`
instances.
