### PR TITLE
Don't delay simplification until Imp

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -29,7 +29,7 @@ import Name
 import Builder
 import Syntax
 import CheckType (CheckableE (..))
-import Simplify (buildBlockSimplified, dceApproxBlock, emitSimplified, simplifyBlockToBlock)
+import Simplify (buildBlockSimplified, dceApproxBlock, emitSimplified)
 import LabeledItems
 import QueryType
 import Util (enumerate)
@@ -139,9 +139,7 @@ toImpExportedFunction cc lam@(NaryLamExpr (NonEmptyNest fb tb) effs body) (Abs b
     resDestAbsPtrs <- applyNaryAbs (sink resDestAbsArgsPtrs) args
     resDest        <- applyNaryAbs resDestAbsPtrs            ptrs
     argAtoms <- extendSubst (baseArgBs @@> map SubstVal (Var <$> args)) $
-      forM (fromListE argRecons) \block -> do
-        block' <- simplifyBlockToBlock =<< substM block
-        dropSubst $ translateBlock Nothing block'
+      traverse (translateBlock Nothing) $ fromListE argRecons
     extendSubst (bs @@> map SubstVal argAtoms) do
       void $ translateBlock (Just $ sink resDest) body
       return []

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -7,7 +7,7 @@
 {-# LANGUAGE UndecidableInstances #-}
 
 module Simplify ( simplifyTopBlock, simplifyTopFunction, SimplifiedBlock (..)
-                , liftSimplifyM, buildBlockSimplified, simplifyBlockToBlock, emitSimplified
+                , liftSimplifyM, buildBlockSimplified, emitSimplified
                 , dceApproxBlock) where
 
 import Control.Category ((>>>))
@@ -55,9 +55,6 @@ buildBlockSimplified m =
   liftSimplifyM do
     block <- liftBuilder $ buildBlock m
     buildBlock $ simplifyBlock block
-
-simplifyBlockToBlock :: EnvReader m => Block n -> m n (Block n)
-simplifyBlockToBlock block = liftSimplifyM $ buildBlock $ simplifyBlock block
 
 instance Simplifier SimplifyM
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -128,6 +128,13 @@ simplifyExpr expr = confuseGHC >>= \_ -> case expr of
     xs' <- mapM simplifyAtom xs
     simplifyTabApp f xs'
   Atom x -> simplifyAtom x
+  -- Handle PrimEffect here, to avoid traversing cb multiple times
+  Op (PrimEffect ref (MExtend (BaseMonoid em cb) x)) -> do
+    ref' <- simplifyAtom ref
+    em' <- simplifyAtom em
+    x' <- simplifyAtom x
+    (cb', IdentityReconAbs) <- simplifyBinaryLam cb
+    emitOp $ PrimEffect ref' $ MExtend (BaseMonoid em' cb') x'
   Op  op  -> (inline traversePrimOp) simplifyAtom op >>= simplifyOp
   Hof hof -> simplifyHof hof
   Case e alts resultTy eff -> do


### PR DESCRIPTION
Ideally we should never call into simplification from Imp, and instead we should ensure that the IR it gets already has been simplified properly. Otherwise, we have to make sure that all possible Core IR elements can be simplified, even if they're technically not supposed to even appear at that stage. This is in particularly annoying for the development of incremental lowerings, which should only happen after simplification, but before Imp.

This PR removes two places where simplification is performed. All remaining call sites deal with Ix. We should ideally move those further up as well, but it seems to be a larger refactor.