### PR TITLE
Accept EOF-terminated expressions, but force a newline when echoing input

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -22,7 +22,7 @@ import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
-import Data.Text (Text, uncons, unsnoc, unpack)
+import Data.Text (Text, snoc, uncons, unsnoc, unpack)
 import qualified Data.Set        as S
 import Data.String (fromString)
 import Data.Maybe (isNothing)
@@ -520,7 +520,13 @@ prettyRecord :: [(String, Doc ann)] -> Doc ann
 prettyRecord xs = foldMap (\(name, val) -> pretty name <> indented val) xs
 
 instance Pretty SourceBlock where
-  pretty block = pretty (sbText block)
+  pretty block = pretty $ ensureNewline (sbText block) where
+    -- Force the SourceBlock to end in a newline for echoing, even if
+    -- it was terminated with EOF in the original program.
+    ensureNewline t = case unsnoc t of
+      Nothing -> t
+      Just (_, '\n') -> t
+      _ -> t `snoc` '\n'
 
 prettyDuration :: Double -> Doc ann
 prettyDuration d = p (showFFloat (Just 3) (d * mult) "") <+> unit

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -166,7 +166,7 @@ sourceBlock' =
   <|> liftM EvalUDecl (instanceDef True  <* eolf)
   <|> liftM EvalUDecl (instanceDef False <* eolf)
   <|> liftM EvalUDecl (interfaceDef <* eolf)
-  <|> liftM (Command (EvalExpr Printed)) (expr <* eol)
+  <|> liftM (Command (EvalExpr Printed)) (expr <* eolf)
   <|> hidden (some eol >> return EmptyLines)
   <|> hidden (sc >> eol >> return CommentLine)
 


### PR DESCRIPTION
This way, we get

```
$ echo -n "1" > no-eof.dx
$ dex script no-eof.dx
1
> 1
```

rather than a parse error or the confusing "1> 1".  This responds to
the original ask in Issue #934.