### PR TITLE
Make output destination allocation explicit outside of Imp

### DIFF
--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -794,6 +794,11 @@ typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
     declareEffs =<< liftHoistExcept (hoist b eff)
     RawRefTy _ <- return carryTy'  -- We might need allow products of references too.
     return carryTy'
+  RememberDest d body -> do
+    dTy@(RawRefTy _) <- getTypeE d
+    Pi (PiType b _ UnitTy) <- getTypeE body
+    checkAlphaEq (binderType b) dTy
+    return dTy
 
 checkRWSAction :: Typer m => RWS -> Atom i -> m i o (Type o, Type o)
 checkRWSAction rws f = do

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -129,6 +129,8 @@ pArg a = prettyPrec a ArgPrec
 
 instance Pretty (Block n) where
   pretty (Block _ decls expr) = prettyBlock decls expr
+instance PrettyPrec (Block n) where
+  prettyPrec (Block _ decls expr) = atPrec LowestPrec $ prettyBlock decls expr
 
 prettyBlock :: (PrettyPrec (e l)) => Nest Decl n l -> e l -> Doc ann
 prettyBlock Empty expr = group $ line <> pLowest expr
@@ -158,6 +160,8 @@ instance PrettyPrec (Expr n) where
     atPrec LowestPrec $ forStr ann <+> prettyLamHelper lamExpr (PrettyFor ann)
   prettyPrec (Hof (Seq ann _ c (Lam (LamExpr (LamBinder b ty _ effs) body)))) =
     atPrec LowestPrec $ "seq" <+> pApp ann <+> pApp c <+> prettyLam (p (b:>ty) <> ".") effs body
+  prettyPrec (Hof (RememberDest d (Lam (LamExpr (LamBinder b _ _ effs) body)))) =
+    atPrec LowestPrec $ "remember" <+> pApp d <+> prettyLam ("\\" <> p b <> ".") effs body
   prettyPrec (Hof hof) = prettyPrec hof
   prettyPrec (Case e alts _ effs) = prettyPrecCase "case" e alts effs
 

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -700,6 +700,7 @@ getTypePrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
     Pi (PiType (PiBinder b _ _) _ resultTy) <- getTypeE f
     return $ MaybeTy $ ignoreHoistFailure $ hoist b resultTy
   Seq _ _ cinit _ -> getTypeE cinit
+  RememberDest d _ -> getTypeE d
 
 getTypeRWSAction :: Atom i -> TypeQueryM i o (Type o, Type o)
 getTypeRWSAction f = do
@@ -785,6 +786,7 @@ exprEffects expr = case expr of
       effs <- functionEffs f
       return $ deleteEff ExceptionEffect effs
     Seq _ _ _ f   -> functionEffs f
+    RememberDest _ f -> functionEffs f
   Case _ _ _ effs -> substM effs
 
 instance HasEffectsE Block where

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -818,6 +818,7 @@ simplifyHof hof = case hof of
     (Lam (LamExpr b body), IdentityReconAbs) <- simplifyLam lam
     dropSubst $ extendSubst (b@>SubstVal UnitVal) $ exceptToMaybeBlock $ body
   Seq _ _ _ _ -> error "Shouldn't ever see a Seq in Simplify"
+  RememberDest _ _ -> error "Shouldn't ever see a RememberDest in Simplify"
 
 simplifyBlock :: Emits o => Block i -> SimplifyM i o (Atom o)
 simplifyBlock (Block _ decls result) = simplifyDecls decls $ simplifyAtom result

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -162,6 +162,7 @@ data PrimHof e =
       | Transpose e
       -- Dex abstract machine ops
       | Seq Direction e e e   -- ix dict, carry dests, body lambda
+      | RememberDest e e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data BaseMonoidP e = BaseMonoid { baseEmpty :: e, baseCombine :: e }

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -24,3 +24,16 @@ def arange_f {n} (off:Nat) : (Fin n)=>Int = for i. id' $ (n_to_i $ ordinal i + o
 -- CHECK: [[x0:.*]]:Int32 = id{{.*}} 2
 -- CHECK-NEXT: [[x2:.*]]:Int32 = id{{.*}} 4
 -- CHECK-NEXT: ([[x0]], [[x2]])
+
+-- CHECK-LABEL: matmul-single-alloc
+"matmul-single-alloc"
+m = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
+
+%passes imp
+m' = m ** m
+-- There's an extra alloca for the accumulator, but we should get rid of it
+-- once we have better destination passing
+-- CHECK: alloc Float32[10000]
+-- CHECK-NOT: alloc
+-- CHECK: alloca Float32[1]
+-- CHECK-NOT: alloc


### PR DESCRIPTION
Right now, Imp is responsible for creating the allocation for the result
of the whole (lowered) compiled block, which means that it doesn't
participate in the destination passing implemented during Lowering. That
usually causes us to include unnecessary copies in our compiled code.
To work around it, we make the abstraction of the output dest explicit
during lowering.