### PR TITLE
Remove an unnecessary RememberDest in lowerFullySequential

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -294,7 +294,8 @@ translateTopLevel cc (Abs bs (Abs (destb:>destTy) body)) = do
       dest <- case destTy of
         RawRefTy ansTy -> makeAllocDest Unmanaged =<< substM ansTy
         _ -> error "Expected a reference type for body destination"
-      extendSubst (destb @> SubstVal dest) $ translateBlock Nothing body
+      extendSubst (destb @> SubstVal dest) $ void $ translateBlock Nothing body
+      destToAtom dest
   refreshAbs ab \bs' ab' -> refreshAbs ab' \decls resultAtom -> do
     (results, recon) <- buildRecon (PairB bs' decls) resultAtom
     let funImpl = Abs bs' $ ImpBlock decls results


### PR DESCRIPTION
I think that this was the only use of RememberDest, but I'll keep it around for now.