### PR TITLE
Ignore parens in type arguments to data definitions.

### DIFF
--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -212,11 +212,13 @@ pattern Identifier name <- (WithSrc _ (CIdentifier name)) where
 
 binOptL :: Bin' -> Group -> (Maybe Group, Maybe Group)
 binOptL tag = \case
+  (WithSrc _ (CParens (ExprBlock content))) -> binOptL tag content
   (Binary tag' lhs rhs) | tag == tag' -> (Just lhs, Just rhs)
   rhs -> (Nothing, Just rhs)
 
 binOptR :: Bin' -> Group -> (Maybe Group, Maybe Group)
 binOptR tag = \case
+  (WithSrc _ (CParens (ExprBlock content))) -> binOptR tag content
   (Binary tag' lhs rhs) | tag == tag' -> (Just lhs, Just rhs)
   lhs -> (Just lhs, Nothing)
 

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -220,3 +220,13 @@ def (foo + bar) : Int = 6
 >     |      ^
 > unexpected 'f'
 > expecting symbol name
+
+'Data definitions allow but do not require type / kind annotations
+
+data MyPair1 a b = MkPair1 a b
+
+data MyPair2 a:Type b:Type = MkPair2 x:a y:b
+
+'which may be grouped with parentheses
+
+data MyPair3 (a:Type) (b:Type) = MkPair3 (x:a) (y:b)

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -202,7 +202,7 @@ data MyData a5       = MkMyData (MyPairOfXs a5)
 > Type error:Couldn't synthesize a class dictionary for: (X a5)
 >
 > data MyData a5       = MkMyData (MyPairOfXs a5)
->                                 ^^^^^^^^^^^^^^^
+>                                  ^^^^^^^^^^^^^
 
 data MyDataBetter a [X a] = MkMyDataBetter (MyPairOfXs a)
 


### PR DESCRIPTION
This fixes #997 as filed, but the example use-case there is now blocked on #1015.