### PR TITLE
Benchmarking Dex runtimes

### DIFF
--- a/benchmarks/continuous.py
+++ b/benchmarks/continuous.py
@@ -172,6 +172,7 @@ class Result:
       return Result(self.benchmark, 'time_rel', self.value / other.value)
     if self.measure == 'runtime':
       return Result(self.benchmark, 'runtime_rel', self.value / other.value)
+    raise NotImplementedError(f"Unrecognized metric type {self.measure}")
 
 
 ALLOC_PATTERN = re.compile(r"^\s*([0-9,]+) bytes allocated in the heap", re.M)

--- a/benchmarks/fused_sum.dx
+++ b/benchmarks/fused_sum.dx
@@ -1,0 +1,6 @@
+n = if dex_test_mode() then 1000 else 1000000
+
+%bench "fused-sum"
+sum $ for i:(Fin n).
+  x = n_to_i64 (ordinal i)
+  x * x

--- a/benchmarks/fused_sum.dx
+++ b/benchmarks/fused_sum.dx
@@ -4,3 +4,8 @@ n = if dex_test_mode() then 1000 else 1000000
 sum $ for i:(Fin n).
   x = n_to_i64 (ordinal i)
   x * x
+> 332833500
+>
+> fused-sum
+> Compile time: 22.192 ms
+> Run time:     5.186 us 	(based on 1 run)

--- a/makefile
+++ b/makefile
@@ -216,9 +216,13 @@ test-names = uexpr-tests adt-tests type-tests eval-tests show-tests read-tests \
 
 doc-names = conditionals functions
 
-all-names = $(test-names:%=tests/%) $(example-names:%=examples/%) $(doc-names:%=doc/%)
+benchmark-names = fused_sum
 
-quine-test-targets = $(all-names:%=run-%)
+quine-test-targets = \
+  $(test-names:%=run-tests/%) \
+  $(example-names:%=run-examples/%) \
+  $(doc-names:%=run-doc/%) \
+  $(benchmark-names:%=run-bench-tests/%)
 
 update-test-targets    = $(test-names:%=update-tests/%)
 update-doc-targets     = $(doc-names:%=update-doc/%)
@@ -264,6 +268,10 @@ run-doc/%: doc/%.dx just-build
 	misc/check-quine $< $(dex) script
 run-examples/%: examples/%.dx just-build
 	misc/check-quine $< $(dex) -O script
+# This runs the benchmark in test mode, which means we're checking
+# that it's not broken, but not actually trying to measure runtimes
+run-bench-tests/%: benchmarks/%.dx just-build
+	misc/check-quine $< $(dex) -O script
 
 lower-tests: export DEX_LOWER=1
 lower-tests: export DEX_ALLOW_CONTRACTIONS=0
@@ -301,7 +309,11 @@ update-examples/%: examples/%.dx just-build
 	$(dex) script $< > $<.tmp
 	mv $<.tmp $<
 
-run-gpu-tests: export DEX_ALLOC_CONTRACTIONS=0
+update-bench-tests/%: benchmarks/%.dx just-build
+	$(dex) script $< > $<.tmp
+	mv $<.tmp $<
+
+run-gpu-tests: export DEX_ALLOW_CONTRACTIONS=0
 run-gpu-tests: tests/gpu-tests.dx just-build
 	misc/check-quine $< $(dex) --backend llvm-cuda script
 

--- a/src/lib/LLVMExec.hs
+++ b/src/lib/LLVMExec.hs
@@ -110,8 +110,11 @@ compileAndBench shouldSyncCUDA logger objFiles ast fname args resultTypes = do
                   freeLitVals resultPtr resultTypes
             let sync = when shouldSyncCUDA $ synchronizeCUDA
             exampleDuration <- snd <$> measureSeconds (run >> sync)
+            test_mode <- (Just "t" ==) <$> E.lookupEnv "DEX_TEST_MODE"
             let timeBudget = 2 -- seconds
-            let benchRuns = (ceiling $ timeBudget / exampleDuration) :: Int
+            let benchRuns = if test_mode
+                  then 1
+                  else (ceiling $ timeBudget / exampleDuration) :: Int
             sync
             totalTime <- liftM snd $ measureSeconds $ do
               forM_ [1..benchRuns] $ const run

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -576,8 +576,10 @@ instance Pretty Output where
     benchName <> hardline <>
     "Compile time: " <> prettyDuration compileTime <> hardline <>
     "Run time:     " <> prettyDuration runTime <+>
-    (case stats of Just (runs, _) -> "\t" <> parens ("based on" <+> p runs <+> "runs")
-                   Nothing        -> "")
+    (case stats of
+       Just (runs, _) ->
+         "\t" <> parens ("based on" <+> p runs <+> plural "run" "runs" runs)
+       Nothing        -> "")
     where benchName = case name of "" -> ""
                                    _  -> "\n" <> p name
   pretty (PassInfo _ s) = p s


### PR DESCRIPTION
This PR adds infrastructure for continuously benchmarking only the runtime of Dex code (as opposed to total time including compilation), and a micro-benchmark using it.

The content of the change is:

- Refactoring benchmarks/continuous.py to admit different benchmark types that have different code for running the benchmark and extracting the metric from it;
- Adding a `DexRuntime` benchmark type that grovels Dex output for the result from a `%bench` directive instead of groveling for GHC `+RTS -s` output;
- Adding a `Python` benchmark type that just times a Python function, so we can have baselines that aren't implemented in Dex;
- Adding a benchmark (create and sum an array, stresses fusion); and
- Teaching the `makefile` to run select benchmarks as tests (under `DEX_TEST_MODE=t`) so we keep them working.