### PR TITLE
Teach Github's doc generator install the /usr/share/dict/words dictionary

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -13,7 +13,7 @@ jobs:
         os: [ubuntu-20.04]
         include:
           - os: ubuntu-20.04
-            install_deps: sudo apt-get install llvm-12-tools llvm-12-dev pkg-config
+            install_deps: sudo apt-get install llvm-12-tools llvm-12-dev pkg-config wamerican
             path_extension: /usr/lib/llvm-12/bin
 
     steps:


### PR DESCRIPTION
since we use it as a data set in one of our rendered examples.