### PR TITLE
Enable lowering by default

### DIFF
--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -563,15 +563,15 @@ typeCheckPrimOp op = case op of
       MExtend _ x -> x|:s >> declareEff (RWSEffect Writer $ Just h') $> UnitTy
   IndexRef ref i -> do
     getTypeE ref >>= \case
-      RefTy h (TabTy (b:>IxType iTy _) eltTy) -> do
+      TC (RefType h (TabTy (b:>IxType iTy _) eltTy)) -> do
         i' <- checkTypeE iTy i
         eltTy' <- applyAbs (Abs b eltTy) (SubstVal i')
-        return $ RefTy h eltTy'
+        return $ TC $ RefType h eltTy'
       ty -> error $ "Not a reference to a table: " ++
                        pprint (Op op) ++ " : " ++ pprint ty
   ProjRef i ref -> do
     getTypeE ref >>= \case
-      RefTy h (ProdTy tys) -> return $ RefTy h $ tys !! i
+      TC (RefType h (ProdTy tys)) -> return $ TC $ RefType h $ tys !! i
       ty -> error $ "Not a reference to a product: " ++ pprint ty
   IOAlloc t n -> do
     n |: IdxRepTy
@@ -712,10 +712,11 @@ typeCheckPrimOp op = case op of
     applySubst subst methodTy
   ExplicitApply _ _ -> error "shouldn't appear after inference"
   MonoLiteral _ -> error "should't appear after inference"
-  AllocDest ty -> checkTypeE TyKind ty
+  AllocDest ty -> RawRefTy <$> checkTypeE TyKind ty
   Place ref val -> do
     ty <- getTypeE val
     ref |: RawRefTy ty
+    declareEff IOEffect
     return UnitTy
   Freeze ref -> do
     RawRefTy ty <- getTypeE ref

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -221,6 +221,9 @@ extendEffRow :: Ord (name n) => S.Set (EffectP name n) -> EffectRowP name n -> E
 extendEffRow effs (EffectRow effs' t) = EffectRow (effs <> effs') t
 {-# INLINE extendEffRow #-}
 
+singletonEffRow :: EffectP name n -> EffectRowP name n
+singletonEffRow eff = EffectRow (S.singleton eff) Nothing
+
 data Arrow =
    PlainArrow
  | ImplicitArrow

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -326,7 +326,7 @@ data LogLevel = LogNothing | PrintEvalTime | PrintBench String
 data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
 
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
-              | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval
+              | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval | LowerPass
               | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass
                 deriving (Ord, Eq, Bounded, Enum, Generic)
 
@@ -338,6 +338,7 @@ instance Show PassName where
     LLVMOpt  -> "llvmopt" ; AsmPass   -> "asm"
     JAXPass  -> "jax"   ; JAXSimpPass -> "jsimp"; ResultPass -> "result"
     LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo";
+    LowerPass -> "lower" ;
     EarlyOptPass -> "early-opt"; OptPass -> "opt"
 
 data EnvQuery =


### PR DESCRIPTION
It's already general enough to handle all of our tests/examples (at
least in the limited scope of lowering we have implemented today), so
let's enable it! It already gives us improvements that are missing from
the Imp path today (destination passing).