### PR TITLE
Replace checked casts in `linalg` with unsafe casts, and move unsafe arithmetic to `Subset` instances.

### DIFF
--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -107,7 +107,7 @@ instance {n} HasDeterminant (LowerTriMap n)
 
 instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMap n) (n=>v)
   apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
-  diag   = \(MkLowerTriMap x).   for i. x.i.(cast i) .* one
+  diag   = \(MkLowerTriMap x).   for i. x.i.(unsafe_cast i) .* one
   solve' = \(MkLowerTriMap x).   forward_substitute x
 
 instance {n} Arbitrary (LowerTriMap n)

--- a/examples/psd.dx
+++ b/examples/psd.dx
@@ -21,7 +21,7 @@ psd : N=>N=>Float =
 def padLowerTriMat {n v} [Add v] (mat:LowerTriMat n v) : n=>n=>v =
   for i j.
     if (ordinal j)<=(ordinal i)
-      then mat.i.(cast j)
+      then mat.i.(unsafe_cast j)
       else zero
 
 l = chol psd

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -33,7 +33,7 @@ def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v =
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero
 
--- TODO: Put these in an Isomorphism typeclass?
+-- TODO: Put these in instances of an Isomorphism interface?
 def transpose_upper_ix {n} [Ix n] (i:n) (j:(i..)) : LowerTriIx n =
   j' = inject n j
   i' = unsafe_cast i
@@ -83,8 +83,8 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
   -- Solves lower triangular linear system (inverse a) **. b
   yield_state zero \sRef.
     for i:n.
-      s = sum for k:(..i).  -- dot product
-        a.i.k .* get sRef!(inject n k)
+      s = sum for k:(..<i).  -- dot product
+        a.i.(inject _ k) .* get sRef!(inject n k)
       sRef!i := (b.i - s) / (lower_tri_diag a).i
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -17,7 +17,7 @@ def first_ix_of {n} [Ix n] (x:n) : n =
 def last_ix_of {n} [NonEmpty n] (x:n) : n =
   unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
 
-def is_last {n} [Ix n] (x:n) : Bool =  -- Todo: add NonEmpty constraint
+def is_last {n} [Ix n] (x:n) : Bool =
   ((ordinal x) + 1) == size n
 
 

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -83,8 +83,8 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
   -- Solves lower triangular linear system (inverse a) **. b
   yield_state zero \sRef.
     for i:n.
-      s = sum for k:(..<i).  -- dot product
-        a.i.(inject _ k) .* get sRef!(inject n k)
+      s = sum for k:(..i).  -- dot product
+        a.i.k .* get sRef!(inject n k)
       sRef!i := (b.i - s) / (lower_tri_diag a).i
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -3,46 +3,73 @@
 - LU Decomposition
 - Matrix Inversion
 
-
 def unsafe_cast {a m} [Ix a, Ix m] (d:a) : m = unsafe_from_ordinal m (ordinal d)
-def unsafe_first_ix {n} [Ix n] : n = unsafe_from_ordinal n 0
-def unsafe_last_ix  {n} [Ix n] : n = unsafe_from_ordinal n (unsafe_nat_diff (size n) 1)
 
-def first_ix_of {n} [Ix n] (x:n) : n =
-  -- This function is safe because one can't produce an element of type n
-  -- if there isn't at least one possible value in its type. So being able
-  -- to produce x to call this function is proof that `n` is non-empty.
-  unsafe_from_ordinal n 0
+'The three functions below are safe because one can't produce an element of type n
+if there isn't at least one possible value in its type. So being able
+to produce x to call this function is proof that `n` is non-empty,
+even though we don't use the `NonEmpty` constraint.
 
-def last_ix_of {n} [NonEmpty n] (x:n) : n =
-  unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
-
-def is_last {n} [Ix n] (x:n) : Bool =
-  ((ordinal x) + 1) == size n
-
+def first_ix_of {n} [Ix n] (x:n) : n = unsafe_from_ordinal n 0
+def last_ix_of  {n} [Ix n] (x:n) : n = unsafe_from_ordinal n (unsafe_nat_diff (size n) 1)
+def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
 
 '### Triangular matrices
 
 def LowerTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..i)=>v
 def UpperTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(i..)=>v
 
-def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.unsafe_first_ix
-def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.unsafe_last_ix
+-- These would be unnecessary if there were syntax for dependent pairs.
+data LowerTriIx n    = MkLowerTriIx    i:n j:(..i)
+data UpperTriIx n    = MkUpperTriIx    i:n j:(i..)
+data LowerTriIxExc n = MkLowerTriIxExc i:n j:(..<i)
+data UpperTriIxExc n = MkUpperTriIxExc i:n j:(i<..)
+
+def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v =
+  view i. u.i.(first_ix_of (from_just $ project _ i))
+def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v =
+  view i. l.i.(last_ix_of (from_just $ project _ i))
 
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero
 
+-- TODO: Put these in an Isomorphism typeclass?
+def transpose_upper_ix {n} [Ix n] (i:n) (j:(i..)) : LowerTriIx n =
+  j' = inject n j
+  i' = unsafe_cast i
+  MkLowerTriIx j' i'
+
+def transpose_lower_ix {n} [Ix n] (i:n) (j:(..i)) : UpperTriIx n =
+  j' = inject n j
+  i' = unsafe_cast i
+  MkUpperTriIx j' i'
+
+def transpose_upper_ix_exc {n} [Ix n] (i:n) (j:(i<..)) : LowerTriIxExc n =
+  j' = inject n j
+  i' = unsafe_cast i
+  MkLowerTriIxExc j' i'
+
+def transpose_lower_ix_exc {n} [Ix n] (i:n) (j:(..<i)) : UpperTriIxExc n =
+  j' = inject n j
+  i' = unsafe_cast i
+  MkUpperTriIxExc j' i'
+
 def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
-  for i:n. for j':(i..).
-    j = inject n j'
-    lower.j.(unsafe_cast i)
+  for i j.
+    (MkLowerTriIx j' i') = transpose_upper_ix i j
+    lower.j'.i'
+
+def transpose_upper_to_lower {n v} (upper:UpperTriMat n v) : LowerTriMat n v =
+  for i j.
+    (MkUpperTriIx j' i') = transpose_lower_ix i j
+    upper.j'.i'
 
 def transpose_lower_to_upper_no_diag {n v}
     (lower:i:n=>(..<i)=>v) :
            i:n=>(i<..)=>v =
   for i j.
-    j' = inject n j
-    lower.j'.(unsafe_cast i)
+    (MkLowerTriIxExc j' i') = transpose_upper_ix_exc i j
+    lower.j'.i'
 
 def skew_symmetric_prod {v n} [VSpace v]
     (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
@@ -56,8 +83,8 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
   -- Solves lower triangular linear system (inverse a) **. b
   yield_state zero \sRef.
     for i:n.
-      s = sum for k:(..<i).  -- dot product
-        a.i.(unsafe_cast k) .* get sRef!(inject n k)
+      s = sum for k:(..i).  -- dot product
+        a.i.k .* get sRef!(inject n k)
       sRef!i := (b.i - s) / (lower_tri_diag a).i
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =
@@ -65,7 +92,7 @@ def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v
   yield_state zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
-        a.i.(unsafe_cast k) .* get sRef!(inject n k)
+        a.i.k .* get sRef!(inject n k)
       sRef!i := (b.i - s) / (upper_tri_diag a).i
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
@@ -83,14 +110,14 @@ def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
     mat = lower_tri_mat buf
     for i:n. for j':(..i).
       j = inject n j'
-      row  = for k:(..<j). get $ mat i (unsafe_cast k)
-      row' = for k:(..<j). get $ mat j (unsafe_cast k)
-      a = x.i.j - vdot row row'
-      if (ordinal i) == (ordinal j)
+      row_i = for k:(..<j'). get $ mat i (inject (..i) k)
+      row_j = for k:(..<j'). get $ mat j (unsafe_cast k)
+      a = x.i.j - vdot row_i row_j
+      if (ordinal j) == (ordinal i)
         then
           mat i j' := sqrt a
         else
-          b = get $ mat j (unsafe_cast j')
+          b = get $ mat j (from_just $ project (..j) j)
           mat i j' := a / b
 
 '### Permutations
@@ -162,9 +189,9 @@ def lu {n} (a: n=>n=>Float) :
     -- Helper functions to index into triangular matrices
     -- from indices that themselves need to be cast or projected
     -- to the right type.
-    def lmat {m} (i:n) (j:m) [Ix m] : Ref _ Float =
+    def unsafe_lmat {m} (i:n) (j:m) [Ix m] : Ref _ Float =
       lower_tri_mat lRef i $ unsafe_cast j
-    def umat {m} (i:n) (j:m) [Ix m, Subset (i..) m] : Ref _ Float =
+    def unsafe_umat {m} (i:n) (j:m) [Ix m, Subset (i..) m] : Ref _ Float =
       upper_tri_mat uRef i $ from_just (project (i..) j)
 
     for j:n.
@@ -173,23 +200,23 @@ def lu {n} (a: n=>n=>Float) :
         s = sum for k:(..i).
           -- TODO: get transitivity of Subset working so we can do a single injection
           k' = inject n (inject (..j) k)
-          ukj = get $ umat k' j
-          lik = get $ lmat i' k
+          ukj = get $ unsafe_umat k' j
+          lik = get $ unsafe_lmat i' k
           ukj * lik
 
-        umat i' j := a.(inject _ i).j - s
+        unsafe_umat i' j := a.(inject _ i).j - s
 
       for i:(j<..).
         i' = inject n i
         s = sum for k:(..j).
           k' = inject n k
-          ukj = get $ umat k' j
-          lik = get $ lmat i' k
+          ukj = get $ unsafe_umat k' j
+          lik = get $ unsafe_lmat i' k
           ukj * lik
 
-        ujj = get $ umat j j
+        ujj = get $ unsafe_umat j j
         i'' = unsafe_cast i'
-        lmat i'' j := (a.i'.j - s) / ujj
+        unsafe_lmat i'' j := (a.i'.j - s) / ujj
   (lower, upper, permutation)
 
 

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -17,7 +17,7 @@ def first_ix_of {n} [Ix n] (x:n) : n =
 def last_ix_of {n} [NonEmpty n] (x:n) : n =
   unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
 
-def is_last {n} [Ix n] (x:n) : Bool =
+def is_last {n} [Ix n] (x:n) : Bool =  -- Todo: add NonEmpty constraint
   ((ordinal x) + 1) == size n
 
 
@@ -115,8 +115,7 @@ def swap_in_place {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Un
 
 def perm_to_table {n} ((perm, _):Permutation n) : n=>n = perm
 def perm_sign    {n} ((_, sign):Permutation n) : PermutationSign = sign
-
-
+  
 
 '### LU decomposition functions
 
@@ -160,33 +159,37 @@ def lu {n} (a: n=>n=>Float) :
   --      lRef!i!j := (a.i.j - s) / (get uRef!j!j)
   --    for i:n. ()
 
-    lmat = lower_tri_mat lRef
-    umat = upper_tri_mat uRef
+    -- Helper functions to index into triangular matrices
+    -- from indices that themselves need to be cast or projected
+    -- to the right type.
+    def lmat {m} (i:n) (j:m) [Ix m] : Ref _ Float =
+      lower_tri_mat lRef i $ unsafe_cast j
+    def umat {m} (i:n) (j:m) [Ix m, Subset (i..) m] : Ref _ Float =
+      upper_tri_mat uRef i $ from_just (project (i..) j)
+
     for j:n.
       for i:(..j).
         i' = inject n i
         s = sum for k:(..i).
           -- TODO: get transitivity of Subset working so we can do a single injection
           k' = inject n (inject (..j) k)
-          ukj = get $ umat k' (unsafe_from_ordinal _ (unsafe_nat_diff (ordinal j) (ordinal k)))
-          lik = get $ lmat i' (unsafe_cast k)
+          ukj = get $ umat k' j
+          lik = get $ lmat i' k
           ukj * lik
 
-        uijRef = umat i' ((unsafe_nat_diff (ordinal j) (ordinal i))@_)
-        uijRef := a.(inject _ i).j - s
+        umat i' j := a.(inject _ i).j - s
 
       for i:(j<..).
         i' = inject n i
         s = sum for k:(..j).
           k' = inject n k
-          ukj = get $ umat k' (unsafe_from_ordinal _ (unsafe_nat_diff (ordinal j) (ordinal k)))
-          lik = get $ lmat i' (unsafe_cast k)
+          ukj = get $ umat k' j
+          lik = get $ lmat i' k
           ukj * lik
 
-        i'' = unsafe_from_ordinal _ ((ordinal i) + (ordinal j) + 1)
-        ujj = get $ umat j unsafe_first_ix
-        lijRef = lmat i'' (unsafe_cast j)
-        lijRef := (a.i'.j - s) / ujj
+        ujj = get $ umat j j
+        i'' = unsafe_cast i'
+        lmat i'' j := (a.i'.j - s) / ujj
   (lower, upper, permutation)
 
 
@@ -221,3 +224,11 @@ def matrix_power {n} (base:n=>n=>Float) (power:Nat) : n=>n=>Float =
 
 def trace {n a} [Add a] (x:n=>n=>a) : a =
   sum for i. x.i.i
+
+
+a : (Fin 1000)=>(Fin 1000)=>Float = arb (new_key 0)
+
+%time
+sign_and_log_determinant a
+
+

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -4,33 +4,51 @@
 - Matrix Inversion
 
 
-def cast {a m} [Ix a, Ix m] (d:a) : m = (ordinal d)@m
+def unsafe_cast {a m} [Ix a, Ix m] (d:a) : m = unsafe_from_ordinal m (ordinal d)
+def unsafe_first_ix {n} [Ix n] : n = unsafe_from_ordinal n 0
+def unsafe_last_ix  {n} [Ix n] : n = unsafe_from_ordinal n (unsafe_nat_diff (size n) 1)
+
+def first_ix_of {n} [Ix n] (x:n) : n =
+  -- This function is safe because one can't produce an element of type n
+  -- if there isn't at least one possible value in its type. So being able
+  -- to produce x to call this function is proof that `n` is non-empty.
+  unsafe_from_ordinal n 0
+
+def last_ix_of {n} [NonEmpty n] (x:n) : n =
+  unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
+
+def is_last {n} [Ix n] (x:n) : Bool =  -- Todo: add NonEmpty constraint
+  ((ordinal x) + 1) == size n
+
 
 '### Triangular matrices
 
 def LowerTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(..i)=>v
 def UpperTriMat (n:Type) [Ix n] (v:Type) : Type = i:n=>(i..)=>v
 
-def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = for i. u.i.(0@_)
-def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = for i. l.i.(cast i)
+def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.unsafe_first_ix
+def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.unsafe_last_ix
+
+def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
+  for i j. select (is_last j) one zero
 
 def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
   for i:n. for j':(i..).
     j = inject n j'
-    lower.j.(cast i)
+    lower.j.(unsafe_cast i)
 
 def transpose_lower_to_upper_no_diag {n v}
     (lower:i:n=>(..<i)=>v) :
            i:n=>(i<..)=>v =
   for i j.
     j' = inject n j
-    lower.j'.(unsafe_from_ordinal _ (ordinal i))
+    lower.j'.(unsafe_cast i)
 
 def skew_symmetric_prod {v n} [VSpace v]
     (lower: i:n=>(..<i)=>Float) (y: n=>v) : n=>v =
+  upper = transpose_lower_to_upper_no_diag lower
   -- We could probably fuse these two for loops.
   lower_prod = for i. sum for j. lower.i.j .* (y.(inject n j))
-  upper = transpose_lower_to_upper_no_diag lower
   upper_prod = for i. sum for j. upper.i.j .* (y.(inject n j))
   lower_prod - upper_prod
 
@@ -39,16 +57,16 @@ def forward_substitute {n v} [VSpace v] (a:LowerTriMat n Float) (b:n=>v) : n=>v 
   yield_state zero \sRef.
     for i:n.
       s = sum for k:(..<i).  -- dot product
-        a.i.(cast k) .* get sRef!(inject n k)
-      sRef!i := (b.i - s) / a.i.(cast i)
+        a.i.(unsafe_cast k) .* get sRef!(inject n k)
+      sRef!i := (b.i - s) / (lower_tri_diag a).i
 
 def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v =
   -- Solves upper triangular linear system (inverse a) **. b
   yield_state zero \sRef.
     rof i:n.
       s = sum for k:(i..).  -- dot product
-        a.i.(cast k) .* get sRef!(inject n k)
-      sRef!i := (b.i - s) / a.i.(0@_) -- 0 is the diagonal index
+        a.i.(unsafe_cast k) .* get sRef!(inject n k)
+      sRef!i := (b.i - s) / (upper_tri_diag a).i
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
 def lower_tri_mat {a b h} (ref:Ref h (LowerTriMat a b)) (i:a) (j:(..i)) : Ref h b =
@@ -65,14 +83,14 @@ def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
     mat = lower_tri_mat buf
     for i:n. for j':(..i).
       j = inject n j'
-      row  = for k:(..<j). get $ mat i (cast k)
-      row' = for k:(..<j). get $ mat j (cast k)
+      row  = for k:(..<j). get $ mat i (unsafe_cast k)
+      row' = for k:(..<j). get $ mat j (unsafe_cast k)
       a = x.i.j - vdot row row'
       if (ordinal i) == (ordinal j)
         then
           mat i j' := sqrt a
         else
-          b = get $ mat j (cast j')
+          b = get $ mat j (unsafe_cast j')
           mat i j' := a / b
 
 '### Permutations
@@ -107,9 +125,8 @@ def pivotize {n} (a:n=>n=>Float) : Permutation n =
   yield_state identity_permutation \permRef.
     for j:n.
       row_with_largest = argmin for i:(j..). (-(abs a.(inject n i).j))
-      case ordinal j == ordinal row_with_largest of
-        True -> ()
-        False -> swap_in_place permRef j (inject n row_with_largest)
+      if (ordinal j) /= (ordinal row_with_largest) then
+        swap_in_place permRef j (inject n row_with_largest)
 
 def lu {n} (a: n=>n=>Float) :
        (LowerTriMat n Float & UpperTriMat n Float & Permutation n) =
@@ -118,8 +135,7 @@ def lu {n} (a: n=>n=>Float) :
   permutation = pivotize a
   a = apply_permutation permutation a
 
-  init_lower = for i:n. for j':(..i).
-    select (ordinal i == (ordinal (inject n j'))) 1.0 0.0
+  init_lower = lower_tri_identity
   init_upper = zero
 
   (lower, upper) = yield_state (init_lower, init_upper) \stateRef.
@@ -151,27 +167,25 @@ def lu {n} (a: n=>n=>Float) :
         i' = inject n i
         s = sum for k:(..i).
           -- TODO: get transitivity of Subset working so we can do a single injection
-          k'' = inject (..j) k
-          k' = inject n k''
-          ukj = get $ umat k' ((unsafe_nat_diff (ordinal j) (ordinal k))@_)
-          lik = get $ lmat i' (cast k)
+          k' = inject n (inject (..j) k)
+          ukj = get $ umat k' (unsafe_from_ordinal _ (unsafe_nat_diff (ordinal j) (ordinal k)))
+          lik = get $ lmat i' (unsafe_cast k)
           ukj * lik
 
         uijRef = umat i' ((unsafe_nat_diff (ordinal j) (ordinal i))@_)
         uijRef := a.(inject _ i).j - s
 
       for i:(j<..).
-        i' = inject _ i
+        i' = inject n i
         s = sum for k:(..j).
-          k' = inject _ k
-          i'' = ((unsafe_nat_diff (ordinal j) (ordinal k))@_)
-          ukj = get $ umat k' i''
-          lik = get $ lmat i' (cast k)
+          k' = inject n k
+          ukj = get $ umat k' (unsafe_from_ordinal _ (unsafe_nat_diff (ordinal j) (ordinal k)))
+          lik = get $ lmat i' (unsafe_cast k)
           ukj * lik
 
-        i'' = ((ordinal i) + (ordinal j) + 1)@_
-        ujj = get $ umat j (0@_)
-        lijRef = lmat i'' (cast j)
+        i'' = unsafe_from_ordinal _ ((ordinal i) + (ordinal j) + 1)
+        ujj = get $ umat j unsafe_first_ix
+        lijRef = lmat i'' (unsafe_cast j)
         lijRef := (a.i'.j - s) / ujj
   (lower, upper, permutation)
 

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -17,7 +17,7 @@ def first_ix_of {n} [Ix n] (x:n) : n =
 def last_ix_of {n} [NonEmpty n] (x:n) : n =
   unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
 
-def is_last {n} [Ix n] (x:n) : Bool =  -- Todo: add NonEmpty constraint
+def is_last {n} [Ix n] (x:n) : Bool =
   ((ordinal x) + 1) == size n
 
 
@@ -115,7 +115,7 @@ def swap_in_place {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Un
 
 def perm_to_table {n} ((perm, _):Permutation n) : n=>n = perm
 def perm_sign    {n} ((_, sign):Permutation n) : PermutationSign = sign
-  
+
 
 '### LU decomposition functions
 
@@ -224,11 +224,3 @@ def matrix_power {n} (base:n=>n=>Float) (power:Nat) : n=>n=>Float =
 
 def trace {n a} [Add a] (x:n=>n=>a) : a =
   sum for i. x.i.i
-
-
-a : (Fin 1000)=>(Fin 1000)=>Float = arb (new_key 0)
-
-%time
-sign_and_log_determinant a
-
-

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -103,22 +103,29 @@ def upper_tri_mat {a b h} (ref:Ref h (UpperTriMat a b)) (i:a) (j:(i..)) : Ref h 
   d = %indexRef ref i
   d!j
 
+def dual_inject {m n} [Ix m, Ix n, Subset m n] (i:m) (j:(..<i)) : LowerTriIxExc n =
+  i' = inject n i
+  j' = from_just $ project _ $ inject n $ inject m j
+  MkLowerTriIxExc i' j'
+
 '### Cholesky decomposition
 
 def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
   yield_state zero \buf.
     mat = lower_tri_mat buf
-    for i:n. for j':(..i).
-      j = inject n j'
-      row_i = for k:(..<j'). get $ mat i (inject (..i) k)
-      row_j = for k:(..<j'). get $ mat j (unsafe_cast k)
-      a = x.i.j - vdot row_i row_j
+    for i:n. for j:(..i).
+      row_i = for k:(..<j). get $ mat i (inject (..i) k)
+      row_j = for k:(..<j).
+        (MkLowerTriIxExc j2 k2) = dual_inject j k
+        get $ mat j2 (inject _ k2)
+      j' = inject n j
+      a = x.i.j' - vdot row_i row_j
       if (ordinal j) == (ordinal i)
         then
-          mat i j' := sqrt a
+          mat i j := sqrt a
         else
-          b = get $ mat j (from_just $ project (..j) j)
-          mat i j' := a / b
+          b = get $ mat j' (from_just $ project (..j') j')
+          mat i j := a / b
 
 '### Permutations
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -900,6 +900,14 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
       then Nothing
       else Just $ UnsafeMkRangeToExc j'
 
+instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) (RangeTo q i)
+  inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' >= i'
+      then Nothing
+      else Just $ UnsafeMkRangeToExc j'
 
 '## Elementary/Special Functions
 This is more or less the standard [LibM fare](https://en.wikipedia.org/wiki/C_mathematical_functions).

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -40,3 +40,18 @@ grad (\x. snd $ pivotize [[x]]) 1.0
 
 grad (\x. snd $ sign_and_log_determinant [[x]]) 2.0
 > 0.5
+
+-- Check forward_substitute solve by comparing
+-- against zero-padding and doing the full solve.
+def padLowerTriMat {n v} [Add v] (mat:LowerTriMat n v) : n=>n=>v =
+  for i j.
+    if (ordinal j)<=(ordinal i)
+      then mat.i.(unsafe_cast j)
+      else zero
+
+lower : LowerTriMat (Fin 4) Float = arb $ new_key 0
+lower_padded = padLowerTriMat lower
+vec : (Fin 4)=>Float = arb $ new_key 0
+
+forward_substitute lower vec ~~ solve lower_padded vec
+> True


### PR DESCRIPTION
I think this is ready for review, as it's a strict improvement over the old version, as far as I can tell.  The logic is (imo) safer, and this change reduces compile time by about 50%, and improves speed by about 10% for computing the determinant of a large matrix:
```
a : (Fin 1000)=>(Fin 1000)=>Float = arb (new_key 0)
```

Before:
```
%time
sign_and_log_determinant a
(-1., 2950.6543)

Compile time: 394.693 ms
Run time:     933.142 ms 
```

After:
```
%time
sign_and_log_determinant a
(-1., 2950.6543)

Compile time: 206.857 ms
Run time:     844.554 ms
```

There might still be some cleanup possible.  In particular, the main logic for the LU decomposition is still littered with casts and injects.  It might be possible to wrap some of the remaining ones into helper functions, but I couldn't make the types work.
