### PR TITLE
Don't inline the body of threefry hash function

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1829,6 +1829,7 @@ Dex's PRNG system is modelled directly after [JAX's](https://github.com/google/j
 -- TODO: newtype
 Key = Word64
 
+@noinline
 def threefry_2x32 (k:Word64) (count:Word64) : Word64 =
   -- Based on jax's threefry_2x32 by Matt Johnson and Peter Hawkins
   rotations1 = [13, 15, 26, 6]


### PR DESCRIPTION
It's huge and it's costing us quite a bit of compile time.