### PR TITLE
Make buildCase simplify eagerly

### DIFF
--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -335,8 +335,9 @@ linearizeExpr expr = case expr of
         resultTyWithTangent <- PairTy <$> substM resultTy
                                       <*> tangentFunType (tangentType resultTy')
         (ans, linLam) <- fromPair =<< buildCase e' resultTyWithTangent \i xs -> do
+          xs' <- mapM emitAtomToName xs
           Abs bs body <- return $ alts !! i
-          extendSubst (bs@@>xs) $ withTangentFunAsLambda $ linearizeBlock body
+          extendSubst (bs @@> xs') $ withTangentFunAsLambda $ linearizeBlock body
         return $ WithTangent ans do
           applyLinToTangents $ sink linLam
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -186,8 +186,9 @@ transposeExpr expr ct = case expr of
       False -> do
         e' <- substNonlin e
         void $ buildCase e' UnitTy \i vs -> do
+          vs' <- mapM emitAtomToName vs
           Abs bs body <- return $ alts !! i
-          extendSubst (bs @@> map RenameNonlin vs) do
+          extendSubst (bs @@> map RenameNonlin vs') do
             transposeBlock body (sink ct)
           return UnitVal
 


### PR DESCRIPTION
There are many callers to buildCase, not all of which examine the
scrutinee to see if the branch is determined. Yet, not doing so can lead
to code bloat, especially when doing automatic transformations like the
exception-to-maybe pass.

We modify buildCase to handle calling trySelectBranch and specializing
eagerly.

Pair-programmed with @dougalm 