### PR TITLE
Add a prototype vectorization pass

### DIFF
--- a/makefile
+++ b/makefile
@@ -245,6 +245,16 @@ update-lower-tests: just-build
 	$(dex) script tests/lower.dx > tests/lower.dx.tmp
 	mv tests/lower.dx.tmp tests/lower.dx
 
+lower-vectorize-tests: export DEX_LOWER=1
+lower-vectorize-tests: export DEX_VECTORIZE=1
+lower-vectorize-tests: export DEX_ALLOW_CONTRACTIONS=0
+lower-vectorize-tests: export DEX_TEST_MODE=t
+lower-vectorize-tests: just-build
+	misc/check-quine tests/lower-vectorize.dx $(dex) script
+update-lower-vectorize-tests: just-build
+	DEX_LOWER=1 DEX_VECTORIZE=1 $(dex) script tests/lower-vectorize.dx > tests/lower-vectorize.dx.tmp
+	mv tests/lower-vectorize.dx.tmp tests/lower-vectorize.dx
+
 update-%: export DEX_ALLOW_CONTRACTIONS=0
 update-%: export DEX_TEST_MODE=t
 

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -17,7 +17,7 @@ module Builder (
   fromPair, getFst, getSnd, getProj, getProjRef, getNaryProjRef, naryApp,
   tabApp, naryTabApp,
   indexRef, naryIndexRef,
-  ptrOffset, unsafePtrLoad, ptrLoad,
+  ptrOffset, unsafePtrLoad,
   getClassDef, getDataCon,
   Emits, EmitsEvidence (..), buildPi, buildNonDepPi,
   buildLam, buildTabLam, buildLamGeneral,
@@ -283,7 +283,8 @@ type BuilderEmissions = RNest Decl
 newtype BuilderT (m::MonadKind) (n::S) (a:: *) =
   BuilderT { runBuilderT' :: InplaceT Env BuilderEmissions m n a }
   deriving ( Functor, Applicative, Monad, MonadTrans1, MonadFail, Fallible
-           , CtxReader, ScopeReader, Alternative, Searcher, MonadWriter w)
+           , CtxReader, ScopeReader, Alternative, Searcher
+           , MonadWriter w, MonadReader r)
 
 type BuilderM = BuilderT HardFailM
 
@@ -1109,11 +1110,8 @@ ptrOffset x i = emitOp $ PtrOffset x i
 unsafePtrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 unsafePtrLoad x = do
   lam <- liftEmitBuilder $ buildLam noHint PlainArrow UnitTy (oneEffect IOEffect) \_ ->
-    ptrLoad =<< sinkM x
+    emitOp . PtrLoad =<< sinkM x
   liftM Var $ emit $ Hof $ RunIO $ lam
-
-ptrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
-ptrLoad x = emitOp $ PtrLoad x
 
 -- === index set type class ===
 

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -733,6 +733,19 @@ typeCheckPrimOp op = case op of
   Freeze ref -> do
     RawRefTy ty <- getTypeE ref
     return ty
+  VectorBroadcast v ty -> do
+    ty'@(BaseTy (Vector _ sbt)) <- checkTypeE TyKind ty
+    v |: BaseTy (Scalar sbt)
+    return ty'
+  VectorIota ty -> do
+    ty'@(BaseTy (Vector _ _)) <- checkTypeE TyKind ty
+    return ty'
+  VectorSubref ref i ty -> do
+    RawRefTy (TabTy b (BaseTy (Scalar sbt))) <- getTypeE ref
+    i |: binderType b
+    ty'@(BaseTy (Vector _ sbt')) <- checkTypeE TyKind ty
+    unless (sbt == sbt') $ throw TypeErr "Scalar type mismatch"
+    return ty'
 
 typeCheckPrimHof :: Typer m => PrimHof (Atom i) -> m i o (Type o)
 typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -311,6 +311,7 @@ loadLitVal ptr (Scalar ty) = liftIO case ty of
 loadLitVal ptrPtr (PtrType t) = do
   ptr <- liftIO $ peek $ castPtr ptrPtr
   return $ PtrLit $ PtrLitVal t ptr
+loadLitVal _ (Vector _ _) = error "Vector loads not implemented"
 
 storeLitVal :: MonadIO m => Ptr () -> LitVal -> m ()
 storeLitVal ptr val = liftIO case val of

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -49,7 +49,7 @@ module Name (
   eMapFromList, eSetFromList,
   SinkableE (..), SinkableB (..), SinkableV, SinkingCoercion,
   withFreshM, sink, sinkList, sinkM, (!), (<>>), withManyFresh, refreshAbsPure,
-  lookupSubstFrag, lookupSubstFragRaw,
+  lookupSubstFrag, lookupSubstFragProjected, lookupSubstFragRaw,
   EmptyAbs, pattern EmptyAbs, NaryAbs, SubstVal (..),
   fmapNest, forEachNestItem, forEachNestItemM,
   substM, ScopedSubstReader, runScopedSubstReader,

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -823,11 +823,14 @@ instance Pretty (ImpInstr n)  where
   pretty ISyncWorkgroup   = "syncWorkgroup"
   pretty IThrowError      = "throwError"
   pretty (ICall f args)   = "call" <+> p f <+> p args
+  pretty (IVectorBroadcast v _) = "vbroadcast" <+> p v
+  pretty (IVectorIota _) = "viota"
 
 instance Pretty BaseType where pretty = prettyFromPrettyPrec
 instance PrettyPrec BaseType where
   prettyPrec b = case b of
     Scalar sb -> prettyPrec sb
+    Vector shape sb -> atPrec ArgPrec $ encloseSep "<" ">" "x" $ (p <$> shape) ++ [p sb]
     PtrType ty -> atPrec AppPrec $ "Ptr" <+> p ty
 
 instance Pretty AddressSpace where
@@ -925,6 +928,9 @@ instance PrettyPrec e => PrettyPrec (PrimOp e) where
     AllocDest ty -> atPrec LowestPrec $ "alloc" <+> pApp ty
     Place r v -> atPrec LowestPrec $ pApp r <+> "r:=" <+> pApp v
     Freeze r  -> atPrec LowestPrec $ "freeze" <+> pApp r
+    VectorBroadcast v vty -> atPrec LowestPrec $ "vbroadcast" <+> pApp v <+> pApp vty
+    VectorIota vty -> atPrec LowestPrec $ "viota" <+> pApp vty
+    VectorSubref ref i _ -> atPrec LowestPrec $ "vrefslice" <+> pApp ref <+> pApp i
     _ -> prettyExprDefault $ OpExpr op
 
 prettyExprDefault :: PrettyPrec e => PrimExpr e -> DocPrec ann

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -615,6 +615,11 @@ getTypePrimOp op = case op of
   Freeze ref -> getTypeE ref >>= \case
     RawRefTy ty -> return ty
     ty -> error $ "Not a reference type: " ++ pprint ty
+  VectorBroadcast _ vty -> substM vty
+  VectorIota vty -> substM vty
+  VectorSubref ref _ vty -> getTypeE ref >>= \case
+    TC (RefType h _) -> TC . RefType h <$> substM vty
+    ty -> error $ "Not a reference type: " ++ pprint ty
 
 getSuperclassDicts :: ClassDef n -> Atom n -> [Atom n]
 getSuperclassDicts (ClassDef _ _ _ (SuperclassBinders classBs _) _) dict =

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -230,12 +230,12 @@ transposeOp op ct = case op of
   ProjRef      _ _      -> notImplemented
   Select       _ _ _    -> notImplemented
   CastOp       _ _      -> notImplemented
-  RecordCons   _ _      -> notImplemented
-  RecordConsDynamic _ _ _ -> notImplemented
-  RecordSplitDynamic _ _  -> notImplemented
-  RecordSplit  _ _      -> notImplemented
-  VariantLift  _ _      -> notImplemented
-  VariantSplit _ _      -> notImplemented
+  RecordCons   _ _      -> unreachable
+  RecordConsDynamic _ _ _ -> unreachable
+  RecordSplitDynamic _ _  -> unreachable
+  RecordSplit  _ _      -> unreachable
+  VariantLift  _ _      -> unreachable
+  VariantSplit _ _      -> unreachable
   SumToVariant _        -> notImplemented
   PtrStore _ _          -> notLinear
   PtrLoad    _          -> notLinear
@@ -248,16 +248,18 @@ transposeOp op ct = case op of
   ToEnum _ _            -> notLinear
   ThrowException _      -> notLinear
   OutputStreamPtr       -> notLinear
-  ProjMethod _ _        -> notLinear
-  ExplicitApply _ _     -> notLinear
-  MonoLiteral _         -> notLinear
-  AllocDest _           -> notLinear
-  Place _ _             -> notLinear
-  Freeze _              -> notLinear
-  VectorBroadcast _ _   -> notLinear
-  VectorIota _          -> notLinear
-  VectorSubref _ _ _    -> notLinear
-  where notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
+  ProjMethod _ _        -> unreachable
+  ExplicitApply _ _     -> unreachable
+  MonoLiteral _         -> unreachable
+  AllocDest _           -> unreachable
+  Place _ _             -> unreachable
+  Freeze _              -> unreachable
+  VectorBroadcast _ _   -> unreachable
+  VectorIota _          -> unreachable
+  VectorSubref _ _ _    -> unreachable
+  where
+    notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
+    unreachable = error $ "Shouldn't appear in transposition: " ++ pprint op
 
 transposeAtom :: HasCallStack => Emits o => Atom i -> Atom o -> TransposeM i o ()
 transposeAtom atom ct = case atom of

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -254,6 +254,9 @@ transposeOp op ct = case op of
   AllocDest _           -> notLinear
   Place _ _             -> notLinear
   Freeze _              -> notLinear
+  VectorBroadcast _ _   -> notLinear
+  VectorIota _          -> notLinear
+  VectorSubref _ _ _    -> notLinear
   where notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
 
 transposeAtom :: HasCallStack => Emits o => Atom i -> Atom o -> TransposeM i o ()

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -113,6 +113,10 @@ data PrimOp e =
       | AllocDest e  -- type
       | Place e e    -- reference, value
       | Freeze e     -- reference
+      -- Vector operations
+      | VectorBroadcast e e  -- value, vector type
+      | VectorIota e  -- vector type
+      | VectorSubref e e e -- ref, base ix, vector type
       -- Extensible record and variant operations:
       -- Concatenate two records.
       | RecordCons   e e
@@ -285,6 +289,7 @@ data ScalarBaseType = Int64Type | Int32Type
                     | Float64Type | Float32Type
                       deriving (Show, Eq, Ord, Generic)
 data BaseType = Scalar  ScalarBaseType
+              | Vector  [Word32] ScalarBaseType
               | PtrType PtrType
                 deriving (Show, Eq, Ord, Generic)
 
@@ -301,10 +306,17 @@ sizeOf t = case t of
   Scalar Word64Type  -> 8
   Scalar Float64Type -> 8
   Scalar Float32Type -> 4
+  Vector _ _         -> error "Not implemented"
   PtrType _          -> ptrSize
 
 ptrSize :: Int
 ptrSize = 8
+
+isIntegral :: ScalarBaseType -> Bool
+isIntegral = \case
+  Float64Type -> False
+  Float32Type -> False
+  _           -> True
 
 getIntLit :: LitVal -> Int
 getIntLit l = case l of


### PR DESCRIPTION
I've been recently nerdsniped into reading a series of ispc-related
stories and I felt bad that Dex doesn't support vectorization. There's
no reason why we should be worse! Any pure innermost loop should be
vectorizable!

This change adds a prototype that can handle some very basic cases, and
quickly fails whenever that doesn't hold. Due to that it's off by
default and gated by as many as two flags! If you want to play around
with it, run `DEX_LOWER=1 DEX_VECTORIZE=1 dex script ...`, or try
`make lower-vectorize-tests`.