### PR TITLE
Use GHA concurrency groups, fix caching MNIST data

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -9,6 +9,10 @@ on:
 env:
   DEX_CI: 1
 
+concurrency:
+  group: haskell-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}
@@ -17,7 +21,7 @@ jobs:
         os: [ubuntu-20.04, macos-latest]
         include:
           - os: macos-latest
-            install_deps: brew install llvm@12 pkg-config wget gzip
+            install_deps: brew install llvm@12 pkg-config wget gzip coreutils
             path_extension: $(brew --prefix llvm@12)/bin
           - os: ubuntu-20.04
             install_deps: sudo apt-get install llvm-12-tools llvm-12-dev pkg-config wget gzip
@@ -31,13 +35,6 @@ jobs:
       run: |
         ${{ matrix.install_deps }}
         echo "${{ matrix.path_extension }}" >> $GITHUB_PATH
-
-    - name: Get example files
-      run: |
-        wget http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz
-        wget http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz
-        gunzip t10k-images-idx3-ubyte.gz t10k-labels-idx1-ubyte.gz
-        mv t10k-images-idx3-ubyte t10k-labels-idx1-ubyte $GITHUB_WORKSPACE/examples/
 
     - name: Cache
       uses: actions/cache@v2

--- a/.github/workflows/julia-ci.yaml
+++ b/.github/workflows/julia-ci.yaml
@@ -9,6 +9,10 @@ on:
 env:
   DEX_CI: 1
 
+concurrency:
+  group: julia-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     if: false  # TODO: Fix Julia bindings!

--- a/.github/workflows/python-ci.yaml
+++ b/.github/workflows/python-ci.yaml
@@ -9,6 +9,10 @@ on:
 env:
   DEX_CI: 1
 
+concurrency:
+  group: python-${{ github.head_ref || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}


### PR DESCRIPTION
GitHub Actions workflows on pull requests are not normally canceled when
a newer commit comes in on the same branch. This wastes CI minutes and
delays PRs. The three CI workflows now use GHA's concurrency groups
feature to cancel stale workflows on the same pull request. Note that
this will not affect workflows on main after merging.

This commit also fixes the unconditional download of the Fashion MNIST
data set by delegating to the Makefile and removing the workflow step.