### PR TITLE
Avoid unrolling loops that contain large table literals

### DIFF
--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -131,6 +131,8 @@ instance GenericTraverser ULS where
               ixDict' <- traverseGenericE ixDict
               return $ Right $ Hof $ For Fwd ixDict' body'
         _ -> nothingSpecial
+    -- Avoid unrolling loops with large table literals
+    Op (TabCon _ els) -> inc (length els) >> nothingSpecial
     _ -> nothingSpecial
     where
       inc i = modify \(ULS n) -> ULS (n + i)

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -37,3 +37,11 @@ m' = m ** m
 -- CHECK-NOT: alloc
 -- CHECK: alloca Float32[1]
 -- CHECK-NOT: alloc
+
+"don't unroll large table literals"
+-- CHECK-LABEL: don't unroll large table literals
+
+%passes opt
+x = for i:(Fin 4). [0, 0, 0, ordinal i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
+-- CHECK: [0, {{.*}}, 0]
+-- CHECK-NOT: [0, {{.*}}, 0]


### PR DESCRIPTION
Our expression size estimation in unrolling is a crude approximation,
so we missed many cases as simple as this one. TabCons can get pretty
large, so we should avoid replicating them.