### PR TITLE
Add support for symbolic representation of zero tangents in custom linearization rules

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1197,6 +1197,17 @@ def deriv (f:Float->Float) (x:Float) : Float = jvp f x 1.0
 
 def deriv_rev (f:Float->Float) (x:Float) : Float = snd (vjp f x) 1.0
 
+-- XXX: Watch out when editing this data type! We depend on its structure
+-- deep inside the compiler (mostly in linearization and during rule registration).
+data SymbolicTangent a =
+  ZeroTangent
+  SomeTangent a
+
+def someTangent {a} [VSpace a] (x:SymbolicTangent a) : a =
+  case x of
+    ZeroTangent    -> zero
+    SomeTangent x' -> x'
+
 '### Approximate Equality
 TODO: move this outside the AD section to be with equality?
 

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -29,7 +29,7 @@ module Builder (
   emitBlock, emitDecls, BuilderEmissions, emitAtomToName,
   TopBuilder (..), TopBuilderT (..), liftTopBuilderTWith, runTopBuilderT, TopBuilder2,
   emitSourceMap, emitSynthCandidates, addInstanceSynthCandidate,
-  emitTopLet, emitImpFunBinding, emitSpecialization, emitCustomLinearization,
+  emitTopLet, emitImpFunBinding, emitSpecialization, emitAtomRules,
   lookupLoadedModule, bindModule, getAllRequiredObjectFiles, extendCache,
   extendImpCache, queryImpCache,
   extendSpecializationCache, querySpecializationCache,
@@ -242,9 +242,9 @@ addInstanceSynthCandidate :: TopBuilder m => ClassName n -> InstanceName n -> m 
 addInstanceSynthCandidate className instanceName =
   emitSynthCandidates $ SynthCandidates [] (M.singleton className [instanceName])
 
-emitCustomLinearization :: TopBuilder m => AtomName n -> Int -> Atom n -> m n ()
-emitCustomLinearization v ni f = emitNamelessEnv $
-  TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v (CustomLinearize ni f) }
+emitAtomRules :: TopBuilder m => AtomName n -> AtomRules n -> m n ()
+emitAtomRules v rules = emitNamelessEnv $
+  TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v rules }
 
 emitTopLet :: (Mut n, TopBuilder m) => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
 emitTopLet hint letAnn expr = do

--- a/src/lib/Parser.hs
+++ b/src/lib/Parser.hs
@@ -110,8 +110,9 @@ declareForeign = do
 
 declareCustomLinearization :: Parser SourceBlock'
 declareCustomLinearization = do
-  keyWord CustomLinearizationKW
-  (DeclareCustomLinearization <$> anyCaseName <*> expr) <* eol
+  zeros <- (keyWord CustomLinearizationSymbolicKW $> SymbolicZeros)
+       <|> (keyWord CustomLinearizationKW $> InstantiateZeros)
+  (DeclareCustomLinearization <$> anyCaseName <*> pure zeros <*> expr) <* eol
 
 sourceBlock :: Parser SourceBlock
 sourceBlock = do
@@ -1101,7 +1102,7 @@ data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
              | ReadKW | WriteKW | StateKW | DataKW | InterfaceKW
              | InstanceKW | WhereKW | IfKW | ThenKW | ElseKW | DoKW
              | ExceptKW | IOKW | ViewKW | ImportKW | ForeignKW | NamedInstanceKW
-             | CustomLinearizationKW
+             | CustomLinearizationKW | CustomLinearizationSymbolicKW
 
 nextChar :: Lexer Char
 nextChar = do
@@ -1162,6 +1163,7 @@ keyWord kw = lexeme $ try $ string s >> notFollowedBy nameTailChar
       ImportKW -> "import"
       ForeignKW -> "foreign"
       CustomLinearizationKW -> "custom-linearization"
+      CustomLinearizationSymbolicKW -> "custom-linearization-symbolic"
 
 keyWordSet :: HS.HashSet String
 keyWordSet = HS.fromList keyWordStrs
@@ -1170,7 +1172,8 @@ keyWordStrs :: [String]
 keyWordStrs = ["def", "for", "for_", "rof", "rof_", "case", "of", "llam",
                "Read", "Write", "Accum", "Except", "IO", "data", "interface",
                "instance", "named-instance", "where", "if", "then", "else",
-               "do", "view", "import", "foreign", "custom-linearization"]
+               "do", "view", "import", "foreign",
+               "custom-linearization", "custom-linearization-symbolic"]
 
 fieldLabel :: Lexer Label
 fieldLabel = label "field label" $ lexeme $

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -358,7 +358,7 @@ simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
       ask >>= \case
         WillLinearize -> do
           lookupCustomRules v >>= \case
-            Just (CustomLinearize _ _) -> return $ Var v
+            Just (CustomLinearize _ _ _) -> return $ Var v
             Nothing -> doInline
         NoLinearize -> doInline
       where

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -269,11 +269,14 @@ data SourceBlock = SourceBlock
 
 type ReachedEOF = Bool
 
+data SymbolicZeros = SymbolicZeros | InstantiateZeros
+                     deriving (Generic, Eq, Show)
+
 data SourceBlock' =
    EvalUDecl (UDecl VoidS VoidS)
  | Command CmdName (UExpr VoidS)
  | DeclareForeign SourceName (UAnnBinder AtomNameC VoidS VoidS)
- | DeclareCustomLinearization SourceName (UExpr VoidS)
+ | DeclareCustomLinearization SourceName SymbolicZeros (UExpr VoidS)
  | GetNameType SourceName
  | ImportModule ModuleSourceName
  | QueryEnv EnvQuery
@@ -464,6 +467,7 @@ instance Eq SourceBlock where
 instance Ord SourceBlock where
   compare x y = compare (sbText x) (sbText y)
 
+instance Store SymbolicZeros
 instance Store LogLevel
 instance Store PassName
 instance Store ModuleSourceName

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -454,3 +454,37 @@ jvp (\x. w x) [1.0, 1.0] [1.0, 0.0]
 -- a partial application of w to some inference holes.
 jvp w [1.0, 1.0] [1.0, 0.0]
 > [2., 0.]
+
+------ Symbolic tangents ------
+
+ST = SymbolicTangent
+
+def q (x:Float) (y:Float) : Float = x * 2 + y
+def qLin (x:Float) (y:Float) : _ =
+  def lin (xt:ST Float) (yt: ST Float) : Float =
+    case yt of
+      ZeroTangent     -> someTangent xt * 4
+      SomeTangent yt' -> someTangent xt * 2 + yt'
+  (q x y, lin)
+
+custom-linearization q qLin
+> Type error:Expected the custom linearization to have type:
+>
+> (Float32 -> Float32 -> (Float32 & (Float32 -> Float32 -> Float32)))
+>
+> but it has type:
+>
+> (Float32
+>  -> Float32
+>  -> (Float32
+>      & ((SymbolicTangent Float32) -> (SymbolicTangent Float32) -> Float32)))
+
+custom-linearization-symbolic q qLin
+
+-- Incorrect derivative, based on the ZeroTangent branch
+deriv (\x. q x 1.0) 1.0
+> 4.
+
+-- Correct derivative, based on the SomeTangent branch
+deriv (\x. q x x) 1.0
+> 3.


### PR DESCRIPTION
When a `custom-linearization-symbolic` directive is used to declare a
custom linearization rule, the linearized function is expected to take
`SymbolicTangent a` as the type of tangents of `a`. This makes it
possible to branch based on the activity of function arguments and use
that information to choose the most efficient linearization rule.