### PR TITLE
Added more `NonEmpty` and `Subset` instances, and improve the CTC example.

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -54,7 +54,7 @@ instance {a} Ix (AllButFirst a)
 instance {a} Subset (AllButFirst a) a
   inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
   project' = \x. case (ordinal x) < (size a) of
-    True  -> unsafe_from_ordinal _ ((ordinal x))
+    True  -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
     False -> Nothing
 
 

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -46,9 +46,9 @@ Computes p(labels | logits), marginalizing over possible alignments and
 and marginalizes over insertion of blanks between characters.
 Todo: add a `[Subset position time]` constraint.
 
-def ctc {vocab time position} [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
+def ctc_inner {vocab time position} [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
     (blank: vocab)
-    (logits: time=>vocab=>(LogSpace Float))
+    (logits: time=>vocab=>LogSpace Float)
     (labels: position=>vocab)
       : LogSpace Float =
   ilabels = prepend_and_interleave blank labels
@@ -86,18 +86,45 @@ def ctc {vocab time position} [NonEmpty vocab, NonEmpty position, NonEmpty time,
   last_label + last_space
 
 
+def ctc {vocab time position} [Eq time, Eq vocab]
+    (blank: vocab)
+    (logits: time=>vocab=>LogSpace Float)
+    (labels: position=>vocab)
+      : LogSpace Float =
+
+  -- This is a wrapper function to check if any of the inputs are empty,
+  -- and cast them into a provably `NonEmpty` form if not.
+  -- If the compiler could generate `NonEmpty` instances for all
+  -- Fin N where N > 0, this function would be unnecessary.
+  if ((size vocab) > 0) && ((size time) > 0) && ((size position) > 0)
+    then
+      vocab_size_m1    = unsafe_nat_diff (size vocab) 1
+      time_size_m1     = unsafe_nat_diff (size time) 1
+      position_size_m1 = unsafe_nat_diff (size position) 1
+
+      vocab'    = (Unit | Fin vocab_size_m1)
+      time'     = (Unit | Fin time_size_m1)
+      position' = (Unit | Fin position_size_m1)
+
+      blank'  = unsafe_from_ordinal vocab' (ordinal blank)
+      logits' = for t:time'. for v:vocab'. logits.(unsafe_from_ordinal _ (ordinal t)).(unsafe_from_ordinal _ (ordinal v))
+      labels' = for p:position'.
+        unsafe_from_ordinal _ (ordinal labels.(unsafe_from_ordinal _ (ordinal p)))
+      
+      ctc_inner blank' logits' labels'
+    else zero
+
 '## Demo
 
--- Todo: Produce proofs that Fin N is NonEmpty for all N > 0
-Vocab = (Unit | Fin 5)
-blank:Vocab = first_ix
+Vocab = Fin 6
+blank:Vocab = 0@Vocab
 
 -- Create random logits
-Time = (Unit | Fin 3)
+Time = Fin 4
 logits : Time => Vocab => (LogSpace Float) = arb $ new_key 0
 
 -- Evaluate marginal probability of labels given logits
-labels = [(3@Vocab), (4@Vocab), (1@Vocab)] :: (Unit | Fin 2)=>Vocab
+labels = [(3@Vocab), (4@Vocab), (1@Vocab)]
 :p ls_to_f $ ctc blank logits labels
 > 0.00209
 
@@ -113,8 +140,8 @@ sum for i:Unit=>Vocab. ls_to_f $ ctc blank logits i
 > 0.031206
 
 -- (Fin N)=>Vocab is the set of all combinations of N tokens.
-sum for i:((Unit | Fin 1)=>Vocab). ls_to_f $ ctc blank logits i
+sum for i:((Fin 2)=>Vocab). ls_to_f $ ctc blank logits i
 > 0.245854
 
-sum for i:((Unit | Fin 2)=>Vocab). ls_to_f $ ctc blank logits i
+sum for i:((Fin 3)=>Vocab). ls_to_f $ ctc blank logits i
 > 0.565374

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -15,6 +15,7 @@ most implementations.
 
 import stats  -- for log-space representation of probabilities.
 
+
 '## Custom index sets
 
 '### Fence and Posts
@@ -22,11 +23,11 @@ Here we create a custom datatype and index set
 that interleaves the elements of a table with another set
 of values representing all the spaces in between those elements.
 
-data FenceAndPosts n =
+data FenceAndPosts n [Ix n] =
   Fence n
   Posts (Post n)
 
-instance {a} [Ix a] Ix (FenceAndPosts a)
+instance {a} Ix (FenceAndPosts a)
   size = 2 * size a + 1
   ordinal = \i. case i of
     Fence j -> 2 * ordinal j + 1
@@ -36,8 +37,24 @@ instance {a} [Ix a] Ix (FenceAndPosts a)
       True  -> Fence $ unsafe_from_ordinal _ (intdiv2 o)
       False -> Posts $ unsafe_from_ordinal _ (intdiv2 o)
 
-instance {a} [NonEmpty a] NonEmpty (FenceAndPosts a)
+instance {a} NonEmpty (FenceAndPosts a)
   first_ix = unsafe_from_ordinal _ 0
+
+instance {a} [Eq a] Eq (FenceAndPosts a)
+  (==) = \x y. case x of
+    Fence x -> case y of
+      Fence y -> x == y
+      Posts y -> False
+    Posts x -> case y of
+      Fence y -> False
+      Posts y -> ordinal x == ordinal y
+
+'#### Test FenceAndPosts
+
+all $ for i:(FenceAndPosts Bool).
+  i == (unsafe_from_ordinal _ $ ordinal i)
+> True
+
 
 '### All but First
 Next we make an index set from any non-empty set
@@ -53,9 +70,29 @@ instance {a} Ix (AllButFirst a)
 
 instance {a} Subset (AllButFirst a) a
   inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
-  project' = \x. case (ordinal x) < (size a) of
-    True  -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
-    False -> Nothing
+  project' = \x. case ordinal x == 0 of
+    True  -> Nothing
+    False -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
+
+instance {a} [Eq a] Eq (AllButFirst a)
+  (==) = \(MkAllButFirst x) (MkAllButFirst y). x == y
+
+'#### Test AllButFirst
+
+all $ for i:(AllButFirst (Unit | Fin 2)).
+  i == (unsafe_from_ordinal _ $ ordinal i)
+> True
+
+all $ for i:(AllButFirst (Bool | Bool)).
+  Just i == (project _ $ inject (Bool | Bool) i)
+> True
+
+for i:(AllButFirst (Bool | Bool)).
+  inject (Bool | Bool) i
+> [(Left True), (Right False), (Right True)]@(AllButFirst (Bool | Bool))
+
+project (AllButFirst (Bool | Bool)) (0@(Bool | Bool))
+> Nothing
 
 
 '### Helper functions
@@ -72,11 +109,11 @@ def normalize {n v} [Fractional v, Add v] (xs:n=>v) : n=>v =
 
 
 '### Main CTC algorithm
-Computes `p(labels | logits)`, marginalizing over possible alignments and
-and marginalizes over insertion of blanks between characters.
+Computes `p(labels | logits)`, marginalizing over possible alignments,
+and over insertion of blanks between characters.
 Todo: add a `[Subset position time]` constraint.
 
-def ctc_inner {vocab time position}
+def ctc_non_empty {vocab time position}
   [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
     (blank: vocab)
     (logits: time=>vocab=>LogSpace Float)
@@ -96,7 +133,7 @@ def ctc_inner {vocab time position}
       then zero
       else prev.(unsafe_from_ordinal _ (unsafe_nat_diff (ordinal s) y))
 
-  same_as_last = \s. if (ordinal s) >= 2
+  same_token_as_last = \s. if (ordinal s) >= 2
     then
       s_minus_2 = unsafe_from_ordinal _ (unsafe_nat_diff (ordinal s) 2)
       ilabels.s == ilabels.s_minus_2
@@ -104,15 +141,16 @@ def ctc_inner {vocab time position}
 
   prob_seq_final = fold prob_seq_at_start \t:(AllButFirst time) prev.
     for s.
-      prob_stay_same       = prev.s
-      prob_from_blank      = safe_idx_sub prev s 1
-      prob_from_last_token = safe_idx_sub prev s 2
+      prob_no_transition              = prev.s
+      prob_transition_from_blank      = safe_idx_sub prev s 1
+      prob_transition_from_last_token = safe_idx_sub prev s 2
 
       -- Equation 6 from CTC paper.
-      ans = if ilabels.s == blank || same_as_last s
-        then prob_stay_same + prob_from_blank
-        else prob_stay_same + prob_from_blank + prob_from_last_token
-      ans * label_probs.(inject _ t).(ilabels.s)
+      transition_prob = if ilabels.s == blank || same_token_as_last s
+        then prob_no_transition + prob_transition_from_blank
+        else prob_no_transition + prob_transition_from_blank +
+          prob_transition_from_last_token
+      transition_prob * label_probs.(inject _ t).(ilabels.s)
 
   -- Sum over last two entries in the table.  Eq 8 from paper.
   end_with_label = prob_seq_final.(Fence last_ix)
@@ -121,9 +159,10 @@ def ctc_inner {vocab time position}
 
 '### Wrapper function to provide proof of `NonEmpty`
 This is a wrapper function to check if any of the inputs are empty,
-and cast them into a provably `NonEmpty` form if not.
-If the compiler could generate `NonEmpty` instances for all
-Fin N where N > 0, this function would be unnecessary.
+and if not, casts them to an equivalent but provably `NonEmpty` form.
+
+'If the compiler could generate `NonEmpty` instances for all
+`Fin N` where `N > 0`, this function would be unnecessary.
 
 def ctc {vocab time position} [Eq time, Eq vocab]
     (blank: vocab)
@@ -146,7 +185,7 @@ def ctc {vocab time position} [Eq time, Eq vocab]
       labels' = view p:position'.
         unsafe_from_ordinal _ (ordinal labels.(unsafe_from_ordinal _ (ordinal p)))
       
-      ctc_inner blank' logits' labels'
+      ctc_non_empty blank' logits' labels'
     else zero
 
 '## Demo
@@ -172,5 +211,6 @@ They don't sum to one.  Maybe there is a bug in the above code
 or the paper.
 
 -- Fin N=>Vocab is the set of all combinations of N tokens.
-sum for i:(Fin 3=>Vocab). ls_to_f $ ctc blank logits i
+sum for i:(Fin 3=>Vocab).
+  ls_to_f $ ctc blank logits i
 > 0.565375

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -13,89 +13,105 @@ However, Dex's autodiff can produce the backward
 pass automatically.  That makes this code much shorter than
 most implementations.
 
-import stats  -- for LogSpace
+import stats  -- for log-space representation of probabilities.
+
+'### Custom index set
+Here we create a custom datatype and index set
+that interleaves the elements of a table with another set
+of values representing all the spaces in between those elements.
+
+data FenceAndPosts n =
+  Fence n
+  Posts (Post n)
+
+instance {a} [Ix a] Ix (FenceAndPosts a)
+  size = 2 * size a + 1
+  ordinal = \i. case i of
+    Fence j -> 2 * ordinal j + 1
+    Posts j -> 2 * ordinal j
+  unsafe_from_ordinal = \o.
+    case is_odd o of
+      True  -> Fence $ unsafe_from_ordinal _ (intdiv2 o)
+      False -> Posts $ unsafe_from_ordinal _ (intdiv2 o)
+
+instance {a} [NonEmpty a] NonEmpty (FenceAndPosts a)
+  first_ix = unsafe_from_ordinal _ 0
+
 
 '### Helper functions
 
-IsBlank = Bool
-
-def interleave {m v} (blank:v) (labels: m=>v) : (m & IsBlank)=>v =
-  -- Turns "text" into "t e x t " by first pairing each letter with a blank,
-  -- then flattening the pairs back into a single-index table.
-  pairs = for i j. case j of
-    True  -> blank
-    False -> labels.i
-  for (i, j). pairs.i.j
-
-def prepend {m v} (first: v) (seq: m=>v) : ((Unit|m)=>v) =
-  -- Concatenates a single element to the beginning of a sequence.
-  for idx. case idx of
-    Left () -> first
-    Right i -> seq.i
-
-def prepend_and_interleave {m v} (blank:v) (seq: m=>v) : ((Unit|(m & IsBlank))=>v) =
+def interleave_blanks {m v} (blank:v) (seq: m=>v) : ((FenceAndPosts m)=>v) =
   -- Turns "text" into " t e x t ".
-  prepend blank (interleave blank seq)
+  for idx. case idx of
+    Fence i -> seq.i
+    Posts i -> blank
 
 def normalize {n v} [Fractional v, Add v] (xs:n=>v) : n=>v =
-  for i. divide xs.i (sum xs)
+  total = sum xs
+  for i. divide xs.i total
 
 
 '### Main CTC algorithm
-Computes p(labels | logits), marginalizing over possible alignments and
+Computes `p(labels | logits)`, marginalizing over possible alignments and
 and marginalizes over insertion of blanks between characters.
 Todo: add a `[Subset position time]` constraint.
 
-def ctc_inner {vocab time position} [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
+def ctc_inner {vocab time position}
+  [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
     (blank: vocab)
     (logits: time=>vocab=>LogSpace Float)
     (labels: position=>vocab)
       : LogSpace Float =
-  ilabels = prepend_and_interleave blank labels
-  normalized_logits = for t. normalize logits.t
+  ilabels = interleave_blanks blank labels
+  label_probs = for t. normalize logits.t
 
-  -- Initialize dynamic programming table.
-  logprob_start_with_blank = normalized_logits.first_ix.blank
-  logprob_of_first_label   = normalized_logits.first_ix.(labels.first_ix)
-  log_prob_seq_t0 = yield_state (for pos. Exp (-10000.0)) \lpRef.
-    lpRef!(Left  first_ix) := logprob_start_with_blank
-    lpRef!(Right first_ix) := logprob_of_first_label  -- 2nd index
+  -- Initialize dynamic programming table to all zeros
+  -- except for starting with either a blank or the first token.
+  prob_seq_at_start = yield_state zero \lpRef.
+    lpRef!(Posts first_ix) := label_probs.first_ix.blank
+    lpRef!(Fence first_ix) := label_probs.first_ix.(labels.first_ix)
 
   safe_idx_sub = \prev s y.
     if (ordinal s) < y
       then zero
       else prev.(unsafe_from_ordinal _ (unsafe_nat_diff (ordinal s) y))
 
-  log_prob_seq_final = fold zero \t prev.
-    case t == first_ix of
-      True -> log_prob_seq_t0
+  same_as_last = \s. if (ordinal s) >= 2
+    then
+      s_minus_2 = unsafe_from_ordinal _ (unsafe_nat_diff (ordinal s) 2)
+      ilabels.s == ilabels.s_minus_2
+    else False
+
+  prob_seq_final = fold zero \time prev.
+    case time == first_ix of
+      True -> prob_seq_at_start
       False -> for s.
-        same_as_last = if (ordinal s) >= 2
-          then ilabels.s == ilabels.(unsafe_from_ordinal _ ((ordinal s) -| 2))
-          else False
+        prob_stay_same       = prev.s
+        prob_from_blank      = safe_idx_sub prev s 1
+        prob_from_last_token = safe_idx_sub prev s 2
 
         -- Equation 6 from CTC paper.
-        ans = if ilabels.s == blank || same_as_last
-          then prev.s + safe_idx_sub prev s 1
-          else prev.s + safe_idx_sub prev s 1 + safe_idx_sub prev s 2
-        ans * normalized_logits.t.(ilabels.s)
+        ans = if ilabels.s == blank || same_as_last s
+          then prob_stay_same + prob_from_blank
+          else prob_stay_same + prob_from_blank + prob_from_last_token
+        ans * label_probs.time.(ilabels.s)
 
-  -- Sum over last two entries in the dynamic programming table.
-  last_label = log_prob_seq_final.(Right (last_ix, False))
-  last_space = log_prob_seq_final.(Right (last_ix, True ))
-  last_label + last_space
+  -- Sum over last two entries in the table.  Eq 8 from paper.
+  end_with_label = prob_seq_final.(Fence last_ix)
+  end_with_space = prob_seq_final.(Posts last_ix)
+  end_with_label + end_with_space
 
+'### Wrapper function to provide proof of `NonEmpty`
+This is a wrapper function to check if any of the inputs are empty,
+and cast them into a provably `NonEmpty` form if not.
+If the compiler could generate `NonEmpty` instances for all
+Fin N where N > 0, this function would be unnecessary.
 
 def ctc {vocab time position} [Eq time, Eq vocab]
     (blank: vocab)
     (logits: time=>vocab=>LogSpace Float)
     (labels: position=>vocab)
       : LogSpace Float =
-
-  -- This is a wrapper function to check if any of the inputs are empty,
-  -- and cast them into a provably `NonEmpty` form if not.
-  -- If the compiler could generate `NonEmpty` instances for all
-  -- Fin N where N > 0, this function would be unnecessary.
   if ((size vocab) > 0) && ((size time) > 0) && ((size position) > 0)
     then
       vocab_size_m1    = unsafe_nat_diff (size vocab) 1
@@ -107,41 +123,36 @@ def ctc {vocab time position} [Eq time, Eq vocab]
       position' = (Unit | Fin position_size_m1)
 
       blank'  = unsafe_from_ordinal vocab' (ordinal blank)
-      logits' = for t:time'. for v:vocab'. logits.(unsafe_from_ordinal _ (ordinal t)).(unsafe_from_ordinal _ (ordinal v))
-      labels' = for p:position'.
+      logits' = view t:time' v:vocab'.
+        logits.(unsafe_from_ordinal _ (ordinal t)).(unsafe_from_ordinal _ (ordinal v))
+      labels' = view p:position'.
         unsafe_from_ordinal _ (ordinal labels.(unsafe_from_ordinal _ (ordinal p)))
       
       ctc_inner blank' logits' labels'
     else zero
 
 '## Demo
+Evaluate marginal probability of some labels given logits.
 
 Vocab = Fin 6
-blank:Vocab = 0@Vocab
-
--- Create random logits
+blank = 0@Vocab
 Time = Fin 4
-logits : Time => Vocab => (LogSpace Float) = arb $ new_key 0
 
--- Evaluate marginal probability of labels given logits
+-- Create random logits and labels
+logits : Time => Vocab => (LogSpace Float) = arb $ new_key 0
 labels = [(3@Vocab), (4@Vocab), (1@Vocab)]
+
+-- Evaluate probability.
 :p ls_to_f $ ctc blank logits labels
 > 0.00209
 
 
 '### Test
+The CTC paper claims that the output of the above algorithm
+computes `p(labels|logits)`, which should sum to 1.0 over all possible labels.
+They don't sum to one.  Maybe there is a bug in the above code
+or the paper.
 
--- The CTC paper claims that the output of the above algorithm
--- computes p(labels|logits), which should sum to 1.0 over all possible labels.
--- They don't sum to one.  Maybe there is a bug in the above code
--- or the paper.
-
-sum for i:Unit=>Vocab. ls_to_f $ ctc blank logits i
-> 0.031206
-
--- (Fin N)=>Vocab is the set of all combinations of N tokens.
-sum for i:((Fin 2)=>Vocab). ls_to_f $ ctc blank logits i
-> 0.245854
-
-sum for i:((Fin 3)=>Vocab). ls_to_f $ ctc blank logits i
+-- Fin N=>Vocab is the set of all combinations of N tokens.
+sum for i:(Fin 3=>Vocab). ls_to_f $ ctc blank logits i
 > 0.565375

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -1,27 +1,30 @@
-'# Connectionist Temporal Classification
-By Alex Graves et alia.
+'# [Connectionist Temporal Classification](https://www.cs.toronto.edu/~graves/icml_2006.pdf)
+By Alex Graves *et alia*, 2006.
 
-'[Link to paper](https://www.cs.toronto.edu/~graves/icml_2006.pdf).
-
-' This dynamic programming algorithm computes the probability of a particular sequences of labels
+'This algorithm computes the probability of a sequence of labels
 (without pauses included) given another sequence of label probabilities
 (with pauses included), marginalizing over all possible combination of
 pause lengths.
 It's used for training speech-to-text models on unaligned training data.
 
-'Most implementations of CTC compute the marginal logprob
-and its gradients combining a forward and a backward pass.
-However, as mentioned in the original paper, we should only
-need the last step of the forward pass to compute the marginal
-probability, and Dex's autodiff should produce the backward
+'Most implementations of CTC compute the log marginal likelihood
+and its gradients through a separate forward and a backward pass.
+However, Dex's autodiff can produce the backward
 pass automatically.  That makes this code much shorter than
 most implementations.
 
+import stats  -- for LogSpace
 
-def interleave {m v} (blank:v) (labels: m=>v) : (m & (Fin 2))=>v =
+'### Helper functions
+
+IsBlank = Bool
+
+def interleave {m v} (blank:v) (labels: m=>v) : (m & IsBlank)=>v =
   -- Turns "text" into "t e x t " by first pairing each letter with a blank,
   -- then flattening the pairs back into a single-index table.
-  pairs = for i. [labels.i, blank]
+  pairs = for i j. case j of
+    True  -> blank
+    False -> labels.i
   for (i, j). pairs.i.j
 
 def prepend {m v} (first: v) (seq: m=>v) : ((Unit|m)=>v) =
@@ -30,115 +33,88 @@ def prepend {m v} (first: v) (seq: m=>v) : ((Unit|m)=>v) =
     Left () -> first
     Right i -> seq.i
 
-def prepend_and_interleave {m v} (blank:v) (seq: m=>v) : ((Unit|(m & (Fin 2)))=>v) =
-  -- Turns "text" into " t e x t".
-  -- The output of this function has a slightly complicated output type, which
-  -- has size 1 + 2 * (size m).
-  interleaved = interleave blank seq
-  prepend blank interleaved
+def prepend_and_interleave {m v} (blank:v) (seq: m=>v) : ((Unit|(m & IsBlank))=>v) =
+  -- Turns "text" into " t e x t ".
+  prepend blank (interleave blank seq)
 
-def clipidx (n:Type) [Ix n] (i:Int) : n =
-  -- Returns element at 0 if less than zero.
-  -- Ideally we could have an alternative
-  -- to Fin that just clips the index at its bounds.
-  from_ordinal n $ unsafe_i_to_n (select (i < 0) 0 i)
+def normalize {n v} [Fractional v, Add v] (xs:n=>v) : n=>v =
+  for i. divide xs.i (sum xs)
 
-def logaddexp (x:Float) (y:Float) : Float =
-  m = max x y
-  m + ( log ( (exp (x - m) + exp (y - m))))
 
-def ctc {vocab time position} [Eq vocab, Eq position, Eq time]
-      (blank:  vocab)
-      (logits: time=>vocab=>Float)
-      (labels: position=>vocab)
-      : Float =
-  -- Computes log p(labels | logits), marginalizing over possible alignments.
-  -- Todo: remove unnecessary implicit type annotations once
-  -- Dex starts putting implicit types in scope.
+'### Main CTC algorithm
+Computes p(labels | logits), marginalizing over possible alignments and
+and marginalizes over insertion of blanks between characters.
+Todo: add a `[Subset position time]` constraint.
 
+def ctc {vocab time position} [NonEmpty vocab, NonEmpty position, NonEmpty time, Eq time, Eq vocab]
+    (blank: vocab)
+    (logits: time=>vocab=>(LogSpace Float))
+    (labels: position=>vocab)
+      : LogSpace Float =
   ilabels = prepend_and_interleave blank labels
+  normalized_logits = for t. normalize logits.t
 
-  normalized_logits = for t. logsoftmax logits.t
+  -- Initialize dynamic programming table.
+  logprob_start_with_blank = normalized_logits.first_ix.blank
+  logprob_of_first_label   = normalized_logits.first_ix.(labels.first_ix)
+  log_prob_seq_t0 = yield_state (for pos. Exp (-10000.0)) \lpRef.
+    lpRef!(Left  first_ix) := logprob_start_with_blank
+    lpRef!(Right first_ix) := logprob_of_first_label  -- 2nd index
 
-  -- Initialization rules
-  logprob_start_with_blank = normalized_logits.(0@_).blank
-  logprob_of_first_label   = normalized_logits.(0@_).(labels.(0@_))
-  log_prob_seq_t0 = for pos.
-    -- TODO: allow pattern-matching on integer literals
-    case ordinal pos == 0 of
-      True -> logprob_start_with_blank
-      False -> case ordinal pos == 1 of
-        True  -> logprob_of_first_label
-        False -> log 0.000001
+  safe_idx_sub = \prev s y.
+    if (ordinal s) < y
+      then zero
+      else prev.(unsafe_from_ordinal _ (unsafe_nat_diff (ordinal s) y))
 
-  same_as_last = \ilabels s.
-    o = n_to_i $ ordinal s
-    select (o >= 2) (ilabels.s == ilabels.(clipidx _ (o - 2))) False
-
-  safe_idx = \prev s.
-    select (s >= 0) prev.(clipidx _ s) (log 0.0)
-
-  -- Todo: As suggested by Adam Paske, we could get rid of these
-  -- logaddexp calls with a newtype that overloads + and *
-  update = \t prev.
-    case ordinal t == 0 of
+  log_prob_seq_final = fold zero \t prev.
+    case t == first_ix of
       True -> log_prob_seq_t0
       False -> for s.
-        cond = ilabels.s == blank || same_as_last ilabels s
-        labar = logaddexp prev.s (safe_idx prev (n_to_i (ordinal s) - 1))
-        other = logaddexp labar  (safe_idx prev (n_to_i (ordinal s) - 2))
-        ans = select cond labar other
-        ans + normalized_logits.t.(ilabels.s)
+        same_as_last = if (ordinal s) >= 2
+          then ilabels.s == ilabels.(unsafe_from_ordinal _ ((ordinal s) -| 2))
+          else False
 
-  log_prob_seq_final = fold log_prob_seq_t0 update
+        -- Equation 6 from CTC paper.
+        ans = if ilabels.s == blank || same_as_last
+          then prev.s + safe_idx_sub prev s 1
+          else prev.s + safe_idx_sub prev s 1 + safe_idx_sub prev s 2
+        ans * normalized_logits.t.(ilabels.s)
 
-  -- Todo: nicer way to get last two elements of log_prob_seq_final.
-  seq_length = 1 + size (position & (Fin 2))
-  endlabel = log_prob_seq_final.((unsafe_nat_diff seq_length 2)@_)
-  endspace = log_prob_seq_final.((unsafe_nat_diff seq_length 1)@_)
-  logaddexp endlabel endspace
+  -- Sum over last two entries in the dynamic programming table.
+  last_label = log_prob_seq_final.(Right (last_ix, False))
+  last_space = log_prob_seq_final.(Right (last_ix, True ))
+  last_label + last_space
 
 
 '## Demo
 
-def randIdxNoZero (n:Type) [Ix n] (k:Key) : n =
-  unif = rand k
-  from_ordinal n $ unsafe_i_to_n $
-    (1 + (f_to_i (floor ( unif * i_to_f ((n_to_i $ size n) - 1)))))
-
-Vocab = Fin 6
-position = Fin 3
-blank = 0@Vocab
+-- Todo: Produce proofs that Fin N is NonEmpty for all N > 0
+Vocab = (Unit | Fin 5)
+blank:Vocab = first_ix
 
 -- Create random logits
-Time = Fin 4
-logits : Time => Vocab => Float = arb $ new_key 0
-
--- Create random labels
-labels = for i:position. randIdxNoZero Vocab (new_key (ordinal i))
-:p labels
-> [(3@(Fin 6)), (4@(Fin 6)), (1@(Fin 6))]
+Time = (Unit | Fin 3)
+logits : Time => Vocab => (LogSpace Float) = arb $ new_key 0
 
 -- Evaluate marginal probability of labels given logits
-:p exp $ ctc blank logits labels
+labels = [(3@Vocab), (4@Vocab), (1@Vocab)] :: (Unit | Fin 2)=>Vocab
+:p ls_to_f $ ctc blank logits labels
 > 0.00209
-
 
 
 '### Test
 
--- Check that the sum of p(labels|logits) sums to 1.0 over all possible labels.
--- They don't yet sum to one, however I'm not 100% sure about the
--- semantics of the marginal likelihood being computed, and whether
--- e.g. the summed-over labels should include blanks.
+-- The CTC paper claims that the output of the above algorithm
+-- computes p(labels|logits), which should sum to 1.0 over all possible labels.
+-- They don't sum to one.  Maybe there is a bug in the above code
+-- or the paper.
 
-sum for i:Vocab. exp $ ctc blank logits [i]
+sum for i:Unit=>Vocab. ls_to_f $ ctc blank logits i
 > 0.031206
 
--- (Fin N)=>Vocab is all combinations of N tokens.
-sum for i:((Fin 2)=>Vocab). exp $ ctc blank logits i
-> 0.245855
+-- (Fin N)=>Vocab is the set of all combinations of N tokens.
+sum for i:((Unit | Fin 1)=>Vocab). ls_to_f $ ctc blank logits i
+> 0.245854
 
-sum for i:((Fin 3)=>Vocab). exp $ ctc blank logits i
-> 0.565388
-
+sum for i:((Unit | Fin 2)=>Vocab). ls_to_f $ ctc blank logits i
+> 0.565374

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -144,4 +144,4 @@ sum for i:((Fin 2)=>Vocab). ls_to_f $ ctc blank logits i
 > 0.245854
 
 sum for i:((Fin 3)=>Vocab). ls_to_f $ ctc blank logits i
-> 0.565374
+> 0.565375

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -15,7 +15,9 @@ most implementations.
 
 import stats  -- for log-space representation of probabilities.
 
-'### Custom index set
+'## Custom index sets
+
+'### Fence and Posts
 Here we create a custom datatype and index set
 that interleaves the elements of a table with another set
 of values representing all the spaces in between those elements.
@@ -36,6 +38,24 @@ instance {a} [Ix a] Ix (FenceAndPosts a)
 
 instance {a} [NonEmpty a] NonEmpty (FenceAndPosts a)
   first_ix = unsafe_from_ordinal _ 0
+
+'### All but First
+Next we make an index set from any non-empty set
+that doesn't contain the first element.
+
+data AllButFirst n [NonEmpty n] =
+  MkAllButFirst n
+
+instance {a} Ix (AllButFirst a)
+  size = unsafe_nat_diff (size a) 1
+  ordinal = \(MkAllButFirst i). ordinal i
+  unsafe_from_ordinal = \o. MkAllButFirst $ unsafe_from_ordinal _ o
+
+instance {a} Subset (AllButFirst a) a
+  inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
+  project' = \x. case (ordinal x) < (size a) of
+    True  -> unsafe_from_ordinal _ ((ordinal x))
+    False -> Nothing
 
 
 '### Helper functions
@@ -82,19 +102,17 @@ def ctc_inner {vocab time position}
       ilabels.s == ilabels.s_minus_2
     else False
 
-  prob_seq_final = fold zero \time prev.
-    case time == first_ix of
-      True -> prob_seq_at_start
-      False -> for s.
-        prob_stay_same       = prev.s
-        prob_from_blank      = safe_idx_sub prev s 1
-        prob_from_last_token = safe_idx_sub prev s 2
+  prob_seq_final = fold prob_seq_at_start \t:(AllButFirst time) prev.
+    for s.
+      prob_stay_same       = prev.s
+      prob_from_blank      = safe_idx_sub prev s 1
+      prob_from_last_token = safe_idx_sub prev s 2
 
-        -- Equation 6 from CTC paper.
-        ans = if ilabels.s == blank || same_as_last s
-          then prob_stay_same + prob_from_blank
-          else prob_stay_same + prob_from_blank + prob_from_last_token
-        ans * label_probs.time.(ilabels.s)
+      -- Equation 6 from CTC paper.
+      ans = if ilabels.s == blank || same_as_last s
+        then prob_stay_same + prob_from_blank
+        else prob_stay_same + prob_from_blank + prob_from_last_token
+      ans * label_probs.(inject _ t).(ilabels.s)
 
   -- Sum over last two entries in the table.  Eq 8 from paper.
   end_with_label = prob_seq_final.(Fence last_ix)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2532,9 +2532,3 @@ instance {a b} [Ix a, Ix b] Ix (a=>b)
 
 instance {a b} [Ix a, NonEmpty b] NonEmpty (a=>b)
   first_ix = unsafe_from_ordinal _ 0
-
-instance {a b} [NonEmpty b, Eq a, Eq b] Subset a (b=>a)
-  inject' = \x. for j. x
-  project' = \table. case all for j. table.j == table.first_ix of
-    True  -> Just table.first_ix
-    False -> Nothing

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -561,6 +561,9 @@ def last_ix {n} [NonEmpty n] : n =
 instance {n} [Ix n] NonEmpty (Post n)
   first_ix = unsafe_from_ordinal (Post n) 0
 
+instance NonEmpty Unit
+  first_ix = unsafe_from_ordinal _ 0
+
 '### Monoid
 A [monoid](https://en.wikipedia.org/wiki/Monoid) is a things that have an associative binary operator and an identity element.
 This is a very useful and general calls of things.
@@ -745,6 +748,24 @@ instance Eq Bool
 instance Eq Unit
   (==) = \x y. True
 
+instance {a b} [Eq a, Eq b] Eq (a | b)
+  (==) = \x y. case x of
+    Left x -> case y of
+      Left y -> x == y
+      Right y -> False
+    Right x -> case y of
+      Left y -> False
+      Right y -> x == y
+
+instance {a} [Eq a] Eq (Maybe a)
+  (==) = \x y. case x of
+    Just x -> case y of
+      Just y -> x == y
+      Nothing -> False
+    Nothing -> case y of
+      Just y -> False
+      Nothing -> True
+
 instance Eq RawPtr
   (==) = \x y. raw_ptr_to_i64 x == raw_ptr_to_i64 y
 
@@ -798,6 +819,40 @@ instance {n} Ord (Fin n)
   (>) = \x y. ordinal x > ordinal y
   (<) = \x y. ordinal x < ordinal y
 
+instance Ix Bool
+  size = 2
+  ordinal = \b. case b of
+    False -> 0
+    True -> 1
+  unsafe_from_ordinal = \i. i > 0
+
+instance {a} [Ix a] Ix (Maybe a)
+  size = size a + 1
+  ordinal = \i. case i of
+    Just ai -> ordinal ai
+    Nothing -> size a
+  unsafe_from_ordinal = \o.
+    case o == size a of
+      False -> Just $ unsafe_from_ordinal _ o
+      True  -> Nothing
+
+instance NonEmpty Bool
+  first_ix = unsafe_from_ordinal _ 0
+
+instance {a b} [NonEmpty a, NonEmpty b] NonEmpty (a & b)
+  first_ix = unsafe_from_ordinal _ 0
+
+instance {a b} [Ix b, NonEmpty a] NonEmpty (a|b)
+  first_ix = unsafe_from_ordinal _ 0
+
+-- The below instance is valid, but causes "multiple candidate dictionaries"
+-- errors if both Left and Right are NonEmpty.
+-- instance {a b} [Ix a, NonEmpty b] NonEmpty (a|b)
+--  first_ix = unsafe_from_ordinal _ 0
+
+instance {a} [Ix a] NonEmpty (Maybe a)
+  first_ix = unsafe_from_ordinal _ 0
+
 def scan {a b n} [Ix n] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
   swap $ run_state init \s. for i.
     c = get s
@@ -837,13 +892,6 @@ instance {a n} [Ord a] Ord (n=>a)
         fold EQ $ \i c. c <> (compare xs.i ys.i)
     f == LT
 
-instance Ix Bool
-  size = 2
-  ordinal = \b. case b of
-    False -> 0
-    True -> 1
-  unsafe_from_ordinal = \i. i > 0
-
 '## Subset class
 
 interface Subset a_sub a
@@ -861,6 +909,24 @@ instance {a b c} [Subset a b, Subset b c] Subset a c
   project' = \x. case project b x of
     Nothing -> Nothing
     Just y -> project a y
+
+instance {a b} Subset a (a|b)
+  inject' = \x. Left x
+  project' = \x. case x of
+    Left  x -> Just x
+    Right x -> Nothing
+
+instance {a b} Subset a (b|a)
+  inject' = \x. Right x
+  project' = \x. case x of
+    Left  x -> Nothing
+    Right x -> Just x
+
+instance {a b} [NonEmpty b, Eq b] Subset a (a & b)
+  inject' = \x. (x, first_ix)
+  project' = \(x, y). case y == first_ix of
+    True  -> Just x
+    False -> Nothing
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
   inject' = \(UnsafeMkRangeFrom j).
@@ -2469,3 +2535,15 @@ instance {a b} [Ix a, Ix b] Ix (a=>b)
   size = intpow (size b) (size a)
   ordinal             = reversed_digits_to_int
   unsafe_from_ordinal = int_to_reversed_digits
+
+instance {a b} [NonEmpty a, NonEmpty b] NonEmpty (a=>b)
+  first_ix = unsafe_from_ordinal _ 0
+
+instance {a b} [NonEmpty a, Ix b, Subset a b] NonEmpty b
+  first_ix = unsafe_from_ordinal _ 0
+
+instance {a b} [NonEmpty b, Eq a, Eq b] Subset a (b=>a)
+  inject' = \x. for j. x
+  project' = \table. case all for j. table.j == table.first_ix of
+    True  -> Just table.first_ix
+    False -> Nothing

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -922,12 +922,6 @@ instance {a b} Subset a (b|a)
     Left  x -> Nothing
     Right x -> Just x
 
-instance {a b} [NonEmpty b, Eq b] Subset a (a & b)
-  inject' = \x. (x, first_ix)
-  project' = \(x, y). case y == first_ix of
-    True  -> Just x
-    False -> Nothing
-
 instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
   inject' = \(UnsafeMkRangeFrom j).
     unsafe_from_ordinal _ $ j + ordinal i
@@ -2536,10 +2530,7 @@ instance {a b} [Ix a, Ix b] Ix (a=>b)
   ordinal             = reversed_digits_to_int
   unsafe_from_ordinal = int_to_reversed_digits
 
-instance {a b} [NonEmpty a, NonEmpty b] NonEmpty (a=>b)
-  first_ix = unsafe_from_ordinal _ 0
-
-instance {a b} [NonEmpty a, Ix b, Subset a b] NonEmpty b
+instance {a b} [Ix a, NonEmpty b] NonEmpty (a=>b)
   first_ix = unsafe_from_ordinal _ 0
 
 instance {a b} [NonEmpty b, Eq a, Eq b] Subset a (b=>a)

--- a/lib/stats.dx
+++ b/lib/stats.dx
@@ -2,7 +2,23 @@
 Probability distributions and other functions useful for statistical computing.
 
 '## Log-space floating point numbers
-When working with probability densities, mass functions, distributions, likelihoods, etc., we often work on a logarithmic scale to prevent floating point overflow/underflow. Working on the log scale makes `product` operations safe, since they correspond to addition on the log scale. However, when it comes to `sum` operations on the raw probability scale, care must be taken to avoid underflow by using a safe [log-sum-exp](https://en.wikipedia.org/wiki/LogSumExp) function. `LogSpace` stores the log value internally, but is "safe" for both `sum` and `product`, since addition is implemented using the log-sum-exp trick. Several of the functions in this library return values as a `LogSpace Float`. The internally stored logarithmic value can be extracted with `ln`, and the actual value being represented (the raw probability) can be computed with `ls_to_f`. Although it is safe to use `sum` on a value of type `n=>LogSpace f`, it may be slightly more accurate and/or performant to instead use `ls_sum`, which applies the standard max-sweep log-sum-exp trick directly, rather than relying on monoid reduction using `add`.
+When working with probability densities, mass functions, distributions,
+likelihoods, etc., we often work on a logarithmic scale to prevent floating
+point overflow/underflow. Working on the log scale makes `product` operations
+safe, since they correspond to addition on the log scale. However, when it
+comes to `sum` operations on the raw probability scale, care must be taken to
+avoid underflow by using a safe
+[log-sum-exp](https://en.wikipedia.org/wiki/LogSumExp) function.
+`LogSpace` stores the log value internally, but is "safe" for both `sum` and
+`product`, since addition is implemented using the log-sum-exp trick.
+
+'Several of the functions in this library return values as a `LogSpace Float`.
+The internally stored logarithmic value can be extracted with `ln`, and the
+actual value being represented (the raw probability) can be computed with
+`ls_to_f`. Although it is safe to use `sum` on a value of type
+`n=>LogSpace f`, it may be slightly more accurate and/or performant to instead
+ use `ls_sum`, which applies the standard max-sweep log-sum-exp trick directly,
+rather than relying on monoid reduction using `add`.
 
 data LogSpace f = Exp f
 
@@ -16,11 +32,25 @@ instance {f} [Sub f] Fractional (LogSpace f)
 instance Arbitrary (LogSpace Float)
   arb = \k. Exp (randn k)
 
+def is_finite {f} [Fractional f, Sub f, Mul f, Ord f] (x:f) : Bool =
+  -- Todo: Make polymorphic versions of these and put them in the prelude.
+  infinity = (divide one zero)
+  neg_infinity = sub zero infinity
+  not (x == infinity || x == neg_infinity)
+
+def log_add_exp {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] (la:f) (lb:f) : f =
+  infinity = (divide one zero)
+  neg_infinity = sub zero infinity
+  if la == infinity && lb == infinity
+    then infinity
+    else if la == neg_infinity && lb == neg_infinity
+      then neg_infinity
+      else if (la > lb)
+        then la + log1p (exp (lb - la))
+        else lb + log1p (exp (la - lb))
+
 instance {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] Add (LogSpace f)
-  add = \(Exp la) (Exp lb).
-    if (la > lb)
-      then Exp $ la + log1p (exp (lb - la))
-      else Exp $ lb + log1p (exp (la - lb))
+  add = \(Exp la) (Exp lb). Exp $ log_add_exp la lb
   zero = Exp (zero - (divide one zero))
 
 def f_to_ls {f} [Floating f] (a:f) : LogSpace f = Exp $ log a
@@ -29,11 +59,16 @@ def ls_to_f {f} [Floating f] ((Exp la):LogSpace f) : f = exp la
 
 def ln {f} [Floating f] ((Exp la):LogSpace f) : f = la
 
-def ls_sum {n f} [Floating f, Add f, Sub f, Ord f] (x:n=>LogSpace f) : LogSpace f =
-  lx = map ln x
-  m = maximum lx
-  Exp $ m + (log $ sum for i. exp (lx.i - m))
+def log_sum_exp {n f} [Fractional f, Sub f, Floating f, Mul f, Ord f] (xs:n=>f) : f =
+  m_raw = maximum xs
+  m = case is_finite m_raw of
+    True  -> m_raw
+    False -> zero
+  m + (log $ sum for i. exp (xs.i - m))
 
+def ls_sum {n f} [Fractional f, Sub f, Floating f, Mul f, Ord f] (x:n=>LogSpace f) : LogSpace f =
+  lx = map ln x
+  Exp $ log_sum_exp lx
 
 '## Probability distributions
 Simulation and evaluation of [probability distributions](https://en.wikipedia.org/wiki/Probability_distribution). Probability distributions which can be sampled should implement `Random`, and those which can be evaluated should implement the `Dist` interface. Distributions over an ordered space (such as typical *univariate* distributions) should also implement `OrderedDist`.

--- a/lib/stats.dx
+++ b/lib/stats.dx
@@ -32,11 +32,12 @@ instance {f} [Sub f] Fractional (LogSpace f)
 instance Arbitrary (LogSpace Float)
   arb = \k. Exp (randn k)
 
-def is_finite {f} [Fractional f, Sub f, Mul f, Ord f] (x:f) : Bool =
+def is_infinite {f} [Fractional f, Sub f, Mul f, Ord f] (x:f) : Bool =
+  -- Note: According to this function, nan is not infinite.
   -- Todo: Make polymorphic versions of these and put them in the prelude.
   infinity = (divide one zero)
   neg_infinity = sub zero infinity
-  not (x == infinity || x == neg_infinity)
+  x == infinity || x == neg_infinity
 
 def log_add_exp {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] (la:f) (lb:f) : f =
   infinity = (divide one zero)
@@ -61,9 +62,9 @@ def ln {f} [Floating f] ((Exp la):LogSpace f) : f = la
 
 def log_sum_exp {n f} [Fractional f, Sub f, Floating f, Mul f, Ord f] (xs:n=>f) : f =
   m_raw = maximum xs
-  m = case is_finite m_raw of
-    True  -> m_raw
-    False -> zero
+  m = case is_infinite m_raw of
+    False -> m_raw
+    True  -> zero
   m + (log $ sum for i. exp (xs.i - m))
 
 def ls_sum {n f} [Fractional f, Sub f, Floating f, Mul f, Ord f] (x:n=>LogSpace f) : LogSpace f =

--- a/lib/stats.dx
+++ b/lib/stats.dx
@@ -13,6 +13,9 @@ instance {f} [Add f] Mul (LogSpace f)
 instance {f} [Sub f] Fractional (LogSpace f)
   divide = \(Exp la) (Exp lb). Exp $ la - lb
 
+instance Arbitrary (LogSpace Float)
+  arb = \k. Exp (randn k)
+
 instance {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] Add (LogSpace f)
   add = \(Exp la) (Exp lb).
     if (la > lb)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1074,7 +1074,7 @@ first_ix :: (Fin 0 & Unit)
 project Unit (inject (Unit | Fin 2) ())
 > (Just ())
 
-project Unit (inject (Unit & (Fin 2 | Unit)) ())
+project Unit (inject (Unit & (Unit | Fin 2)) ())
 > (Just ())
 
 project Bool (inject (Bool=>Bool) True)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1052,19 +1052,19 @@ first_ix :: ((Unit | Fin 2) | Fin 3)
 
 first_ix :: (Fin 0)
 > Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0))
-> 
+>
 > first_ix :: (Fin 0)
 > ^^^^^^^^^
 
 first_ix :: (Fin 0 | Fin 0)
 > Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0 | Fin 0))
-> 
+>
 > first_ix :: (Fin 0 | Fin 0)
 > ^^^^^^^^^
 
 first_ix :: (Fin 0 & Unit)
 > Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0 & Unit))
-> 
+>
 > first_ix :: (Fin 0 & Unit)
 > ^^^^^^^^^
 

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -595,6 +595,22 @@ def unflatten {n m} (params:Params n m) : (Weights n m & Biases n) =
 :p (for i:(Fin 4). 1.0) == (for i:(Fin 4). 2.0)
 > False
 
+((Left 1) :: (Int | Bool)) == (Left 1 :: (Int | Bool))
+> True
+
+((Right False) :: (Int | Bool)) == (Left 1 :: (Int | Bool))
+> False
+
+((Right False) :: (Bool | Bool)) == (Left False :: (Bool | Bool))
+> False
+
+Just 1 == Just 1
+> True
+
+Just 1 == Just 0
+> False
+
+
 -- Userspace-Bool breaks these
 
 -- -- Needed to avoid ambiguous type variables if both sides use the same constructor
@@ -988,6 +1004,10 @@ all for x:((Bool & Fin 3)=>(Fin 4)).
   x == (unsafe_from_ordinal _ (ordinal x))
 > True
 
+all $ for i:(Maybe (Fin 2)).
+  i == (unsafe_from_ordinal _ (ordinal i))
+> True
+
 def all_prefixes (s:String)  : List String =
   (AsList _ s') = s
   to_list for i. post_slice s' first_ix i
@@ -1006,3 +1026,56 @@ def scan_over {n} (xs:n=>Float) : n=>Float =
 
 scan_over [1.0, 2.0, 3.0]
 > [1., 2., 4.]
+
+-- NonEmpty tests
+
+first_ix :: Unit
+> ()
+
+first_ix :: (Unit | Fin 2)
+> (Left ())
+
+first_ix :: Bool
+> False
+
+first_ix :: (Unit | Fin 2)=>(Unit | Fin 3)
+> [(Left ()), (Left ()), (Left ())]@(Unit | Fin 2)
+
+first_ix :: ((Unit | Fin 2) & (Fin 3 | Unit))
+> ((Left ()), (Left (0@(Fin 3))))
+
+first_ix :: ((Unit | Fin 2) | Fin 3)
+> (Left (Left ()))
+
+
+-- Check that empty sets can't satisfy NonEmpty
+
+first_ix :: (Fin 0)
+> Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0))
+> 
+> first_ix :: (Fin 0)
+> ^^^^^^^^^
+
+first_ix :: (Fin 0 | Fin 0)
+> Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0 | Fin 0))
+> 
+> first_ix :: (Fin 0 | Fin 0)
+> ^^^^^^^^^
+
+first_ix :: (Fin 0 & Unit)
+> Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0 & Unit))
+> 
+> first_ix :: (Fin 0 & Unit)
+> ^^^^^^^^^
+
+
+-- Subset tests
+
+project Unit (inject (Unit | Fin 2) ())
+> (Just ())
+
+project Unit (inject (Unit & (Fin 2 | Unit)) ())
+> (Just ())
+
+project Bool (inject (Bool=>Bool) True)
+> (Just True)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1042,7 +1042,7 @@ first_ix :: (Unit | Fin 2)=>(Unit | Fin 3)
 > [(Left ()), (Left ()), (Left ())]@(Unit | Fin 2)
 
 first_ix :: ((Unit | Fin 2) & (Unit | Fin 3))
-> ((Left ()), (Left (0@(Fin 3))))
+> ((Left ()), (Left ()))
 
 first_ix :: ((Unit | Fin 2) | Fin 3)
 > (Left (Left ()))
@@ -1073,9 +1073,3 @@ first_ix :: (Fin 0 & Unit)
 
 project Unit (inject (Unit | Fin 2) ())
 > (Just ())
-
-project Unit (inject (Unit & (Unit | Fin 2)) ())
-> (Just ())
-
-project Bool (inject (Bool=>Bool) True)
-> (Just True)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1041,7 +1041,7 @@ first_ix :: Bool
 first_ix :: (Unit | Fin 2)=>(Unit | Fin 3)
 > [(Left ()), (Left ()), (Left ())]@(Unit | Fin 2)
 
-first_ix :: ((Unit | Fin 2) & (Fin 3 | Unit))
+first_ix :: ((Unit | Fin 2) & (Unit | Fin 3))
 > ((Left ()), (Left (0@(Fin 3))))
 
 first_ix :: ((Unit | Fin 2) | Fin 3)

--- a/tests/stats-tests.dx
+++ b/tests/stats-tests.dx
@@ -36,6 +36,18 @@ ls_to_f (f_to_ls 0.4 * f_to_ls 0.5) ~~ 0.2
 ls_to_f (divide (f_to_ls 0.4) (f_to_ls 0.5)) ~~ 0.8
 > True
 
+Exp (-infinity) + Exp (-infinity)  -- ok
+> (Exp -Infinity)
+
+Exp (infinity) + Exp (infinity)
+> (Exp Infinity)
+
+ls_sum [Exp (-infinity), Exp (-infinity)]
+> (Exp -Infinity)
+
+ls_sum [Exp (infinity), Exp (infinity)]
+> (Exp Infinity)
+
 
 -- mainly cross-checking against results from R
 

--- a/tests/stats-tests.dx
+++ b/tests/stats-tests.dx
@@ -36,10 +36,13 @@ ls_to_f (f_to_ls 0.4 * f_to_ls 0.5) ~~ 0.2
 ls_to_f (divide (f_to_ls 0.4) (f_to_ls 0.5)) ~~ 0.8
 > True
 
-Exp (-infinity) + Exp (-infinity)  -- ok
+
+-- Log-sum-exp
+
+Exp (-infinity) + Exp (-infinity)
 > (Exp -Infinity)
 
-Exp (infinity) + Exp (infinity)
+Exp infinity + Exp infinity
 > (Exp Infinity)
 
 ls_sum [Exp (-infinity), Exp (-infinity)]
@@ -47,6 +50,27 @@ ls_sum [Exp (-infinity), Exp (-infinity)]
 
 ls_sum [Exp (infinity), Exp (infinity)]
 > (Exp Infinity)
+
+Exp infinity + Exp (nan)
+> (Exp NaN)
+
+ls_sum [Exp (-infinity), Exp nan]
+> (Exp NaN)
+
+ln $ Exp nan
+> NaN
+
+is_infinite infinity
+> True
+
+is_infinite (-infinity)
+> True
+
+is_infinite 0.0
+> False
+
+is_infinite nan
+> False
 
 
 -- mainly cross-checking against results from R
@@ -262,7 +286,3 @@ variance_matrix (transpose [[1.0,2.0,3.0],[4.0,8.0,6.0]]) ~~ [[1,1],[1,4]]
 
 correlation_matrix (transpose [[1.0,2.0,3.0],[4.0,8.0,6.0]]) ~~ [[1,0.5],[0.5,1]]
 > True
-
-
--- eof
-


### PR DESCRIPTION
The CTC demo was a rat's nest of unsafe indexing arithmetic and would fail for empty inputs.  This PR revisits the CTC demo in light of some of the upgrades to the language, and my under better understanding of functional programming.

Specifically, this PR uses `NonEmpty` instances to replace every instance of `(0@_)` indexing, and manual indexing math, with `first_ix` and `last_ix`.  Along the way I also added a bunch more `NonEmpty` instances to the prelude.

I also took advantage of the new `LogSpace` typeclass to make the math look more like the equations in the paper, hiding away all the `logaddexp` logic and replacing it with simple `+` and '*'.

I also tried to include a `Subset` constraint in the type signature for `ctc`, but ran into the problem that I'd have to create all sorts of instances like `Subset (Fin 10) (Fin 20)`.

I also (with @axch 's help) created two new custom `Ix` instances: `FenceAndPosts` and `AllButFirst`.  To me these are really pleasing ways of factoring out indexing logic into meaningful, reusable, and easily testable chunks.  And together I think they make a compelling demo of how fancy types can help us safely and clearly handle fencepost and off-by-one issues.

The big question to me is if there is some way to automatically generate `NonEmpty` and `Subset` instances for `Fin N` as needed.  One argument for why it's worth adding to the compiler is that we might already want to add special automatic `NonEmpty` instances whenever a `for` loop is entered.