### PR TITLE
Add a loop unrolling optimization

### DIFF
--- a/misc/file-check
+++ b/misc/file-check
@@ -14,7 +14,7 @@ if [[ -z "$FILECHECK" ]]; then
   exit 1
 fi
 
-if ${@:2} $1 | $FILECHECK $1 ; then
+if ${@:2} $1 --outfmt result-only | $FILECHECK $1 ; then
   echo "OK"
   exit 0
 else

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -11,3 +11,16 @@ def id' (x:Int) : Int = x
 -- CHECK: === Result ===
 -- CHECK-NEXT: 6
 
+def arange_f {n} (off:Nat) : (Fin n)=>Int = for i. id' $ (n_to_i $ ordinal i + off)
+
+-- CHECK-LABEL: unroll-eliminate-table
+"unroll-eliminate-table"
+
+%passes opt
+:p
+  [x0, x1, x2] = arange_f 2
+  (x0, x2)
+-- CHECK: === Result ===
+-- CHECK: [[x0:.*]]:Int32 = id{{.*}} 2
+-- CHECK-NEXT: [[x2:.*]]:Int32 = id{{.*}} 4
+-- CHECK-NEXT: ([[x0]], [[x2]])


### PR DESCRIPTION
We like to write n-ary helpers such as `split_key`, but they often end
up being used with very little arities (especially binary). In those
simple cases, we end up introducing unnecessary intermediate arrays,
index casts, and array indexing operations, that could have been
simplified to a direct evaluation of the body.

This pass adds a simple form of loop unrolling that tries to counter
those issues, under a potential limited code blowup.