### PR TITLE
Print full localhost URL

### DIFF
--- a/src/lib/Live/Web.hs
+++ b/src/lib/Live/Web.hs
@@ -26,7 +26,7 @@ import TopLevel
 runWeb :: FilePath -> EvalConfig -> TopStateEx -> IO ()
 runWeb fname opts env = do
   resultsChan <- watchAndEvalFile fname opts env
-  putStrLn "Streaming output to localhost:8000"
+  putStrLn "Streaming output to http://localhost:8000/"
   run 8000 $ serveResults resultsChan
 
 serveResults :: ToJSON a => PChan (PChan a) -> Application


### PR DESCRIPTION
Small quality of life improvement:
When running `dex web`, this should make the localhost URL clickable in most terminals, opening a browser tab to `localhost:8000`.

I'm not super familiar with Haskell, so I hope this is a valid string.