### PR TITLE
Remove the `IxTy` constructor for `Atom`.

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -774,13 +774,13 @@ buildForAnn
   => NameHint -> ForAnn -> IxType n
   -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
   -> m n (Atom n)
-buildForAnn hint ann ixTy@(IxType ty _) body = do
+buildForAnn hint ann ixTy@(IxType iTy ixDict) body = do
   lam <- withFreshBinder hint ixTy \b -> do
     let v = binderName b
     body' <- buildBlock $ body $ sink v
     effs <- getEffects body'
-    return $ Lam $ LamExpr (LamBinder b ty PlainArrow effs) body'
-  liftM Var $ emit $ Hof $ For ann (IxTy ixTy) lam
+    return $ Lam $ LamExpr (LamBinder b iTy PlainArrow effs) body'
+  liftM Var $ emit $ Hof $ For ann iTy ixDict lam
 
 buildFor :: (Emits n, ScopableBuilder m)
          => NameHint -> Direction -> IxType n

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -247,7 +247,6 @@ instance HasType Atom where
       params' <- mapM substM params
       checkArgTys paramBs params'
       return TyKind
-    IxTy ixTy -> checkE ixTy >> return (TC IxTypeKind)
     LabeledRow elems -> checkFieldRowElems elems $> LabeledRowKind
     Record items -> StaticRecordTy <$> mapM getTypeE items
     RecordTy elems -> checkFieldRowElems elems $> TyKind
@@ -476,7 +475,6 @@ typeCheckPrimTC tc = case tc of
   EffectRowKind    -> return TyKind
   LabeledRowKindTC -> return TyKind
   LabelType        -> return TyKind
-  IxTypeKind       -> return TyKind
 
 typeCheckPrimCon :: Typer m => PrimCon (Atom i) -> m i o (Type o)
 typeCheckPrimCon con = case con of
@@ -724,14 +722,13 @@ typeCheckPrimOp op = case op of
 
 typeCheckPrimHof :: Typer m => PrimHof (Atom i) -> m i o (Type o)
 typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
-  For _ ixTyAtom f -> do
-    IxTy ixTy <- return ixTyAtom
-    ixTy' <- checkE ixTy
+  For _ iTy ixDict f -> do
+    ixTy <- checkE $ IxType iTy ixDict
     Pi (PiType (PiBinder b argTy PlainArrow) eff eltTy) <- getTypeE f
-    checkAlphaEq (ixTypeType ixTy') argTy
+    checkAlphaEq (ixTypeType ixTy) argTy
     eff' <- liftHoistExcept $ hoist b eff
     declareEffs eff'
-    return $ TabTy (b:>ixTy') eltTy
+    return $ TabTy (b:>ixTy) eltTy
   While body -> do
     Pi (PiType (PiBinder b UnitTy PlainArrow) eff condTy) <- getTypeE body
     PairE eff' condTy' <- liftHoistExcept $ hoist b $ PairE eff condTy
@@ -773,12 +770,11 @@ typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
     PairE eff' resultTy' <- liftHoistExcept $ hoist b $ PairE eff resultTy
     extendAllowedEffect ExceptionEffect $ declareEffs eff'
     return $ MaybeTy resultTy'
-  Seq _ ixTyAtom carry f -> do
-    IxTy ixTy <- return ixTyAtom
-    ixTy' <- checkE ixTy
+  Seq _ iTy ixDict carry f -> do
+    ixTy <- checkE $ IxType iTy ixDict
     carryTy' <- getTypeE carry
     Pi (PiType (PiBinder b argTy PlainArrow) eff UnitTy) <- getTypeE f
-    checkAlphaEq (PairTy (ixTypeType ixTy') carryTy') argTy
+    checkAlphaEq (PairTy (ixTypeType ixTy) carryTy') argTy
     declareEffs =<< liftHoistExcept (hoist b eff)
     RawRefTy _ <- return carryTy'  -- We might need allow products of references too.
     return carryTy'

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -90,7 +90,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   DictCon dictExpr -> DictCon <$> tge dictExpr
   DictTy (DictType sn cn params) ->
     DictTy <$> (DictType sn <$> substM cn <*> mapM tge params)
-  IxTy (IxType ty d) -> IxTy <$> (IxType <$> tge ty <*> tge d)
   LabeledRow elems -> LabeledRow <$> traverseGenericE elems
   Record items -> Record <$> mapM tge items
   RecordTy elems -> RecordTy <$> traverseGenericE elems

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -548,8 +548,8 @@ toImpHof :: Emits o => Maybe (Dest o) -> PrimHof (Atom i) -> SubstImpM i o (Atom
 toImpHof maybeDest hof = do
   resultTy <- getTypeSubst (Hof hof)
   case hof of
-    For d (IxTy ixTy) (Lam (LamExpr b body)) -> do
-      ixTy' <- substM ixTy
+    For d iTy ixDict (Lam (LamExpr b body)) -> do
+      ixTy' <- substM $ IxType iTy ixDict
       n <- indexSetSizeImp ixTy'
       dest <- allocDest maybeDest resultTy
       emitLoop (getNameHint b) d n \i -> do
@@ -591,8 +591,8 @@ toImpHof maybeDest hof = do
     RunIO (Lam (LamExpr b body)) ->
       extendSubst (b@>SubstVal UnitVal) $
         translateBlock maybeDest body
-    Seq d (IxTy ixTy) carry (Lam (LamExpr b body)) -> do
-      ixTy' <- substM ixTy
+    Seq d iTy ixDict carry (Lam (LamExpr b body)) -> do
+      ixTy' <- substM $ IxType iTy ixDict
       carry' <- substM carry
       n <- indexSetSizeImp ixTy'
       emitLoop (getNameHint b) d n \i -> do

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -856,8 +856,8 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
         checkULam uLamExpr lamPiTy
       Check _ -> inferULam allowedEff uLamExpr
       Infer   -> inferULam allowedEff uLamExpr
-    ixTy <- asIxType $ binderType b'
-    result <- liftM Var $ emit $ Hof $ For dir (IxTy ixTy) lam
+    IxType iTy ixDict <- asIxType $ binderType b'
+    result <- liftM Var $ emit $ Hof $ For dir iTy ixDict lam
     matchRequirement result
   UApp _ _ -> do
     let (f, args) = asNaryApp $ WithSrcE pos expr
@@ -930,7 +930,6 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
   UHole -> case reqTy of
     Infer -> throw MiscErr "Can't infer type of hole"
     Check ty -> freshType ty
-  UIndexType ty -> IxTy <$> (checkUType ty >>= asIxType)
   UTypeAnn val ty -> do
     ty' <- zonk =<< checkUType ty
     val' <- checkSigma val ty'
@@ -2217,7 +2216,6 @@ instance Unifiable Atom where
         zipWithM_ unify (toList con) (toList con')
       (Eff eff, Eff eff') -> unify eff eff'
       (DictTy d, DictTy d') -> unify d d'
-      (IxTy ixTy, IxTy ixTy') -> unify ixTy ixTy'
       _ -> unifyEq e1 e2
 
 instance Unifiable DictType where

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -91,7 +91,6 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   TC  tc  -> TC  <$> mapM rec tc
   DictCon _ -> substM atom
   DictTy  _ -> substM atom
-  IxTy    _ -> substM atom
   Eff _ -> substM atom
   TypeCon sn defName (DataDefParams params dicts) -> do
     defName' <- substM defName

--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -40,26 +40,27 @@ instance HoistableState LFS where
 
 instance GenericTraverser LFS where
   traverseExpr expr = case expr of
-    Hof (For dir ixTy (Lam body)) -> traverseFor Nothing dir ixTy body
+    Hof (For dir iTy ixDict (Lam body)) -> traverseFor Nothing dir iTy ixDict body
     _ -> traverseExprDefault expr
 
 type Dest = Atom
 
-traverseFor :: Emits o => Maybe (Dest o) -> ForAnn -> Atom i -> LamExpr i -> LowerM i o (Expr o)
-traverseFor maybeDest dir ixTy lam@(LamExpr (LamBinder ib ty arr eff) body) = do
+traverseFor :: Emits o => Maybe (Dest o) -> ForAnn -> Atom i -> Atom i -> LamExpr i -> LowerM i o (Expr o)
+traverseFor maybeDest dir iTy ixDict lam@(LamExpr (LamBinder ib ty arr eff) body) = do
   initDest <- case maybeDest of
     Just  d -> return d
-    Nothing -> emitOp . AllocDest =<< getTypeSubst (Hof $ For dir ixTy (Lam lam))
+    Nothing -> emitOp . AllocDest =<< getTypeSubst (Hof $ For dir iTy ixDict (Lam lam))
   destTy <- getType initDest
   ty' <- substM ty
-  ixTy' <- substM ixTy
+  iTy' <- substM iTy
+  ixDict' <- substM ixDict
   eff' <- substM $ ignoreHoistFailure $ hoist ib eff
   body' <- buildLam noHint arr (PairTy ty' destTy) eff' \b' -> do
     (i, dest) <- fromPair $ Var b'
     idest <- emitOp $ IndexRef dest i
     extendSubst (ib @> SubstVal i) $ traverseBlockWithDest idest body
     return UnitVal
-  let seqHof = Hof $ Seq dir ixTy' initDest body'
+  let seqHof = Hof $ Seq dir iTy' ixDict' initDest body'
   case maybeDest of
     Just _  -> return seqHof
     Nothing -> Op . Freeze . Var <$> emit seqHof
@@ -109,7 +110,7 @@ traverseDeclNestWithDestS destMap s = \case
 
 traverseExprWithDest :: Emits o => Maybe (Dest o) -> Expr i -> LowerM i o (Expr o)
 traverseExprWithDest dest expr = case expr of
-  Hof (For dir ixTy (Lam body)) -> traverseFor dest dir ixTy body
+  Hof (For dir iTy ixDict (Lam body)) -> traverseFor dest dir iTy ixDict body
   _ -> do
     expr' <- traverseExprDefault expr
     case dest of
@@ -162,14 +163,13 @@ vectorizeLoopsRec frag = \case
     let narrowestTypeByteWidth = 1  -- TODO: This is too conservative! Find the shortest type in the loop.
     let loopWidth = vectorByteWidth `div` narrowestTypeByteWidth
     v <- case expr of
-      Hof (Seq dir (IxTy (IxType _ (DictCon (IxFin (IdxRepVal n))))) dest (Lam body))
+      Hof (Seq dir _ (DictCon (IxFin (IdxRepVal n))) dest (Lam body))
         | n `mod` loopWidth == 0 -> do
           Distinct <- getDistinct
           let vn = IdxRepVal $ n `div` loopWidth
-          let ixTy' = IxTy $ IxType (TC $ Fin vn) (DictCon $ IxFin vn)
           body' <- vectorizeSeq loopWidth (TC $ Fin vn) frag body
           dest' <- applySubst frag dest
-          emit $ Hof $ Seq dir ixTy' dest' body'
+          emit $ Hof $ Seq dir (TC $ Fin vn) (DictCon $ IxFin vn) dest' body'
       _ -> emitDecl (getNameHint b) ann =<< applySubst frag expr
     vectorizeLoopsRec (frag <.> b @> v) rest
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -153,9 +153,9 @@ instance PrettyPrec (Expr n) where
   prettyPrec (App f xs) = atPrec AppPrec $ pApp f <+> spaced (toList xs)
   prettyPrec (TabApp f xs) = atPrec AppPrec $ pApp f <> "." <> dotted (toList xs)
   prettyPrec (Op  op ) = prettyPrec op
-  prettyPrec (Hof (For ann _ (Lam lamExpr))) =
+  prettyPrec (Hof (For ann _ _ (Lam lamExpr))) =
     atPrec LowestPrec $ forStr ann <+> prettyLamHelper lamExpr (PrettyFor ann)
-  prettyPrec (Hof (Seq ann _ c (Lam (LamExpr (LamBinder b ty _ effs) body)))) =
+  prettyPrec (Hof (Seq ann _ _ c (Lam (LamExpr (LamBinder b ty _ effs) body)))) =
     atPrec LowestPrec $ "seq" <+> pApp ann <+> pApp c <+> prettyLam (p (b:>ty) <> ".") effs body
   prettyPrec (Hof hof) = prettyPrec hof
   prettyPrec (Case e alts _ effs) = prettyPrecCase "case" e alts effs
@@ -266,7 +266,6 @@ instance PrettyPrec (Atom n) where
       _  -> atPrec LowestPrec $ pAppArg (p name) params
     DictCon d -> atPrec LowestPrec $ p d
     DictTy  t -> atPrec LowestPrec $ p t
-    IxTy ixTy -> atPrec LowestPrec $ p ixTy
     LabeledRow elems -> prettyRecordTyRow elems "?"
     Record items -> prettyLabeledItems items (line' <> ",") " ="
     Variant _ label i value -> prettyVariant ls label value where
@@ -371,7 +370,7 @@ prettyLamHelper lamExpr lamType = let
         | lamType == PrettyLam arr' ->
             let (binders', effs'', block) = rec next False
             in (thisOne <> binders', unsafeCoerceE (effs' <> effs''), unsafeCoerceE block)
-      Abs Empty (Hof (For ann _ (Lam next)))
+      Abs Empty (Hof (For ann _ _ (Lam next)))
         | lamType == PrettyFor ann ->
             let (binders', effs'', block) = rec next False
             in (thisOne <> binders', unsafeCoerceE (effs' <> effs''), unsafeCoerceE block)
@@ -639,7 +638,6 @@ instance PrettyPrec (UExpr' n) where
     UTabPi piType -> prettyPrec piType
     UDecl declExpr -> prettyPrec declExpr
     UHole -> atPrec ArgPrec "_"
-    UIndexType ty -> atPrec ArgPrec $ "IxTy" <+> p ty
     UTypeAnn v ty -> atPrec LowestPrec $
       group $ pApp v <> line <> ":" <+> pApp ty
     UTabCon xs -> atPrec ArgPrec $ p xs
@@ -870,7 +868,6 @@ instance PrettyPrec e => PrettyPrec (PrimTC e) where
     EffectRowKind -> atPrec ArgPrec "EffKind"
     LabeledRowKindTC -> atPrec ArgPrec "Fields"
     LabelType -> atPrec ArgPrec "Label"
-    _ -> prettyExprDefault $ TCExpr con
 
 instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimCon e) where
@@ -930,7 +927,7 @@ prettyExprDefault expr =
 instance PrettyPrec e => Pretty (PrimHof e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimHof e) where
   prettyPrec hof = case hof of
-    For ann _ lam -> atPrec LowestPrec $ forStr ann <+> pArg lam
+    For ann _ _ lam -> atPrec LowestPrec $ forStr ann <+> pArg lam
     _ -> prettyExprDefault $ HofExpr hof
 
 instance PrettyPrec Direction where

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -675,9 +675,7 @@ uPrim = withSrc $ do
   s <- primName
   case strToPrimName s of
     Just prim -> UPrimExpr <$> traverse (const leafExpr) prim
-    Nothing -> case s of
-      "IndexType" -> UIndexType <$> leafExpr
-      _ -> fail $ "Unrecognized primitive: " ++ s
+    Nothing -> fail $ "Unrecognized primitive: " ++ s
 
 uVariantExpr :: Parser (UExpr VoidS)
 uVariantExpr = withSrc $ parseVariant expr UVariant UVariantLift

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -196,7 +196,6 @@ instance SourceRenamableE UExpr' where
     UCase scrut alts ->
       UCase <$> sourceRenameE scrut <*> mapM sourceRenameE alts
     UHole -> return UHole
-    UIndexType ty -> UIndexType <$> sourceRenameE ty
     UTypeAnn e ty -> UTypeAnn <$> sourceRenameE e <*> sourceRenameE ty
     UTabCon xs -> UTabCon <$> mapM sourceRenameE xs
     UPrimExpr e -> UPrimExpr <$> mapM sourceRenameE e

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -286,7 +286,6 @@ transposeAtom atom ct = case atom of
   DictCon _       -> notTangent
   DictTy _        -> notTangent
   TypeCon _ _ _   -> notTangent
-  IxTy _          -> notTangent
   LabeledRow _    -> notTangent
   RecordTy _      -> notTangent
   VariantTy _     -> notTangent
@@ -310,9 +309,9 @@ transposeAtom atom ct = case atom of
 
 transposeHof :: Emits o => Hof i -> Atom o -> TransposeM i o ()
 transposeHof hof ct = case hof of
-  For ann ~(IxTy d) (Lam (LamExpr b  body)) -> do
-    ty <- substNonlin d
-    void $ buildForAnn (getNameHint b) (flipDir ann) ty \i -> do
+  For ann iTy d (Lam (LamExpr b  body)) -> do
+    ixTy <- substNonlin $ IxType iTy d
+    void $ buildForAnn (getNameHint b) (flipDir ann) ixTy \i -> do
       ctElt <- tabApp (sink ct) (Var i)
       extendSubst (b@>RenameNonlin i) $ transposeBlock body ctElt
       return UnitVal

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -60,7 +60,6 @@ data Atom (n::S) =
  | TypeCon SourceName (DataDefName n) (DataDefParams n)
  | DictCon (DictExpr n)
  | DictTy  (DictType n)
- | IxTy    (IxType n)
  | LabeledRow (FieldRowElems n)
  | Record (LabeledItems (Atom n))
  | RecordTy  (FieldRowElems n)
@@ -953,13 +952,12 @@ instance GenericE Atom where
   {- TC -}         (ComposeE PrimTC  Atom)
   {- Eff -}        EffectRow
   {- ACase -}      ( Atom `PairE` ListE (AltP Atom) `PairE` Type )
-            ) (EitherE4
+            ) (EitherE3
   {- BoxedRef -}   ( ListE (Atom `PairE` Block) `PairE` NaryAbs AtomNameC Atom )
   {- DataConRef -} ( DataDefName                    `PairE`
                      DataDefParams                  `PairE`
                      EmptyAbs (Nest DataConRefBinding) )
-  {- DepPairRef -} ( Atom `PairE` Abs Binder Atom `PairE` DepPairType)
-  {- IxTy -}       IxType)
+  {- DepPairRef -} ( Atom `PairE` Abs Binder Atom `PairE` DepPairType))
 
   fromE atom = case atom of
     Var v -> Case0 (Case0 v)
@@ -994,7 +992,6 @@ instance GenericE Atom where
     DataConRef defName params bs -> Case5 $ Case1 $ defName `PairE` params `PairE` bs
     DepPairRef lhs rhs ty ->
       Case5 $ Case2 $ lhs `PairE` rhs `PairE` ty
-    IxTy ixTy -> Case5 $ Case3 ixTy
   {-# INLINE fromE #-}
 
   toE atom = case atom of
@@ -1039,7 +1036,6 @@ instance GenericE Atom where
       Case0 (ListE ptrsAndSizes `PairE` ab) -> BoxedRef (map fromPairE ptrsAndSizes) ab
       Case1 (defName `PairE` params `PairE` bs) -> DataConRef defName params bs
       Case2 (lhs `PairE` rhs `PairE` ty) -> DepPairRef lhs rhs ty
-      Case3 ixTy -> IxTy ixTy
       _ -> error "impossible"
   {-# INLINE toE #-}
 

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -54,7 +54,6 @@ data PrimTC e =
       | EffectRowKind
       | LabeledRowKindTC
       | LabelType
-      | IxTypeKind
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 traversePrimTC :: Applicative f => (e -> f e') -> PrimTC e -> f (PrimTC e')
@@ -151,7 +150,7 @@ traversePrimOp = inline traverse
 {-# INLINABLE traversePrimOp #-}
 
 data PrimHof e =
-        For ForAnn e e        -- Ix type, body lambda
+        For ForAnn e e e        -- index type, ix dict, body lambda
       | While e
       | RunReader e e
       | RunWriter (BaseMonoidP e) e
@@ -161,7 +160,7 @@ data PrimHof e =
       | Linearize e
       | Transpose e
       -- Dex abstract machine ops
-      | Seq Direction e e e   -- Ix type, carry dests, body lambda
+      | Seq Direction e e e e   -- index type, ix dict, carry dests, body lambda
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data BaseMonoidP e = BaseMonoid { baseEmpty :: e, baseCombine :: e }

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -84,7 +84,6 @@ data UExpr' (n::S) =
  | UFor Direction (UForExpr n)
  | UCase (UExpr n) [UAlt n]
  | UHole
- | UIndexType (UExpr n)
  | UTypeAnn (UExpr n) (UExpr n)
  | UTabCon [UExpr n]
  | UPrimExpr (PrimExpr (UExpr n))


### PR DESCRIPTION
Instead, `For` and `Seq` take the index type and the dict as separate argumnets.