### PR TITLE
Avoid specializing on the "data" components of types.

### DIFF
--- a/makefile
+++ b/makefile
@@ -202,6 +202,7 @@ example-names = mandelbrot pi sierpinski rejection-sampler \
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests read-tests \
              shadow-tests monad-tests io-tests exception-tests sort-tests \
+             standalone-function-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests \
              linalg-tests set-tests fft-tests

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -58,6 +58,7 @@ import Control.Monad.Writer.Strict hiding (Alt)
 import Control.Monad.State.Strict (MonadState, StateT (..), runStateT)
 import qualified Data.Set        as S
 import qualified Data.Map.Strict as M
+import Data.Foldable (toList)
 import Data.Functor ((<&>))
 import Data.Graph (graphFromEdges, topSort)
 import Data.Text.Prettyprint.Doc (Pretty (..), group, line, nest)
@@ -769,7 +770,9 @@ buildNaryLam binderNest body = do
           naryAbsToNaryLam $ Abs bs block
 
 asNaryLam :: EnvReader m => NaryPiType n -> Atom n -> m n (NaryLamExpr n)
-asNaryLam = undefined
+asNaryLam ty f = liftBuilder do
+  buildNaryLamExpr ty \xs ->
+    naryApp (sink f) (map Var $ toList xs)
 
 buildNaryLamExpr
   :: ScopableBuilder m

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -183,10 +183,9 @@ instance CheckableE AtomBinding where
         UnspecializedTopFun n f' -> do
           f'' <- checkTypeE (naryPiTypeAsType ty') f'
           return $ UnspecializedTopFun n f''
-        SpecializedTopFun f' args -> do
-           unspecializedTy <- getTypeE f'
-           specializedTy <- checkApp unspecializedTy args
-           matches <- alphaEq (naryPiTypeAsType ty') specializedTy
+        SpecializedTopFun s -> do
+           specializedTy <- specializedFunType =<< substM s
+           matches <- alphaEq ty' specializedTy
            unless matches $ throw TypeErr "Specialization args don't match function type"
            substM f
         SimpTopFun lam -> do

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -329,6 +329,10 @@ instance BindsEnv b => (BindsEnv (Nest b)) where
   toEnvFrag = nestToEnvFrag
   {-# INLINE toEnvFrag #-}
 
+instance BindsEnv (LiftB e) where
+  toEnvFrag (LiftB _) = EnvFrag emptyOutFrag mempty
+  {-# INLINE toEnvFrag #-}
+
 nestToEnvFragRec :: (BindsEnv b, Distinct l) => EnvFrag n h -> Nest b h l -> EnvFrag n l
 nestToEnvFragRec f = \case
   Empty       -> f
@@ -502,6 +506,9 @@ withFreshPiBinder hint binding@(PiBinding arr ty) cont = do
   withFreshBinder hint binding \b ->
     withAllowedEffects Pure $
       cont $ PiBinder b ty arr
+
+plainPiBinder :: Binder n l -> PiBinder n l
+plainPiBinder (b:>ty) = PiBinder b ty PlainArrow
 
 withAllowedEffects :: EnvExtender m => EffectRow n -> m n a -> m n a
 withAllowedEffects effs cont =

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -49,8 +49,9 @@ prepareFunctionForExport' cc f = do
     ExportedSignature argSig _ _ -> do
       case sinkFromTop $ EmptyAbs argSig of
         Abs argSig' UnitE -> liftEnvReaderM $ exportArgRecon argSig'
+  f' <- asNaryLam naryPi f
   -- TODO: figure out how to handle specialization cache emissions when compiling for export
-  fSimp <- simplifyTopFunctionAssumeNoTopEmissions naryPi f []
+  fSimp <- simplifyTopFunctionAssumeNoTopEmissions f'
   fImp <- toImpExportedFunction cc fSimp argRecon
   return (fImp, sig)
   where

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -32,7 +32,7 @@ import CheckType (CheckableE (..))
 import Simplify (buildBlockSimplified, dceApproxBlock, emitSimplified)
 import LabeledItems
 import QueryType
-import Util (enumerate)
+import Util (enumerate, SnocList (..), unsnoc)
 import Types.Primitives
 import Types.Imp
 import Algebra
@@ -693,14 +693,6 @@ instance ExtOutMap Env DestDeclEmissions where
 instance ExtOutFrag DestEmissions DestDeclEmissions where
   extendOutFrag (DestEmissions p d) (DestDeclEmissions d') = DestEmissions p $ RNest d d'
   {-# INLINE extendOutFrag #-}
-
-newtype SnocList a = ReversedList { fromReversedList :: [a] }
-instance Semigroup (SnocList a) where
-  (ReversedList x) <> (ReversedList y) = ReversedList $ y ++ x
-instance Monoid (SnocList a) where
-  mempty = ReversedList []
-unsnoc :: SnocList a -> [a]
-unsnoc (ReversedList x) = reverse x
 
 data DestPtrEmissions (n::S) (l::S)
   = DestPtrEmissions (SnocList (DestPtrInfo n))  -- pointer types and allocation sizes

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -345,7 +345,7 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
           scalarArgs <- liftM toList $ mapM fromScalarAtom xs
           results <- impCall v' scalarArgs
           restructureScalarOrPairType resultTy results
-        TopFunBound piTy (SpecializedTopFun _ _) -> do
+        TopFunBound piTy (SpecializedTopFun _) -> do
           if length (toList xs') /= numNaryPiArgs piTy
             then notASimpExpr
             else do

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -24,7 +24,8 @@ module Name (
   E, B, V, HasNamesE, HasNamesB, BindsNames (..), HasScope (..), RecSubstFrag (..), RecSubst (..),
   lookupTerminalSubstFrag, noShadows, checkNoBinders,
   BindsOneName (..), BindsAtMostOneName (..), BindsNameList (..), (@@>),
-  Abs (..), Nest (..), RNest (..), unRNest, NonEmptyNest (..), nonEmptyToNest,
+  Abs (..), Nest (..), RNest (..), unRNest, NonEmptyNest (..),
+  nonEmptyToNest, nestToNonEmpty,
   PairB (..), UnitB (..),
   IsVoidS (..), UnitE (..), VoidE, PairE (..), toPairE, fromPairE,
   ListE (..), ComposeE (..), MapE (..), NonEmptyListE (..),
@@ -366,6 +367,10 @@ data NonEmptyNest (b::B) (n::S) (l::S) where
 
 nonEmptyToNest :: NonEmptyNest b n l -> Nest b n l
 nonEmptyToNest (NonEmptyNest b bs) = Nest b bs
+
+nestToNonEmpty :: Nest b n l -> Maybe (NonEmptyNest b n l)
+nestToNonEmpty Empty = Nothing
+nestToNonEmpty (Nest b bs) = Just $ NonEmptyNest b bs
 
 -- === Sinkings and projections ===
 

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -24,7 +24,7 @@ module Name (
   E, B, V, HasNamesE, HasNamesB, BindsNames (..), HasScope (..), RecSubstFrag (..), RecSubst (..),
   lookupTerminalSubstFrag, noShadows, checkNoBinders,
   BindsOneName (..), BindsAtMostOneName (..), BindsNameList (..), (@@>),
-  Abs (..), Nest (..), RNest (..), unRNest, NonEmptyNest (..),
+  Abs (..), Nest (..), RNest (..), unRNest, toRNest, NonEmptyNest (..),
   nonEmptyToNest, nestToNonEmpty,
   PairB (..), UnitB (..),
   IsVoidS (..), UnitE (..), VoidE, PairE (..), toPairE, fromPairE,
@@ -347,6 +347,14 @@ unRNest rn = go Empty rn
     go acc = \case
       REmpty     -> acc
       RNest bs b -> go (Nest b acc) bs
+
+toRNest :: Nest b n l -> RNest b n l
+toRNest n = go REmpty n
+  where
+    go :: RNest b n h -> Nest b h l -> RNest b n l
+    go acc = \case
+      Empty     -> acc
+      Nest b bs -> go (RNest acc b) bs
 
 data BinderP (c::C) (ann::E) (n::S) (l::S) =
   (:>) (NameBinder c n l) (ann n)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -433,9 +433,13 @@ instance Pretty (AtomBinding n) where
 instance Pretty (TopFunBinding n) where
   pretty = \case
     UnspecializedTopFun _ f -> p f
-    SpecializedTopFun f args -> p f <+> spaced args
+    SpecializedTopFun f -> p f
     SimpTopFun f -> p f
     FFITopFun  f -> p f
+
+instance Pretty (SpecializationSpec n) where
+  pretty (AppSpecialization f (Abs bs (ListE args))) =
+    "Specialization" <+> p f <+> p bs <+> p args
 
 instance Pretty (LamBinding n) where
   pretty (LamBinding arr ty) =

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -182,7 +182,7 @@ naryLamExprType (NaryLamExpr (NonEmptyNest b bs) eff body) = liftTypeQueryM idSu
     binderToPiBinder (nameBinder:>ty) = PiBinder nameBinder ty PlainArrow
 
 specializedFunType :: EnvReader m => SpecializationSpec n -> m n (NaryPiType n)
-specializedFunType (AppSpecialization ~(Var f) ab) = liftEnvReaderM $
+specializedFunType (AppSpecialization f ab) = liftEnvReaderM $
   refreshAbs ab \extraArgBs (ListE staticArgs) -> do
     let extraArgBs' = fmapNest plainPiBinder extraArgBs
     lookupAtomName (sink f) >>= \case

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -397,10 +397,11 @@ generalizeDataComponentsNestRec (Abs (Nest b bs) UnitE) (x:xs) accum = do
         xGeneral <- generalizeInstance dTy x'
         return (Abs Empty xGeneral, [])
       _ -> error "not implemented"
-  ListE newerArgs' <- return $ ignoreHoistFailure $ hoist newBs $ ListE newerArgs
+  let ListE newerArgs' = ignoreHoistFailure $ hoist newBs $ ListE newerArgs
   refreshAbs ab \newerBs x' -> do
     extendSubst (b @> SubstVal x') do
       let newAccum = ( newBs >>> toRNest newerBs
+                     -- TODO: avoid mapping `sink` over the full list of args here
                      , fmap sink generalizedArgs `snoc` x'
                      , newArgs <> toSnocList newerArgs')
       generalizeDataComponentsNestRec (Abs bs UnitE) xs newAccum

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -69,7 +69,7 @@ module Syntax (
     TopEnvFrag (..), ToBinding (..), PartialTopEnvFrag (..), withFreshBinders,
     refreshBinders, substBinders, withFreshBinder,
     withFreshLamBinder, withFreshPureLamBinder,
-    withFreshPiBinder, catEnvFrags,
+    withFreshPiBinder, catEnvFrags, plainPiBinder,
     EnvFrag (..), lookupEnv, lookupDataDef, lookupClassDef, lookupInstanceDef,
     lookupAtomName, lookupImpFun, lookupModule,
     lookupEnvPure, lookupSourceMap, lookupSourceMapPure,

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -288,24 +288,31 @@ newtype SnocList a = ReversedList { fromReversedList :: [a] }
 
 instance Semigroup (SnocList a) where
   (ReversedList x) <> (ReversedList y) = ReversedList $ y ++ x
+  {-# INLINE (<>) #-}
 
 instance Monoid (SnocList a) where
   mempty = ReversedList []
+  {-# INLINE mempty #-}
 
 instance Foldable SnocList where
   foldMap f (ReversedList xs) = foldMap f (reverse xs)
+  {-# INLINE foldMap #-}
 
 snoc :: SnocList a -> a -> SnocList a
 snoc (ReversedList xs) x = ReversedList (x:xs)
+{-# INLINE snoc #-}
 
 emptySnocList :: SnocList a
 emptySnocList = ReversedList []
+{-# INLINE emptySnocList #-}
 
 unsnoc :: SnocList a -> [a]
 unsnoc (ReversedList x) = reverse x
+{-# INLINE unsnoc #-}
 
 toSnocList :: [a] -> SnocList a
 toSnocList xs = ReversedList $ reverse xs
+{-# INLINE toSnocList #-}
 
 -- === bytestrings paired with their hash digest ===
 

--- a/tests/standalone-function-tests.dx
+++ b/tests/standalone-function-tests.dx
@@ -1,0 +1,30 @@
+
+@noinline
+def standalone_sum {n v} [Add v] (xs:n=>v) : v =
+  sum xs
+
+vec3 = [1,2,3]
+vec2 = [4,5]
+
+-- TODO: test that we only get one copy inlined (hard to without dumping IR
+-- until we have logging for that sort of thing)
+:p standalone_sum vec2 + standalone_sum vec3
+> 15
+
+mat23 = [[1,2,3],[4,5,6]]
+mat32 = [[1,2],[3,4],[5,6]]
+
+@noinline
+def standalone_transpose {n m a} (x:n=>m=>a) : m=>n=>a =
+  view i j. x.j.i
+
+:p (standalone_transpose mat23, standalone_transpose mat32)
+> ([[1, 4], [2, 5], [3, 6]], [[1, 3, 5], [2, 4, 6]])
+
+-- This crashes because the standalone function needs access to a data pointer
+-- xs = [1,2,3]
+
+-- @noinline
+-- def foo (_:Unit) : Nat = sum xs
+
+-- foo 1


### PR DESCRIPTION
The idea is that we don't want to specialize so aggressively that `Fin 4` and
`Fin 5` yield different specializations. In both cases, we only want to
specialize at `Fin n` "for all n". For now, we've special-cased this to `Fin`,
but we should be able to generalize to any type parameter that has a runtime
representation (i.e. anything we consider "data").