### PR TITLE
Complete cleanups from #1049

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -986,7 +986,8 @@ fromNewtypeWrapper ty = do
   TypeCon _ defName params <- return ty
   def <- lookupDataDef defName
   [con] <- instantiateDataDef def params
-  DataConDef _ (EmptyAbs (Nest (_:>wrappedTy) Empty)) _ _ <- return con
+  -- Single field constructors are represented by their field
+  DataConDef _ wrappedTy [_] <- return con
   return wrappedTy
 
 tangentBaseMonoidFor :: Builder m => Type n -> m n (BaseMonoid n)
@@ -1048,7 +1049,7 @@ emitInstanceDef instanceDef@(InstanceDef className _ _ _) = do
 emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> Atom n -> m n (Name DataConNameC n)
 emitDataConName dataDefName conIdx conAtom = do
   DataDef _ _ dataCons <- lookupDataDef dataDefName
-  let (DataConDef name _ _ _) = dataCons !! conIdx
+  let (DataConDef name _ _) = dataCons !! conIdx
   emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx conAtom
 
 zipNest :: (forall ii ii'. a -> b ii ii' -> b' ii ii')

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -834,9 +834,9 @@ buildCase :: (Emits n, ScopableBuilder m)
           -> m n (Atom n)
 buildCase scrut resultTy indexedAltBody = do
   case trySelectBranch scrut of
-    Just (i, args) -> do
+    Just (i, arg) -> do
       Distinct <- getDistinct
-      indexedAltBody i (map sink args)
+      indexedAltBody i [sink arg]
     Nothing -> do
       scrutTy <- getType scrut
       altBinderTys <- caseAltsBinderTys scrutTy

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -858,8 +858,7 @@ checkCaseAltsBinderTys ty = case ty of
 
 checkAlt :: (HasType body, Typer m)
          => Type o -> Type o -> AltP body i -> m i o ()
-checkAlt resultTyReq bTyReq (Abs bs body) = do
-  Nest b Empty <- return bs
+checkAlt resultTyReq bTyReq (Abs b body) = do
   bTy <- substM $ binderType b
   checkAlphaEq bTyReq bTy
   substBinders b \_ -> do

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -602,9 +602,9 @@ fromNonDepTabType ty = do
   return (ixTy, resultTy')
 
 nonDepDataConTys :: DataConDef n -> Maybe [Type n]
-nonDepDataConTys (DataConDef _ (Abs binders UnitE) repTy _) =
+nonDepDataConTys (DataConDef _ repTy idxs) =
   case repTy of
-    ProdTy tys | nestLength binders == length tys -> Just tys
+    ProdTy tys | length idxs == length tys -> Just tys
     _ -> Nothing
 
 infixr 1 ?-->

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -718,9 +718,9 @@ mkBundleTy = bundleFold UnitTy PairTy
 mkBundle :: [Atom n] -> (Atom n, BundleDesc)
 mkBundle = bundleFold UnitVal PairVal
 
-trySelectBranch :: Atom n -> Maybe (Int, [Atom n])
+trySelectBranch :: Atom n -> Maybe (Int, Atom n)
 trySelectBranch e = case e of
-  SumVal _ i value -> Just (i, [value])
+  SumVal _ i value -> Just (i, value)
   Con (SumAsProd _ (TagRepVal tag) vals) -> Just (i, vals !! i)
     where i = fromIntegral tag
   Con (Newtype _ e') -> trySelectBranch e'

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -185,14 +185,9 @@ traverseAlt
   :: GenericTraverser s
   => Alt i
   -> GenericTraverserM s i o (Alt o)
-traverseAlt (Abs Empty body) = Abs Empty <$> tge body
-traverseAlt (Abs (Nest (b:>ty) bs) body) = do
+traverseAlt (Abs (b:>ty) body) = do
   ty' <- tge ty
-  Abs b' (Abs bs' body') <-
-    buildAbs (getNameHint b) ty' \v -> do
-      extendRenamer (b@>v) $
-        traverseAlt $ Abs bs body
-  return $ Abs (Nest b' bs') body'
+  buildAbs (getNameHint b) ty' \v -> extendRenamer (b@>v) $ tge body
 
 -- See Note [Confuse GHC] from Simplify.hs
 confuseGHC :: EnvReader m => m n (DistinctEvidence n)

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -368,8 +368,8 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
     e' <- substM e
     case trySelectBranch e' of
       Just (con, arg) -> do
-        Abs bs body <- return $ alts !! con
-        extendSubst (bs @@> [SubstVal arg]) $ translateBlock maybeDest body
+        Abs b body <- return $ alts !! con
+        extendSubst (b @> SubstVal arg) $ translateBlock maybeDest body
       Nothing -> case e' of
         Con (Newtype (VariantTy _) (Con (SumAsProd _ tag xss))) -> go tag xss
         Con (Newtype (TypeCon _ _ _) (Con (SumAsProd _ tag xss))) -> go tag xss
@@ -380,8 +380,8 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
             tag' <- fromScalarAtom tag
             dest <- allocDest maybeDest =<< substM ty
             emitSwitch tag' (zip xss alts) $
-              \(xs, Abs bs body) ->
-                 void $ extendSubst (bs @@> [SubstVal $ sink xs]) $
+              \(xs, Abs b body) ->
+                 void $ extendSubst (b @> SubstVal (sink xs)) $
                    translateBlock (Just $ sink dest) body
             destToAtom dest
   where

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -1390,7 +1390,7 @@ dataConDefAsAtom defName conIx = liftBuilder do
           []  -> error "unreachable"
           [_] -> conProd
           _   -> SumVal conTys conIx conProd
-            where conTys = SumTy $ sinkList $ conDefs <&> \(DataConDef _ _ rty _) -> rty
+            where conTys = sinkList $ conDefs <&> \(DataConDef _ _ rty _) -> rty
 
 buildDataCon :: EnvReader m => Type n -> [Atom n] -> m n (Atom n)
 buildDataCon repTy topArgs = wrap repTy topArgs

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -156,8 +156,8 @@ evalExpr expr = case expr of
     case trySelectBranch e' of
       Nothing -> error "branch should be chosen at this point"
       Just (con, arg) -> do
-        Abs bs body <- return $ alts !! con
-        extendSubst (bs @@> [SubstVal arg]) $ evalBlock body
+        Abs b body <- return $ alts !! con
+        extendSubst (b @> SubstVal arg) $ evalBlock body
   Hof hof -> case hof of
     RunIO (Lam (LamExpr b body)) ->
       extendSubst (b @> SubstVal UnitTy) $

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -249,7 +249,7 @@ matchUPat (WithSrcB _ pat) x = do
     (UPatCon _ ps, Con (Newtype (TypeCon _ dataDefName _) _)) -> do
       DataDef _ _ cons <- lookupDataDef dataDefName
       case cons of
-        [DataConDef _ _ _ idxs] -> matchUPats ps [getProjection ix x' | ix <- idxs]
+        [DataConDef _ _ idxs] -> matchUPats ps [getProjection ix x' | ix <- idxs]
         _ -> error "Expected a single ADt constructor"
     (UPatPair (PairB p1 p2), PairVal x1 x2) -> do
       matchUPat p1 x1 >>= (`followedByFrag` matchUPat p2 x2)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -367,10 +367,10 @@ linearizeExpr expr = case expr of
         resultTangentType <- tangentType resultTy'
         resultTyWithTangent <- PairTy <$> substM resultTy
                                       <*> tangentFunType resultTangentType
-        (ans, linLam) <- fromPair =<< buildCase e' resultTyWithTangent \i xs -> do
-          xs' <- mapM emitAtomToName xs
-          Abs bs body <- return $ alts !! i
-          extendSubst (bs @@> xs') $ withTangentFunAsLambda $ linearizeBlock body
+        (ans, linLam) <- fromPair =<< buildCase e' resultTyWithTangent \i x -> do
+          x' <- emitAtomToName x
+          Abs b body <- return $ alts !! i
+          extendSubst (b @> x') $ withTangentFunAsLambda $ linearizeBlock body
         return $ WithTangent ans do
           applyLinToTangents $ sink linLam
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -177,8 +177,7 @@ prettyPrecCase name e alts effs = atPrec LowestPrec $
     effectLine row = hardline <> "case annotated with effects" <+> p row
 
 prettyAlt :: PrettyE e => AltP e n -> Doc ann
-prettyAlt (Abs bs body) = hsep (map prettyBinderNoAnn  bs') <+> "->" <> nest 2 (p body)
-  where bs' = fromNest bs
+prettyAlt (Abs b body) = prettyBinderNoAnn b <+> "->" <> nest 2 (p body)
 
 prettyBinderNoAnn :: Binder n l -> Doc ann
 prettyBinderNoAnn (b:>_) = p b

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -488,8 +488,8 @@ instance Pretty (DataDef n) where
     "data" <+> p name <+> p bs <> prettyLines cons
 
 instance Pretty (DataConDef n) where
-  pretty (DataConDef name bs _ _) =
-    p name <+> ":" <+> p bs
+  pretty (DataConDef name repTy _) =
+    p name <+> ":" <+> p repTy
 
 instance Pretty (ClassDef n) where
   pretty (ClassDef classSourceName methodNames params superclasses methodTys) =

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -390,8 +390,8 @@ getTypePrimCon :: PrimCon (Atom i) -> TypeQueryM i o (Type o)
 getTypePrimCon con = case con of
   Lit l -> return $ BaseTy $ litType l
   ProdCon xs -> ProdTy <$> mapM getTypeE xs
-  SumCon ty _ _ -> substM ty
-  SumAsProd ty _ _ -> substM ty
+  SumCon tys _ _ -> SumTy <$> traverse substM tys
+  SumAsProd tys _ _ -> SumTy <$> traverse substM tys
   Newtype ty _ -> substM ty
   BaseTypeRef p -> do
     (PtrTy (_, b)) <- getTypeE p
@@ -402,8 +402,8 @@ getTypePrimCon con = case con of
   ConRef conRef -> case conRef of
     ProdCon xs -> RawRefTy <$> (ProdTy <$> mapM getTypeRef xs)
     Newtype ty _ -> RawRefTy <$> substM ty
-    SumAsProd ty _ _ -> do
-      RawRefTy <$> substM ty
+    SumAsProd tys _ _ -> do
+      RawRefTy . SumTy <$> traverse substM tys
     _ -> error $ "Not a valid ref: " ++ pprint conRef
   LabelCon _   -> return $ TC $ LabelType
   ExplicitDict dictTy _ -> substM dictTy

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -141,7 +141,7 @@ prettyVal val = case val of
     prettyData :: (MonadIO1 m, EnvReader m, Fallible1 m) => DataDefName n -> Int -> Atom n -> m n (Doc ann)
     prettyData dataDefName t rep = do
       DataDef _ _ dataCons <- lookupDataDef dataDefName
-      DataConDef conName _ _ idxs <- return $ dataCons !! t
+      DataConDef conName _ idxs <- return $ dataCons !! t
       prettyArgs <- forM idxs \ix -> prettyVal $ getProjection (init ix) rep
       return $ case prettyArgs of
         []   -> pretty conName

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -124,15 +124,15 @@ prettyVal val = case val of
       return $ pretty (xStr, yStr)
     ProdCon _ -> error "Unexpected product type: only binary products available in surface language."
     Newtype vty@(VariantTy (NoExt types)) (Con (SumAsProd _ (TagRepVal trep) payload)) ->
-      return $ pretty $ Newtype vty $ SumVal (SumTy $ toList types) t value
-      where t = fromIntegral trep; [value] = payload !! t
+      return $ pretty $ Newtype vty $ SumVal (toList types) t value
+      where t = fromIntegral trep; value = payload !! t
     -- Pretty-print strings
     Newtype (TypeCon "List" _ (DataDefParams [Word8Ty] _)) _ -> do
       s <- getDexString val
       return $ pretty $ "\"" ++ s ++ "\""
     Newtype (TypeCon _ dataDefName _) (Con (SumCon _ t e)) -> prettyData dataDefName t e
     Newtype (TypeCon _ dataDefName _) (Con (SumAsProd _ (TagRepVal trep) payload)) -> prettyData dataDefName t e
-      where t = fromIntegral trep; [e] = payload !! t
+      where t = fromIntegral trep; e = payload !! t
     Newtype (TypeCon _ dataDefName _) e -> prettyData dataDefName 0 e
     SumAsProd _ _ _ -> error "SumAsProd with an unsupported type"
     _ -> return $ pretty con

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -185,10 +185,10 @@ transposeExpr expr ct = case expr of
       True  -> notImplemented
       False -> do
         e' <- substNonlin e
-        void $ buildCase e' UnitTy \i vs -> do
-          vs' <- mapM emitAtomToName vs
-          Abs bs body <- return $ alts !! i
-          extendSubst (bs @@> map RenameNonlin vs') do
+        void $ buildCase e' UnitTy \i v -> do
+          v' <- emitAtomToName v
+          Abs b body <- return $ alts !! i
+          extendSubst (b @> RenameNonlin v') do
             transposeBlock body (sink ct)
           return UnitVal
 

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -127,11 +127,10 @@ data DataDef n where
   -- binder name is in UExpr and Env
   DataDef :: SourceName -> DataDefBinders n l -> [DataConDef l] -> DataDef n
 
--- TODO: The binder nest should be unnecessary. Try to get rid of it.
 data DataConDef n =
   -- Name for pretty printing, constructor elements, representation type,
   -- list of projection indices that recovers elements from the representation.
-  DataConDef SourceName (EmptyAbs (Nest Binder) n) (Type n) [[Int]]
+  DataConDef SourceName (Type n) [[Int]]
   deriving (Show, Generic)
 
 data DataDefBinders n l where
@@ -877,10 +876,10 @@ instance AlphaEqE DataDef
 instance AlphaHashableE DataDef
 
 instance GenericE DataConDef where
-  type RepE DataConDef = (LiftE (SourceName, [[Int]])) `PairE` (Abs (Nest Binder) UnitE) `PairE` Type
-  fromE (DataConDef name ab repTy idxs) = (LiftE (name, idxs)) `PairE` ab `PairE` repTy
+  type RepE DataConDef = (LiftE (SourceName, [[Int]])) `PairE` Type
+  fromE (DataConDef name repTy idxs) = (LiftE (name, idxs)) `PairE` repTy
   {-# INLINE fromE #-}
-  toE   ((LiftE (name, idxs)) `PairE` ab `PairE` repTy) = DataConDef name ab repTy idxs
+  toE   ((LiftE (name, idxs)) `PairE` repTy) = DataConDef name repTy idxs
   {-# INLINE toE #-}
 instance SinkableE DataConDef
 instance HoistableE  DataConDef

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -681,8 +681,8 @@ pattern Record ty xs = Con (Newtype (StaticRecordTy ty) (ProdVal xs))
 pattern SumTy :: [Type n] -> Type n
 pattern SumTy cs = TC (SumType cs)
 
-pattern SumVal :: Type n -> Int -> Atom n -> Atom n
-pattern SumVal ty tag payload = Con (SumCon ty tag payload)
+pattern SumVal :: [Type n] -> Int -> Atom n -> Atom n
+pattern SumVal tys tag payload = Con (SumCon tys tag payload)
 
 pattern PairVal :: Atom n -> Atom n -> Atom n
 pattern PairVal x y = Con (ProdCon [x, y])
@@ -740,10 +740,10 @@ pattern MaybeTy :: Type n -> Type n
 pattern MaybeTy a = SumTy [UnitTy, a]
 
 pattern NothingAtom :: Type n -> Atom n
-pattern NothingAtom a = SumVal (MaybeTy a) 0 UnitVal
+pattern NothingAtom a = SumVal [UnitTy, a] 0 UnitVal
 
 pattern JustAtom :: Type n -> Atom n -> Atom n
-pattern JustAtom a x = SumVal (MaybeTy a) 1 x
+pattern JustAtom a x = SumVal [UnitTy, a] 1 x
 
 pattern BoolTy :: Type n
 pattern BoolTy = Word8Ty

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -107,9 +107,8 @@ type BaseMonoid n = BaseMonoidP (Atom n)
 
 type AtomBinderP = BinderP AtomNameC
 type Binder = AtomBinderP Type
- -- TODO: Alts don't need binder nests anymore --- we have Atom projections!
-type AltP (e::E) = Abs (Nest Binder) e :: E
-type Alt = AltP Block                  :: E
+type AltP (e::E) = Abs Binder e :: E
+type Alt = AltP Block           :: E
 
 -- The additional invariant enforced by this newtype is that the list should
 -- never contain empty StaticFields members, nor StaticFields in two consecutive

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -62,10 +62,9 @@ traversePrimTC = inline traverse
 
 data PrimCon e =
         Lit LitVal
-      | ProdCon [e]
-      | SumCon    e Int e     -- type, tag, payload
-      -- TODO: type is always a sum type, payload can be unary now!
-      | SumAsProd e e   [[e]] -- type, tag, payload
+      | ProdCon   [e]
+      | SumCon    [e] Int e     -- type, tag, payload
+      | SumAsProd [e] e   [e]   -- type, tag, payload
       | LabelCon String
       | Newtype e e           -- type, payload
       -- References


### PR DESCRIPTION
[Eliminate coercions from sum type constructors, make payloads unary](https://github.com/google-research/dex-lang/commit/b6524ff5588b7e572c00be3e3c69f87d33e3bc17) 
 
[Only keep a single Binder in Alts](https://github.com/google-research/dex-lang/commit/0f3fb9b7c0bd2559a243902532787976b32208db) 
 
[Remove the binder nest from DataConDef](https://github.com/google-research/dex-lang/commit/cbcf6eb1dc52bc398ac05c42e1cb43b167c98476)