### PR TITLE
Tweak the quine script to suppress differences due to Dex timing pragmas

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -24,7 +24,7 @@ jobs:
             install_deps: brew install llvm@12 pkg-config wget gzip coreutils
             path_extension: $(brew --prefix llvm@12)/bin
           - os: ubuntu-20.04
-            install_deps: sudo apt-get install llvm-12-tools llvm-12-dev pkg-config wget gzip
+            install_deps: sudo apt-get install llvm-12-tools llvm-12-dev pkg-config wget gzip wamerican
             path_extension: /usr/lib/llvm-12/bin
 
     steps:

--- a/examples/levenshtein-distance.dx
+++ b/examples/levenshtein-distance.dx
@@ -90,9 +90,6 @@ distance function on words:
 
 (AsList ct words) = lines $ unsafe_io do read_file "/usr/share/dict/words"
 
-ct
-> 104334
-
 def closest_word (s:String) : String =
   (AsList _ s') = s
   fst $ minimum_by snd for i.

--- a/makefile
+++ b/makefile
@@ -190,16 +190,22 @@ dexrt-llvm: src/lib/dexrt.bc
 
 # --- running tests ---
 
-example-names = mandelbrot pi sierpinski rejection-sampler \
-                regression brownian_motion particle-swarm-optimizer \
-                ode-integrator mcmc ctc raytrace particle-filter \
-                isomorphisms fluidsim \
-                sgd psd kernelregression nn \
-                quaternions manifold-gradients schrodinger tutorial \
-                latex linear-maps
+example-names := \
+  mandelbrot pi sierpinski rejection-sampler \
+  regression brownian_motion particle-swarm-optimizer \
+  ode-integrator mcmc ctc raytrace particle-filter \
+  isomorphisms fluidsim \
+  sgd psd kernelregression nn \
+  quaternions manifold-gradients schrodinger tutorial \
+  latex linear-maps
 # TODO: re-enable
 # fft vega-plotting
-# TODO: enable levenshtein-distance (has timings in the outputs)
+
+# Only test levenshtein-distance on Linux, because MacOS ships with a
+# different (apparently _very_ different) word list.
+ifeq ($(shell uname -s),Linux)
+  example-names += levenshtein-distance
+endif
 
 test-names = uexpr-tests adt-tests type-tests eval-tests show-tests read-tests \
              shadow-tests monad-tests io-tests exception-tests sort-tests \
@@ -334,9 +340,6 @@ bench-summary:
 # --- building docs ---
 
 slow-pages = pages/examples/mnist-nearest-neighbors.html
-# Not actually slow, but not tested because it shows timings
-# https://github.com/google-research/dex-lang/issues/910
-slow-pages += pages/examples/levenshtein-distance.html
 
 doc-files = $(doc-names:%=doc/%.dx)
 pages-doc-files = $(doc-names:%=pages/%.html)

--- a/misc/check-quine
+++ b/misc/check-quine
@@ -23,7 +23,11 @@ tmpout=$(mktemp)
 errout=$(mktemp)
 
 if ${@:2} $1 > $tmpout 2> $errout ; then
-    misc/check-no-diff $1 $tmpout
+    # We check for differences up to timing outputs from the %time or %bench
+    # commands, because those are expected to vary from run to run.
+    misc/check-no-diff \
+      <(grep -vE "> (Compile|Run) time: " $1) \
+      <(grep -vE "> (Compile|Run) time: " $tmpout)
     status=$?
 else
     status=$?


### PR DESCRIPTION
Also remove the Levenshtein distance example from the block-list,
because it can now safely be quine tested.

Fixes #910.