### PR TITLE
Proposal to change the syntax for "type-annotate expression" to use `::`, not `:`

### DIFF
--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -44,13 +44,13 @@ that produce isos. We will start with the first two:
 - `#?x` produces a "prism-like" variant matcher `Iso {x:a | ...r} (a | {|...r})`
 
 %passes parse
-:t #b : Iso {a:Int & b:Float & c:Unit} _
+:t #b :: Iso {a:Int & b:Float & c:Unit} _
 > (Iso {a: Int32 & b: Float32 & c: Unit} (Float32 & {a: Int32 & c: Unit}))
 > (MkIso {fwd=(\{b=x, ...r}. (,) x r), bwd=(\(x, r). {b=x, ...r})}
 >  : Iso {a: Int & b: Float & c: Unit} _)
 
 %passes parse
-:t #?b : Iso {a:Int | b:Float | c:Unit} _
+:t #?b :: Iso {a:Int | b:Float | c:Unit} _
 > (Iso {a: Int32 | b: Float32 | c: Unit} (Float32 | {a: Int32 | c: Unit}))
 > (MkIso
 >    {fwd=(\v. case v
@@ -112,16 +112,16 @@ Similarly, there are prism-like helpers
 
 'which can be used with variant accessors or any other prism-like isomorphism:
 
-:p match_with #?foo $ {|foo = 1|}:{foo:Int | bar:Float}
+:p match_with #?foo $ {|foo = 1|}::{foo:Int | bar:Float}
 > (Just 1)
 
-:p match_with #?foo $ {|bar = 1.0|}:{foo:Int | bar:Float}
+:p match_with #?foo $ {|bar = 1.0|}::{foo:Int | bar:Float}
 > Nothing
 
-:p build_with #?foo 3 : {foo:Int | bar:Float}
+:p build_with #?foo 3 :: {foo:Int | bar:Float}
 > {| foo = 3 |}
 
-:p match_with (except_prism #?foo) $  {|bar = 1.0|}:{foo:Int | bar:Float}
+:p match_with (except_prism #?foo) $  {|bar = 1.0|}::{foo:Int | bar:Float}
 > (Just {| bar = 1. |})
 
 '## Record zipper isomorphisms
@@ -132,7 +132,7 @@ a "zipper isomorphism", which moves a subset of fields from one place to
 another. For instance:
 
 %passes parse
-:t #&a : Iso ({&} & {a:Int & b:Float & c:Unit}) _
+:t #&a :: Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
 >    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32} & {b: Float32 & c: Unit}))
@@ -141,7 +141,7 @@ another. For instance:
 >    , bwd=(\({a=x, ...l}, {...r}). (,) {...l} {a=x, ...r})}
 >  : Iso ((&) {} {a: Int & b: Float & c: Unit}) _)
 
-:t (#&a &>> #&b) : Iso ({&} & {a:Int & b:Float & c:Unit}) _
+:t (#&a &>> #&b) :: Iso ({&} & {a:Int & b:Float & c:Unit}) _
 > (Iso
 >    ({&} & {a: Int32 & b: Float32 & c: Unit})
 >    ({a: Int32 & b: Float32} & {c: Unit}))
@@ -225,7 +225,7 @@ Just as there are record zipper isomorphisms, there are also variant
 zipper isomorphisms:
 
 %passes parse
-:t #|a : Iso ({|} | {a:Int | b:Float | c:Unit}) _
+:t #|a :: Iso ({|} | {a:Int | b:Float | c:Unit}) _
 > (Iso
 >    ({ |} | {a: Int32 | b: Float32 | c: Unit})
 >    ({a: Int32} | {b: Float32 | c: Unit}))

--- a/examples/rejection-sampler.dx
+++ b/examples/rejection-sampler.dx
@@ -77,7 +77,7 @@ def binomialBatch {a} [Ix a] (n:Nat) (p:Prob) (k:Key) : a => Nat =
   logprobs = for i:(Fin m). logBinomialProb n p $ ordinal i
   map ordinal $ categorical_batch logprobs k
 
-inversionBatchSamples = (binomialBatch n p k0) : Fin numSamples => Nat
+inversionBatchSamples = (binomialBatch n p k0) :: Fin numSamples => Nat
 
 :p slice inversionBatchSamples 0 $ Fin 10
 > [6, 7, 6, 5, 3, 2, 4, 4, 3, 4]

--- a/examples/schrodinger.dx
+++ b/examples/schrodinger.dx
@@ -115,26 +115,26 @@ def gaussian {n m} [Ix n, Ix m] ((ux, uy):(Float & Float)) ((ox, oy):(Float & Fl
 
 -- Create an animation of the evolution of the given wavefunction under the given potential.
 def run {m n} (psi:m=>n=>Complex) (v:m=>n=>Float) : Html =
-  animate (map toImg (cut (map pdf (evolve psi v))):(Fin gifFrames=>_))
+  animate (map toImg (cut (map pdf (evolve psi v)))::(Fin gifFrames=>_))
 
 ' Centred particle in a zero-potential box.
 
 :html (run
-        ((gaussian (0.5, 0.5) (0.1, 0.1)):(D=>D=>_))
+        ((gaussian (0.5, 0.5) (0.1, 0.1))::(D=>D=>_))
         (for i j. 0.))
 > <html output>
 
 ' Off-centre particle tunnelling through a high-potential barrier
 
 :html (run
-        ((gaussian (0.25, 0.5) (0.1, 0.1)):(D=>D=>_))
+        ((gaussian (0.25, 0.5) (0.1, 0.1))::(D=>D=>_))
         (for i j. if (ordinal j) == 20 then 1000. else 0.))
 > <html output>
 
 ' Ramp potential confining a particle to a corner over time
 
 :html (run
-        ((gaussian (0.5, 0.5) (0.1, 0.1)):(D=>D=>_))
+        ((gaussian (0.5, 0.5) (0.1, 0.1))::(D=>D=>_))
         (for i j. n_to_f $ ordinal i + ordinal j))
 > <html output>
 
@@ -146,6 +146,6 @@ def run {m n} (psi:m=>n=>Complex) (v:m=>n=>Float) : Html =
             x = ordinal j
             if x >= 15 && y >= 15 && x < 25 && y < 25
                then fToC 0.01
-               else fToC 0.0):(D=>D=>_))
+               else fToC 0.0)::(D=>D=>_))
         (for i j. 0.))
 > <html output>

--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -125,13 +125,13 @@ mean y
   let's consider how it works. Critically, one cannot
   simply index an table with an integer.
 
-r = x.(2 : Int)
+r = x.(2 :: Int)
 > Type error:
 > Expected: (Fin 3)
 >   Actual: Int32
 >
-> r = x.(2 : Int)
->          ^^
+> r = x.(2 :: Int)
+>          ^^^
 
 ' Instead, it is necessary to cast the integer into the index type of the
   current shape. This type annotation is done with the `@` operator.

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -531,7 +531,7 @@ def n_to_i (x:Nat) : Int =
   internal_cast _ x
 
 def i_to_n (x:Int) : Maybe Nat =
-  if w8_to_b $ %ilt x (0:Int)
+  if w8_to_b $ %ilt x (0::Int)
     then Nothing
     else Just $ unsafe_i_to_n x
 
@@ -2129,8 +2129,8 @@ def pad_to {n a} (m:Type) [Ix m] (x:a) (xs:n=>a) : m=>a =
       False -> x
 
 def idiv_ceil (x:Nat) (y:Nat) : Nat = idiv x y + b_to_n (rem x y /= 0)
-def intdiv2 (x:Nat) : Nat = %shr x (1 : Nat)
-def intpow2 (power:Nat) : Nat = %shl (1 : Nat) power
+def intdiv2 (x:Nat) : Nat = %shr x (1 :: Nat)
+def intpow2 (power:Nat) : Nat = %shl (1 :: Nat) power
 def is_odd  (x:Nat) : Bool = rem x 2 == 1
 def is_even (x:Nat) : Bool = rem x 2 == 0
 
@@ -2151,7 +2151,7 @@ def natlog2 (x:Nat) : Nat =
         if x >= (get cmpRef)
           then
             ansRef := (get ansRef) + 1
-            cmpRef := %shl (get cmpRef) (1 : Nat)
+            cmpRef := %shl (get cmpRef) (1 :: Nat)
             True
           else
             False
@@ -2217,7 +2217,7 @@ def concat {n a} (lists:n=>(List a)) : List a =
         xs.(eltIdxVal@_)
 
 def cat_maybes {a n} (xs:n=>Maybe a) : List a =
-  (num_res, res_inds) = yield_state (0:Nat, for i:n. Nothing) \ref.
+  (num_res, res_inds) = yield_state (0::Nat, for i:n. Nothing) \ref.
     for i. case xs.i of
       Just _ ->
         ix = get $ fst_ref ref

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -344,7 +344,7 @@ dataConDefBinder = annBinder <|> (UAnnBinder UIgnore <$> containedExpr)
 
 decl :: Parser (UDecl VoidS VoidS)
 decl = do
-  lhs <- simpleLet <|> funDefLet
+  lhs <- funDefLet <|> (try $ simpleLet <* lookAhead (sym "="))
   rhs <- sym "=" >> blockOrExpr
   return $ lhs rhs
 
@@ -1090,7 +1090,7 @@ limFromMaybe (Just x) = InclusiveLim x
 
 annotatedExpr :: Operator Parser (UExpr VoidS)
 annotatedExpr = InfixL $ opWithSrc $
-  sym ":" $> (\pos v ty -> WithSrcE (Just pos) $ UTypeAnn v ty)
+  sym "::" $> (\pos v ty -> WithSrcE (Just pos) $ UTypeAnn v ty)
 
 inpostfix :: Parser (UExpr VoidS -> Maybe (UExpr VoidS) -> UExpr VoidS)
           -> Operator Parser (UExpr VoidS)
@@ -1208,7 +1208,7 @@ doubleLit = lexeme $
 
 knownSymStrs :: HS.HashSet String
 knownSymStrs = HS.fromList
-  [".", ":", "!", "=", "-", "+", "||", "&&", "$", "&", "|", ",", "+=", ":="
+  [".", ":", "::", "!", "=", "-", "+", "||", "&&", "$", "&", "|", ",", "+=", ":="
   , "->", "=>", "?->", "?=>", "--o", "--", "<<<", ">>>", "<<&", "&>>"
   , "..", "<..", "..<", "..<", "<..<", "?"]
 

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -628,7 +628,7 @@ def unflatten {n m} (params:Params n m) : (Weights n m & Biases n) =
 -- > False
 
 -- TODO: within-module version of this (currently fails in Imp checking)
-upperBound = sum $ for i:(Fin 4). (1:Nat)
+upperBound = sum $ for i:(Fin 4). (1::Nat)
 :p for j:(Fin upperBound). 1.0
 > [1., 1., 1., 1.]
 

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -99,3 +99,14 @@ def myInt2 : {State Int} Int = 1
     if True
       then ref += 2.
 > 9.
+
+-- Check that a syntax error in a funDefLet doesn't try to reparse the
+-- whole definition as something it's not.
+def frob (x:Int) (y:Int) : + =
+
+> Parse error:105:30:
+>     |
+> 105 | def frob (x:Int) (y:Int) : + =
+>     |                              ^
+> unexpected '='
+> expecting expression

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -73,13 +73,13 @@ Syntax for records, variants, and their types.
 'Variants (enums)
 
 
-:p {| a=3 |} : {a:Int | b:Float}
+:p {| a=3 |} :: {a:Int | b:Float}
 > {| a = 3 |}
 
-:p {| a | a = 3.0 |} : {a:Int | a:Float | a:Int}
+:p {| a | a = 3.0 |} :: {a:Int | a:Float | a:Int}
 > {|a| a = 3. |}
 
-:t {| a | a = 3.0 |} : {a:Int | a:Float | a:Int}
+:t {| a | a = 3.0 |} :: {a:Int | a:Float | a:Int}
 > {a: Int32 | a: Float32 | a: Int32}
 
 :p
@@ -98,7 +98,7 @@ Syntax for records, variants, and their types.
 > 94 | :p {a:Int & b:Float | c:Int }
 >    |                     ^
 > unexpected '|'
-> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', ':', '}', arrow, backquoted name, expression, or infix operator
+> expecting "..", "..<", "::", "<..", "<..<", "=>", "{|", '$', '&', '.', '}', arrow, backquoted name, expression, or infix operator
 
 :p {a:Int,}
 
@@ -107,7 +107,7 @@ Syntax for records, variants, and their types.
 > 103 | :p {a:Int,}
 >     |          ^
 > unexpected ','
-> expecting "..", "..<", "<..", "<..<", "=>", "{|", '$', '&', '.', ':', '?', '|', '}', arrow, backquoted name, expression, or infix operator
+> expecting "..", "..<", "::", "<..", "<..<", "=>", "{|", '$', '&', '.', '?', '|', '}', arrow, backquoted name, expression, or infix operator
 
 :p {|3}
 

--- a/tests/serialize-tests.dx
+++ b/tests/serialize-tests.dx
@@ -31,10 +31,10 @@ x = ['a', 'b']
 :p {a="1234", b=[1, 2, 3]}
 > {a = "1234", b = [1, 2, 3]}
 
-:p [{| a=1 |}, {| b=2.0 |}] : (Fin 2) => {a:Int | b:Float}
+:p [{| a=1 |}, {| b=2.0 |}] :: (Fin 2) => {a:Int | b:Float}
 > [{| a = 1 |}, {| b = 2. |}]
 
-:p {table = [{| a=1 |}, {| b=2.0 |}]} : {table: (Fin 2) => {a:Int | b:Float}}
+:p {table = [{| a=1 |}, {| b=2.0 |}]} :: {table: (Fin 2) => {a:Int | b:Float}}
 > {table = [{| a = 1 |}, {| b = 2. |}]}
 
 'Values without a pretty-printer (currently shows warning message):

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -31,7 +31,7 @@ set2 = to_set ["Bob", "Xeno", "Charlie"]
 
 '#### Empty set tests
 
-emptyset = to_set ([]:(Fin 0)=>String)
+emptyset = to_set ([]::(Fin 0)=>String)
 
 :p emptyset == emptyset
 > True

--- a/tests/show-tests.dx
+++ b/tests/show-tests.dx
@@ -6,36 +6,36 @@
 
 -- Int32
 
-:p show (1234: Int32)
+:p show (1234 :: Int32)
 > "1234"
 
-:p show (-1234: Int32)
+:p show (-1234 :: Int32)
 > "-1234"
 
-:p show ((f_to_i (-(pow 2. 31.))): Int32)
+:p show ((f_to_i (-(pow 2. 31.))) :: Int32)
 > "-2147483648"
 
 -- Int64
 
-:p show (i_to_i64 1234: Int64)
+:p show (i_to_i64 1234 :: Int64)
 > "1234"
 
-:p show (i_to_i64 (-1234): Int64)
+:p show (i_to_i64 (-1234) :: Int64)
 > "-1234"
 
 -- Float32
 
-:p show (123.456789: Float32)
+:p show (123.456789 :: Float32)
 > "123.456787"
 
-:p show ((pow 2. 16.): Float32)
+:p show ((pow 2. 16.) :: Float32)
 > "65536"
 
 -- FIXME(https://github.com/google-research/dex-lang/issues/316):
 -- Unparenthesized expression with type ascription does not parse.
 -- :p show (nan: Float32)
 
-:p show ((nan): Float32)
+:p show (nan :: Float32)
 > "nan"
 
 -- Note: `show nan` (Dex runtime dtoa implementation) appears different from
@@ -43,7 +43,7 @@
 :p nan
 > NaN
 
-:p show ((infinity): Float32)
+:p show (infinity :: Float32)
 > "inf"
 
 -- Note: `show infinity` (Dex runtime dtoa implementation) appears different from
@@ -53,13 +53,13 @@
 
 -- Float64
 
-:p show (f_to_f64 123.456789: Float64)
+:p show (f_to_f64 123.456789:: Float64)
 > "123.456787109375"
 
-:p show (f_to_f64 (pow 2. 16.): Float64)
+:p show (f_to_f64 (pow 2. 16.):: Float64)
 > "65536"
 
-:p show ((f_to_f64 nan): Float64)
+:p show ((f_to_f64 nan):: Float64)
 > "nan"
 
 -- Note: `show nan` (Dex runtime dtoa implementation) appears different from
@@ -67,7 +67,7 @@
 :p (f_to_f64 nan)
 > NaN
 
-:p show ((f_to_f64 infinity): Float64)
+:p show ((f_to_f64 infinity):: Float64)
 > "inf"
 
 -- Note: `show infinity` (Dex runtime dtoa implementation) appears different from

--- a/tests/sort-tests.dx
+++ b/tests/sort-tests.dx
@@ -1,6 +1,6 @@
 import sort
 
-:p is_sorted $ sort []:((Fin 0)=>Int)
+:p is_sorted $ sort []::((Fin 0)=>Int)
 > True
 :p is_sorted $ sort [9, 3, 7, 4, 6, 1, 9, 1, 9, -1, 10, 10, 100, 0]
 > True
@@ -29,10 +29,10 @@ import sort
 :p "a" < "aa"
 > True
 
-:p ("": List Word8) > ("": List Word8)
+:p ("" :: List Word8) > ("" :: List Word8)
 > False
 
-:p ("": List Word8) < ("": List Word8)
+:p ("" :: List Word8) < ("" :: List Word8)
 > False
 
 :p "a" > "a"

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -403,16 +403,16 @@ def mkEmpty (a:Type) : (Fin 0)=>a = []
 > ((Fin 2) => Float32)
 :t [[0.0], [1.0]]
 > ((Fin 2) => (Fin 1) => Float32)
-:t [0.0, 1.0] : (Fin 2)=>Float
+:t [0.0, 1.0] :: (Fin 2)=>Float
 > ((Fin 2) => Float32)
-:t [0.0, 1.0] : ((Fin 1) & (Fin 2))=>Float
+:t [0.0, 1.0] :: ((Fin 1) & (Fin 2))=>Float
 > ((Fin 1 & Fin 2) => Float32)
 
-:t [[0.0], [1.0, 2.0]] : i:(Fin 2)=>(..i)=>Float
+:t [[0.0], [1.0, 2.0]] :: i:(Fin 2)=>(..i)=>Float
 > ((v#0:(Fin 2)) => (..v#0) => Float32)
-:t [[[0.0, 1.0]], [[2.0, 3.0], [4.0, 5.0]]] : i:(Fin 2)=>(..i)=>(Fin 2)=>Float
+:t [[[0.0, 1.0]], [[2.0, 3.0], [4.0, 5.0]]] :: i:(Fin 2)=>(..i)=>(Fin 2)=>Float
 > ((v#0:(Fin 2)) => (..v#0) => (Fin 2) => Float32)
-:t [0@_, 1@_]:(i:(Fin 2)=>(..i))
+:t [0@_, 1@_]::(i:(Fin 2)=>(..i))
 > ((v#0:(Fin 2)) => ..v#0)
 
 def uncurryTable {a} (x : ((Fin 2) & (Fin 2))=>a) : (Fin 2)=>(Fin 2)=>a =
@@ -448,29 +448,29 @@ q 5
 -- Dereference variable names when resolving table type annotations
 -- This is a regression test for
 -- https://github.com/google-research/dex-lang/issues/563
-:t [0.0, 1.0]:(Bool=>Float)
+:t [0.0, 1.0]::(Bool=>Float)
 > (Bool => Float32)
 
 -- Regression test for
 -- https://github.com/google-research/dex-lang/issues/912.
 -- This should not take a long time, because we should compare sizes
 -- before constructing the indices of the annotated index set.
-:t [0.0, 1.0]:((Fin 100000000)=>Float)
+:t [0.0, 1.0]::((Fin 100000000)=>Float)
 > Type error:Literal has 2 elements, but required type has 100000000.
 >
-> :t [0.0, 1.0]:((Fin 100000000)=>Float)
+> :t [0.0, 1.0]::((Fin 100000000)=>Float)
 >    ^^^^^^^^^^
 
-:t [0.0, 1.0]:(i:(Fin 100000000)=>(..i)=>Float)
+:t [0.0, 1.0]::(i:(Fin 100000000)=>(..i)=>Float)
 > Type error:Literal has 2 elements, but required type has 100000000.
 >
-> :t [0.0, 1.0]:(i:(Fin 100000000)=>(..i)=>Float)
+> :t [0.0, 1.0]::(i:(Fin 100000000)=>(..i)=>Float)
 >    ^^^^^^^^^^
 
 -- Make sure we fail gracefully when the annotated index set doesn't
 -- have a static size.
 def frob {n} (_:Unit) : Unit =
-  [0.0, 1.0]:((Fin n)=>Float)
+  [0.0, 1.0]::((Fin n)=>Float)
   ()
 > Type error:
 > Expected: ((Fin n) => Float32)
@@ -481,8 +481,39 @@ def frob {n} (_:Unit) : Unit =
 > a concrete index set; try adding an explicit
 > annotation.
 >
->   [0.0, 1.0]:((Fin n)=>Float)
+>   [0.0, 1.0]::((Fin n)=>Float)
 >   ^^^^^^^^^^
+
+'### Parser disambiguation of type annotations
+
+-- Regression tests for https://github.com/google-research/dex-lang/issues/933
+
+-- foo is a function with all-implicit arguments (whether that's a
+-- good idea or not).
+def foo {a} [Ix a] : a=>Float =
+  for z:a. 1.0
+
+:t foo
+> ((a:Type) ?-> (v#0:(Ix a)) ?=> a => Float32)
+
+-- Reference foo with a type annotation (no parens needed)
+foo :: (Fin 3) => Float
+> [1., 1., 1.]
+
+-- Type annotation is an operator
+sum $ foo :: (Fin 3) => Float
+> 3.
+
+-- A pi type that locally binds foo to the index
+foo : (Fin 3) => Float
+> (Fin 3) => Float32
+
+-- The equals sign makes it a type-annotated top-level binding for foo
+foo : Fin 3 => Float = [1.0, 2.0, 3.0]
+> Error: variable already defined: foo
+>
+> foo : Fin 3 => Float = [1.0, 2.0, 3.0]
+> ^^^^
 
 '### Tests for function VSpace
 

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -118,10 +118,10 @@ myPair = (1, 2.3)
   x
 > [1, 2, 3, 4]@(Fin 2 & Fin 2)
 
-:p [] : (Fin 0 => Int)
+:p [] :: (Fin 0 => Int)
 > []
 
-:p [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
+:p [1, 2, 3, 4] :: ((Fin 2 & Fin 2) => Int)
 > [1, 2, 3, 4]@(Fin 2 & Fin 2)
 
 
@@ -285,20 +285,19 @@ def eitherFloor (x:(Int|Float)) : Int = case x of
 
 -- Can only unpack tables indexed by `Fin n`
 :p
-  [a, b, c, d] = [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
+  [a, b, c, d] = [1, 2, 3, 4] :: ((Fin 2 & Fin 2) => Int)
   (a, b, c, d)
 > Type error:
 > Expected: ((Fin 2 & Fin 2) => Int32)
 >   Actual: ((Fin 4) => a)
 > (Solving for: [a])
 >
->   [a, b, c, d] = [1, 2, 3, 4] : ((Fin 2 & Fin 2) => Int)
+>   [a, b, c, d] = [1, 2, 3, 4] :: ((Fin 2 & Fin 2) => Int)
 >   ^^^^^^^^^^^^^
 
 -- Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
 -- :p
---   -- parentheses needed to stop the parser from reading "zero" as a binder name
---   [a, b, c, d] = (zero) : (_ => Int)
+--   [a, b, c, d] = zero :: (_ => Int)
 --   (a, b, c, d)
 -- > (0, (0, (0, 0)))
 


### PR DESCRIPTION
Why?  The `:` already means "type-annotate binder", and in particular
serves as the marker that distinguishers a binder from a variable
reference.  For instance,

  foo : (Fin 3) => Float

parses as a pi type for an array whose indices are named `foo`, but
whose elements happen not to depend on the index, even though it is in
scope.  In the situation where the user wants to write a reference
to the variable `foo` and annotate it with the type `(Fin 3) =>
Float`, this change allows them to write

  foo :: (Fin 3) => Float

instead of the unintuitive (to me, at least)

  (foo) : (Fin 3) => Float

that is required by the status quo.

This PR also tweaks the parse rule for `decl` to commit only when it
sees the `=` sign, rather than committing eagerly on `:`.  That way,
we can keep the behavior that

  foo : (Fin 3) => Float = stuff

parses as binding `foo` to `stuff` while annotating `foo` with the
type `(Fin 3) => Float` while simultaneously allowing a line beginning
with

  foo : (Fin 3) => Float

to parse as a pi type instead of trying to parse as a binding of `foo`
and failing.

Committing later is presumably something of a performance regression
for the parser, but I think it only matters in this case, namely
trying to parse

  foo : (Fin 3) => Float

as a binding, then giving up for lack of an `=` sign and re-parsing it
as a pi type.

Fixes #933.