### PR TITLE
Clarify `if` syntax

### DIFF
--- a/doc/conditionals.dx
+++ b/doc/conditionals.dx
@@ -1,0 +1,129 @@
+'# Syntax of if expressions
+
+'The basic syntax of `if` in Dex is
+```
+if <condition> then <consequent> [else <alternate>]
+```
+
+'It can be a bit confusing, though, because of all the tokens it may make sense to indent.
+
+'The main rules are:
+- The `else` clause is optional (regardless of indentation)
+- The `then` and `else` keywords can be inline with the preceding
+  code, or indented relative to the `if`.
+- The code for each arm of the `if` can be either an inline expression
+  or start a new indentation level (relative to its keyword if that is
+  indented, or relative to the whole `if` otherwise).
+
+'This produces four combinations for one-armed `if`, all of which are legal:
+
+:p
+  yield_accum (AddMonoid Float) \ref.
+    if True then ref += 3.
+    if True then
+      ref += 1.
+      ref += 2.
+    if True
+      then ref += 3.
+    if False
+      then
+        ref += 1.
+        ref += 2.
+> 9.
+
+'However, not every one of the 16 concievable combinations makes sense for two-armed `if`.
+To wit:
+- If the consequent is indented, it makes no sense to have the `else`
+  inline (eliminating 4 combinations).
+- If `then` is inline, there can be no indented `else` either, because
+  there is no readable level at which to indent it (elimintaing 2 more
+  combinations).
+
+'The following contrived code block shows all the acceptable configurations:
+
+:p
+  yield_accum (AddMonoid Float) \ref.
+    -- Two-armed `if` with `then` and the consequent both inline.
+    x = if False then 1. else 3.
+    if False then ref += 100. else
+      ref += 1.
+      ref += 2.
+    if False then ref += 200.
+      else ref += x
+    if False then ref += 300.
+      else
+        ref += 1.
+        ref += 2.
+
+    -- Two-armed `if` with `then` indented but the consequent inline.
+    y = if False
+          then 1. else 3.
+    if False
+      then ref += 100. else
+        ref += 1.
+        ref += 2.
+    if False
+      then ref += 200.
+      else ref += y
+    if False
+      then ref += 300.
+      else
+        ref += 1.
+        ref += 2.
+
+    -- Two-armed `if` with `then` and the consequent both indented.
+    if False
+      then
+        ref += 100.
+        ref += 200.
+      else ref += 3.
+    if False
+      then
+        ref += 100.
+        ref += 200.
+      else
+        ref += 2.
+        ref += 4.
+> 27.
+
+'And here are expample configurations that don't work, showing the resulting parse errors.
+
+'Inline `else` is not allowed after indented consequent, whether the
+`then` keyword is indented or not:
+
+if True
+  then
+    x = 6
+    x else 5
+
+> Parse error:97:12:
+>    |
+> 97 |     x else 5
+>    |            ^
+> Same-line `else` may not follow indented consequent; put the `else` on the next line.
+
+if True then
+  x = 6
+  x else 5
+
+> Parse error:107:10:
+>     |
+> 107 |   x else 5
+>     |          ^
+> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
+
+'Indented `else` is not allowed after inline `then` and indented
+consequent either, because there is no indentation level for it to match.
+
+:p
+ if True then
+   x = 6
+   x
+  else 5
+
+> Parse error:122:8:
+>     |
+> 122 |   else 5
+>     |        ^
+> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
+

--- a/makefile
+++ b/makefile
@@ -210,7 +210,7 @@ test-names = uexpr-tests adt-tests type-tests eval-tests show-tests read-tests \
 
 lib-names = diagram plot png
 
-doc-names = functions
+doc-names = conditionals functions
 
 all-names = $(test-names:%=tests/%) $(example-names:%=examples/%) $(doc-names:%=doc/%)
 

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -160,23 +160,21 @@ if True
     x = 6
     x else 5
 
-> Parse error:161:7:
+> Parse error:161:12:
 >     |
 > 161 |     x else 5
->     |       ^^
-> unexpected "el"
-> expecting "..", "<..", ';', backquoted name, end of input, end of line, or infix operator
+>     |            ^
+> Same-line `else` may not follow indented consequent; put the `else` on the next line.
 -- No inline `else` after inline `then` and indented consequent
 if True then
   x = 6
   x else 5
 
-> Parse error:172:5:
+> Parse error:171:10:
 >     |
-> 172 |   x else 5
->     |     ^^
-> unexpected "el"
-> expecting "..", "<..", ';', backquoted name, end of input, end of line, or infix operator
+> 171 |   x else 5
+>     |          ^
+> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
 -- No indented `else` after inline `then` and indented consequent either
 :p
  if True then
@@ -184,20 +182,19 @@ if True then
    x
   else 5
 
-> Parse error:185:2:
+> Parse error:183:8:
 >     |
-> 185 |   else 5
->     |  ^^^^^^^^
-> unexpected " else 5<newline><newline>> Par"
-> expecting "..", "...", "..<", "@...", "named-instance", '+', '-', function definition, name, or symbol name
+> 183 |   else 5
+>     |        ^
+> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
 
 -- Check that a syntax error in a funDefLet doesn't try to reparse the
 -- whole definition as something it's not.
 def frob (x:Int) (y:Int) : + =
 
-> Parse error:196:30:
+> Parse error:193:30:
 >     |
-> 196 | def frob (x:Int) (y:Int) : + =
+> 193 | def frob (x:Int) (y:Int) : + =
 >     |                              ^
 > unexpected '='
 > expecting name or symbol name
@@ -206,17 +203,17 @@ def frob (x:Int) (y:Int) : + =
 for i.
 i
 
-> Parse error:207:1:
+> Parse error:204:1:
 >     |
-> 207 | i
+> 204 | i
 >     | ^
 > expecting end of line or space
 
 def (foo + bar) : Int = 6
 
-> Parse error:215:6:
+> Parse error:212:6:
 >     |
-> 215 | def (foo + bar) : Int = 6
+> 212 | def (foo + bar) : Int = 6
 >     |      ^
 > unexpected 'f'
 > expecting symbol name

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -81,121 +81,14 @@ def myInt2 : {State Int} Int = 1
 > def myInt2 : {State Int} Int = 1
 > ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
--- Check all the if syntaxes.  The principles are
--- - `else` is optional (regardless of indentation)
--- - `then` and `else` can be inline with the preceding, or indented relative
---   to the `if`
--- - The code for each arm of the `if` be either an inline expression
---   or start a new indentation level (relative to its keyword if that
---   is indented, or relative to the `if` otherwise)
---
--- This produces four combinations for one-armed `if`, all of which are legal.
---
--- For two-armed `if`, this produces 16 combinations, but:
--- - If the consequent is indented, it makes so sense to have the `else`
---   inline (eliminating 4 combinations).
--- - If additionally `then` is inline, there can be no indented `else`
---   either, because there is no readable level at which to indent it
---   (elimintaing 2 more combinations).
-:p
-  yield_accum (AddMonoid Float) \ref.
-    -- All indentations of one-armed `if` are ok.
-    if True then ref += 3.
-    if True then
-      ref += 1.
-      ref += 2.
-    if True
-      then ref += 3.
-    if False
-      then
-        ref += 1.
-        ref += 2.
-
-    -- Two-armed `if` with `then` and the consequent both inline.
-    x = if False then 1. else 3.
-    if False then ref += 100. else
-      ref += 1.
-      ref += 2.
-    if False then ref += 200.
-      else ref += x
-    if False then ref += 300.
-      else
-        ref += 1.
-        ref += 2.
-
-    -- Two-armed `if` with `then` indented but the consequent inline.
-    y = if False
-          then 1. else 3.
-    if False
-      then ref += 100. else
-        ref += 1.
-        ref += 2.
-    if False
-      then ref += 200.
-      else ref += y
-    if False
-      then ref += 300.
-      else
-        ref += 1.
-        ref += 2.
-
-    -- Two-armed `if` with `then` and the consequent both indented.
-    if False
-      then
-        ref += 100.
-        ref += 200.
-      else ref += 3.
-    if False
-      then
-        ref += 100.
-        ref += 200.
-      else
-        ref += 2.
-        ref += 4.
-> 36.
-
--- No inline `else` after indented `then` and consequent
-if True
-  then
-    x = 6
-    x else 5
-
-> Parse error:161:12:
->     |
-> 161 |     x else 5
->     |            ^
-> Same-line `else` may not follow indented consequent; put the `else` on the next line.
--- No inline `else` after inline `then` and indented consequent
-if True then
-  x = 6
-  x else 5
-
-> Parse error:171:10:
->     |
-> 171 |   x else 5
->     |          ^
-> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
--- No indented `else` after inline `then` and indented consequent either
-:p
- if True then
-   x = 6
-   x
-  else 5
-
-> Parse error:183:8:
->     |
-> 183 |   else 5
->     |        ^
-> No `else` may follow same-line `then` and indented consequent; indent and align both `then` and `else`, or write the whole `if` on one line.
-
 -- Check that a syntax error in a funDefLet doesn't try to reparse the
 -- whole definition as something it's not.
 def frob (x:Int) (y:Int) : + =
 
-> Parse error:193:30:
->     |
-> 193 | def frob (x:Int) (y:Int) : + =
->     |                              ^
+> Parse error:86:30:
+>    |
+> 86 | def frob (x:Int) (y:Int) : + =
+>    |                              ^
 > unexpected '='
 > expecting name or symbol name
 
@@ -203,17 +96,17 @@ def frob (x:Int) (y:Int) : + =
 for i.
 i
 
-> Parse error:204:1:
->     |
-> 204 | i
->     | ^
+> Parse error:97:1:
+>    |
+> 97 | i
+>    | ^
 > expecting end of line or space
 
 def (foo + bar) : Int = 6
 
-> Parse error:212:6:
+> Parse error:105:6:
 >     |
-> 212 | def (foo + bar) : Int = 6
+> 105 | def (foo + bar) : Int = 6
 >     |      ^
 > unexpected 'f'
 > expecting symbol name


### PR DESCRIPTION
Both in a new documentation notebook that explains with words and examples what the syntax is, and in a better error message that detects misplaced `else` clauses and tells the programmer how to fix them.