### PR TITLE
Refactor evidence fabrication for marker classes (Ext, Distinct, Mut, Emits, EmitsInf)

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Builder (
@@ -528,19 +529,18 @@ data EmitsEvidence (n::S) where
 instance Emits UnsafeS
 
 fabricateEmitsEvidence :: forall n. EmitsEvidence n
-fabricateEmitsEvidence =
-  withEmitsEvidence (error "pure fabrication" :: EmitsEvidence n) Emits
+fabricateEmitsEvidence = withFabricatedEmits @n Emits
 {-# INLINE fabricateEmitsEvidence #-}
 
 fabricateEmitsEvidenceM :: forall m n. Monad1 m => m n (EmitsEvidence n)
 fabricateEmitsEvidenceM = return fabricateEmitsEvidence
 {-# INLINE fabricateEmitsEvidenceM #-}
 
-withEmitsEvidence :: forall n a. EmitsEvidence n -> (Emits n => a) -> a
-withEmitsEvidence _ cont = fromWrapWithEmits
+withFabricatedEmits :: forall n a. (Emits n => a) -> a
+withFabricatedEmits cont = fromWrapWithEmits
  ( TrulyUnsafe.unsafeCoerce ( WrapWithEmits cont :: WrapWithEmits n       a
                                                ) :: WrapWithEmits UnsafeS a)
-{-# INLINE withEmitsEvidence #-}
+{-# INLINE withFabricatedEmits #-}
 
 newtype WrapWithEmits n r =
   WrapWithEmits { fromWrapWithEmits :: Emits n => r }

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -4,6 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
+{-# LANGUAGE AllowAmbiguousTypes #-}
 {-# LANGUAGE UndecidableInstances #-}
 
 module Inference
@@ -2766,14 +2767,13 @@ data EmitsInfEvidence (n::S) where
 instance EmitsInf UnsafeS
 
 fabricateEmitsInfEvidence :: forall n. EmitsInfEvidence n
-fabricateEmitsInfEvidence =
-  withEmitsInfEvidence (error "pure fabrication" :: EmitsInfEvidence n) EmitsInf
+fabricateEmitsInfEvidence = withFabricatedEmitsInf @n EmitsInf
 
 fabricateEmitsInfEvidenceM :: forall m n. Monad1 m => m n (EmitsInfEvidence n)
 fabricateEmitsInfEvidenceM = return fabricateEmitsInfEvidence
 
-withEmitsInfEvidence :: forall n a. EmitsInfEvidence n -> (EmitsInf n => a) -> a
-withEmitsInfEvidence _ cont = fromWrapWithEmitsInf
+withFabricatedEmitsInf :: forall n a. (EmitsInf n => a) -> a
+withFabricatedEmitsInf cont = fromWrapWithEmitsInf
  ( TrulyUnsafe.unsafeCoerce ( WrapWithEmitsInf cont :: WrapWithEmitsInf n       a
                                                   ) :: WrapWithEmitsInf UnsafeS a)
 newtype WrapWithEmitsInf n r =

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -2577,9 +2577,11 @@ class ExtEnd (n::S)
 
 getExtEvidence :: Ext n l => ExtEvidence n l
 getExtEvidence = ExtEvidence
+{-# INLINE getExtEvidence #-}
 
 absurdExtEvidence :: ExtEvidence VoidS n
 absurdExtEvidence = fabricateExtEvidence
+{-# INLINE absurdExtEvidence #-}
 
 -- We give this one a ' because the more general one defined in Name is the
 -- version we usually want to use.
@@ -2606,8 +2608,6 @@ data ExtEvidence (n::S) (l::S) where
 instance Category ExtEvidence where
   id = ExtEvidence
   {-# INLINE id #-}
-  -- Unfortunately, we can't write the class version of this transitivity axiom
-  -- because the intermediate type would be ambiguous.
   ExtEvidence . ExtEvidence = ExtEvidence
   {-# INLINE (.) #-}
 

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -61,7 +61,6 @@ module Name (
   EitherE2, EitherE3, EitherE4, EitherE5, EitherE6, EitherE7, EitherE8 (..),
   splitNestAt, joinNest, joinRNest, nestLength, nestToList, binderAnn,
   OutReaderT (..), OutReader (..), runOutReaderT,
-  ExtWitness (..),
   toSubstPairs, fromSubstPairs, SubstPair (..),
   InFrag (..), InMap (..), OutFrag (..), OutMap (..), ExtOutMap (..), ExtOutFrag (..),
   hoist, hoistToTop, sinkFromTop, fromConstAbs, exchangeBs, HoistableE (..),
@@ -76,7 +75,7 @@ module Name (
   unsafeCoerceE, unsafeCoerceB, ColorsEqual (..), eqColorRep,
   sinkR, fmapSubstFrag, catRecSubstFrags, extendRecSubst,
   freeVarsList, isFreeIn, anyFreeIn, isInNameSet, todoSinkableProof,
-  locallyMutableInplaceT, liftBetweenInplaceTs, toExtWitness,
+  locallyMutableInplaceT, liftBetweenInplaceTs,
   updateSubstFrag, nameSetToList, toNameSet, hoistFilterNameSet, NameSet, absurdExtEvidence,
   Mut, fabricateDistinctEvidence, nameSetRawNames,
   MonadTrans1 (..), collectGarbage,
@@ -375,9 +374,6 @@ class ProvesExt (b :: B) where
   default toExtEvidence :: BindsNames b => b n l -> ExtEvidence n l
   toExtEvidence b = toExtEvidence $ toScopeFrag b
 
-toExtWitness :: ProvesExt b => b n l -> ExtWitness n l
-toExtWitness b = withExtEvidence (toExtEvidence b) ExtW
-
 class ProvesExt b => BindsNames (b :: B) where
   toScopeFrag :: b n l -> ScopeFrag n l
 
@@ -410,21 +406,6 @@ sinkM e = do
   Distinct <- getDistinct
   return $ sink e
 {-# INLINE sinkM #-}
-
-data ExtWitness (n::S) (l::S) where
-  ExtW :: Ext n l => ExtWitness n l
-
-instance ProvesExt ExtWitness where
-  toExtEvidence ExtW = getExtEvidence
-
-instance SinkableE (ExtWitness n) where
-  sinkingProofE :: forall l l'. SinkingCoercion l l' -> ExtWitness n l -> ExtWitness n l'
-  sinkingProofE fresh ExtW =
-    withExtEvidence (sinkingProofE fresh (getExtEvidence :: ExtEvidence n l)) ExtW
-
-instance Category ExtWitness where
-  id = ExtW
-  ExtW . ExtW = ExtW
 
 -- XXX: this only (monadically) visits each name once, even if a name has
 -- multiple occurrences. So don't use it to count occurrences or anything like

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -572,7 +572,7 @@ bindersTypes :: (Distinct l, ProvesExt b, BindsNames b, BindsOneAtomName b)
              => Nest b n l -> [Type l]
 bindersTypes Empty = []
 bindersTypes (Nest b bs) = ty : bindersTypes bs
-  where ty = withExtEvidence b $ withSubscopeDistinct bs $ sink (binderType b)
+  where ty = withExtEvidence (Nest b bs) $ sink (binderType b)
 
 instance BindsOneAtomName (BinderP AtomNameC Type) where
   binderType (_ :> ty) = ty

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -571,8 +571,8 @@ class BindsOneName b AtomNameC => BindsOneAtomName (b::B) where
 bindersTypes :: (Distinct l, ProvesExt b, BindsNames b, BindsOneAtomName b)
              => Nest b n l -> [Type l]
 bindersTypes Empty = []
-bindersTypes (Nest b bs) = ty : bindersTypes bs
-  where ty = withExtEvidence (Nest b bs) $ sink (binderType b)
+bindersTypes n@(Nest b bs) = ty : bindersTypes bs
+  where ty = withExtEvidence n $ sink (binderType b)
 
 instance BindsOneAtomName (BinderP AtomNameC Type) where
   binderType (_ :> ty) = ty


### PR DESCRIPTION
Working on the safer names paper makes me both want to and understand enough to clean this up.

Specifically
- `FooEvidence` should actually carry the class `Foo`.
- `withFooEvidence` should just unpack the class `Foo` from the evidence and run the continuation.
- Fabrication has to be done by coercing class dictionaries, because the class has to exist eventually; name this operation `withFabricatedFoo`.
- `withFabricatedFoo` doesn't need a value-level argument, since it's fabricating anyway; rely on type application to disambiguate the type at which the class is to be fabricated.
- Where called for, also provide `fabricatedFoo` to create a fabricated GADT carrying the desired class.

This obviates `ExtWitness` (because now `ExtEvidence` does that job), so delete it (was unused anyway).