### PR TITLE
Make sure that variables defined outside of the block are placed

### DIFF
--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -755,3 +755,5 @@ freshNameM hint = do
   Distinct <- getDistinct
   return $ withFresh hint scope \b -> Abs b (binderName b)
 {-# INLINE freshNameM #-}
+
+type AtomNameMap = NameMap AtomNameC


### PR DESCRIPTION
Normally, when variables to be placed in a destination are defined
within the decls of the block, the `Place` operations get emitted during
the decl traversal. However, we didn't handle the case when they're
defined outside of the block!

This also switches destination propagation to use a RawName-based map,
for efficiency.