### PR TITLE
Add `erf` and `erfc`.  Implement `cumulative`  and `survivor`  for `NormalDist`.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -934,6 +934,8 @@ interface Floating a
   sqrt   : a -> a
   pow    : a -> a -> a
   lgamma : a -> a
+  erf    : a -> a
+  erfc   : a -> a
 
 def lbeta {a} [Sub a, Floating a] : a -> a -> a = \x y. lgamma x + lgamma y - lgamma (x + y)
 
@@ -968,6 +970,8 @@ instance Floating Float64
   sqrt   = \x. %sqrt   x
   pow    = \x y. %fpow x y
   lgamma = \x. %lgamma x
+  erf    = \x. %erf    x
+  erfc   = \x. %erfc   x
 
 instance Floating Float32
   exp    = \x. %exp x
@@ -988,6 +992,8 @@ instance Floating Float32
   sqrt   = \x. %sqrt   x
   pow    = \x y. %fpow x y
   lgamma = \x. %lgamma x
+  erf    = \x. %erf    x
+  erfc   = \x. %erfc   x
 
 '## Raw pointer operations
 
@@ -1102,6 +1108,8 @@ instance {a n} [Floating a] Floating (n=>a)
   sqrt   = map sqrt
   pow    = \x y. for i. pow x.i y.i
   lgamma = map lgamma
+  erf    = map erf
+  erfc   = map erfc
 
 '### Axis Restructuring
 
@@ -2196,6 +2204,12 @@ complex_lgamma : Complex -> Complex = \x:Complex.
   todo  -- This one is pretty hairy.
         -- See https://cs.uwaterloo.ca/research/tr/1994/23/CS-94-23.pdf
 
+complex_erf : Complex -> Complex = \x:Complex.
+  todo
+
+complex_erfc : Complex -> Complex = \x:Complex.
+  todo
+
 def complex_log1p (x:Complex) : Complex =
   (MkComplex a b) = x
   case a == 0.0 of
@@ -2225,6 +2239,8 @@ instance Floating Complex
   sqrt   = complex_sqrt
   pow    = complex_pow
   lgamma = complex_lgamma
+  erf    = complex_erf
+  erfc   = complex_erfc
 
 
 '## Miscellaneous utilities

--- a/lib/stats.dx
+++ b/lib/stats.dx
@@ -192,7 +192,12 @@ instance Dist NormalDist Float Float
   density = \(Normal loc scale) x.
     Exp $ -0.5 * (log (2 * pi * (sq scale)) + (sq ((x - loc) / scale)))
 
--- TODO: with some kind of "error function" (and inverse) exposed, could and should also implement OrderedDist
+instance OrderedDist NormalDist Float Float
+  cumulative = \(Normal loc scale) x.
+    Exp $ log (0.5 * erfc ((loc - x) / (scale * sqrt(2.0))))
+  survivor = \(Normal loc scale) x.
+    Exp $ log (0.5 * erfc ((x - loc) / (scale * sqrt(2.0))))
+  quantile = todo  -- Add `erfinv`.
 
 
 '### Poisson distribution

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -1034,6 +1034,8 @@ checkUnOp op x = do
       Ceil             -> (f, sr)
       Round            -> (f, sr)
       LGamma           -> (f, sr)
+      Erf              -> (f, sr)
+      Erfc             -> (f, sr)
       FNeg             -> (f, sr)
       BNot             -> (u, sr)
       where

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -912,7 +912,7 @@ builtinNames = M.fromList
   , ("tan"  , unary  Tan),   ("sqrt"  , unary Sqrt)
   , ("floor", unary  Floor), ("ceil"  , unary Ceil), ("round", unary Round)
   , ("log1p", unary  Log1p), ("lgamma", unary LGamma)
-  , ("erf", unary Erf), ("erfc", unary Erfc)
+  , ("erf", unary Erf),      ("erfc", unary Erfc)
   , ("sumToVariant"   , OpExpr $ SumToVariant ())
   , ("throwError"     , OpExpr $ ThrowError ())
   , ("throwException" , OpExpr $ ThrowException ())

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -912,6 +912,7 @@ builtinNames = M.fromList
   , ("tan"  , unary  Tan),   ("sqrt"  , unary Sqrt)
   , ("floor", unary  Floor), ("ceil"  , unary Ceil), ("round", unary Round)
   , ("log1p", unary  Log1p), ("lgamma", unary LGamma)
+  , ("erf", unary Erf), ("erfc", unary Erfc)
   , ("sumToVariant"   , OpExpr $ SumToVariant ())
   , ("throwError"     , OpExpr $ ThrowError ())
   , ("throwException" , OpExpr $ ThrowException ())

--- a/src/lib/JIT.hs
+++ b/src/lib/JIT.hs
@@ -658,6 +658,8 @@ gpuUnaryIntrinsic op x = case typeOf x of
       Ceil   -> callFloatIntrinsic ty $ "__nv_ceil"   ++ suffix
       Round  -> callFloatIntrinsic ty $ "__nv_round"  ++ suffix
       LGamma -> callFloatIntrinsic ty $ "__nv_lgamma" ++ suffix
+      Erf    -> callFloatIntrinsic ty $ "__nv_erf"    ++ suffix
+      Erfc   -> callFloatIntrinsic ty $ "__nv_erfc"   ++ suffix
       _   -> error $ "Unsupported GPU operation: " ++ show op
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x]
@@ -982,6 +984,8 @@ cpuUnaryIntrinsic op x = case typeOf x of
       Ceil            -> callFloatIntrinsic ty $ "llvm.ceil"  ++ llvmSuffix
       Round           -> callFloatIntrinsic ty $ "llvm.round" ++ llvmSuffix
       LGamma          -> callFloatIntrinsic ty $ "lgamma"     ++ libmSuffix
+      Erf             -> callFloatIntrinsic ty $ "erf"        ++ libmSuffix
+      Erfc            -> callFloatIntrinsic ty $ "erfc"       ++ libmSuffix
       _ -> error $ "Unsupported CPU operation: " ++ show op
     floatIntrinsic ty name = ExternFunSpec (L.mkName name) ty [] [] [ty]
     callFloatIntrinsic ty name = emitExternCall (floatIntrinsic ty name) [x]

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -469,6 +469,8 @@ linearizeUnOp op x' = do
     Ceil   -> emitZeroT
     Round  -> emitZeroT
     LGamma -> notImplemented
+    Erf    -> notImplemented
+    Erfc   -> notImplemented
     FNeg   -> withT (neg x) (neg =<< tx)
     BNot   -> emitZeroT
 

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -182,7 +182,7 @@ data UnOp = Exp | Exp2
           | Log | Log2 | Log10 | Log1p
           | Sin | Cos | Tan | Sqrt
           | Floor | Ceil | Round
-          | LGamma
+          | LGamma | Erf | Erfc
           | FNeg | BNot
             deriving (Show, Eq, Generic)
 

--- a/tests/stats-tests.dx
+++ b/tests/stats-tests.dx
@@ -163,6 +163,12 @@ ln (density (Normal 1.0 2.0) 3.0) ~~ -2.112086
 rand_vec 5 (draw $ Normal 1.0 2.0) (new_key 0) :: Fin 5=>Float
 > [-1.93355, 4.198111, 0.529252, 0.018863, 2.921813]
 
+ln (cumulative (Normal 1.0 2.0) 0.5) ~~ -0.9130617
+> True
+
+ln (survivor (Normal 1.0 2.0) 0.1) ~~ -0.3950523
+> True
+
 -- poisson
 
 ln (density (Poisson 5.0) 8) ~~ -2.7291


### PR DESCRIPTION
The new stats library looks great!

It looks like Cuda has `erfinv` but LLVM and libm don’t, so I didn’t add the quantile function (I’m happy to, if someone has thoughts on where to get it, or a preferred approximation). 

`cumulative` and `survivor` could have better numerics. Do you think we should emulate Cephes/TFP’s ndtr? https://github.com/tensorflow/probability/blob/main/tensorflow_probability/python/internal/special_math.py If so (or if you have another preferred impl) I’ll update the PR.

I also punted on `Linearize` for now.