### PR TITLE
Use newtypes to represent variants

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -215,9 +215,6 @@ instance CheaplyReducibleE Atom Atom where
     DataCon sourceName dataDefName params con args ->
       DataCon sourceName <$> substM dataDefName <*> cheapReduceE params
                          <*> pure con <*> mapM cheapReduceE args
-    Variant ty l c p -> do
-      ExtLabeledItemsE ty' <- substM $ ExtLabeledItemsE ty
-      Variant ty' l c <$> cheapReduceE p
     DictCon d -> cheapReduceE d
     -- Do recursive reduction via substitution
     -- TODO: we don't collect the dict holes here, so there's a danger of

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -263,19 +263,6 @@ instance HasType Atom where
       return TyKind
     LabeledRow elems -> checkFieldRowElems elems $> LabeledRowKind
     RecordTy elems -> checkFieldRowElems elems $> TyKind
-    Variant vtys@(Ext (LabeledItems types) _) label i arg -> do
-      let ty = VariantTy vtys
-      let maybeArgTy = do
-            labelTys <- M.lookup label types
-            guard $ i < length labelTys
-            return $ labelTys NE.!! i
-      case maybeArgTy of
-        Just argTy -> do
-          argTy' <- substM argTy
-          arg |: argTy'
-        Nothing -> throw TypeErr $ "Bad variant: " <> pprint atom
-                                   <> " with type " <> pprint ty
-      checkTypeE TyKind ty
     VariantTy row -> checkLabeledRow row $> TyKind
     ACase e alts resultTy -> checkCase e alts resultTy Pure
     DataConRef defName params args -> do
@@ -506,6 +493,7 @@ typeCheckPrimCon con = case con of
     case ty' of
       TC (Fin _) -> e|:IdxRepTy
       StaticRecordTy tys -> e|:ProdTy (toList tys)
+      VariantTy (NoExt tys) -> e |: SumTy (toList tys)
       _ -> error $ "Unsupported newtype: " ++ pprint ty
     return ty'
   BaseTypeRef p -> do
@@ -521,6 +509,7 @@ typeCheckPrimCon con = case con of
       case ty' of
         TC (Fin _) -> e|:(RawRefTy IdxRepTy)
         StaticRecordTy tys -> e|:(RawRefTy $ ProdTy $ toList tys)
+        VariantTy (NoExt tys) -> e|:(RawRefTy $ SumTy $ toList tys)
         _ -> error $ "Unsupported newtype: " ++ pprint ty
       return $ RawRefTy ty'
     SumAsProd ty tag _ -> do    -- TODO: check args!
@@ -696,6 +685,12 @@ typeCheckPrimOp op = case op of
                           <> ")"
     diff <- labeledRowDifference full (NoExt types')
     return $ SumTy $ [ VariantTy $ NoExt types', VariantTy diff ]
+  VariantMake ty label i e -> do
+    ty'@(VariantTy (Ext items _)) <- checkTypeE TyKind ty
+    let labelTys = lookupLabel items label
+    unless (0 <= i && i < length labelTys) $ throw TypeErr "Invalid variant index"
+    e |: (labelTys !! i)
+    return ty'
   DataConTag x -> do
     TypeCon _ _ _ <- getTypeE x
     return TagRepTy

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -695,8 +695,7 @@ typeCheckPrimOp op = case op of
                           <> pprint variant <> " (of type " <> pprint fullty
                           <> ")"
     diff <- labeledRowDifference full (NoExt types')
-    return $ VariantTy $ NoExt $
-      Unlabeled [ VariantTy $ NoExt types', VariantTy diff ]
+    return $ SumTy $ [ VariantTy $ NoExt types', VariantTy diff ]
   DataConTag x -> do
     TypeCon _ _ _ <- getTypeE x
     return TagRepTy

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -27,13 +27,10 @@ import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.Writer.Strict hiding (Alt)
 import Control.Monad.State
-import qualified Data.List.NonEmpty    as NE
 import qualified Data.Map.Strict       as M
 
 import Name
 import Err
-import LabeledItems
-import Util (enumerate)
 
 import Types.Core
 import Types.Imp
@@ -735,14 +732,11 @@ mkBundle = bundleFold UnitVal PairVal
 trySelectBranch :: Atom n -> Maybe (Int, [Atom n])
 trySelectBranch e = case e of
   DataCon _ _ _ con args -> return (con, args)
-  Variant (NoExt types) label i value -> do
-    let LabeledItems ixtypes = enumerate types
-    let index = fst $ (ixtypes M.! label) NE.!! i
-    return (index, [value])
   SumVal _ i value -> Just (i, [value])
   Con (SumAsProd _ (TagRepVal tag) vals) -> do
     let i = fromIntegral tag
     return (i , vals !! i)
+  Con (Newtype _ e') -> trySelectBranch e'
   _ -> Nothing
 
 freeAtomVarsList :: HoistableE e => e n -> [AtomName n]

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -96,10 +96,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
     DictTy <$> (DictType sn <$> substM cn <*> mapM tge params)
   LabeledRow elems -> LabeledRow <$> traverseGenericE elems
   RecordTy elems -> RecordTy <$> traverseGenericE elems
-  Variant ext label i value -> do
-    ext' <- traverseExtLabeledItems ext
-    value' <- tge value
-    return $ Variant ext' label i value'
   VariantTy ext -> VariantTy <$> traverseExtLabeledItems ext
   ProjectElt _ _ -> substM atom
   DepPairTy dty -> DepPairTy <$> tge dty

--- a/src/lib/LabeledItems.hs
+++ b/src/lib/LabeledItems.hs
@@ -8,8 +8,7 @@ module LabeledItems
   ( Label, LabeledItems (..), labeledSingleton, reflectLabels, getLabels
   , withLabels, lookupLabelHead, lookupLabel, ExtLabeledItems (..), prefixExtLabeledItems
   , unzipExtLabeledItems, splitLabeledItems, popLabeledItems
-  , pattern NoLabeledItems, pattern NoExt, pattern InternalSingletonLabel
-  , pattern Unlabeled ) where
+  , pattern NoLabeledItems, pattern NoExt ) where
 
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
@@ -89,25 +88,6 @@ pattern NoLabeledItems <- ((\(LabeledItems items) -> M.null items) -> True)
 
 pattern NoExt :: LabeledItems a -> ExtLabeledItems a b
 pattern NoExt a = Ext a Nothing
-
--- An internal label that we can use to treat records and variants as unlabeled
--- internal sum and product types. Note that this is not a valid label in the
--- concrete syntax and will be rejected by the parser (although there wouldn't
--- be any serious problems with overloading a user-written label).
-pattern InternalSingletonLabel :: Label
-pattern InternalSingletonLabel = "%UNLABELED%"
-
-_getUnlabeled :: LabeledItems a -> Maybe [a]
-_getUnlabeled (LabeledItems items) = case length items of
-  0 -> Just []
-  1 -> NE.toList <$> M.lookup InternalSingletonLabel items
-  _ -> Nothing
-
-pattern Unlabeled :: [a] -> LabeledItems a
-pattern Unlabeled as <- (_getUnlabeled -> Just as)
-  where Unlabeled as = case NE.nonEmpty as of
-          Just ne -> LabeledItems (M.singleton InternalSingletonLabel ne)
-          Nothing -> NoLabeledItems
 
 splitLabeledItems :: LabeledItems a -> LabeledItems b -> (LabeledItems b, LabeledItems b)
 splitLabeledItems (LabeledItems litems) (LabeledItems fullItems) =

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -266,10 +266,6 @@ linearizeAtom atom = case atom of
   DictCon _ -> notImplemented
   DictTy _  -> notImplemented
   DepPair _ _ _     -> notImplemented
-  Variant t l i e -> do
-    t' <- substM $ ExtLabeledItemsE t
-    linearizeAtom e `bindLin` \e' ->
-      return $ Variant (fromExtLabeledItemsE $ sink t') l i e'
   TypeCon _ _ _   -> emitZeroT
   LabeledRow _    -> emitZeroT
   RecordTy _      -> emitZeroT

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -269,10 +269,6 @@ instance PrettyPrec (Atom n) where
     DictCon d -> atPrec LowestPrec $ p d
     DictTy  t -> atPrec LowestPrec $ p t
     LabeledRow elems -> prettyRecordTyRow elems "?"
-    Variant _ label i value -> prettyVariant ls label value where
-      ls = LabeledItems $ case i of
-            0 -> M.empty
-            _ -> M.singleton label $ NE.fromList $ fmap (const ()) [1..i]
     RecordTy elems -> prettyRecordTyRow elems "&"
     VariantTy items -> prettyExtLabeledItems items Nothing (line <> "|") ":"
     ACase e alts _ -> prettyPrecCase "acase" e alts Pure
@@ -930,6 +926,12 @@ instance PrettyPrec (PrimCon (Atom n)) where
   prettyPrec = \case
     Newtype (StaticRecordTy ty) (ProdVal itemList) ->
       prettyLabeledItems (restructure itemList ty) (line' <> ",") " ="
+    Newtype (VariantTy (Ext tys _)) (SumVal _ fieldIx value) -> do
+      let (label, i) = toList (reflectLabels tys) !! fieldIx
+      let ls = LabeledItems $ case i of
+                 0 -> M.empty
+                 _ -> M.singleton label $ NE.fromList $ fmap (const ()) [1..i]
+      prettyVariant ls label value
     con -> prettyPrecPrimCon con
 
 prettyPrecPrimCon :: PrettyPrec e => PrimCon e -> DocPrec ann

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -333,7 +333,6 @@ instance HasType Atom where
     DictTy (DictType _ _ _) -> return TyKind
     LabeledRow _ -> return LabeledRowKind
     RecordTy _ -> return TyKind
-    Variant vtys _ _ _ -> substM $ VariantTy vtys
     VariantTy _ -> return TyKind
     ACase _ _ resultTy -> substM resultTy
     DataConRef defName params _ -> do
@@ -613,6 +612,7 @@ getTypePrimOp op = case op of
                           <> ")"
     diff <- labeledRowDifference' full (NoExt types')
     return $ SumTy [ VariantTy $ NoExt types', VariantTy diff ]
+  VariantMake ty _ _ _ -> substM ty
   DataConTag _ -> return TagRepTy
   ToEnum t _ -> substM t
   SumToVariant x -> getTypeE x >>= \case

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -612,8 +612,7 @@ getTypePrimOp op = case op of
                           <> pprint variant <> " (of type " <> pprint fullty
                           <> ")"
     diff <- labeledRowDifference' full (NoExt types')
-    return $ VariantTy $ NoExt $
-      Unlabeled [ VariantTy $ NoExt types', VariantTy diff ]
+    return $ SumTy [ VariantTy $ NoExt types', VariantTy diff ]
   DataConTag _ -> return TagRepTy
   ToEnum t _ -> substM t
   SumToVariant x -> getTypeE x >>= \case

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -133,21 +133,17 @@ prettyVal val = case val of
       yStr <- pprintVal y
       return $ pretty (xStr, yStr)
     ProdCon _ -> error "Unexpected product type: only binary products available in surface language."
-    SumAsProd ty (TagRepVal trep) payload -> do
+    Newtype vty@(VariantTy (NoExt types)) (Con (SumAsProd _ (TagRepVal trep) payload)) ->
+      return $ pretty $ Newtype vty $ SumVal (SumTy $ toList types) t value
+      where t = fromIntegral trep; [value] = payload !! t
+    SumAsProd (TypeCon _ dataDefName _) (TagRepVal trep) payload -> do
       let t = fromIntegral trep
-      case ty of
-        TypeCon _ dataDefName _ -> do
-          DataDef _ _ dataCons <- lookupDataDef dataDefName
-          DataConDef conName _ <- return $ dataCons !! t
-          mapM prettyVal (payload !! t) <&> \case
-            []   -> pretty conName
-            args -> parens $ pretty conName <+> hsep args
-        VariantTy (NoExt types) -> return $ pretty variant
-          where
-            [value] = payload !! t
-            (theLabel, repeatNum) = toList (reflectLabels types) !! t
-            variant = Variant (NoExt types) theLabel repeatNum value
-        _ -> error "SumAsProd with an unsupported type"
+      DataDef _ _ dataCons <- lookupDataDef dataDefName
+      DataConDef conName _ <- return $ dataCons !! t
+      mapM prettyVal (payload !! t) <&> \case
+        []   -> pretty conName
+        args -> parens $ pretty conName <+> hsep args
+    SumAsProd _ _ _ -> error "SumAsProd with an unsupported type"
     _ -> return $ pretty con
   atom -> return $ prettyPrec atom LowestPrec
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -238,6 +238,7 @@ transposeOp op ct = case op of
   RecordSplit  _ _      -> unreachable
   VariantLift  _ _      -> unreachable
   VariantSplit _ _      -> unreachable
+  VariantMake  _ _ _ _  -> unreachable
   SumToVariant _        -> notImplemented
   PtrStore _ _          -> notLinear
   PtrLoad    _          -> notLinear
@@ -275,7 +276,6 @@ transposeAtom atom ct = case atom of
   Con con         -> transposeCon con ct
   DepPair _ _ _   -> notImplemented
   DataCon _ _ _ _ e -> void $ zipWithT transposeAtom e =<< getUnpacked ct
-  Variant _ _ _ _ -> notImplemented
   TabVal b body   -> do
     ty <- substNonlin $ binderAnn b
     void $ buildFor noHint Fwd ty \i -> do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -61,7 +61,6 @@ data Atom (n::S) =
  | DictTy  (DictType n)
  | LabeledRow (FieldRowElems n)
  | RecordTy  (FieldRowElems n)
- | Variant   (ExtLabeledItems (Type n) (AtomName n)) Label Int (Atom n)
  | VariantTy (ExtLabeledItems (Type n) (AtomName n))
  | Con (Con n)
  | TC  (TC  n)
@@ -994,11 +993,9 @@ instance GenericE Atom where
   {- TypeCon -}    ( LiftE SourceName `PairE` DataDefName `PairE` DataDefParams)
   {- DictCon  -}   DictExpr
   {- DictTy  -}    DictType
-            ) (EitherE4
+            ) (EitherE3
   {- LabeledRow -} ( FieldRowElems )
   {- RecordTy -}   ( FieldRowElems )
-  {- Variant -}    ( ExtLabeledItemsE Type AtomName `PairE`
-                     LiftE (Label, Int) `PairE` Atom )
   {- VariantTy -}  ( ExtLabeledItemsE Type AtomName )
             ) (EitherE4
   {- Con -}        (ComposeE PrimCon Atom)
@@ -1032,9 +1029,7 @@ instance GenericE Atom where
     DictTy  d -> Case2 $ Case5 d
     LabeledRow elems    -> Case3 $ Case0 $ elems
     RecordTy elems -> Case3 $ Case1 elems
-    Variant extItems l con payload -> Case3 $ Case2 $
-      ExtLabeledItemsE extItems `PairE` LiftE (l, con) `PairE` payload
-    VariantTy extItems  -> Case3 $ Case3 $ ExtLabeledItemsE extItems
+    VariantTy extItems  -> Case3 $ Case2 $ ExtLabeledItemsE extItems
     Con con -> Case4 $ Case0 $ ComposeE con
     TC  con -> Case4 $ Case1 $ ComposeE con
     Eff effs -> Case4 $ Case2 $ effs
@@ -1072,10 +1067,7 @@ instance GenericE Atom where
     Case3 val -> case val of
       Case0 elems -> LabeledRow elems
       Case1 elems -> RecordTy elems
-      Case2 ( (ExtLabeledItemsE extItems) `PairE`
-              LiftE (l, con)              `PairE`
-              payload) -> Variant extItems l con payload
-      Case3 (ExtLabeledItemsE extItems) -> VariantTy extItems
+      Case2 (ExtLabeledItemsE extItems) -> VariantTy extItems
       _ -> error "impossible"
     Case4 val -> case val of
       Case0 (ComposeE con) -> Con con

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -131,6 +131,8 @@ data PrimOp e =
       -- Left arg contains the types of the fields to extract (e.g. a:A, b:B).
       -- (see https://github.com/google-research/dex-lang/pull/201#discussion_r471591972)
       | VariantSplit (LabeledItems e) e
+      -- type, label, how deeply shadowed, payload
+      | VariantMake e Label Int e
       -- Ask which constructor was used, as its Word8 index
       | DataConTag e
       -- Create an enum (payload-free ADT) from a Word8


### PR DESCRIPTION
Just like with records. Variants do not add extra expressive power and
degenerate to sum types once the set of cases is statically known.