### PR TITLE
Add support for declaring custom function linearizations

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -619,7 +619,7 @@ def (+=) {h w} [am:AccumMonoid h w] (ref:Ref h w) (x:w) : {Accum h} Unit =
   (UnsafeMkAccumMonoidData b bm) = %projMethod0 am
   empty = %projMethod0 bm
   combine = %projMethod1 bm
-  %mextend ref empty combine x
+  %mextend ref empty (\x y. combine x y) x
 
 def (!) {h n a} (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
 def fst_ref {h a b} (ref: Ref h (a & b)) : Ref h a = %fstRef ref
@@ -655,7 +655,7 @@ def run_accum
     accumBaseMonoid = %explicitDict (AccumMonoid h' b) accumMonoidData
     action' = %explicitApply (%explicitApply action h') accumBaseMonoid
     action' ref
-  %runWriter empty combine explicitAction
+  %runWriter empty (\x y. combine x y) explicitAction
 
 def yield_accum
       {a b w eff}
@@ -1181,9 +1181,11 @@ def cumsum_low {n a} [Add a] (xs: n=>a) : n=>a =
 '### AD operations
 
 -- TODO: add vector space constraints
-def linearize {a b} (f:a->b) (x:a) : (b & a --o b) = %linearize f x
+def linearize {a b} (f:a->b) (x:a) : (b & a --o b) = %linearize (\x. f x) x
 def jvp {a b} (f:a->b) (x:a) : a --o b = snd (linearize f x)
-def transpose_linear {a b} (f:a --o b) : b --o a = %linearTranspose f
+def transpose_linear {a b} (f:a --o b) : b --o a =
+  f' : a --o b = \x. f x
+  %linearTranspose f'
 
 def vjp {a b} (f:a->b) (x:a) : (b & b --o a) =
   (y, df) = linearize f x

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -29,7 +29,7 @@ module Builder (
   emitBlock, emitDecls, BuilderEmissions, emitAtomToName,
   TopBuilder (..), TopBuilderT (..), liftTopBuilderTWith, runTopBuilderT, TopBuilder2,
   emitSourceMap, emitSynthCandidates, addInstanceSynthCandidate,
-  emitTopLet, emitImpFunBinding,
+  emitTopLet, emitImpFunBinding, emitCustomLinearization,
   lookupLoadedModule, bindModule, getAllRequiredObjectFiles, extendCache,
   extendImpCache, queryImpCache, extendObjCache, queryObjCache, getCache, emitObjFile,
   TopEnvFrag (..), emitPartialTopEnvFrag, emitLocalModuleEnv,
@@ -72,6 +72,7 @@ import {-# SOURCE #-} Interpreter
 import LabeledItems
 import Util (enumerate, restructure, transitiveClosureM, bindM2, iota)
 import Err
+import Types.Core
 import Core
 
 -- === Ordinary (local) builder class ===
@@ -148,6 +149,10 @@ emitSynthCandidates sc = emitLocalModuleEnv $ mempty {envSynthCandidates = sc}
 addInstanceSynthCandidate :: TopBuilder m => ClassName n -> InstanceName n -> m n ()
 addInstanceSynthCandidate className instanceName =
   emitSynthCandidates $ SynthCandidates [] (M.singleton className [instanceName])
+
+emitCustomLinearization :: TopBuilder m => AtomName n -> Atom n -> m n ()
+emitCustomLinearization v f = emitNamelessEnv $
+  TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v (CustomLinearize f) }
 
 emitTopLet :: (Mut n, TopBuilder m) => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
 emitTopLet hint letAnn expr = do

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -6,7 +6,7 @@
 
 module CheckType (
   CheckableE (..), CheckableB (..),
-  checkTypes, checkTypesM,
+  checkTypes, checkTypesM, checkHasType,
   checkExtends, checkedApplyClassParams,
   tryGetType,
   checkUnOp, checkBinOp,
@@ -48,6 +48,10 @@ checkTypesM e = liftExcept =<< checkTypes e
 tryGetType :: (EnvReader m, Fallible1 m, HasType e) => e n -> m n (Type n)
 tryGetType e = liftExcept =<< liftTyperT (getTypeE e)
 {-# INLINE tryGetType #-}
+
+checkHasType :: (EnvReader m, HasType e) => e n -> Type n -> m n (Except ())
+checkHasType e ty = liftM void $ liftTyperT $ checkTypeE ty e
+{-# INLINE checkHasType #-}
 
 -- === the type checking/querying monad ===
 

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -377,6 +377,11 @@ lookupAtomName :: EnvReader m => AtomName n -> m n (AtomBinding n)
 lookupAtomName name = lookupEnv name >>= \case AtomNameBinding x -> return x
 {-# INLINE lookupAtomName #-}
 
+lookupCustomRules :: EnvReader m => AtomName n -> m n (Maybe (AtomRules n))
+lookupCustomRules name = liftM fromMaybeE $ withEnv $
+  toMaybeE . M.lookup name . customRulesMap . envCustomRules . topEnv
+{-# INLINE lookupCustomRules #-}
+
 lookupImpFun :: EnvReader m => ImpFunName n -> m n (ImpFunction n)
 lookupImpFun name = lookupEnv name >>= \case ImpFunBinding f -> return f
 {-# INLINE lookupImpFun #-}

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -72,7 +72,7 @@ module Name (
   newName, newNameM, newNames,
   unsafeCoerceE, unsafeCoerceB, ColorsEqual (..), eqColorRep,
   sinkR, fmapSubstFrag, catRecSubstFrags, extendRecSubst,
-  freeVarsList, isFreeIn, anyFreeIn, todoSinkableProof,
+  freeVarsList, isFreeIn, anyFreeIn, isInNameSet, todoSinkableProof,
   locallyMutableInplaceT, liftBetweenInplaceTs, toExtWitness,
   updateSubstFrag, nameSetToList, toNameSet, hoistFilterNameSet, NameSet, absurdExtEvidence,
   Mut, fabricateDistinctEvidence,
@@ -2665,6 +2665,9 @@ toNameSet (UnsafeMakeScopeFrag s) = s
 nameSetRawNames :: NameSet n -> [RawName]
 nameSetRawNames m = R.keys m
 
+isInNameSet :: Name c n -> NameSet n -> Bool
+isInNameSet v ns = getRawName v `R.member` ns
+
 isFreeIn :: HoistableE e => Name c n -> e n -> Bool
 isFreeIn v e = getRawName v `R.member` freeVarsE e
 
@@ -2838,10 +2841,10 @@ substFragAsScope m = UnsafeMakeScopeFrag $ TrulyUnsafe.unsafeCoerce m
 -- === garbage collection ===
 
 collectGarbage :: (HoistableV v, HoistableE e)
-               => Distinct l => RecSubstFrag v n l -> e l
+               => Distinct l => RecSubstFrag v n l -> (Name c l -> NameSet l) -> e l
                -> (forall l'. Distinct l' => RecSubstFrag v n l' -> e l' -> a)
                -> a
-collectGarbage (RecSubstFrag (UnsafeMakeSubst env)) e cont = do
+collectGarbage (RecSubstFrag (UnsafeMakeSubst env)) extraDeps e cont = do
   let seedNames = R.keys $ freeVarsE e
   let accessibleNames = transitiveClosure getParents seedNames
   let env' = RecSubstFrag $ UnsafeMakeSubst $ R.restrictKeys env accessibleNames
@@ -2854,7 +2857,7 @@ collectGarbage (RecSubstFrag (UnsafeMakeSubst env)) e cont = do
       Just item | itemDistinctness item == ShadowingName ->
         error "shouldn't be possible, due to Distinct constraint"
 #endif
-      Just item -> R.keys $ fromSubstItemPoly item freeVarsE
+      Just item -> (R.keys $ fromSubstItemPoly item freeVarsE) <> (R.keys $ extraDeps $ UnsafeMakeName name)
 
 -- === iterating through env pairs ===
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -37,6 +37,7 @@ import LabeledItems
 import Err
 import Name
 import Syntax
+import Types.Core
 import Parser (showPrimName)
 
 -- A DocPrec is a slightly context-aware Doc, specifically one that
@@ -503,10 +504,14 @@ instance Pretty (MethodType n) where
 deriving instance (forall c n. Pretty (v c n)) => Pretty (RecSubst v o)
 
 instance Pretty (TopEnv n) where
-  pretty (TopEnv defs cache ms) =
+  pretty (TopEnv defs rules cache ms) =
     prettyRecord [ ("Defs"          , p defs)
+                 , ("Rules"         , p rules)
                  , ("Cache"         , p cache)
                  , ("Loaded modules", p ms)]
+
+instance Pretty (CustomRules n) where
+  pretty _ = "TODO: Rule printing"
 
 instance Pretty (ImportStatus n) where
   pretty imports = pretty $ S.toList $ directImports imports

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -108,6 +108,11 @@ declareForeign = do
   eol
   return $ DeclareForeign foreignName $ UAnnBinder (fromString b) ty
 
+declareCustomLinearization :: Parser SourceBlock'
+declareCustomLinearization = do
+  keyWord CustomLinearizationKW
+  (DeclareCustomLinearization <$> anyCaseName <*> expr) <* eol
+
 sourceBlock :: Parser SourceBlock
 sourceBlock = do
   offset <- getOffset
@@ -177,6 +182,7 @@ topLevelCommand :: Parser SourceBlock'
 topLevelCommand =
       importModule
   <|> declareForeign
+  <|> declareCustomLinearization
   <|> (QueryEnv <$> envQuery)
   <|> explicitCommand
   <?> "top-level command"
@@ -1095,6 +1101,7 @@ data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
              | ReadKW | WriteKW | StateKW | DataKW | InterfaceKW
              | InstanceKW | WhereKW | IfKW | ThenKW | ElseKW | DoKW
              | ExceptKW | IOKW | ViewKW | ImportKW | ForeignKW | NamedInstanceKW
+             | CustomLinearizationKW
 
 nextChar :: Lexer Char
 nextChar = do
@@ -1154,6 +1161,7 @@ keyWord kw = lexeme $ try $ string s >> notFollowedBy nameTailChar
       ViewKW -> "view"
       ImportKW -> "import"
       ForeignKW -> "foreign"
+      CustomLinearizationKW -> "custom-linearization"
 
 keyWordSet :: HS.HashSet String
 keyWordSet = HS.fromList keyWordStrs
@@ -1162,7 +1170,7 @@ keyWordStrs :: [String]
 keyWordStrs = ["def", "for", "for_", "rof", "rof_", "case", "of", "llam",
                "Read", "Write", "Accum", "Except", "IO", "data", "interface",
                "instance", "named-instance", "where", "if", "then", "else",
-               "do", "view", "import", "foreign"]
+               "do", "view", "import", "foreign", "custom-linearization"]
 
 fieldLabel :: Lexer Label
 fieldLabel = label "field label" $ lexeme $

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -46,8 +46,10 @@ import Serialize (HasPtrs (..), pprintVal, getDexString, takePtrSnapshot, restor
 import Name
 import Parser
 import Syntax
+import Core
+import Types.Core
 import Builder
-import CheckType (CheckableE (..), asFFIFunType, asFirstOrderFunction)
+import CheckType (CheckableE (..), asFFIFunType, asFirstOrderFunction, checkHasType)
 #ifdef DEX_DEBUG
 import CheckType (checkTypesM)
 #endif
@@ -231,6 +233,51 @@ evalSourceBlock' mname block = case sbContents block of
         UBindSource sourceName <- return b
         emitSourceMap $ SourceMap $
           M.singleton sourceName [ModuleVar mname (Just $ UAtomVar vCore)]
+  DeclareCustomLinearization fname expr -> do
+    lookupSourceMap fname >>= \case
+      Nothing -> throw UnboundVarErr $ pprint fname
+      Just (UAtomVar fname') -> do
+        lookupCustomRules fname' >>= \case
+          Nothing -> return ()
+          Just _  -> throw TypeErr $ pprint fname ++ " already has a custom linearization"
+        impl <- evalUExpr expr
+        fType <- getType fname'
+        let but = ", but " ++ pprint fname ++ " has type " ++ pprint fType
+        case fType of
+          Pi (PiType (PiBinder binder a arr) eff b') -> do
+            unless (arr == PlainArrow) $ throw TypeErr $
+              "Custom linearization can only be defined for regular functions" ++ but
+            unless (eff == Pure) $ throw TypeErr $
+              "Custom linearization can only be defined for pure functions" ++ but
+            b <- case hoist binder b' of
+              HoistSuccess b -> return b
+              HoistFailure _ -> throw TypeErr $
+                "Custom linearization cannot be defined for dependent functions" ++ but
+            at <- maybeTangentType a >>= \case
+              Just at -> return at
+              Nothing -> throw TypeErr $
+                "The type of argument of " ++ pprint fname ++ " does not have a well-defined tangent space"
+            bt <- maybeTangentType b >>= \case
+              Just bt -> return bt
+              Nothing -> throw TypeErr $
+                "The type of result of " ++ pprint fname ++ " does not have a well-defined tangent space." ++
+                " Is it a unary function?"
+            tanFunTy <- at --> bt
+            linFunTy <- a --> PairTy b tanFunTy
+            impl `checkHasType` linFunTy >>= \case
+              Failure _ -> do
+                implTy <- getType impl
+                throw TypeErr $ unlines
+                  [ "Expected the custom linearization to have type:"
+                  , pprint linFunTy
+                  , "but it has type:"
+                  , pprint implTy
+                  ]
+              Success () -> return ()
+            emitCustomLinearization fname' impl
+          _ -> throw TypeErr $
+            "Custom linearization can only be defined for functions" ++ but
+      Just _ -> throw TypeErr $ "Custom linearization can only be defined for functions"
   GetNameType v -> do
     ty <- sourceNameType v
     logTop $ TextOut $ pprintCanonicalized ty
@@ -357,9 +404,9 @@ evalPartiallyParsedUModule partiallyParsed = do
 evalUModule :: (Topper m  ,Mut n) => UModule -> m n (Module n)
 evalUModule (UModule name _ blocks) = do
   Abs topFrag UnitE <- localTopBuilder $ mapM_ (evalSourceBlock' name) blocks >> return UnitE
-  TopEnvFrag envFrag (PartialTopEnvFrag cache loadedModules moduleEnv) <- return topFrag
+  TopEnvFrag envFrag (PartialTopEnvFrag cache rules loadedModules moduleEnv) <- return topFrag
   ModuleEnv (ImportStatus directDeps transDeps) sm scs objs _ <- return moduleEnv
-  let fragToReEmit = TopEnvFrag envFrag $ PartialTopEnvFrag cache loadedModules mempty
+  let fragToReEmit = TopEnvFrag envFrag $ PartialTopEnvFrag cache rules loadedModules mempty
   let evaluatedModule = Module name directDeps transDeps sm scs objs
   emitEnv $ Abs fragToReEmit evaluatedModule
 
@@ -629,9 +676,15 @@ clearCache = liftIO do
 -- TODO: real garbage collection (maybe leave it till after we have a
 -- database-backed cache and we can do it incrementally)
 stripEnvForSerialization :: TopStateEx -> TopStateEx
-stripEnvForSerialization (TopStateEx (Env (TopEnv (RecSubst defs) cache _) _)) =
-  collectGarbage (RecSubstFrag defs) cache \(RecSubstFrag defs') cache' -> do
-    TopStateEx $ Env (TopEnv (RecSubst defs') cache' mempty) emptyModuleEnv
+stripEnvForSerialization (TopStateEx (Env (TopEnv (RecSubst defs) (CustomRules rules) cache _) _)) =
+  collectGarbage (RecSubstFrag defs) ruleFreeVars cache \defsFrag'@(RecSubstFrag defs') cache' -> do
+    let liveNames = toNameSet $ toScopeFrag defsFrag'
+    let rules' = unsafeCoerceE $ CustomRules $ M.filterWithKey (\k _ -> k `isInNameSet` liveNames) rules
+    TopStateEx $ Env (TopEnv (RecSubst defs') rules' cache' mempty) emptyModuleEnv
+  where
+    ruleFreeVars v = case M.lookup v rules of
+      Nothing -> mempty
+      Just r  -> freeVarsE r
 
 snapshotPtrs :: MonadIO m => TopStateEx -> m TopStateEx
 snapshotPtrs s = traverseBindingsTopStateEx s \case

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -284,6 +284,21 @@ data DictExpr (n::S) =
  | IxFin (Atom n)
    deriving (Show, Generic)
 
+-- TODO: Use an IntMap
+newtype CustomRules (n::S) = CustomRules { customRulesMap :: M.Map (AtomName n) (AtomRules n) }
+                             deriving (Semigroup, Monoid, Store)
+newtype AtomRules (n::S) = CustomLinearize (Atom n)
+                           deriving (Store, SinkableE, HoistableE, AlphaEqE, SubstE Name)
+
+instance GenericE CustomRules where
+  type RepE CustomRules = ListE (PairE AtomName AtomRules)
+  fromE (CustomRules m) = ListE $ toPairE <$> M.toList m
+  toE (ListE l) = CustomRules $ M.fromList $ fromPairE <$> l
+instance SinkableE CustomRules
+instance HoistableE CustomRules
+instance AlphaEqE CustomRules
+instance SubstE Name CustomRules
+
 -- === envs and modules ===
 
 -- `ModuleEnv` contains data that only makes sense in the context of evaluating
@@ -296,6 +311,7 @@ data Env n = Env
 
 data TopEnv (n::S) = TopEnv
   { envDefs  :: RecSubst Binding n
+  , envCustomRules :: CustomRules n
   , envCache :: Cache n
   , envLoadedModules :: LoadedModules n }
   deriving (Generic)
@@ -350,6 +366,7 @@ data TopEnvFrag n l = TopEnvFrag (EnvFrag n l) (PartialTopEnvFrag l)
 -- names to reflect that.
 data PartialTopEnvFrag n = PartialTopEnvFrag
   { fragCache           :: Cache n
+  , fragCustomRules     :: CustomRules n
   , fragLoadedModules   :: LoadedModules n
   , fragLocalModuleEnv  :: ModuleEnv n }
 
@@ -472,18 +489,19 @@ instance OutFrag EnvFrag where
 
 instance OutMap Env where
   emptyOutMap =
-    Env (TopEnv (RecSubst emptyInFrag) mempty emptyLoadedModules)
+    Env (TopEnv (RecSubst emptyInFrag) mempty mempty emptyLoadedModules)
         emptyModuleEnv
   {-# INLINE emptyOutMap #-}
 
 instance ExtOutMap Env (RecSubstFrag Binding)  where
   -- TODO: We might want to reorganize this struct to make this
   -- do less explicit sinking etc. It's a hot operation!
-  extendOutMap (Env (TopEnv defs cache loaded)
+  extendOutMap (Env (TopEnv defs rules cache loaded)
                     (ModuleEnv imports sm scs objs effs)) frag =
     withExtEvidence frag $ Env
       (TopEnv
         (defs  `extendRecSubst` frag)
+        (sink rules)
         (sink cache)
         (sink loaded))
       (ModuleEnv
@@ -1735,11 +1753,12 @@ instance SubstB Name EnvFrag
 
 instance GenericE PartialTopEnvFrag where
   type RepE PartialTopEnvFrag = Cache
+                              `PairE` CustomRules
                               `PairE` LoadedModules
                               `PairE` ModuleEnv
-  fromE (PartialTopEnvFrag cache loaded env) = cache `PairE` loaded `PairE` env
+  fromE (PartialTopEnvFrag cache rules loaded env) = cache `PairE` rules `PairE` loaded `PairE` env
   {-# INLINE fromE #-}
-  toE (cache `PairE` loaded `PairE` env) = PartialTopEnvFrag cache loaded env
+  toE (cache `PairE` rules `PairE` loaded `PairE` env) = PartialTopEnvFrag cache rules loaded env
   {-# INLINE toE #-}
 
 instance SinkableE      PartialTopEnvFrag
@@ -1748,11 +1767,11 @@ instance AlphaEqE       PartialTopEnvFrag
 instance SubstE Name    PartialTopEnvFrag
 
 instance Semigroup (PartialTopEnvFrag n) where
-  PartialTopEnvFrag x1 x2 x3 <> PartialTopEnvFrag y1 y2 y3 =
-    PartialTopEnvFrag (x1<>y1) (x2<>y2) (x3<>y3)
+  PartialTopEnvFrag x1 x2 x3 x4 <> PartialTopEnvFrag y1 y2 y3 y4=
+    PartialTopEnvFrag (x1<>y1) (x2<>y2) (x3<>y3) (x4<>y4)
 
 instance Monoid (PartialTopEnvFrag n) where
-  mempty = PartialTopEnvFrag mempty mempty mempty
+  mempty = PartialTopEnvFrag mempty mempty mempty mempty
   mappend = (<>)
 
 instance GenericB TopEnvFrag where
@@ -1781,13 +1800,14 @@ instance OutFrag TopEnvFrag where
 -- extend the synthesis candidates based on the annotated let-bound names. It
 -- only extends synth candidates when they're supplied explicitly.
 instance ExtOutMap Env TopEnvFrag where
-  extendOutMap env (TopEnvFrag (EnvFrag frag _) (PartialTopEnvFrag cache' loaded' mEnv')) = result
+  extendOutMap env (TopEnvFrag (EnvFrag frag _) (PartialTopEnvFrag cache' rules' loaded' mEnv')) = result
     where
-      Env (TopEnv defs cache loaded) mEnv = env
+      Env (TopEnv defs rules cache loaded) mEnv = env
       result = Env newTopEnv newModuleEnv
 
       newTopEnv = withExtEvidence frag $ TopEnv
         (defs `extendRecSubst` frag)
+        (sink rules <> rules')
         (sink cache <> cache')
         (sink loaded <> loaded')
 

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -273,6 +273,7 @@ data SourceBlock' =
    EvalUDecl (UDecl VoidS VoidS)
  | Command CmdName (UExpr VoidS)
  | DeclareForeign SourceName (UAnnBinder AtomNameC VoidS VoidS)
+ | DeclareCustomLinearization SourceName (UExpr VoidS)
  | GetNameType SourceName
  | ImportModule ModuleSourceName
  | QueryEnv EnvQuery

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -69,8 +69,9 @@ def sum' {n} (xs:n=>Float) : Float = yield_accum (AddMonoid Float) \ref. for i. 
 :p jvp sum' [1., 2.] [10.0, 20.0]
 > 30.
 
-f : Float -> Float = \x. yield_accum (AddMonoid Float) \ref. ref += x
-:p jvp f 1.0 1.0
+:p
+  f : Float -> Float = \x. yield_accum (AddMonoid Float) \ref. ref += x
+  jvp f 1.0 1.0
 > 1.
 
 :p
@@ -369,3 +370,52 @@ grad (\x . (min' x (x+1))) 1.0
 
 grad (\x . [x].(argmin [x])) 1.0
 > 1.
+
+-------------------- Custom linearization --------------------
+
+f = \x:Float. x * 2
+fLin = \x:Float. (f x, \xt:Float. xt * 4)
+
+custom-linearization f fLin
+
+deriv (\x. f (x * 2) * 5) 1.0
+> 40.
+
+deriv f 1.0
+> 4.
+
+-- Custom derivative is preserved even when we defunctionalize for
+flip deriv 1.0 \x:Float.
+  farr = for i:(Fin 5). f
+  farr.(unsafe_from_ordinal _ 1) x
+> 4.
+
+-- Custom derivative is preserved even when we defunctionalize case
+flip deriv 1.0 \x:Float.
+  total = sum $ for i:(Fin 10). ordinal i
+  f2 = case total > 10 of
+    True  -> f
+    False -> \x:Float. x
+  f2 x
+> 4.
+
+g = \x:(Float & Float). 4 .* x
+
+custom-linearization g \x. (g x, g x)
+> Type error:Expected the custom linearization to have type:
+> ((Float32 & Float32)
+>  -> ((Float32 & Float32) & ((Float32 & Float32) -> (Float32 & Float32))))
+> but it has type:
+> ((Float32 & Float32) -> ((Float32 & Float32) & (Float32 & Float32)))
+
+data IHaveNoTangentType = MkIHaveNoTangentType
+
+noInputTangent = \x:IHaveNoTangentType. 2.0
+
+custom-linearization noInputTangent \x. (noInputTangent x, 0.0)
+> Type error:The type of argument of noInputTangent does not have a well-defined tangent space
+
+noOutputTangent = \x:Float. MkIHaveNoTangentType
+
+custom-linearization noOutputTangent \x. (noOutputTangent x, 0.0)
+> Type error:The type of result of noOutputTangent does not have a well-defined tangent space. Is it a unary function?


### PR DESCRIPTION
This change adds a new syntax for
```
custom-linearization var expr
```
which declares `expr` to be the expression defining the custom
linearization of function defined by `var`. If the type of `var` is
`a -> b`, then `expr` should have type `a -> (b, a -> b)`. I didn't use
linear arrows, because linearity is a bit sketchy in the surface
language at the moment.

It is however still limited, and is mostly meant to be a prototype
implementation to figure out most annoyances. I will make it more
general in following changes (adding support for nary functions and
polymorphism).

---

This required quite a bit of care around simplification, because now the
identities (names) of functions have meaningful effects on AD, so we
can't just inline them all over the place. As such, we now refrain from
inlining bodies of functions defined at the top level. They only get
inlined when they appear on the lhs of an application, except for when
we're under `linearize` and we know that the function has a custom rule
defined.

Note that this inlining now sometimes has to go through multiple hops.
Consider the following program:
```
f = \x. ...
g = f
g 1.0
```
Before, when we began analyzing the expression `g 1.0`, the environment
roughly looked like this:
```
f @> \x. ...
g @> \x. ...  -- inlined body of f
```
However, after this change, `f` will not get inlined eagerly into the
definition of `g`, and the env will look as follows:
```
f @> \x. ...
g @> f
```
meaning that inlining of `g` into `g 1.0` requires us to go through a
chain of lookups.

The impact of that change on performance is unclear, but I would expect
it to be a net positive. We might end up doing more lookups, but they're
generally cheap, and we generally don't write long chains of function
aliases. At the same time, we actually can gain quite a bit by inlining
less eagerly. If we were to serialize the environment after evaluating
the example program ablve, the new one would have a much more compact
representation than the old.