### PR TITLE
Map BUILTIN_LIBRARIES in --lib-path to the standard library path

### DIFF
--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -41,7 +41,7 @@ data AtomEx where
 
 dexCreateContext :: IO (Ptr Context)
 dexCreateContext = do
-  let evalConfig = EvalConfig LLVM Nothing Nothing Nothing Nothing
+  let evalConfig = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing
   cachedEnv <- loadCache
   runTopperM evalConfig cachedEnv (evalSourceBlockRepl preludeImportBlock) >>= \case
     (Result _  (Success  ()), preludeEnv) -> toStablePtr $ Context evalConfig preludeEnv


### PR DESCRIPTION
`--lib-path` is useful to extend the search path with custom libraries,
but it also removes the default search path, unless it is specified
explicitly. After this patch one can use a special `BUILTIN_LIBRARIES`
placeholder in the directory list, which will get replaced with the
directory in which the standard libraries have been installed.