### PR TITLE
Add a newtype constructor

### DIFF
--- a/doc/functions.dx
+++ b/doc/functions.dx
@@ -193,7 +193,7 @@ is actually why `from_ordinal` takes the type as an explicit argument,
 so that it _can_ be supplied when it would not be inferrable.
 
 from_ordinal (Fin 2) 0
-> (0@Fin 2)
+> (0@(Fin 2))
 
 '## Standalone function types
 

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -117,7 +117,7 @@ logits : Time => Vocab => Float = arb $ new_key 0
 -- Create random labels
 labels = for i:position. randIdxNoZero Vocab (new_key (ordinal i))
 :p labels
-> [(3@Fin 6), (4@Fin 6), (1@Fin 6)]
+> [(3@(Fin 6)), (4@(Fin 6)), (1@(Fin 6))]
 
 -- Evaluate marginal probability of labels given logits
 :p exp $ ctc blank logits labels

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -62,6 +62,7 @@ import qualified Data.Map.Strict as M
 import Data.Foldable (toList)
 import Data.Functor ((<&>))
 import Data.Graph (graphFromEdges, topSort)
+import Data.List.NonEmpty qualified as NE
 import Data.Text.Prettyprint.Doc (Pretty (..), group, line, nest)
 import GHC.Stack
 
@@ -1293,11 +1294,11 @@ projectIxFinMethod methodIx n = liftBuilder do
     -- size
     0 -> return n
     -- ordinal
-    1 -> buildPureLam noHint PlainArrow IdxRepTy \ix ->
-           emitOp $ CastOp IdxRepTy $ Var ix
+    1 -> buildPureLam noHint PlainArrow (TC $ Fin n) \ix ->
+           return $ ProjectElt (0 NE.:| []) ix
     -- unsafe_from_ordinal
     2 -> buildPureLam noHint PlainArrow IdxRepTy \ix ->
-           return $ Con $ FinVal (sink n) $ Var ix
+           return $ Con $ Newtype (TC $ Fin $ sink n) $ Var ix
     _ -> error "Ix only has three methods"
 
 -- === pseudo-prelude ===

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -209,10 +209,6 @@ evalOp expr = mapM evalAtom expr >>= \case
     let failedCast = error $ "Cast not implemented: " ++ pprint sourceTy ++
                              " -> " ++ pprint destTy
     case (sourceTy, destTy) of
-      (IdxRepTy, TC (Fin n)) -> return $ Con $ FinVal n x
-      (TC (Fin _), IdxRepTy) -> do
-        let Con (FinVal _ ord) = x
-        return ord
       (BaseTy (Scalar sb), BaseTy (Scalar db)) -> case (sb, db) of
         (Int64Type, Int32Type) -> do
           let Con (Lit (Int64Lit v)) = x

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -527,7 +527,9 @@ linearizePrimCon con = case con of
       elemsT <- forM elemsWithT \elemsWithT' ->
                   forM elemsWithT' \(WithTangent _ t) -> t
       return $ Con $ SumAsProd (sink ty') (sink tg') elemsT
-  FinVal _ _            -> emitZeroT
+  Newtype ty _    -> case ty of
+    TC (Fin _) -> emitZeroT
+    _ -> error $ "Unsupported newtype: " ++ pprint ty
   LabelCon _     -> error "Unexpected label"
   BaseTypeRef _  -> error "Unexpected ref"
   TabRef _       -> error "Unexpected ref"

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -916,14 +916,14 @@ instance PrettyPrec e => PrettyPrec (PrimCon e) where
 
 prettyPrecPrimCon :: PrettyPrec e => PrimCon e -> DocPrec ann
 prettyPrecPrimCon con = case con of
-  Lit l       -> prettyPrec l
+  Lit l        -> prettyPrec l
   ProdCon xs  -> atPrec ArgPrec $ align $ group $
     encloseSep "(" ")" ", " $ fmap pLowest xs
   SumCon _ tag payload -> atPrec ArgPrec $
     "(" <> p tag <> "|" <+> pApp payload <+> "|)"
   SumAsProd ty tag payload -> atPrec LowestPrec $
     "SumAsProd" <+> pApp ty <+> pApp tag <+> pApp payload
-  FinVal n i -> atPrec LowestPrec $ pApp i <> "@" <> pApp (Fin n)
+  Newtype ty e -> atPrec LowestPrec $ pArg e <> "@" <> (parens $ pLowest ty)
   BaseTypeRef ptr -> atPrec ArgPrec $ "Ref" <+> pApp ptr
   TabRef tab -> atPrec ArgPrec $ "Ref" <+> pApp tab
   ConRef conRef -> atPrec AppPrec $ "Ref" <+> pApp conRef

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -729,7 +729,6 @@ simplifyOp op = case op of
     return $ Con $ Lit $ Int32Lit $ fromIntegral val
   CastOp (BaseTy (Scalar Word32Type)) (Con (Lit (Word64Lit val))) ->
     return $ Con $ Lit $ Word32Lit $ fromIntegral val
-  CastOp IdxRepTy (Con (FinVal _ i)) -> return i
   -- Those are not no-ops! Builder methods do algebraic simplification!
   BinOp ISub x y -> isub x y
   BinOp IAdd x y -> iadd x y

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -351,9 +351,11 @@ transposeCon con ct = case con of
   ProdCon xs ->
     forM_ (enumerate xs) \(i, x) ->
       getProj i ct >>= transposeAtom x
+  Newtype ty _      -> case ty of
+    TC (Fin _) -> notTangent
+    _          -> notImplemented
   SumCon _ _ _      -> notImplemented
   SumAsProd _ _ _   -> notImplemented
-  FinVal _ _        -> notTangent
   LabelCon _     -> notTangent
   BaseTypeRef _  -> notTangent
   TabRef _       -> notTangent

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -68,7 +68,6 @@ data Atom (n::S) =
  | Con (Con n)
  | TC  (TC  n)
  | Eff (EffectRow n)
-   -- only used within Simplify
  | ACase (Atom n) [AltP Atom n] (Type n)
    -- single-constructor only for now
  | DataConRef (DataDefName n) (DataDefParams n) (EmptyAbs (Nest DataConRefBinding) n)
@@ -1131,6 +1130,7 @@ getProjection (i:is) a = case getProjection is a of
   DataCon _ _ _ _ xs -> xs !! i
   Record items -> toList items !! i
   Con (ProdCon xs) -> xs !! i
+  Con (Newtype _ x) | i == 0 -> x
   DepPair l _ _ | i == 0 -> l
   DepPair _ r _ | i == 1 -> r
   ACase scrut alts resultTy -> ACase scrut alts' resultTy'

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -66,7 +66,7 @@ data PrimCon e =
       | SumCon    e Int e     -- type, tag, payload
       | SumAsProd e e   [[e]] -- type, tag, payload
       | LabelCon String
-      | FinVal e e
+      | Newtype e e           -- type, payload
       -- References
       | BaseTypeRef e
       | TabRef e

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -278,39 +278,39 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 > (1, (2, 3))
 
 :p for i:(Fin 3). i
-> [(0@Fin 3), (1@Fin 3), (2@Fin 3)]
+> [(0@(Fin 3)), (1@(Fin 3)), (2@(Fin 3))]
 
 :p for i:(Fin 3). i
-> [(0@Fin 3), (1@Fin 3), (2@Fin 3)]
+> [(0@(Fin 3)), (1@(Fin 3)), (2@(Fin 3))]
 
 :p from_ordinal (Fin 1) 0
-> (0@Fin 1)
+> (0@(Fin 1))
 
 :p 0@(Fin 1)
-> (0@Fin 1)
+> (0@(Fin 1))
 
 :p 5@(Fin 5 & Fin 3)
-> ((1@Fin 5), (2@Fin 3))
+> ((1@(Fin 5)), (2@(Fin 3)))
 
 :p ordinal (1@(Fin 5), 2@(Fin 3))
 > 5
 
 :p for i:(Fin 3 & Fin 5). i
-> [ ((0@Fin 3), (0@Fin 5))
-> , ((0@Fin 3), (1@Fin 5))
-> , ((0@Fin 3), (2@Fin 5))
-> , ((0@Fin 3), (3@Fin 5))
-> , ((0@Fin 3), (4@Fin 5))
-> , ((1@Fin 3), (0@Fin 5))
-> , ((1@Fin 3), (1@Fin 5))
-> , ((1@Fin 3), (2@Fin 5))
-> , ((1@Fin 3), (3@Fin 5))
-> , ((1@Fin 3), (4@Fin 5))
-> , ((2@Fin 3), (0@Fin 5))
-> , ((2@Fin 3), (1@Fin 5))
-> , ((2@Fin 3), (2@Fin 5))
-> , ((2@Fin 3), (3@Fin 5))
-> , ((2@Fin 3), (4@Fin 5)) ]@(Fin 3 & Fin 5)
+> [ ((0@(Fin 3)), (0@(Fin 5)))
+> , ((0@(Fin 3)), (1@(Fin 5)))
+> , ((0@(Fin 3)), (2@(Fin 5)))
+> , ((0@(Fin 3)), (3@(Fin 5)))
+> , ((0@(Fin 3)), (4@(Fin 5)))
+> , ((1@(Fin 3)), (0@(Fin 5)))
+> , ((1@(Fin 3)), (1@(Fin 5)))
+> , ((1@(Fin 3)), (2@(Fin 5)))
+> , ((1@(Fin 3)), (3@(Fin 5)))
+> , ((1@(Fin 3)), (4@(Fin 5)))
+> , ((2@(Fin 3)), (0@(Fin 5)))
+> , ((2@(Fin 3)), (1@(Fin 5)))
+> , ((2@(Fin 3)), (2@(Fin 5)))
+> , ((2@(Fin 3)), (3@(Fin 5)))
+> , ((2@(Fin 3)), (4@(Fin 5))) ]@(Fin 3 & Fin 5)
 
 :p [1, 2, 3].(0@_)
 > 1
@@ -504,10 +504,10 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 > [[1, 3], [2, 4]]
 
 :p argmin [1.0, 2.0, 0.4, 5.0]
-> (2@Fin 4)
+> (2@(Fin 4))
 
 :p select True (from_ordinal (Fin 2) 0) (from_ordinal (Fin 2) 1)
-> (0@Fin 2)
+> (0@(Fin 2))
 
 -- TODO: printing (also parsing) tables with alternative index sets
 -- :p
@@ -655,17 +655,17 @@ for i:(Fin 2 & Fin 2). 1.0
 > [1., 1., 1., 1.]@(Fin 2 & Fin 2)
 
 1@(Fin 2 & Fin 2)
-> ((0@Fin 2), (1@Fin 2))
+> ((0@(Fin 2)), (1@(Fin 2)))
 
 for i:(Fin 5). for j:(..i).
   ir = n_to_f $ ordinal i
   jr = n_to_f $ ordinal j
   ir * (ir + 1.0) / 2.0 + jr
-> [ [0.]@(..(0@Fin 5))
-> , [1., 2.]@(..(1@Fin 5))
-> , [3., 4., 5.]@(..(2@Fin 5))
-> , [6., 7., 8., 9.]@(..(3@Fin 5))
-> , [10., 11., 12., 13., 14.]@(..(4@Fin 5)) ]
+> [ [0.]@(..(0@(Fin 5)))
+> , [1., 2.]@(..(1@(Fin 5)))
+> , [3., 4., 5.]@(..(2@(Fin 5)))
+> , [6., 7., 8., 9.]@(..(3@(Fin 5)))
+> , [10., 11., 12., 13., 14.]@(..(4@(Fin 5))) ]
 
 -- TODO: fix!
 -- -- Exercise the use of free variables in the sum solver
@@ -842,10 +842,10 @@ s1 = "hello world"
 
 triLit : (i:Fin 4)=>(..i)=>Int = [ [0], [1, 2], [3, 4, 5], [6, 7, 8, 9] ]
 triLit
-> [ [0]@(..(0@Fin 4))
-> , [1, 2]@(..(1@Fin 4))
-> , [3, 4, 5]@(..(2@Fin 4))
-> , [6, 7, 8, 9]@(..(3@Fin 4)) ]
+> [ [0]@(..(0@(Fin 4)))
+> , [1, 2]@(..(1@(Fin 4)))
+> , [3, 4, 5]@(..(2@(Fin 4)))
+> , [6, 7, 8, 9]@(..(3@(Fin 4))) ]
 
 -- @noinline
 def fromLeftFloat (x:(Float | Int)) : Float =

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -182,7 +182,7 @@ def effectsAtZero {eff:Effects} (f: Int ->{|eff} Unit) : {|eff} Unit =
 > (AsList 2 [7, 6])
 
 :p arg_filter (\x. x > 5) [0, 7, -1, 6]
-> (AsList 2 [(1@Fin 4), (3@Fin 4)])
+> (AsList 2 [(1@(Fin 4)), (3@(Fin 4))])
 
 -- Test list equality
 (AsList _ [1, 2]) == (AsList _ [1, 2])

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -39,5 +39,6 @@ m' = m ** m
 
 %passes opt
 x = for i:(Fin 4). [0, 0, 0, ordinal i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
--- CHECK: [0, {{.*}}, 0]
--- CHECK-NOT: [0, {{.*}}, 0]
+-- CHECK: [ 0
+-- CHECK: , 0 ]
+-- CHECK-NOT: [0

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -323,16 +323,16 @@ instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
 :p ordinal {a=(7@Fin 10), b=(2@Fin 3)}
 > 27
 :p from_ordinal {a:Fin 10 & b:Fin 3} 14
-> {a = (4@Fin 10), b = (1@Fin 3)}
+> {a = (4@(Fin 10)), b = (1@(Fin 3))}
 
 recordsAsIndices : {a:Fin 2 & b:Fin 3}=>{a:Fin 2 & b:Fin 3} = for i. i
 :p recordsAsIndices
-> [ {a = (0@Fin 2), b = (0@Fin 3)}
-> , {a = (1@Fin 2), b = (0@Fin 3)}
-> , {a = (0@Fin 2), b = (1@Fin 3)}
-> , {a = (1@Fin 2), b = (1@Fin 3)}
-> , {a = (0@Fin 2), b = (2@Fin 3)}
-> , {a = (1@Fin 2), b = (2@Fin 3)} ]@{a: Fin 2 & b: Fin 3}
+> [ {a = (0@(Fin 2)), b = (0@(Fin 3))}
+> , {a = (1@(Fin 2)), b = (0@(Fin 3))}
+> , {a = (0@(Fin 2)), b = (1@(Fin 3))}
+> , {a = (1@(Fin 2)), b = (1@(Fin 3))}
+> , {a = (0@(Fin 2)), b = (2@(Fin 3))}
+> , {a = (1@(Fin 2)), b = (2@(Fin 3))} ]@{a: Fin 2 & b: Fin 3}
 
 -- TODO: this still causes an error
 -- :p for i:(Fin 6). recordsAsIndices.((ordinal i) @ _)
@@ -359,26 +359,26 @@ instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
 > 12
 
 :p from_ordinal {a:Fin 10 | b:Fin 3} 4
-> {| a = 4@Fin 10 |}
+> {| a = 4@(Fin 10) |}
 
 :p from_ordinal {a:Fin 10 | b:Fin 3} 11
-> {| b = 1@Fin 3 |}
+> {| b = 1@(Fin 3) |}
 
 variantsAsIndices : {a:Fin 10 | b:Fin 3}=>{a:Fin 10 | b:Fin 3} = for i. i
 :p variantsAsIndices
-> [ {| a = 0@Fin 10 |}
-> , {| a = 1@Fin 10 |}
-> , {| a = 2@Fin 10 |}
-> , {| a = 3@Fin 10 |}
-> , {| a = 4@Fin 10 |}
-> , {| a = 5@Fin 10 |}
-> , {| a = 6@Fin 10 |}
-> , {| a = 7@Fin 10 |}
-> , {| a = 8@Fin 10 |}
-> , {| a = 9@Fin 10 |}
-> , {| b = 0@Fin 3 |}
-> , {| b = 1@Fin 3 |}
-> , {| b = 2@Fin 3 |} ]@{a: Fin 10 | b: Fin 3}
+> [ {| a = 0@(Fin 10) |}
+> , {| a = 1@(Fin 10) |}
+> , {| a = 2@(Fin 10) |}
+> , {| a = 3@(Fin 10) |}
+> , {| a = 4@(Fin 10) |}
+> , {| a = 5@(Fin 10) |}
+> , {| a = 6@(Fin 10) |}
+> , {| a = 7@(Fin 10) |}
+> , {| a = 8@(Fin 10) |}
+> , {| a = 9@(Fin 10) |}
+> , {| b = 0@(Fin 3) |}
+> , {| b = 1@(Fin 3) |}
+> , {| b = 2@(Fin 3) |} ]@{a: Fin 10 | b: Fin 3}
 
 -- === First-class labels ===
 

--- a/tests/serialize-tests.dx
+++ b/tests/serialize-tests.dx
@@ -11,7 +11,7 @@
 > [[1., 2., 3.], [4., 5., 6.]]
 
 :p from_ordinal (Fin 10) 7
-> (7@Fin 10)
+> (7@(Fin 10))
 
 :p [True, False]
 > [True, False]

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -358,7 +358,7 @@ def triRefIndex {h n} (ref:Ref h ((i':n)=>(..i')=>Float)) (i:n) : Ref h ((..i)=>
 -- There was a time when this wasn't possible, because checking mode would unify the
 -- input type with a non-dependent function type, leading to a later unification errors.
 id (for i:(Fin 2). for j:(..i). 1.0)
-> [[1.]@(..(0@Fin 2)), [1., 1.]@(..(1@Fin 2))]
+> [[1.]@(..(0@(Fin 2))), [1., 1.]@(..(1@(Fin 2)))]
 
 def weakerInferenceReduction {n} (l : (i:n)=>(..i)=>Float) (j:n): Unit =
   for i:(..j).


### PR DESCRIPTION
The Core IR has quite a bit of redundancy in its representations.
Records, one constructor ADTs and products are all... just products,
with different types. And we should represent them that way!

This change adds a "newtype" atom constructor that can take a single
value payload to construct another type. At the moment it is only used
for `Fin` values (letting us remove the `FinVal` constructor). `Nat`s
(as a type different from Word32) are the next step.