### PR TITLE
Use newtypes to represent records

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -215,7 +215,6 @@ instance CheaplyReducibleE Atom Atom where
     DataCon sourceName dataDefName params con args ->
       DataCon sourceName <$> substM dataDefName <*> cheapReduceE params
                          <*> pure con <*> mapM cheapReduceE args
-    Record items -> Record <$> mapM cheapReduceE items
     Variant ty l c p -> do
       ExtLabeledItemsE ty' <- substM $ ExtLabeledItemsE ty
       Variant ty' l c <$> cheapReduceE p

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -95,7 +95,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   DictTy (DictType sn cn params) ->
     DictTy <$> (DictType sn <$> substM cn <*> mapM tge params)
   LabeledRow elems -> LabeledRow <$> traverseGenericE elems
-  Record items -> Record <$> mapM tge items
   RecordTy elems -> RecordTy <$> traverseGenericE elems
   Variant ext label i value -> do
     ext' <- traverseExtLabeledItems ext

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -24,12 +24,13 @@ import CUDA
 import LLVMExec
 import Err
 import LabeledItems
+import Types.Core
 
 import Name
 import Syntax
 import QueryType
 import PPrint ()
-import Util ((...), iota)
+import Util ((...), iota, restructure)
 import Builder
 import CheapReduction (cheapNormalize)
 
@@ -100,7 +101,6 @@ traverseSurfaceAtomNames atom doWithName = case atom of
     DataCon printName defName'
       <$> (DataDefParams <$> mapM rec params <*> mapM rec dicts)
       <*> pure con <*> mapM rec args
-  Record items -> Record <$> mapM rec items
   RecordTy _ -> substM atom
   Variant ty l con payload ->
     Variant
@@ -253,27 +253,31 @@ matchUPat (WithSrcB _ pat) x = do
     (UPatPair (PairB p1 p2), PairVal x1 x2) -> do
       matchUPat p1 x1 >>= (`followedByFrag` matchUPat p2 x2)
     (UPatUnit UnitB, UnitVal) -> return emptyInFrag
-    (UPatRecord pats, Record initXs) -> go initXs pats
+    (UPatRecord pats, Record initTys initXs) -> go initTys (restructure initXs initTys) pats
       where
-        go :: Interp m => LabeledItems (Atom o) -> UFieldRowPat i i' -> m i o (SubstFrag AtomSubstVal i i' o)
-        go xs = \case
+        go :: Interp m
+           => LabeledItems (Type o) -> LabeledItems (Atom o)
+           -> UFieldRowPat i i' -> m i o (SubstFrag AtomSubstVal i i' o)
+        go tys xs = \case
           UEmptyRowPat    -> return emptyInFrag
-          URemFieldsPat b -> return $ b @> SubstVal (Record xs)
+          URemFieldsPat b -> return $ b @> SubstVal (Record tys $ toList xs)
           UDynFieldsPat ~(InternalName _ (UAtomVar v)) b rest ->
             evalAtom (Var v) >>= \case
               LabeledRow f | [StaticFields fields] <- fromFieldRowElems f -> do
                 let (items, remItems) = splitLabeledItems fields xs
-                frag <- matchUPat b (Record items)
-                frag `followedByFrag` go remItems rest
+                let (itemTys, remTys) = splitLabeledItems fields tys
+                frag <- matchUPat b (Record itemTys $ toList items)
+                frag `followedByFrag` go remTys remItems rest
               _ -> error "Unevaluated fields?"
           UDynFieldPat ~(InternalName _ (UAtomVar v)) b rest ->
             evalAtom (Var v) >>= \case
-              Con (LabelCon l) -> go xs $ UStaticFieldPat l b rest
+              Con (LabelCon l) -> go tys xs $ UStaticFieldPat l b rest
               _ -> error "Unevaluated label?"
           UStaticFieldPat l b rest -> case popLabeledItems l xs of
             Just (val, xsTail) -> do
+              let Just (_, tysTail) = popLabeledItems l tys
               headFrag <- matchUPat b val
-              headFrag `followedByFrag` go xsTail rest
+              headFrag `followedByFrag` go tysTail xsTail rest
             Nothing -> error "Field missing in record"
     (UPatVariant _ _ _  , _) -> error "can't have top-level may-fail pattern"
     (UPatVariantLift _ _, _) -> error "can't have top-level may-fail pattern"

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -273,7 +273,6 @@ transposeAtom atom ct = case atom of
       LinRef ref -> emitCTToRef ref ct
       LinTrivial -> return ()
   Con con         -> transposeCon con ct
-  Record e        -> void $ zipWithT transposeAtom e =<< getUnpacked ct
   DepPair _ _ _   -> notImplemented
   DataCon _ _ _ _ e -> void $ zipWithT transposeAtom e =<< getUnpacked ct
   Variant _ _ _ _ -> notImplemented
@@ -351,16 +350,16 @@ transposeCon con ct = case con of
   ProdCon xs ->
     forM_ (enumerate xs) \(i, x) ->
       getProj i ct >>= transposeAtom x
-  Newtype ty _      -> case ty of
+  Newtype ty e      -> case ty of
     TC (Fin _) -> notTangent
-    _          -> notImplemented
+    StaticRecordTy _ -> transposeAtom e (unwrapNewtype ct)
+    _ -> notImplemented
   SumCon _ _ _      -> notImplemented
   SumAsProd _ _ _   -> notImplemented
   LabelCon _     -> notTangent
   BaseTypeRef _  -> notTangent
   TabRef _       -> notTangent
   ConRef _       -> notTangent
-  RecordRef _    -> notTangent
   ExplicitDict _ _ -> notTangent
   DictHole _ _ -> notTangent
   where notTangent = error $ "Not a tangent atom: " ++ pprint (Con con)

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -71,7 +71,6 @@ data PrimCon e =
       | BaseTypeRef e
       | TabRef e
       | ConRef (PrimCon e)
-      | RecordRef (LabeledItems e)
       -- Misc hacks
       | ExplicitDict e e  -- Dict type, method. Used in prelude for `run_accum`.
       | DictHole (AlwaysEqual SrcPosCtx) e -- Only used during type inference


### PR DESCRIPTION
Records don't add any additional expressive power over n-ary product
types, so we can represent them as such. This lets us get rid of two
constructors, one in `Atom` and one in `PrimCon`.