### PR TITLE
Upgrade dependencies to use consistent resolver

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -14,7 +14,7 @@ import Data.Functor
 import Data.Ratio
 import Control.Applicative
 import Data.Map.Strict hiding (foldl, map, empty, (!))
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Data.List (intersperse)
 import Data.Tuple (swap)
 

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -62,7 +62,7 @@ import Data.Foldable (toList)
 import Data.Functor ((<&>))
 import Data.Graph (graphFromEdges, topSort)
 import Data.List.NonEmpty qualified as NE
-import Data.Text.Prettyprint.Doc (Pretty (..), group, line, nest)
+import Prettyprinter (Pretty (..), group, line, nest)
 import GHC.Stack
 
 import qualified Unsafe.Coerce as TrulyUnsafe

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -27,8 +27,8 @@ import Control.Monad.Reader
 import Data.Coerce
 import Data.Text (Text)
 import Data.Text qualified as T
-import Data.Text.Prettyprint.Doc.Render.Text
-import Data.Text.Prettyprint.Doc
+import Prettyprinter.Render.Text
+import Prettyprinter
 import GHC.Stack
 import System.Environment
 import System.IO.Unsafe

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -14,7 +14,7 @@ module Imp
 import Prelude hiding ((.), id)
 import Data.Functor
 import Data.Foldable (toList)
-import Data.Text.Prettyprint.Doc (Pretty (..), hardline)
+import Prettyprinter (Pretty (..), hardline)
 import Control.Category
 import Control.Monad.Identity
 import Control.Monad.Reader

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -25,7 +25,7 @@ import Data.Function ((&))
 import Data.Functor (($>), (<&>))
 import Data.List (sortOn, intercalate)
 import Data.Maybe (fromJust)
-import Data.Text.Prettyprint.Doc (Pretty (..))
+import Prettyprinter (Pretty (..))
 import Data.Word
 import qualified Data.HashMap.Strict as HM
 import qualified Data.List.NonEmpty as NE

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -35,7 +35,7 @@ import Data.ByteString.Short (toShort)
 import qualified Data.ByteString.Char8 as B
 import Data.String
 import Data.Foldable
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import GHC.Stack
 import qualified Data.Set as S
 

--- a/src/lib/Live/Eval.hs
+++ b/src/lib/Live/Eval.hs
@@ -15,7 +15,7 @@ import qualified Data.Map.Strict as M
 
 import Data.Aeson (ToJSON, toJSON, (.=))
 import qualified Data.Aeson as A
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import System.Directory (getModificationTime)
 
 import Actor

--- a/src/lib/Logging.hs
+++ b/src/lib/Logging.hs
@@ -13,7 +13,7 @@ module Logging (Logger, LoggerT (..), MonadLogger (..), logIO, runLoggerT,
 
 import Control.Monad
 import Control.Monad.Reader
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Control.Concurrent.MVar
 import Prelude hiding (log)
 import System.IO

--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -10,7 +10,7 @@ import Data.Word
 import Data.Functor
 import Data.Set qualified as S
 import Data.List.NonEmpty qualified as NE
-import Data.Text.Prettyprint.Doc (pretty, viaShow, (<+>))
+import Prettyprinter (pretty, viaShow, (<+>))
 import Control.Monad.Reader
 import Unsafe.Coerce
 import GHC.Exts (inline)

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -101,7 +101,7 @@ import Data.Hashable
 import Data.Kind (Type)
 import Data.Function ((&))
 import Data.List.NonEmpty (NonEmpty (..))
-import Data.Text.Prettyprint.Doc  hiding (nest)
+import Prettyprinter hiding (nest)
 import GHC.Stack
 import GHC.Exts (Constraint, dataToTag#, tagToEnum#, Int(..))
 import qualified GHC.Exts as GHC.Exts

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -20,8 +20,8 @@ import Data.Functor ((<&>))
 import qualified Data.ByteString.Lazy.Char8 as B
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Map.Strict as M
-import Data.Text.Prettyprint.Doc.Render.Text
-import Data.Text.Prettyprint.Doc
+import Prettyprinter.Render.Text
+import Prettyprinter
 import Data.Text (Text, snoc, uncons, unsnoc, unpack)
 import qualified Data.Set        as S
 import Data.String (fromString)

--- a/src/lib/RawName.hs
+++ b/src/lib/RawName.hs
@@ -23,7 +23,7 @@ import Data.Char
 import Data.Bits
 import Data.Coerce
 import Data.Store
-import Data.Text.Prettyprint.Doc  hiding (nest)
+import Prettyprinter hiding (nest)
 import GHC.Generics (Generic)
 
 -- === RawName ===

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -18,7 +18,7 @@ import Data.Foldable
 import qualified Data.Map.Strict as M
 import Data.Int
 import Data.Store hiding (size)
-import Data.Text.Prettyprint.Doc  hiding (brackets)
+import Prettyprinter hiding (brackets)
 import Data.Word
 import System.IO (stderr, hPutStrLn)
 import Foreign.Ptr

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -18,7 +18,7 @@ import Control.Monad.Reader
 import Data.Maybe
 import Data.List (elemIndex)
 import Data.Foldable (toList)
-import Data.Text.Prettyprint.Doc (Pretty (..), hardline)
+import Prettyprinter (Pretty (..), hardline)
 import qualified Data.List.NonEmpty as NE
 import qualified Data.Set as S
 import GHC.Exts (inline)

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -21,7 +21,7 @@ import Control.Monad.State.Strict
 import Control.Monad.Reader
 import qualified Data.ByteString as BS
 import Data.Text (Text)
-import Data.Text.Prettyprint.Doc
+import Prettyprinter
 import Data.Store (Store (..), encode, decode)
 import Data.List (partition)
 import qualified Data.Map.Strict as M

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -26,7 +26,7 @@ import Data.Int
 import Data.Word
 import Data.Hashable
 import Data.Store (Store (..))
-import Data.Text.Prettyprint.Doc (Pretty (..))
+import Prettyprinter (Pretty (..))
 import qualified Data.Store.Internal as SI
 import Foreign.Ptr
 import GHC.Exts (inline)

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -25,7 +25,7 @@ import Data.Foldable
 import qualified Data.Map.Strict       as M
 import Data.String (IsString, fromString)
 import Data.Text (Text)
-import Data.Text.Prettyprint.Doc (Pretty (..), hardline, (<+>))
+import Prettyprinter (Pretty (..), hardline, (<+>))
 import Data.Word
 
 import GHC.Generics (Generic (..))

--- a/stack-llvm-head.yaml
+++ b/stack-llvm-head.yaml
@@ -17,9 +17,3 @@ extra-deps:
       - llvm-hs-pure
   - github: google/mlir-hs
     commit: 7a4f4984c71e8fb0d7730bc541e9f2daf1971073
-  - megaparsec-8.0.0
-  - prettyprinter-1.6.2
-  - store-0.7.8@sha256:0b604101fd5053b6d7d56a4ef4c2addf97f4e08fe8cd06b87ef86f958afef3ae,8001
-  - store-core-0.4.4.4@sha256:a19098ca8419ea4f6f387790e942a7a5d0acf62fe1beff7662f098cfb611334c,1430
-  - th-utilities-0.2.4.1@sha256:b37d23c8bdabd678aee5a36dd4373049d4179e9a85f34eb437e9cd3f04f435ca,1869
-

--- a/stack-macos.yaml
+++ b/stack-macos.yaml
@@ -15,11 +15,6 @@ extra-deps:
     subdirs:
       - llvm-hs
       - llvm-hs-pure
-  - megaparsec-8.0.0
-  - prettyprinter-1.6.2
-  - store-0.7.8@sha256:0b604101fd5053b6d7d56a4ef4c2addf97f4e08fe8cd06b87ef86f958afef3ae,8001
-  - store-core-0.4.4.4@sha256:a19098ca8419ea4f6f387790e942a7a5d0acf62fe1beff7662f098cfb611334c,1430
-  - th-utilities-0.2.4.1@sha256:b37d23c8bdabd678aee5a36dd4373049d4179e9a85f34eb437e9cd3f04f435ca,1869
 
 flags:
   llvm-hs:

--- a/stack.yaml
+++ b/stack.yaml
@@ -15,11 +15,6 @@ extra-deps:
     subdirs:
       - llvm-hs
       - llvm-hs-pure
-  - megaparsec-8.0.0
-  - prettyprinter-1.6.2
-  - store-0.7.8@sha256:0b604101fd5053b6d7d56a4ef4c2addf97f4e08fe8cd06b87ef86f958afef3ae,8001
-  - store-core-0.4.4.4@sha256:a19098ca8419ea4f6f387790e942a7a5d0acf62fe1beff7662f098cfb611334c,1430
-  - th-utilities-0.2.4.1@sha256:b37d23c8bdabd678aee5a36dd4373049d4179e9a85f34eb437e9cd3f04f435ca,1869
 
 nix:
   enable: false


### PR DESCRIPTION
Trying to use Template Haskell with the existing dependency overrides raised some difficult-to-resolve errors. Upgrading our pinned dependencies to use a consistent resolver (lts-18.23) should make TH experiments simpler.

Basically all that needed to happen was to replace `Data.Text.Prettyprint.Doc` with `Prettyprinter` in imports.