### PR TITLE
Use newtypes to represent ADTs

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -24,7 +24,6 @@ module Builder (
   buildLam, buildTabLam, buildLamGeneral,
   buildAbs, buildNaryAbs, buildNaryLam, buildNullaryLam, buildNaryLamExpr, asNaryLam,
   buildAlt, buildUnaryAlt, buildUnaryAtomAlt,
-  buildNewtype,
   emitDataDef, emitClassDef, emitInstanceDef, emitDataConName, emitTyConName,
   buildCase, emitMaybeCase, buildSplitCase,
   emitBlock, emitDecls, BuilderEmissions, emitAtomToName,
@@ -77,7 +76,7 @@ import CheapReduction
 import MTL1
 import {-# SOURCE #-} Interpreter
 import LabeledItems
-import Util (enumerate, transitiveClosureM, bindM2, iota)
+import Util (enumerate, transitiveClosureM, bindM2)
 import Err
 import Types.Core
 import Core
@@ -827,17 +826,6 @@ buildUnaryAtomAlt ty body = do
     Distinct <- getDistinct
     body v
 
-buildNewtype :: ScopableBuilder m
-             => SourceName
-             -> EmptyAbs (Nest Binder) n
-             -> (forall l. DExt n l => [AtomName l] -> m l (Type l))
-             -> m n (DataDef n)
-buildNewtype name paramBs body = do
-  Abs paramBs' argBs <- buildNaryAbs paramBs \params -> do
-    ty <- body params
-    singletonBinderNest noHint ty
-  return $ DataDef name (DataDefBinders paramBs' Empty) [DataConDef ("mk" <> name) argBs]
-
 -- TODO: consider a version with nonempty list of alternatives where we figure
 -- out the result type from one of the alts rather than providing it explicitly
 buildCase :: (Emits n, ScopableBuilder m)
@@ -851,15 +839,13 @@ buildCase scrut resultTy indexedAltBody = do
       indexedAltBody i (map sink args)
     Nothing -> do
       scrutTy <- getType scrut
-      altsBinderTys <- caseAltsBinderTys scrutTy
-      (alts, effs) <- unzip <$> forM (enumerate altsBinderTys) \(i, bs) -> do
-        (Abs bs' (body `PairE` eff')) <- buildNaryAbs bs \xs -> do
-          blk <- buildBlock do
-            ListE xs' <- sinkM $ ListE xs
-            indexedAltBody i (Var <$> xs')
+      altBinderTys <- caseAltsBinderTys scrutTy
+      (alts, effs) <- unzip <$> forM (enumerate altBinderTys) \(i, bTy) -> do
+        (Abs b' (body `PairE` eff')) <- buildAbs noHint bTy \x -> do
+          blk <- buildBlock $ indexedAltBody i [Var $ sink x]
           eff <- getEffects blk
           return $ blk `PairE` eff
-        return (Abs bs' body, ignoreHoistFailure $ hoist bs' eff')
+        return (Abs (Nest b' Empty) body, ignoreHoistFailure $ hoist b' eff')
       liftM Var $ emit $ Case scrut alts resultTy $ mconcat effs
 
 buildSplitCase :: (Emits n, ScopableBuilder m)
@@ -990,6 +976,7 @@ maybeTangentType ty = liftEnvReaderT $ maybeTangentType' ty
 maybeTangentType' :: Type n -> EnvReaderT Maybe n (Type n)
 maybeTangentType' ty = case ty of
   StaticRecordTy items -> StaticRecordTy <$> mapM rec items
+  -- TODO: Delete this case! This is a hack!
   TypeCon _ _ _ -> rec =<< fromNewtypeWrapper ty
   TabTy b bodyTy -> do
     refreshAbs (Abs b bodyTy) \b' bodyTy' -> do
@@ -1010,7 +997,7 @@ fromNewtypeWrapper ty = do
   TypeCon _ defName params <- return ty
   def <- lookupDataDef defName
   [con] <- instantiateDataDef def params
-  DataConDef _ (EmptyAbs (Nest (_:>wrappedTy) Empty)) <- return con
+  DataConDef _ (EmptyAbs (Nest (_:>wrappedTy) Empty)) _ _ <- return con
   return wrappedTy
 
 tangentBaseMonoidFor :: Builder m => Type n -> m n (BaseMonoid n)
@@ -1072,7 +1059,7 @@ emitInstanceDef instanceDef@(InstanceDef className _ _ _) = do
 emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> Atom n -> m n (Name DataConNameC n)
 emitDataConName dataDefName conIdx conAtom = do
   DataDef _ _ dataCons <- lookupDataDef dataDefName
-  let (DataConDef name _) = dataCons !! conIdx
+  let (DataConDef name _ _ _) = dataCons !! conIdx
   emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx conAtom
 
 zipNest :: (forall ii ii'. a -> b ii ii' -> b' ii ii')
@@ -1218,8 +1205,8 @@ getUnpacked :: (Fallible1 m, EnvReader m) => Atom n -> m n [Atom n]
 getUnpacked atom = do
   atom' <- cheapNormalize atom
   ty <- getType atom'
-  (len, suffix) <- projectLength ty
-  return $ map (\i -> getProjection (i:suffix) atom') (iota len)
+  idxs <- projectionIndices ty
+  return $ idxs <&> flip getProjection atom'
 {-# SCC getUnpacked #-}
 
 emitUnpacked :: (Builder m, Emits n) => Atom n -> m n [AtomName n]

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -212,9 +212,6 @@ instance CheaplyReducibleE Atom Atom where
     -- We traverse the Atom constructors that might contain lambda expressions
     -- explicitly, to make sure that we can skip normalizing free vars inside those.
     Con con -> Con <$> (inline traversePrimCon) cheapReduceE con
-    DataCon sourceName dataDefName params con args ->
-      DataCon sourceName <$> substM dataDefName <*> cheapReduceE params
-                         <*> pure con <*> mapM cheapReduceE args
     DictCon d -> cheapReduceE d
     -- Do recursive reduction via substitution
     -- TODO: we don't collect the dict holes here, so there's a danger of

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -27,7 +27,7 @@ import qualified Data.Map.Strict as M
 import LabeledItems
 
 import Err
-import Util (forMZipped_, iota)
+import Util (forMZipped_)
 import QueryType hiding (HasType)
 
 import CheapReduction
@@ -241,15 +241,6 @@ instance HasType Atom where
     Con con  -> typeCheckPrimCon con
     TC tyCon -> typeCheckPrimTC  tyCon
     Eff eff  -> checkE eff $> EffKind
-    DataCon _ defName params conIx args -> do
-      defName' <- substM defName
-      def@(DataDef sourceName _ _) <- lookupDataDef defName'
-      params' <- checkE params
-      cons' <- checkedInstantiateDataDef def params'
-      let DataConDef _ conParamAbs' = cons' !! conIx
-      args'   <- traverse checkE args
-      void $ checkedApplyNaryAbs conParamAbs' args'
-      return $ TypeCon sourceName defName' params'
     TypeCon _ defName params -> do
       def <- lookupDataDef =<< substM defName
       params' <- checkE params
@@ -269,7 +260,7 @@ instance HasType Atom where
       defName' <- substM defName
       def@(DataDef sourceName _ _) <- lookupDataDef defName'
       params' <- checkE params
-      [DataConDef _ argBs] <- checkedInstantiateDataDef def params'
+      [DataConDef _ argBs _ _] <- checkedInstantiateDataDef def params'
       checkDataConRefEnv argBs args
       return $ RawRefTy $ TypeCon sourceName defName' params'
     DepPairRef l (Abs b r) ty -> do
@@ -294,22 +285,15 @@ instance HasType Atom where
               Nothing -> Var v
               Just is' -> ProjectElt is' v
       case ty of
-        TypeCon _ defName params -> do
-          v' <- substM v
-          def <- lookupDataDef defName
-          [DataConDef _ (Abs bs' UnitE)] <- checkedInstantiateDataDef def params
-          PairB bsInit (Nest (_:>bTy) _) <- return $ splitNestAt i bs'
-          -- `ty` can depend on earlier binders from this constructor. Rewrite
-          -- it to also use projections.
-          dropSubst $
-            applyNaryAbs (Abs bsInit bTy)
-              [ SubstVal (ProjectElt (j NE.:| is) v')
-              | j <- iota $ nestLength bsInit]
         ProdTy xs -> return $ xs !! i
         DepPairTy t | i == 0 -> return $ depPairLeftTy t
         DepPairTy t | i == 1 -> do v' <- substM v
                                    instantiateDepPairTy t (ProjectElt (0 NE.:| is) v')
         -- Newtypes
+        TypeCon _ defName params | i == 0 -> do
+          def <- lookupDataDef defName
+          [DataConDef _ _ repTy _] <- checkedInstantiateDataDef def params
+          return repTy
         TC (Fin _) | i == 0 -> return IdxRepTy
         StaticRecordTy types | i == 0 -> return $ ProdTy $ toList types
         RecordTy _ -> throw CompilerErr "Can't project partially-known records"
@@ -494,6 +478,10 @@ typeCheckPrimCon con = case con of
       TC (Fin _) -> e|:IdxRepTy
       StaticRecordTy tys -> e|:ProdTy (toList tys)
       VariantTy (NoExt tys) -> e |: SumTy (toList tys)
+      TypeCon _ defName params -> do
+        def <- lookupDataDef defName
+        cons <- checkedInstantiateDataDef def params
+        e |: dataDefRep cons
       _ -> error $ "Unsupported newtype: " ++ pprint ty
     return ty'
   BaseTypeRef p -> do
@@ -510,6 +498,10 @@ typeCheckPrimCon con = case con of
         TC (Fin _) -> e|:(RawRefTy IdxRepTy)
         StaticRecordTy tys -> e|:(RawRefTy $ ProdTy $ toList tys)
         VariantTy (NoExt tys) -> e|:(RawRefTy $ SumTy $ toList tys)
+        TypeCon _ defName params -> do
+          def <- lookupDataDef defName
+          cons <- checkedInstantiateDataDef def params
+          e |: RawRefTy (dataDefRep cons)
         _ -> error $ "Unsupported newtype: " ++ pprint ty
       return $ RawRefTy ty'
     SumAsProd ty tag _ -> do    -- TODO: check args!
@@ -700,7 +692,7 @@ typeCheckPrimOp op = case op of
     case t' of
       TypeCon _ dataDefName (DataDefParams [] []) -> do
         DataDef _ _ dataConDefs <- lookupDataDef dataDefName
-        forM_ dataConDefs \(DataConDef _ (Abs binders _)) -> checkEmptyNest binders
+        forM_ dataConDefs \(DataConDef _ (Abs binders _) _ _) -> checkEmptyNest binders
       VariantTy _ -> return ()  -- TODO: check empty payload
       SumTy cases -> forM_ cases \cty -> checkAlphaEq cty UnitTy
       _ -> error $ "Not a sum type: " ++ pprint t'
@@ -855,17 +847,15 @@ checkCase scrut alts resultTy effs = do
     checkAlt resultTy' bs alt
   return resultTy'
 
-checkCaseAltsBinderTys :: (Fallible1 m, EnvReader m)
-                  => Type n -> m n [EmptyAbs (Nest Binder) n]
+checkCaseAltsBinderTys :: (Fallible1 m, EnvReader m) => Type n -> m n [Type n]
 checkCaseAltsBinderTys ty = case ty of
   TypeCon _ defName params -> do
     def <- lookupDataDef defName
     cons <- checkedInstantiateDataDef def params
-    return [bs | DataConDef _ bs <- cons]
-  VariantTy (NoExt types) -> do
-    mapM typeAsBinderNest $ toList types
+    return [repTy | DataConDef _ _ repTy _ <- cons]
+  SumTy types -> return types
+  VariantTy (NoExt types) -> return $ toList types
   VariantTy _ -> fail "Can't pattern-match partially-known variants"
-  SumTy cases -> mapM typeAsBinderNest cases
   _ -> fail $ "Case analysis only supported on ADTs and variants, not on " ++ pprint ty
 
 checkDataConRefEnv :: Typer m
@@ -884,12 +874,13 @@ checkDataConRefEnv (EmptyAbs (Nest b restBs)) (EmptyAbs (Nest refBinding restRef
     checkDataConRefEnv restBs' (EmptyAbs restRefs)
 checkDataConRefEnv _ _ = throw CompilerErr $ "Mismatched args and binders"
 
-checkAlt :: HasType body => Typer m
-         => Type o -> EmptyAbs (Nest Binder) o -> AltP body i -> m i o ()
-checkAlt resultTyReq reqBs (Abs bs body) = do
-  bs' <- substM (EmptyAbs bs)
-  checkAlphaEq reqBs bs'
-  substBinders bs \_ -> do
+checkAlt :: (HasType body, Typer m)
+         => Type o -> Type o -> AltP body i -> m i o ()
+checkAlt resultTyReq bTyReq (Abs bs body) = do
+  Nest b Empty <- return bs
+  bTy <- substM $ binderType b
+  checkAlphaEq bTyReq bTy
+  substBinders b \_ -> do
     resultTyReq' <- sinkM resultTyReq
     body |: resultTyReq'
 
@@ -1289,8 +1280,7 @@ checkDataLike ty = case ty of
     params' <- substM params
     def <- lookupDataDef =<< substM defName
     dataCons <- instantiateDataDef def params'
-    dropSubst $ forM_ dataCons \(DataConDef _ bs) ->
-      checkDataLikeBinderNest bs
+    dropSubst $ forM_ dataCons \(DataConDef _ _ repTy _) -> checkDataLike repTy
   TC con -> case con of
     BaseType _       -> return ()
     ProdType as      -> mapM_ recur as
@@ -1299,9 +1289,3 @@ checkDataLike ty = case ty of
     _ -> throw TypeErr $ pprint ty
   _   -> throw TypeErr $ pprint ty
   where recur = checkDataLike
-
-checkDataLikeBinderNest :: Typer m => EmptyAbs (Nest Binder) i -> m i o ()
-checkDataLikeBinderNest (Abs Empty UnitE) = return ()
-checkDataLikeBinderNest (Abs (Nest b rest) UnitE) = do
-  checkDataLike $ binderType b
-  substBinders b \_ -> checkDataLikeBinderNest $ Abs rest UnitE

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -323,12 +323,6 @@ instance BindsEnv EnvFrag where
 instance BindsEnv (RecSubstFrag Binding) where
   toEnvFrag frag = EnvFrag frag mempty
 
--- This is needed to be able to derive generic traversals over Atoms, and is
--- ok to be left unimplemented for as long as it's _dynamically_ unreachable.
--- Since references are only used in Imp lowering, we're generally ok.
-instance BindsEnv DataConRefBinding where
-  toEnvFrag = error "not implemented"
-
 instance (BindsEnv b1, BindsEnv b2)
          => (BindsEnv (PairB b1 b2)) where
   toEnvFrag (PairB b1 b2) = do

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -98,7 +98,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   DepPairTy dty -> DepPairTy <$> tge dty
   DepPair l r dty -> DepPair <$> tge l <*> tge r <*> tge dty
   ACase _ _ _ -> nyi
-  DataConRef _ _ _ -> nyi
   DepPairRef _ _ _ -> nyi
   BoxedRef _ -> nyi
   where nyi = error $ "not implemented: " ++ pprint atom

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -86,9 +86,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   Con con -> Con <$> mapM tge con
   TC  tc  -> TC  <$> mapM tge tc
   Eff _   -> substM atom
-  DataCon sourceName dataDefName params con args ->
-    DataCon sourceName <$> substM dataDefName <*>
-      tge params <*> pure con <*> mapM tge args
   TypeCon sn dataDefName params ->
     TypeCon sn <$> substM dataDefName <*> tge params
   DictCon dictExpr -> DictCon <$> tge dictExpr

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -1379,7 +1379,7 @@ tyConDefAsAtom defName = liftBuilder do
 dataConDefAsAtom :: EnvReader m => DataDefName n -> Int -> m n (Atom n)
 dataConDefAsAtom defName conIx = liftBuilder do
   buildTyConLam defName ImplicitArrow \_ params -> do
-    let defName' = sink defName
+    defName' <- sinkM defName
     def@(DataDef sourceName _ _ ) <- lookupDataDef defName'
     conDefs <- instantiateDataDef def params
     DataConDef _ (EmptyAbs conArgBinders) conRep _ <- return $ conDefs !! conIx

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -17,6 +17,7 @@ import qualified Data.List.NonEmpty as NE
 import Data.Maybe (fromJust)
 import Data.List (elemIndex)
 import Data.Foldable (toList)
+import Data.Functor
 import Data.Word
 import Foreign.Ptr
 import Foreign.Marshal.Alloc
@@ -98,11 +99,6 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   TypeCon sn defName (DataDefParams params dicts) -> do
     defName' <- substM defName
     TypeCon sn defName' <$> (DataDefParams <$> mapM rec params <*> mapM rec dicts)
-  DataCon printName defName (DataDefParams params dicts) con args -> do
-    defName' <- substM defName
-    DataCon printName defName'
-      <$> (DataDefParams <$> mapM rec params <*> mapM rec dicts)
-      <*> pure con <*> mapM rec args
   RecordTy _ -> substM atom
   VariantTy _      -> substM atom
   LabeledRow _     -> substM atom
@@ -222,7 +218,8 @@ evalOp expr = mapM evalAtom expr >>= \case
     _ -> error $ "Invalid select condition: " ++ pprint cond
   ToEnum ty@(TypeCon _ defName _) i -> do
       DataDef _ _ cons <- lookupDataDef defName
-      return $ Con $ SumAsProd ty i (map (const []) cons)
+      return $ Con $ Newtype ty $ Con $
+        SumAsProd (SumTy $ cons <&> const UnitTy) i (cons <&> const [UnitVal])
   ProjMethod dict i -> evalProjectDictMethod dict i
   VariantMake ty@(VariantTy (NoExt tys)) label i v -> do
     let ix = fromJust $ elemIndex (label, i) $ toList $ reflectLabels tys
@@ -250,7 +247,11 @@ matchUPat (WithSrcB _ pat) x = do
   x' <- dropSubst $ evalAtom x
   case (pat, x') of
     (UPatBinder b, _) -> return $ b @> SubstVal x'
-    (UPatCon _ ps, DataCon _ _ _ _ xs) -> matchUPats ps xs
+    (UPatCon _ ps, Con (Newtype (TypeCon _ dataDefName _) _)) -> do
+      DataDef _ _ cons <- lookupDataDef dataDefName
+      case cons of
+        [DataConDef _ _ _ idxs] -> matchUPats ps [getProjection ix x' | ix <- idxs]
+        _ -> error "Expected a single ADt constructor"
     (UPatPair (PairB p1 p2), PairVal x1 x2) -> do
       matchUPat p1 x1 >>= (`followedByFrag` matchUPat p2 x2)
     (UPatUnit UnitB, UnitVal) -> return emptyInFrag

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -104,7 +104,6 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   LabeledRow _     -> substM atom
   ACase scrut alts resultTy ->
     ACase <$> rec scrut <*> mapM substM alts <*> rec resultTy
-  DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _       -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> rec (Var v)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -280,7 +280,6 @@ linearizeAtom atom = case atom of
   -- Those should be gone after simplification
   Lam _            -> error "Unexpected non-table lambda"
   ACase _ _ _      -> error "Unexpected ACase"
-  DataConRef _ _ _ -> error "Unexpected ref"
   BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   where emitZeroT = withZeroT $ substM atom

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -267,8 +267,6 @@ instance PrettyPrec (Atom n) where
     RecordTy elems -> prettyRecordTyRow elems "&"
     VariantTy items -> prettyExtLabeledItems items Nothing (line <> "|") ":"
     ACase e alts _ -> prettyPrecCase "acase" e alts Pure
-    DataConRef _ params args -> atPrec LowestPrec $
-      "DataConRef" <+> p params <+> p args
     BoxedRef (Abs (NonDepNest b ptrsSizes) body) -> atPrec LowestPrec $
       "Box" <+> p b <+> "<-" <+> p ptrsSizes <+> hardline <> "in" <+> p body
     ProjectElt idxs v ->
@@ -294,10 +292,6 @@ instance Pretty (FieldRowElem n) where
       withLabels items <&> \(l, _, ty) -> p l <> ":" <+> pLowest ty
     DynField  l ty -> "@" <> p l <> ":" <+> p ty
     DynFields f    -> "..." <> p f
-
-instance Pretty (DataConRefBinding n l) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (DataConRefBinding n l) where
-  prettyPrec (DataConRefBinding b x) = atPrec AppPrec $ p b <+> "<-" <+> p x
 
 prettyExtLabeledItems :: (PrettyPrec a, PrettyPrec b)
   => ExtLabeledItems a b -> Maybe (Doc ann) -> Doc ann -> Doc ann -> DocPrec ann

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -251,11 +251,6 @@ instance PrettyPrec (Atom n) where
     TC  e -> prettyPrec e
     Con e -> prettyPrec e
     Eff e -> atPrec ArgPrec $ p e
-    DataCon name _ _ _ xs -> case xs of
-      [] -> atPrec ArgPrec $ p name
-      [l, r] | Just sym <- fromInfix (fromString name) -> atPrec ArgPrec $ align $ group $
-        parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
-      _ ->  atPrec LowestPrec $ pAppArg (p name) xs
     TypeCon "RangeTo"      _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ ".."  <> pApp i
     TypeCon "RangeToExc"   _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ "..<" <> pApp i
     TypeCon "RangeFrom"    _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ pApp i <>  ".."
@@ -500,7 +495,7 @@ instance Pretty (DataDef n) where
     "data" <+> p name <+> p bs <> prettyLines cons
 
 instance Pretty (DataConDef n) where
-  pretty (DataConDef name bs) =
+  pretty (DataConDef name bs _ _) =
     p name <+> ":" <+> p bs
 
 instance Pretty (ClassDef n) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -11,10 +11,11 @@ module QueryType (
   caseAltsBinderTys, depPairLeftTy, extendEffect,
   getAppType, getTabAppType, getBaseMonoidType, getReferentTy,
   getMethodIndex,
-  instantiateDataDef, instantiateNaryPi, instantiateDepPairTy, instantiatePi, instantiateTabPi,
+  instantiateDataDef, dataDefRep,
+  instantiateNaryPi, instantiateDepPairTy, instantiatePi, instantiateTabPi,
   litType, lamExprTy,
   numNaryPiArgs, naryLamExprType, specializedFunType,
-  oneEffect, projectLength, sourceNameType, typeAsBinderNest, typeBinOp, typeUnOp,
+  oneEffect, projectionIndices, sourceNameType, typeBinOp, typeUnOp,
   isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict
   ) where
 
@@ -74,16 +75,15 @@ getEffectsSubst e = do
 -- === Exposed helpers for querying types and effects ===
 
 caseAltsBinderTys :: (Fallible1 m, EnvReader m)
-                  => Type n -> m n [EmptyAbs (Nest Binder) n]
+                  => Type n -> m n [Type n]
 caseAltsBinderTys ty = case ty of
   TypeCon _ defName params -> do
     def <- lookupDataDef defName
     cons <- instantiateDataDef def params
-    return [bs | DataConDef _ bs <- cons]
-  VariantTy (NoExt types) -> do
-    mapM typeAsBinderNest $ toList types
+    return [repTy | DataConDef _ _ repTy _ <- cons]
+  SumTy types -> return types
+  VariantTy (NoExt types) -> return $ toList types
   VariantTy _ -> fail "Can't pattern-match partially-known variants"
-  SumTy cases -> mapM typeAsBinderNest cases
   _ -> fail $ "Case analysis only supported on ADTs and variants, not on " ++ pprint ty
 
 depPairLeftTy :: DepPairType n -> Type n
@@ -126,8 +126,16 @@ getMethodIndex className methodSourceName = do
 
 instantiateDataDef :: ScopeReader m => DataDef n -> DataDefParams n -> m n [DataConDef n]
 instantiateDataDef (DataDef _ (DataDefBinders bs1 bs2) cons) (DataDefParams xs1 xs2) = do
-  fromListE <$> applyNaryAbs (Abs (bs1 >>> bs2) (ListE cons)) (map SubstVal $ xs1 <> xs2)
+  fromListE <$> applySubst (bs1 @@> (SubstVal <$> xs1) <.> bs2 @@> (SubstVal <$> xs2)) (ListE cons)
 {-# INLINE instantiateDataDef #-}
+
+-- Returns a representation type (type of an TypeCon-typed Newtype payload)
+-- given a list of instantiated DataConDefs.
+dataDefRep :: [DataConDef n] -> Type n
+dataDefRep = \case
+  [] -> error "unreachable"  -- There's no representation for a void type
+  [DataConDef _ _ ty _] -> ty
+  tys -> SumTy $ tys <&> \(DataConDef _ _ ty _) -> ty
 
 instantiateNaryPi :: EnvReader m => NaryPiType n -> [Atom n] -> m n (NaryPiType n)
 instantiateNaryPi (NaryPiType bs eff resultTy) args = do
@@ -198,18 +206,17 @@ specializedFunType (AppSpecialization f ab) = liftEnvReaderM $
 oneEffect :: Effect n -> EffectRow n
 oneEffect eff = EffectRow (S.singleton eff) Nothing
 
--- Returns the number of components available for projection in the first
--- result, and the suffix of ProjectElt that has to be used to reach them
--- (we might need to unwrap newtypes to uncover them).
-projectLength :: (Fallible1 m, EnvReader m) => Type n -> m n (Int, [Int])
-projectLength ty = case ty of
-  TypeCon _ defName params -> do
-    def <- lookupDataDef defName
-    [DataConDef _ (Abs bs UnitE)] <- instantiateDataDef def params
-    return $ (nestLength bs, [])
-  StaticRecordTy types -> return $ (length types, [0])
-  ProdTy tys -> return $ (length tys, [])
-  _ -> error $ "Projecting a type that doesn't support projecting: " ++ pprint ty
+projectionIndices :: (Fallible1 m, EnvReader m) => Type n -> m n [[Int]]
+projectionIndices ty = case ty of
+  TypeCon _ defName _ -> do
+    DataDef _ _ cons <- lookupDataDef defName
+    case cons of
+      [DataConDef _ _ _ idxs] -> return idxs
+      _ -> unsupported
+  StaticRecordTy types -> return $ iota (length types) <&> (:[0])
+  ProdTy tys -> return $ iota (length tys) <&> (:[])
+  _ -> unsupported
+  where unsupported = error $ "Projecting a type that doesn't support projecting: " ++ pprint ty
 
 sourceNameType :: (EnvReader m, Fallible1 m)
                => SourceName -> m n (Type n)
@@ -225,12 +232,6 @@ sourceNameType v = do
       UEffectVar   _ -> error "not implemented: sourceNameType::UEffectVar"
       UEffectOpVar _ -> error "not implemented: sourceNameType::UEffectOpVar"
       UHandlerVar  _ -> error "not implemented: sourceNameType::UHandlerVar"
-
-typeAsBinderNest :: ScopeReader m => Type n -> m n (Abs (Nest Binder) UnitE n)
-typeAsBinderNest ty = do
-  Abs ignored body <- toConstAbs UnitE
-  return $ Abs (Nest (ignored:>ty) Empty) body
-{-# INLINE typeAsBinderNest #-}
 
 typeBinOp :: BinOp -> BaseType -> BaseType
 typeBinOp binop xTy = case binop of
@@ -323,11 +324,6 @@ instance HasType Atom where
     Con con -> getTypePrimCon con
     TC _ -> return TyKind
     Eff _ -> return EffKind
-    DataCon _ defName params _ _ -> do
-      defName' <- substM defName
-      (DataDef sourceName _ _) <- lookupDataDef defName'
-      params' <- substM params
-      return $ TypeCon sourceName defName' params'
     TypeCon _ _ _ -> return TyKind
     DictCon dictExpr -> getTypeE dictExpr
     DictTy (DictType _ _ _) -> return TyKind
@@ -354,19 +350,6 @@ instance HasType Atom where
               Nothing -> Var v
               Just is' -> ProjectElt is' v
       case ty of
-        TypeCon _ defName params -> do
-          v' <- substM (Var v) >>= \case
-            (Var v') -> return v'
-            _ -> error "!??"
-          def <- lookupDataDef defName
-          [DataConDef _ (Abs bs' UnitE)] <- instantiateDataDef def params
-          PairB bsInit (Nest (_:>bTy) _) <- return $ splitNestAt i bs'
-          -- `ty` can depend on earlier binders from this constructor. Rewrite
-          -- it to also use projections.
-          dropSubst $
-            applyNaryAbs (Abs bsInit bTy)
-              [ SubstVal (ProjectElt (j NE.:| is) v')
-              | j <- iota $ nestLength bsInit]
         ProdTy xs -> return $ xs !! i
         DepPairTy t | i == 0 -> return $ depPairLeftTy t
         DepPairTy t | i == 1 -> do v' <- substM (Var v) >>= \case
@@ -376,6 +359,10 @@ instance HasType Atom where
         -- Newtypes
         TC (Fin _) | i == 0 -> return IdxRepTy
         StaticRecordTy types | i == 0 -> return $ ProdTy $ toList types
+        TypeCon _ defName params | i == 0 -> do
+          def <- lookupDataDef defName
+          [DataConDef _ _ repTy _] <- instantiateDataDef def params
+          return repTy
         RecordTy _ -> throw CompilerErr "Can't project partially-known records"
         Var _ -> throw CompilerErr $ "Tried to project value of unreduced type " <> pprint ty
         _ -> throw TypeErr $

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -331,11 +331,6 @@ instance HasType Atom where
     RecordTy _ -> return TyKind
     VariantTy _ -> return TyKind
     ACase _ _ resultTy -> substM resultTy
-    DataConRef defName params _ -> do
-      defName' <- substM defName
-      DataDef sourceName _ _ <- lookupDataDef defName'
-      params' <- substM params
-      return $ RawRefTy $ TypeCon sourceName defName' params'
     DepPairRef _ _ ty -> do
       ty' <- substM ty
       return $ RawRefTy $ DepPairTy ty'

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -491,9 +491,6 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   TC tc -> TC <$> (inline traversePrimTC) simplifyAtom tc
   Eff eff -> Eff <$> substM eff
   TypeCon _ _ _ -> substM atom
-  DataCon name def params con args ->
-    DataCon name <$> substM def <*> substM params
-                 <*> pure con <*> mapM simplifyAtom args
   DictCon d -> DictCon <$> substM d
   DictTy  t -> DictTy  <$> substM t
   RecordTy _ -> substM atom >>= cheapNormalize >>= \atom' -> case atom' of

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -520,7 +520,6 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
             extendSubst (bs @@> map Rename xs) $
               simplifyAtom body
         return $ ACase e' alts' rTy'
-  DataConRef _ _ _ -> error "Should only occur in Imp lowering"
   BoxedRef _       -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> simplifyVar v

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -41,7 +41,7 @@ module Syntax (
     ImportStatus (..), emptyModuleEnv,
     ModuleSourceName (..), LoadedModules (..), Cache (..), ObjectFiles (..),
     BindsEnv (..), BindsOneAtomName (..), AtomNameBinder,
-    DataConRefBinding (..), AltP, Alt, AtomBinding (..),
+    AltP, Alt, AtomBinding (..),
     SolverBinding (..), TopFunBinding (..), SpecializationSpec (..),
     SubstE (..), SubstB (..), Ptr, PtrType,
     AddressSpace (..), Device (..),

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -17,7 +17,7 @@ import Name
 import Syntax
 import Builder
 import QueryType
-import Util (zipWithT, enumerate)
+import Util (enumerate)
 import GHC.Stack
 
 transpose :: (MonadFail1 m, EnvReader m) => Atom n -> m n (Atom n)
@@ -275,7 +275,6 @@ transposeAtom atom ct = case atom of
       LinTrivial -> return ()
   Con con         -> transposeCon con ct
   DepPair _ _ _   -> notImplemented
-  DataCon _ _ _ _ e -> void $ zipWithT transposeAtom e =<< getUnpacked ct
   TabVal b body   -> do
     ty <- substNonlin $ binderAnn b
     void $ buildFor noHint Fwd ty \i -> do

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -295,7 +295,6 @@ transposeAtom atom ct = case atom of
   TC _            -> notTangent
   Eff _           -> notTangent
   ACase _ _ _     -> error "Unexpected ACase"
-  DataConRef _ _ _ -> error "Unexpected ref"
   BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   ProjectElt idxs v -> do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -129,8 +129,9 @@ data DataDef n where
   DataDef :: SourceName -> DataDefBinders n l -> [DataConDef l] -> DataDef n
 
 -- TODO: The binder nest should be unnecessary. Try to get rid of it.
--- As above, the `SourceName` is just for pretty-printing
 data DataConDef n =
+  -- Name for pretty printing, constructor elements, representation type,
+  -- list of projection indices that recovers elements from the representation.
   DataConDef SourceName (EmptyAbs (Nest Binder) n) (Type n) [[Int]]
   deriving (Show, Generic)
 

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -64,6 +64,7 @@ data PrimCon e =
         Lit LitVal
       | ProdCon [e]
       | SumCon    e Int e     -- type, tag, payload
+      -- TODO: type is always a sum type, payload can be unary now!
       | SumAsProd e e   [[e]] -- type, tag, payload
       | LabelCon String
       | Newtype e e           -- type, payload

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -40,6 +40,7 @@ class IsBool a where
 
 iota :: (Enum a, Integral a) => a -> [a]
 iota n = take (fromEnum n) [0..] -- XXX: `[0..(n-1)]` is incorrect for unsigned ints!
+{-# INLINE iota #-}
 
 swapAt :: Int -> a -> [a] -> [a]
 swapAt _ _ [] = error "swapping to empty list"

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -216,7 +216,7 @@ def catLists {a} (xs:List a) (ys:List a) : List a =
 def listToTable {a} ((AsList n xs): List a) : (Fin n)=>a = xs
 
 :t listToTable
-> ((a:Type) ?-> (v#0:(List a)) -> (Fin (ProjectElt [0] v#0)) => a)
+> ((a:Type) ?-> (v#0:(List a)) -> (Fin (ProjectElt [0, 0] v#0)) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -228,7 +228,7 @@ def listToTable2 {a} (l: List a) : (Fin (list_length l))=>a =
   xs
 
 :t listToTable2
-> ((a:Type) ?-> (l:(List a)) -> (Fin (ProjectElt [0] l)) => a)
+> ((a:Type) ?-> (l:(List a)) -> (Fin (ProjectElt [0, 0] l)) => a)
 
 :p
   l = AsList _ [1, 2, 3]


### PR DESCRIPTION
ADTs now desugar to newtypes over sums of (dependent) products. Of
course, when there's a single constructor we elide the sum. Similarly,
when a constructor has a single field, we elide the product. Finally,
constructors with no dependent fields do not use dependent products in
their representation.

This patch already seems to simplify the implementation quite a bit, but
there are still a few improvements left on the table:
- `Alt`s don't need binder nests anymore
- `DataConDef`s shouldn't need to carry the binder nest, just the
  representation type
- `SumAsProd` type is now always a sum type

And beyond the simplifications, it also generalizes our support for
dependent ADTs! We used to only allow dependent fields in
single-constructor types, but this requirement is now lifted (with the
implementation of dependent pair types doing all the heavy lifting).