### PR TITLE
Infer implicit arguments for jax.jit(dex.eval()).

### DIFF
--- a/python/tests/jax_test.py
+++ b/python/tests/jax_test.py
@@ -8,6 +8,7 @@ import unittest
 import numpy as np
 from functools import partial
 from contextlib import contextmanager
+from textwrap import dedent
 
 import jax
 import jax.numpy as jnp
@@ -208,6 +209,24 @@ class JAXTest(unittest.TestCase):
     np.testing.assert_allclose(
         jax.jit(grad_dex)(x, y),
         jax.jit(grad_jax)(x, y))
+
+  def test_dex_not_knowing_shape(self):
+    m = dex.Module(dedent("""
+    def sqr {n: Nat} (x:(Fin n => Float)) : Fin n => Float =
+      for i. x.i * x.i
+    """))
+    dex_sqr = primitive(m.sqr)
+    x = jnp.linspace(-0.2, 0.5, num=10)
+    np.testing.assert_allclose(dex_sqr(x), x * x)
+
+  def test_dex_not_knowing_shape_jit(self):
+    m = dex.Module(dedent("""
+    def sqr {n: Nat} (x:(Fin n => Float)) : Fin n => Float =
+      for i. x.i * x.i
+    """))
+    dex_sqr = primitive(m.sqr)
+    x = jnp.linspace(-0.2, 0.5, num=10)
+    np.testing.assert_allclose(jax.jit(dex_sqr)(x), x * x)
 
 def lax_test(prim, arg_thunk, **kwargs):
   def test(self):

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -84,7 +84,7 @@ dexDestroyJIT jitPtr = do
 intAsCC :: CInt -> ExportCC
 intAsCC 0 = FlatExportCC
 intAsCC 1 = XLAExportCC
-intAsCC _ = error "Unregognized calling convention"
+intAsCC _ = error "Unrecognized calling convention"
 
 dexCompile :: Ptr JIT -> CInt -> Ptr Context -> Ptr AtomEx -> IO NativeFunctionAddr
 dexCompile jitPtr ccInt ctxPtr funcAtomPtr = catchErrors $ do


### PR DESCRIPTION
To wit, we already had code in `dex_call_abstract_eval_with_shape` for
inferring implicit arguments; this change just reuses it in
`dex_apply_lowering` to construct appropriate MLIR constants to pass
as arguments to the compiled function.

The catch is that this whole system relies heavily on the
restrictedness of types that can travel across the Jax-Dex boundary,
to wit, only scalars and rectangular arrays; and on the fact that the
only allowed implicit arguments are the sizes of the dynamic
dimensions of said rectangular arrays.

However, that restriction is already present in the status quo before
this change.