### PR TITLE
Teach Dex-side implementation of vmap to annotate types and implicit arguments

### DIFF
--- a/python/tests/jax_test.py
+++ b/python/tests/jax_test.py
@@ -228,6 +228,17 @@ class JAXTest(unittest.TestCase):
     x = jnp.linspace(-0.2, 0.5, num=10)
     np.testing.assert_allclose(jax.jit(dex_sqr)(x), x * x)
 
+  def test_dex_not_knowing_shape_vmap(self):
+    m = dex.Module(dedent("""
+    def sqr {n: Nat} (x:(Fin n => Float)) : Fin n => Float =
+      for i. x.i * x.i
+    """))
+    dex_sqr = primitive(m.sqr)
+    x = jnp.linspace(jnp.array([1.0, -0.2]),
+                     jnp.array([1.1, 0.5]), num=10, dtype=jnp.float32)
+    np.testing.assert_allclose(
+        jax.vmap(dex_sqr, in_axes=1, out_axes=1)(x), x * x)
+
 def lax_test(prim, arg_thunk, **kwargs):
   def test(self):
     f = dexjit(partial(prim, **kwargs))


### PR DESCRIPTION
Jax vmap of a Dex primitive used to form an expression like
```
\ x0 x1 x2. for i:(Fin batch_size). f x0.i x1.i x2.i
```
which would not compile if `f` had implicit arguments (e.g., dynamic
array size).

Now we add type annotations to the `xi`, which may mention size
parameters; and also implicit arguments to the lambda form, which bind
said size parameters.  The result is an expression like
```
\ {n m}
  (x:(Fin batch_size) => (Fin n) => Float)
  (y:(Fin batch_size) => (Fin m) => Float)
  (z:(Fin batch_size) => (Fin 4) => Float)
  . for i:(Fin batch_size). f x.i y.i z.i
```
(here `batch_size` is a metavariable standing for the actual batch size).

Fixes #1005.