### PR TITLE
Allow custom linearizations of polymorphic functions

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -150,9 +150,9 @@ addInstanceSynthCandidate :: TopBuilder m => ClassName n -> InstanceName n -> m 
 addInstanceSynthCandidate className instanceName =
   emitSynthCandidates $ SynthCandidates [] (M.singleton className [instanceName])
 
-emitCustomLinearization :: TopBuilder m => AtomName n -> Atom n -> m n ()
-emitCustomLinearization v f = emitNamelessEnv $
-  TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v (CustomLinearize f) }
+emitCustomLinearization :: TopBuilder m => AtomName n -> Int -> Atom n -> m n ()
+emitCustomLinearization v ni f = emitNamelessEnv $
+  TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v (CustomLinearize ni f) }
 
 emitTopLet :: (Mut n, TopBuilder m) => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
 emitTopLet hint letAnn expr = do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -287,7 +287,7 @@ simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
       ask >>= \case
         WillLinearize -> do
           lookupCustomRules v >>= \case
-            Just (CustomLinearize _) -> return $ Var v
+            Just (CustomLinearize _ _) -> return $ Var v
             Nothing -> doInline
         NoLinearize -> doInline
       where

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -287,8 +287,17 @@ data DictExpr (n::S) =
 -- TODO: Use an IntMap
 newtype CustomRules (n::S) = CustomRules { customRulesMap :: M.Map (AtomName n) (AtomRules n) }
                              deriving (Semigroup, Monoid, Store)
-newtype AtomRules (n::S) = CustomLinearize (Atom n)
-                           deriving (Store, SinkableE, HoistableE, AlphaEqE, SubstE Name)
+data AtomRules (n::S) = CustomLinearize Int (Atom n)  -- number of implicit args, linearization function
+                        deriving (Generic)
+
+instance GenericE AtomRules where
+  type RepE AtomRules = (LiftE Int) `PairE` Atom
+  fromE (CustomLinearize ni a) = LiftE ni `PairE` a
+  toE (LiftE ni `PairE` a) = CustomLinearize ni a
+instance SinkableE AtomRules
+instance HoistableE AtomRules
+instance AlphaEqE AtomRules
+instance SubstE Name AtomRules
 
 instance GenericE CustomRules where
   type RepE CustomRules = ListE (PairE AtomName AtomRules)
@@ -1988,6 +1997,7 @@ instance Store (PiType n)
 instance Store (TabPiType n)
 instance Store (DepPairType  n)
 instance Store (SuperclassBinders n l)
+instance Store (AtomRules n)
 instance Store (ClassDef     n)
 instance Store (InstanceDef  n)
 instance Store (InstanceBody n)

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -439,3 +439,18 @@ custom-linearization h hLin
 
 deriv (\x. h x x) 1.0 == deriv (\x. x + x) 1.0
 > True
+
+-- Index-polymorphic custom linearization
+def w {n} [Ix n] (x:n=>Float) : n=>Float = 2 .* x
+def wLin {n} [Ix n] (x:n=>Float) : (n=>Float & n=>Float -> n=>Float) = (w x, \xt:(n=>Float). 4 .* xt)
+
+custom-linearization w wLin
+
+jvp (\x. w x) [1.0, 1.0] [1.0, 0.0]
+> [4., 0.]
+
+-- This is a little unexpected at first, but the result makes sense when you think about it...
+-- w has implicit args, so we're really taking a jvp of (w _ _), which is a function returned by
+-- a partial application of w to some inference holes.
+jvp w [1.0, 1.0] [1.0, 0.0]
+> [2., 0.]


### PR DESCRIPTION
Unfortunately, this has a bit of a limited utility, because full
polymorphism is still not allowed. That's because the tangent type
mapping has no user-space definition, so there's no way to spell out a
function of type `Tangent a -> Tangent a` (which is the type of
linearization of `a -> a`). But we can at least handle shape polymorphic
function.