### PR TITLE
Implement dead code elimination

### DIFF
--- a/makefile
+++ b/makefile
@@ -241,12 +241,15 @@ tutorial-data: $(tutorial-data)
 
 run-examples/tutorial: tutorial-data
 
-tests: unit-tests lower-tests quine-tests repl-test module-tests
+tests: opt-tests unit-tests lower-tests quine-tests repl-test module-tests
 
 # Keep the unit tests in their own working directory too, due to
 # https://github.com/commercialhaskell/stack/issues/4977
 unit-tests:
 	$(STACK) test --work-dir .stack-work-test $(STACK_FLAGS)
+
+opt-tests: just-build
+	misc/file-check tests/opt-tests.dx $(dex) -O script
 
 quine-tests: $(quine-test-targets)
 
@@ -254,11 +257,11 @@ run-%: export DEX_ALLOW_CONTRACTIONS=0
 run-%: export DEX_TEST_MODE=t
 
 run-tests/%: tests/%.dx just-build
-	misc/check-quine $< $(dex) script
+	misc/check-quine $< $(dex) -O script
 run-doc/%: doc/%.dx just-build
 	misc/check-quine $< $(dex) script
 run-examples/%: examples/%.dx just-build
-	misc/check-quine $< $(dex) script
+	misc/check-quine $< $(dex) -O script
 
 lower-tests: export DEX_LOWER=1
 lower-tests: export DEX_ALLOW_CONTRACTIONS=0

--- a/misc/file-check
+++ b/misc/file-check
@@ -1,0 +1,23 @@
+#!/bin/bash
+
+declare -a possible_filecheck_locations=("FileCheck-12"
+                                         "FileCheck")
+FILECHECK=$(\
+  for fc in "${possible_filecheck_locations[@]}" ; do \
+    if [[ $(command -v "$fc" 2>/dev/null) ]]; \
+      then echo "$fc" ; break ; \
+    fi ; \
+  done)
+
+if [[ -z "$FILECHECK" ]]; then
+  echo "FileCheck not found"
+  exit 1
+fi
+
+if ${@:2} $1 | $FILECHECK $1 ; then
+  echo "OK"
+  exit 0
+else
+  exit $?
+fi
+

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -41,7 +41,7 @@ data AtomEx where
 
 dexCreateContext :: IO (Ptr Context)
 dexCreateContext = do
-  let evalConfig = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing
+  let evalConfig = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing Optimize
   cachedEnv <- loadCache
   runTopperM evalConfig cachedEnv (evalSourceBlockRepl preludeImportBlock) >>= \case
     (Result _  (Success  ()), preludeEnv) -> toStablePtr $ Context evalConfig preludeEnv

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -17,6 +17,7 @@ import System.Posix.IO (stdOutput)
 import System.IO (openFile, IOMode (..))
 
 import Data.List
+import Data.Functor
 import qualified Data.Text as T
 import qualified Data.Text.IO as T
 import qualified Data.Map.Strict as M
@@ -205,6 +206,7 @@ parseEvalOpts = EvalConfig
                     <> metavar "FILE"
                     <> help "File to log to" <> showDefault)
   <*> pure Nothing
+  <*> flag NoOptimize Optimize (short 'O' <> help "Optimize generated code")
   where
     backends = [ ("llvm", LLVM)
                , ("llvm-mc", LLVMMC)

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -32,6 +32,7 @@ import QueryType hiding (HasType)
 
 import CheapReduction
 import {-# SOURCE #-} Interpreter
+import Types.Core
 import Syntax
 import Name
 import PPrint ()
@@ -294,8 +295,8 @@ instance HasType Atom where
         rTy <- instantiateDepPairTy ty'' $ Var (binderName b')
         r |: RawRefTy rTy
       return $ RawRefTy $ DepPairTy ty'
-    BoxedRef ptrsAndSizes (Abs bs body) -> do
-      ptrTys <- forM ptrsAndSizes \(ptr, numel) -> do
+    BoxedRef (Abs (NonDepNest bs ptrsAndSizes) body) -> do
+      ptrTys <- forM ptrsAndSizes \(BoxPtr ptr numel) -> do
         numel |: IdxRepTy
         ty@(PtrTy _) <- getTypeE ptr
         return ty

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -111,7 +111,7 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   ACase scrut alts resultTy ->
     ACase <$> rec scrut <*> mapM substM alts <*> rec resultTy
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
-  BoxedRef _ _     -> error "Should only occur in Imp lowering"
+  BoxedRef _       -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> rec (Var v)
   where rec x = traverseSurfaceAtomNames x doWithName

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -288,7 +288,7 @@ linearizeAtom atom = case atom of
   Lam _            -> error "Unexpected non-table lambda"
   ACase _ _ _      -> error "Unexpected ACase"
   DataConRef _ _ _ -> error "Unexpected ref"
-  BoxedRef _ _     -> error "Unexpected ref"
+  BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   where emitZeroT = withZeroT $ substM atom
 

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -4,9 +4,13 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Optimize (earlyOptimize) where
+{-# LANGUAGE UndecidableInstances #-}
 
+module Optimize (earlyOptimize, optimize) where
+
+import Data.Functor
 import Control.Monad
+import Control.Monad.State.Strict
 
 import Types.Core
 import Types.Primitives
@@ -19,6 +23,9 @@ import QueryType
 
 earlyOptimize :: EnvReader m => Block n -> m n (Block n)
 earlyOptimize = unrollTrivialLoops
+
+optimize :: EnvReader m => Block n -> m n (Block n)
+optimize = dceBlock
 
 -- === Trivial loop unrolling ===
 -- This pass unrolls loops that use Fin 0 or Fin 1 as an index set.
@@ -61,3 +68,170 @@ instance GenericTraverser UTLS where
 
 unrollTrivialLoops :: EnvReader m => Block n -> m n (Block n)
 unrollTrivialLoops b = liftM fst $ liftGenericTraverserM UTLS $ traverseGenericE b
+
+-- === Dead code elimination ===
+
+newtype FV n = FV (NameSet n) deriving (Semigroup, Monoid)
+instance SinkableE FV where
+  sinkingProofE _ _ = todoSinkableProof
+instance HoistableState FV where
+  hoistState _ b (FV ns) = FV $ hoistFilterNameSet b ns
+  {-# INLINE hoistState #-}
+
+type DCEM = StateT1 FV EnvReaderM
+
+dceBlock :: EnvReader m => Block n -> m n (Block n)
+dceBlock b = liftEnvReaderM $ evalStateT1 (dce b) mempty
+
+class HasDCE (e::E) where
+  dce :: e n -> DCEM n (e n)
+  default dce :: (GenericE e, HasDCE (RepE e)) => e n -> DCEM n (e n)
+  dce e = confuseGHC >>= \_ -> toE <$> dce (fromE e)
+
+-- The interesting instances
+
+instance Color c => HasDCE (Name c) where
+  dce n = modify (<> FV (freeVarsE n)) $> n
+
+instance HasDCE Block where
+  dce (Block ann decls ans) = case (ann, decls) of
+    (NoBlockAnn      , Empty) -> Block NoBlockAnn Empty <$> dce ans
+    (NoBlockAnn      , _    ) -> error "should be unreachable"
+    (BlockAnn ty effs, _    ) -> do
+      -- The free vars accumulated in the state of DCEM should correspond to
+      -- the free vars of the Abs of the block answer, by the decls traversed
+      -- so far. dceNest takes care to uphold this invariant, but we temporarily
+      -- reset the state to an empty map, just so that names from the surrounding
+      -- block don't end up influencing elimination decisions here. Note that we
+      -- restore the state (and accumulate free vars of the DCE'd block into it)
+      -- right after dceNest.
+      old <- get
+      put mempty
+      Abs decls' ans' <- dceNest decls ans
+      modify (<> old)
+      ty' <- dce ty
+      effs' <- dce effs
+      return $ Block (BlockAnn ty' effs') decls' ans'
+
+data CachedFVs e n = UnsafeCachedFVs { _cachedFVs :: (NameSet n), fromCachedFVs :: (e n) }
+instance HoistableE (CachedFVs e) where
+  freeVarsE (UnsafeCachedFVs fvs _) = fvs
+
+wrapWithCachedFVs :: HoistableE e => e n -> DCEM n (CachedFVs e n)
+wrapWithCachedFVs e = do
+  FV fvs <- get
+#ifdef DEX_DEBUG
+  let fvsAreCorrect = nameSetRawNames fvs == nameSetRawNames (freeVarsE e)
+#else
+  -- Verification of this invariant defeats the performance benefits of
+  -- avoiding the extra traversal (e.g. actually having linear complexity),
+  -- so we only do that in debug builds.
+  let fvsAreCorrect = True
+#endif
+  case fvsAreCorrect of
+    True -> return $ UnsafeCachedFVs fvs e
+    False -> error "Free variables were computed incorrectly."
+
+hoistUsingCachedFVs :: (BindsNames b, HoistableE e) => b n l -> e l -> DCEM l (HoistExcept (e n))
+hoistUsingCachedFVs b e = do
+  ec <- wrapWithCachedFVs e
+  return $ case hoist b ec of
+    HoistSuccess e' -> HoistSuccess $ fromCachedFVs e'
+    HoistFailure err -> HoistFailure err
+
+data ElimResult n where
+  ElimSuccess :: Abs (Nest Decl) Atom n -> ElimResult n
+  ElimFailure :: Decl n l -> Abs (Nest Decl) Atom l -> ElimResult n
+
+dceNest :: Nest Decl n l -> Atom l -> DCEM n (Abs (Nest Decl) Atom n)
+dceNest decls ans = case decls of
+  Empty -> Abs Empty <$> dce ans
+  Nest b@(Let _ decl) bs -> do
+    isPureDecl <- isPure decl
+    -- Note that we only ever dce the abs below under this refreshAbs,
+    -- which will remove any references to b upon exit (it happens
+    -- because refreshAbs of StateT1 triggers hoistState, which we
+    -- implement by deleting the entries that can't hoist).
+    dceAttempt <- refreshAbs (Abs b (Abs bs ans)) \b' (Abs bs' ans') -> do
+      below <- dceNest bs' ans'
+      case isPureDecl of
+        False -> return $ ElimFailure b' below
+        True  -> do
+          hoistUsingCachedFVs b' below <&> \case
+            HoistSuccess below' -> ElimSuccess below'
+            HoistFailure _ -> ElimFailure b' below
+    case dceAttempt of
+      ElimSuccess below' -> return below'
+      ElimFailure (Let b' decl') (Abs bs'' ans'') -> do
+        decl'' <- dce decl'
+        modify (<>FV (freeVarsB b'))
+        return $ Abs (Nest (Let b' decl'') bs'') ans''
+
+-- The generic instances
+
+instance (HasDCE e1, HasDCE e2) => HasDCE (ExtLabeledItemsE e1 e2)
+instance HasDCE Expr
+instance HasDCE Atom
+instance HasDCE LamExpr
+instance HasDCE TabLamExpr
+instance HasDCE PiType
+instance HasDCE TabPiType
+instance HasDCE DepPairType
+instance HasDCE EffectRow
+instance HasDCE Effect
+instance HasDCE DictExpr
+instance HasDCE DictType
+instance HasDCE FieldRowElems
+instance HasDCE FieldRowElem
+instance HasDCE DataDefParams
+instance HasDCE DeclBinding
+
+-- The instances for RepE types
+
+instance (HasDCE e1, HasDCE e2) => HasDCE (PairE e1 e2) where
+  dce (PairE l r) = PairE <$> dce l <*> dce r
+  {-# INLINE dce #-}
+instance (HasDCE e1, HasDCE e2) => HasDCE (EitherE e1 e2) where
+  dce = \case
+    LeftE  l -> LeftE  <$> dce l
+    RightE r -> RightE <$> dce r
+  {-# INLINE dce #-}
+instance ( HasDCE e0, HasDCE e1, HasDCE e2, HasDCE e3
+         , HasDCE e4, HasDCE e5, HasDCE e6, HasDCE e7
+         ) => HasDCE (EitherE8 e0 e1 e2 e3 e4 e5 e6 e7) where
+  dce = \case
+    Case0 x0 -> Case0 <$> dce x0
+    Case1 x1 -> Case1 <$> dce x1
+    Case2 x2 -> Case2 <$> dce x2
+    Case3 x3 -> Case3 <$> dce x3
+    Case4 x4 -> Case4 <$> dce x4
+    Case5 x5 -> Case5 <$> dce x5
+    Case6 x6 -> Case6 <$> dce x6
+    Case7 x7 -> Case7 <$> dce x7
+  {-# INLINE dce #-}
+instance (BindsEnv b, SubstB Name b, HoistableB b, SubstE Name e, HasDCE e) => HasDCE (Abs b e) where
+  dce a = do
+    a'@(Abs b' _) <- refreshAbs a \b e -> Abs b <$> dce e
+    modify (<>FV (freeVarsB b'))
+    return a'
+  {-# INLINE dce #-}
+instance HasDCE (LiftE a) where
+  dce x = return x
+  {-# INLINE dce #-}
+instance HasDCE VoidE where
+  dce _ = error "impossible"
+  {-# INLINE dce #-}
+instance HasDCE UnitE where
+  dce UnitE = return UnitE
+  {-# INLINE dce #-}
+instance (Traversable f, HasDCE e) => HasDCE (ComposeE f e) where
+  dce (ComposeE xs) = ComposeE <$> traverse dce xs
+  {-# INLINE dce #-}
+instance HasDCE e => HasDCE (ListE e) where
+  dce (ListE xs) = ListE <$> traverse dce xs
+  {-# INLINE dce #-}
+
+-- See Note [Confuse GHC] from Simplify.hs
+confuseGHC :: EnvReader m => m n (DistinctEvidence n)
+confuseGHC = getDistinct
+{-# INLINE confuseGHC #-}

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -278,12 +278,15 @@ instance PrettyPrec (Atom n) where
     ACase e alts _ -> prettyPrecCase "acase" e alts Pure
     DataConRef _ params args -> atPrec LowestPrec $
       "DataConRef" <+> p params <+> p args
-    BoxedRef ptrsSizes (Abs b body) -> atPrec LowestPrec $
+    BoxedRef (Abs (NonDepNest b ptrsSizes) body) -> atPrec LowestPrec $
       "Box" <+> p b <+> "<-" <+> p ptrsSizes <+> hardline <> "in" <+> p body
     ProjectElt idxs v ->
       atPrec LowestPrec $ "ProjectElt" <+> p idxs <+> p v
     DepPairRef l (Abs b r) _ -> atPrec LowestPrec $
       "DepPairRef" <+> p l <+> "as" <+> p b <+> "in" <+> p r
+
+instance Pretty (BoxPtr n) where
+  pretty (BoxPtr ptrptr sb) = pretty (ptrptr, sb)
 
 prettyRecordTyRow :: FieldRowElems n -> Doc ann -> DocPrec ann
 prettyRecordTyRow elems separator = do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -476,7 +476,7 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
               simplifyAtom body
         return $ ACase e' alts' rTy'
   DataConRef _ _ _ -> error "Should only occur in Imp lowering"
-  BoxedRef _ _     -> error "Should only occur in Imp lowering"
+  BoxedRef _       -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> simplifyVar v
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -297,7 +297,7 @@ transposeAtom atom ct = case atom of
   Eff _           -> notTangent
   ACase _ _ _     -> error "Unexpected ACase"
   DataConRef _ _ _ -> error "Unexpected ref"
-  BoxedRef _ _     -> error "Unexpected ref"
+  BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   ProjectElt idxs v -> do
     lookupSubstM v >>= \case

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -1,0 +1,13 @@
+@noinline
+def id' (x:Int) : Int = x
+
+-- CHECK-LABEL: dce-dead-app
+"dce-dead-app"
+
+%passes opt
+:p
+  x = id' 1
+  5 + 1
+-- CHECK: === Result ===
+-- CHECK-NEXT: 6
+


### PR DESCRIPTION
This change reimplements dead code elimination after safer names. I
think that it's the first of the passes that utilize information about
binder usage, so it was a good exercise that will make the
implementation of other similar passes (e.g. inlining) easier.

Thanks to the way we represent bindings in Dex Core, DCE is fundamentally
about traversing the whole IR in search of blocks, and then performing
DCE on every block. I thought about using a generic traversal for that
purpose, but ultimately decided against it. It wasn't a good match,
because it is written with forward-traversals in mind, and requires us
to carry a substitution, which is not necessary in the case of DCE.

The implementation strategy I ended up with is very similar to the way
we generate code for substitutions and free variable computation. Which
makes sense, because DCE also wants to compute free variables. To avoid
repeated traversals of subtrees, we fuse this computation with the
block-searching-traversal. Note that the hoisting component is a bit
unsafe, but we verify the invariants in debug mode (by paying for the
repeated traversals).

I also verified that all the generics get inlined and optimized away, so
this approach ends up yielding code similar to one we would get by
writing explicit `case` expressions over our IR. However, this approach has
the benefit of automatically adapting to any changes in the Core IR.