### PR TITLE
Remove an unnecessary space printed before each Decl

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -191,7 +191,8 @@ instance Pretty (Decl n l) where
     -- This is just to reduce clutter a bit. We can comment it out when needed.
     -- Let (v:>Pi _)   bound -> p v <+> "=" <+> p bound
     Let b (DeclBinding ann ty rhs) ->
-      align $ p ann <+> p (b:>ty) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+      align $ annDoc <> p (b:>ty) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
+      where annDoc = case ann of PlainLet -> mempty; _ -> pretty ann <> " "
 
 instance Pretty (NaryLamExpr n) where
   pretty (NaryLamExpr (NonEmptyNest b bs) _ body) =

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -309,9 +309,9 @@ def bug (n : Type) : Unit =
   ()
 > Leaked local variables:[v#0]
 > Block:
->   v#0:n = todo n
->   w:n = v#0
->   v#1:((v#0..) => Unit) = for i:(v#0..). ()
+>  v#0:n = todo n
+>  w:n = v#0
+>  v#1:((v#0..) => Unit) = for i:(v#0..). ()
 >  v#1
 > Of type: ((v#0..) => Unit)
 > With effects: {}


### PR DESCRIPTION
Even though pretty much all let bindings we use are plain lets, we ended
up defensively prepending a space to separate the let annotation from
the binder every time. This usually resuted in really weird indentation.