### PR TITLE
Add a Read-like interface for parsing Strings into Dex values

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1461,6 +1461,12 @@ def string_from_char_ptr (n:Nat) (ptr:Ptr Char) : {IO} String =
 -- TODO. This is ASCII code point. It really should be Int32 for Unicode codepoint
 def codepoint (c:Char) : Int = w8_to_i c
 
+data CString = MkCString RawPtr
+-- TODO: check the string contains no nulls
+def with_c_string {a} (s:String) (action: CString -> {IO} a) : {IO} a =
+  (AsList n s') = s <> "\NUL"
+  with_table_ptr s' \(MkPtr ptr). action $ MkCString ptr
+
 '### Show interface
 For things that can be shown.
 `show` gives a string representation of its input.
@@ -1512,6 +1518,25 @@ instance Show Float64
 instance {a b} [Show a, Show b] Show (a & b)
   show = \(a, b). "(" <> show a <> ", " <> show b <> ")"
 
+'### Parse interface
+For types that can be parsed from a `String`.
+
+interface Parse a
+  parseString : String -> Maybe a
+
+foreign "strtof" strtofFFI : RawPtr -> RawPtr -> {IO} Float
+
+instance Parse Float
+  parseString = \str. unsafe_io do
+    (AsList str_len _) = str
+    with_c_string str \(MkCString str_ptr).
+      with_alloc 1 \end_ptr:(Ptr (Ptr Char)).
+        (MkPtr raw_end_ptr) = end_ptr
+        result = strtofFFI str_ptr raw_end_ptr
+        (MkPtr str_end_ptr) = load end_ptr
+        consumed = raw_ptr_to_i64 str_end_ptr - raw_ptr_to_i64 str_ptr
+        if consumed == (n_to_i64 str_len) then Just result else Nothing
+
 '## pipe-like reverse function application
 TODO: move this
 
@@ -1548,7 +1573,6 @@ def either_is_nan (x:Float) (y:Float) : Bool = (isnan x) || (isnan y)
 '## File system operations
 
 FilePath : Type = String
-data CString = MkCString RawPtr
 
 def null_raw_ptr : RawPtr = i64_to_raw_ptr $ i_to_i64 0
 
@@ -1566,11 +1590,6 @@ data StreamMode =
   WriteMode
 
 data Stream mode:StreamMode = MkStream RawPtr
-
--- TODO: check the string contains no nulls
-def with_c_string {a} (s:String) (action: CString -> {IO} a) : {IO} a =
-  (AsList n s') = s <> "\NUL"
-  with_table_ptr s' \(MkPtr ptr). action $ MkCString ptr
 
 '### Stream IO
 

--- a/makefile
+++ b/makefile
@@ -200,7 +200,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
 # TODO: re-enable
 # fft vega-plotting
 
-test-names = uexpr-tests adt-tests type-tests eval-tests show-tests \
+test-names = uexpr-tests adt-tests type-tests eval-tests show-tests read-tests \
              shadow-tests monad-tests io-tests exception-tests sort-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests \
@@ -239,7 +239,7 @@ $(tutorial-data):
 .PHONY: tutorial-data
 tutorial-data: $(tutorial-data)
 
-run-examples/tutorial: tutorial-data 
+run-examples/tutorial: tutorial-data
 
 tests: unit-tests lower-tests quine-tests repl-test module-tests
 

--- a/tests/read-tests.dx
+++ b/tests/read-tests.dx
@@ -1,0 +1,8 @@
+parseString "123"   :: Maybe Float
+> (Just 123.)
+parseString "123.4" :: Maybe Float
+> (Just 123.4)
+parseString "123x"  :: Maybe Float
+> Nothing
+parseString "x123"  :: Maybe Float
+> Nothing


### PR DESCRIPTION
... with an initial implementation supporting `Float`s, with parsing
implemented via the `strtof` C function. Obviously that won't fly on the
GPU, but it's not like `String`s work great in that setting, so it
should be good enough for now.

I wanted to call this interface `Read` to match the Haskell
implementation, but it turns out it's already taken for the `Read`
effect. I think there's little reason to even keep that effect visible
in the user space, since one might just pass the value that can be read
in place of the reference it can be read from...