### PR TITLE
Add tutorial data download commands to Makefile

### DIFF
--- a/makefile
+++ b/makefile
@@ -219,11 +219,17 @@ doc-example-names = $(example-names:%=doc/examples/%.html)
 
 doc-lib-names = $(lib-names:%=doc/lib/%.html)
 
+t10k-images-idx3-ubyte-sha256 = 346e55b948d973a97e58d2351dde16a484bd415d4595297633bb08f03db6a073
+t10k-labels-idx1-ubyte-sha256 = 67da17c76eaffca5446c3361aaab5c3cd6d1c2608764d35dfb1850b086bf8dd5
+
 tutorial-data = t10k-images-idx3-ubyte t10k-labels-idx1-ubyte
 tutorial-data := $(tutorial-data:%=examples/%)
 
 $(tutorial-data):
 	wget -qO $@.gz http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/$(@F).gz
+	@echo $($(@F)-sha256) $@.gz > $@.sha256
+	sha256sum -c $@.sha256
+	$(RM) $@.sha256
 	gunzip $@.gz
 
 .PHONY: tutorial-data

--- a/makefile
+++ b/makefile
@@ -219,6 +219,18 @@ doc-example-names = $(example-names:%=doc/examples/%.html)
 
 doc-lib-names = $(lib-names:%=doc/lib/%.html)
 
+tutorial-data = t10k-images-idx3-ubyte t10k-labels-idx1-ubyte
+tutorial-data := $(tutorial-data:%=examples/%)
+
+$(tutorial-data):
+	wget -qO $@.gz http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/$(@F).gz
+	gunzip $@.gz
+
+.PHONY: tutorial-data
+tutorial-data: $(tutorial-data)
+
+run-examples/tutorial: tutorial-data 
+
 tests: unit-tests lower-tests quine-tests repl-test module-tests
 
 # Keep the unit tests in their own working directory too, due to
@@ -314,4 +326,5 @@ doc/lib/%.html: lib/%.dx
 
 clean:
 	$(STACK) clean
-	rm -rf src/lib/dexrt.bc
+	$(RM) src/lib/dexrt.bc
+	$(RM) $(tutorial-data)


### PR DESCRIPTION
The data is downloaded precisely as a dependency to the tutorial test
case. Naturallly, this requires an internet connection to succeed, but
one may also place the data files in the expected location manually
(e.g. as GitHub Actions currently does).

Also adds a phony `tutorial-data` target for easy downloading (e.g. if
we want to update the GHA workflows to use this) and adjusts the clean
target appropriately.