### PR TITLE
Docfix: Add camera.ppm download to docs.yaml

### DIFF
--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -31,6 +31,8 @@ jobs:
         wget http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz
         gunzip t10k-images-idx3-ubyte.gz t10k-labels-idx1-ubyte.gz
         mv t10k-images-idx3-ubyte t10k-labels-idx1-ubyte $GITHUB_WORKSPACE/examples/
+        wget https://gist.github.com/niklasschmitz/03be29c2850ac3bbdf6ce86229b71d8f/raw/300962b117fe8595913fb1f35db546b53974576c/camera.ppm
+        mv camera.ppm $GITHUB_WORKSPACE/examples/
 
     - name: Cache
       uses: actions/cache@v2

--- a/.github/workflows/docs.yaml
+++ b/.github/workflows/docs.yaml
@@ -25,15 +25,6 @@ jobs:
         ${{ matrix.install_deps }}
         echo "${{ matrix.path_extension }}" >> $GITHUB_PATH
 
-    - name: Get example files
-      run: |
-        wget http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-images-idx3-ubyte.gz
-        wget http://fashion-mnist.s3-website.eu-central-1.amazonaws.com/t10k-labels-idx1-ubyte.gz
-        gunzip t10k-images-idx3-ubyte.gz t10k-labels-idx1-ubyte.gz
-        mv t10k-images-idx3-ubyte t10k-labels-idx1-ubyte $GITHUB_WORKSPACE/examples/
-        wget https://gist.github.com/niklasschmitz/03be29c2850ac3bbdf6ce86229b71d8f/raw/300962b117fe8595913fb1f35db546b53974576c/camera.ppm
-        mv camera.ppm $GITHUB_WORKSPACE/examples/
-
     - name: Cache
       uses: actions/cache@v2
       with:

--- a/makefile
+++ b/makefile
@@ -384,9 +384,12 @@ pages-prelude: lib/prelude.dx
 	mkdir -p pages
 	$(dex) --prelude /dev/null script lib/prelude.dx --outfmt html > pages/prelude.html
 
+pages/examples/tutorial.html: tutorial-data
+pages/examples/dither.html: dither-data
+
 pages/examples/%.html: examples/%.dx
 	mkdir -p pages/examples
-	$(dex) script $^ --outfmt html > $@
+	$(dex) script $< --outfmt html > $@
 
 pages/lib/%.html: lib/%.dx
 	mkdir -p pages/lib


### PR DESCRIPTION
The rendered dither.dx example at https://google-research.github.io/dex-lang/examples/dither.html currently throws a runtime error due to missing camera.ppm. 

This PR adds the download link of camera.ppm from the makefile also to the docs.yaml GH action.