### PR TITLE
Minor bugfixes and improvements for lowering

### DIFF
--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -576,15 +576,15 @@ typeCheckPrimOp op = case op of
       MExtend _ x -> x|:s >> declareEff (RWSEffect Writer $ Just h') $> UnitTy
   IndexRef ref i -> do
     getTypeE ref >>= \case
-      RefTy h (TabTy (b:>IxType iTy _) eltTy) -> do
+      TC (RefType h (TabTy (b:>IxType iTy _) eltTy)) -> do
         i' <- checkTypeE iTy i
         eltTy' <- applyAbs (Abs b eltTy) (SubstVal i')
-        return $ RefTy h eltTy'
+        return $ TC $ RefType h eltTy'
       ty -> error $ "Not a reference to a table: " ++
                        pprint (Op op) ++ " : " ++ pprint ty
   ProjRef i ref -> do
     getTypeE ref >>= \case
-      RefTy h (ProdTy tys) -> return $ RefTy h $ tys !! i
+      TC (RefType h (ProdTy tys)) -> return $ TC $ RefType h $ tys !! i
       ty -> error $ "Not a reference to a product: " ++ pprint ty
   IOAlloc t n -> do
     n |: IdxRepTy
@@ -725,7 +725,7 @@ typeCheckPrimOp op = case op of
     applySubst subst methodTy
   ExplicitApply _ _ -> error "shouldn't appear after inference"
   MonoLiteral _ -> error "should't appear after inference"
-  AllocDest ty -> checkTypeE TyKind ty
+  AllocDest ty -> RawRefTy <$> checkTypeE TyKind ty
   Place ref val -> do
     ty <- getTypeE val
     ref |: RawRefTy ty

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -63,7 +63,7 @@ module Name (
   InFrag (..), InMap (..), OutFrag (..), OutMap (..), ExtOutMap (..), ExtOutFrag (..),
   hoist, hoistToTop, sinkFromTop, fromConstAbs, exchangeBs, HoistableE (..),
   HoistExcept (..), liftHoistExcept', liftHoistExcept, abstractFreeVars, abstractFreeVar,
-  abstractFreeVarsNoAnn,
+  abstractFreeVarsNoAnn, decideScope,
   WithRenamer (..), ignoreHoistFailure,
   HoistableB (..), HoistableV, withScopeFromFreeVars, canonicalizeForPrinting,
   ClosedWithScope (..),
@@ -2648,6 +2648,13 @@ hoistToTop e =
 sinkFromTop :: SinkableE e => e VoidS -> e n
 sinkFromTop = unsafeCoerceE
 {-# INLINE sinkFromTop #-}
+
+decideScope :: ScopeFrag n l -> Name c l -> Either (Name c n) (Name c (n:=>:l))
+decideScope (UnsafeMakeScopeFrag frag) (UnsafeMakeName rn) =
+  case R.member rn frag of
+    False -> Left  $ UnsafeMakeName rn
+    True  -> Right $ UnsafeMakeName rn
+{-# INLINE decideScope #-}
 
 freeVarsList :: (HoistableE e, Color c) => e n -> [Name c n]
 freeVarsList e = nameSetToList $ freeVarsE e

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -437,7 +437,7 @@ evalBlock typed = do
   SimplifiedBlock simp recon <- checkPass SimpPass $ simplifyTopBlock synthed
   lowered <- case useExperimentalLowering of
     False -> return simp
-    True  -> do
+    True  -> checkPass LowerPass do
       simp' <- lowerFullySequential simp
       case useExperimentalVectorization of
         True -> vectorizeLoops (512 `div` 8) simp'

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -214,7 +214,7 @@ data PiType  (n::S) where
   PiType :: PiBinder n l -> EffectRow l -> Type l -> PiType n
 
 data DepPairType (n::S) where
-  DepPairType :: Binder n l -> Type  l -> DepPairType n
+  DepPairType :: Binder n l -> Type l -> DepPairType n
 
 type Val  = Atom
 type Type = Atom

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -295,7 +295,7 @@ data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
 
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
               | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval
-              | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass
+              | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass | LowerPass
                 deriving (Ord, Eq, Bounded, Enum, Generic)
 
 instance Show PassName where
@@ -306,7 +306,7 @@ instance Show PassName where
     LLVMOpt  -> "llvmopt" ; AsmPass   -> "asm"
     JAXPass  -> "jax"   ; JAXSimpPass -> "jsimp"; ResultPass -> "result"
     LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo";
-    EarlyOptPass -> "early-opt"; OptPass -> "opt"
+    EarlyOptPass -> "early-opt"; OptPass -> "opt"; LowerPass -> "lower"
 
 data EnvQuery =
    DumpSubst


### PR DESCRIPTION
With all of those, we're actually able to run all tests and all examples except for `schrodinger`!

#### Add missing Atom cases in GenericTraversal
 
#### Fix a bug in destination passing implementation

Destination passing tries to lift the writes to the destination for the
block result up to the places where the written values are defined. But,
not all block results have to be defined in the same block! The old
implementation would fail to insert the necessary writes, leaving us
with uninitialized dests.
 
#### Run type-checks and logs after lowering pass

In particular, enable `%passes lower`.