### PR TITLE
More typecheking changes for algebraic effects

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -25,7 +25,7 @@ module Builder (
   buildAbs, buildNaryAbs, buildNaryLam, buildNullaryLam, buildNaryLamExpr, asNaryLam,
   buildAlt, buildUnaryAtomAlt,
   emitDataDef, emitClassDef, emitInstanceDef, emitDataConName, emitTyConName,
-  emitEffectDef, emitHandlerDef, emitEffectOp,
+  emitEffectDef, emitHandlerDef, emitEffectOpDef,
   buildCase, emitMaybeCase, buildSplitCase,
   emitBlock, emitDecls, BuilderEmissions, emitAtomToName,
   TopBuilder (..), TopBuilderT (..), liftTopBuilderTWith, runTopBuilderT, TopBuilder2,
@@ -1047,19 +1047,11 @@ emitHandlerDef :: (Mut n, TopBuilder m) => SourceName -> HandlerDef n -> m n (Ha
 emitHandlerDef name handlerDef =
   emitBinding (getNameHint name) $ HandlerBinding handlerDef
 
-emitEffectOp :: (Mut n, TopBuilder m) => EffectName n -> Int -> SourceName -> m n (Name EffectOpNameC n)
-emitEffectOp effName i opName = do
+emitEffectOpDef :: (Mut n, TopBuilder m) => EffectName n -> Int -> SourceName -> m n (Name EffectOpNameC n)
+emitEffectOpDef effName i opName = do
   let hint = getNameHint opName
-  perform <- makePerformOp effName i
-  let opDef = EffectOpDef effName (OpIdx i) perform
+  let opDef = EffectOpDef effName (OpIdx i)
   emitBinding hint $ EffectOpBinding opDef
-
-makePerformOp :: EnvReader m => EffectName n -> Int -> m n (Atom n)
-makePerformOp effName opIdx = do
-  effName' <- sinkM effName
-  EffectDef _ ops <- getEffectDef effName'
-  let (_, opType) = ops !! opIdx
-  return $ EffOp (UserEffect effName') opIdx opType
 
 emitClassDef :: (Mut n, TopBuilder m) => ClassDef n -> m n (Name ClassNameC n)
 emitClassDef classDef@(ClassDef name _ _ _ _) =
@@ -1117,11 +1109,6 @@ getClassDef :: EnvReader m => Name ClassNameC n -> m n (ClassDef n)
 getClassDef classDefName = do
   ~(ClassBinding classDef) <- lookupEnv classDefName
   return classDef
-
-getEffectDef :: EnvReader m => EffectName n -> m n (EffectDef n)
-getEffectDef effDefName = do
-  ~(EffectBinding def) <- lookupEnv effDefName
-  return def
 
 -- === builder versions of common local ops ===
 

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -86,12 +86,15 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   Con con -> Con <$> mapM tge con
   TC  tc  -> TC  <$> mapM tge tc
   Eff _   -> substM atom
-  EffOp _ _ _ -> substM atom -- TODO(alex): check correctness
   TypeCon sn dataDefName params ->
     TypeCon sn <$> substM dataDefName <*> tge params
   DictCon dictExpr -> DictCon <$> tge dictExpr
   DictTy (DictType sn cn params) ->
     DictTy <$> (DictType sn <$> substM cn <*> mapM tge params)
+  HandlerDictCon (HandlerDictExpr v r args) ->
+    HandlerDictCon <$> (HandlerDictExpr <$> substM v <*> tge r <*> mapM tge args)
+  HandlerDictTy (HandlerDictType sn effName) -> HandlerDictTy <$>
+    (HandlerDictType sn <$> substM effName)
   LabeledRow elems -> LabeledRow <$> traverseGenericE elems
   RecordTy elems -> RecordTy <$> traverseGenericE elems
   VariantTy ext -> VariantTy <$> traverseExtLabeledItems ext

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -95,8 +95,11 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   TC  tc  -> TC  <$> mapM rec tc
   DictCon _ -> substM atom
   DictTy  _ -> substM atom
+  -- TODO(alex): check correctness
+  HandlerDictCon _ -> substM atom
+  HandlerDictTy  _ -> substM atom
+  --
   Eff _ -> substM atom
-  EffOp _ _ _ -> substM atom  -- TODO(alex): check correctness
   TypeCon sn defName (DataDefParams params dicts) -> do
     defName' <- substM defName
     TypeCon sn defName' <$> (DataDefParams <$> mapM rec params <*> mapM rec dicts)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -264,6 +264,10 @@ linearizeAtom atom = case atom of
           extendSubst (b@>i) $ linearizeBlock body
   DictCon _ -> notImplemented
   DictTy _  -> notImplemented
+  -- TODO(alex): check correctness
+  HandlerDictCon _ -> notImplemented
+  HandlerDictTy _ -> notImplemented
+  --
   DepPair _ _ _     -> notImplemented
   TypeCon _ _ _   -> emitZeroT
   LabeledRow _    -> emitZeroT
@@ -274,7 +278,6 @@ linearizeAtom atom = case atom of
   DepPairTy _     -> emitZeroT
   TC _            -> emitZeroT
   Eff _           -> emitZeroT
-  EffOp _ _ _     -> emitZeroT  -- TODO(alex): check correctness
   ProjectElt idxs v ->
     linearizeAtom (Var v) `bindLin` \x ->
       return $ getProjection (toList idxs) x
@@ -535,6 +538,7 @@ linearizePrimCon con = case con of
   ConRef _       -> error "Unexpected ref"
   ExplicitDict  _ _ -> error "Unexpected ExplicitDict"
   DictHole _ _ -> error "Unexpected DictHole"
+  HandlerHole _ _ -> error "Unexpected HandlerHole"
   where emitZeroT = withZeroT $ substM $ Con con
 
 linearizeHof :: Emits o => Hof i -> LinM i o Atom Atom

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -979,11 +979,14 @@ instance (Color c, SinkableE atom, SubstE Name atom)
 instance (SinkableE atom, SubstE Name atom) => SubstV Name (SubstVal cMatch atom)
 
 -- TODO: we can fill out the full (N^2) set of instances if we need to
-instance ColorsNotEqual AtomNameC DataDefNameC where notEqProof = \case
-instance ColorsNotEqual AtomNameC ClassNameC   where notEqProof = \case
-instance ColorsNotEqual AtomNameC InstanceNameC   where notEqProof = \case
-instance ColorsNotEqual AtomNameC ImpFunNameC     where notEqProof = \case
-instance ColorsNotEqual AtomNameC PtrNameC        where notEqProof = \case
+instance ColorsNotEqual AtomNameC DataDefNameC  where notEqProof = \case
+instance ColorsNotEqual AtomNameC ClassNameC    where notEqProof = \case
+instance ColorsNotEqual AtomNameC EffectNameC   where notEqProof = \case
+instance ColorsNotEqual AtomNameC EffectOpNameC where notEqProof = \case
+instance ColorsNotEqual AtomNameC HandlerNameC  where notEqProof = \case
+instance ColorsNotEqual AtomNameC InstanceNameC where notEqProof = \case
+instance ColorsNotEqual AtomNameC ImpFunNameC   where notEqProof = \case
+instance ColorsNotEqual AtomNameC PtrNameC      where notEqProof = \case
 
 -- === alpha-renaming-invariant equality checking ===
 

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -265,6 +265,8 @@ instance HasDCE Effect
 instance HasDCE EffectOpType
 instance HasDCE DictExpr
 instance HasDCE DictType
+instance HasDCE HandlerDictExpr
+instance HasDCE HandlerDictType
 instance HasDCE FieldRowElems
 instance HasDCE FieldRowElem
 instance HasDCE DataDefParams

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -231,6 +231,14 @@ instance Pretty (DictType n) where
   pretty (DictType classSourceName _ params) =
     p classSourceName <+> spaced params
 
+instance Pretty (HandlerDictExpr n) where
+  pretty (HandlerDictExpr name r args) =
+    "HandlerDictExpr" <+> p name <+> p r <+> p args
+
+instance Pretty (HandlerDictType n) where
+  pretty (HandlerDictType handlerSourceName effectName) =
+    "HandlerDictType" <+> p handlerSourceName <+> p effectName
+
 instance Pretty (DepPairType n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (DepPairType n) where
   prettyPrec (DepPairType b rhs) =
@@ -253,7 +261,6 @@ instance PrettyPrec (Atom n) where
     TC  e -> prettyPrec e
     Con e -> prettyPrec e
     Eff e -> atPrec ArgPrec $ p e
-    EffOp _ _ ty -> atPrec ArgPrec $ p ty
     TypeCon "RangeTo"      _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ ".."  <> pApp i
     TypeCon "RangeToExc"   _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ "..<" <> pApp i
     TypeCon "RangeFrom"    _ (DataDefParams [_, i] _) -> atPrec LowestPrec $ pApp i <>  ".."
@@ -266,6 +273,8 @@ instance PrettyPrec (Atom n) where
       _  -> atPrec LowestPrec $ pAppArg (p name) params
     DictCon d -> atPrec LowestPrec $ p d
     DictTy  t -> atPrec LowestPrec $ p t
+    HandlerDictCon d -> atPrec LowestPrec $ p d
+    HandlerDictTy  t -> atPrec LowestPrec $ p t
     LabeledRow elems -> prettyRecordTyRow elems "?"
     RecordTy elems -> prettyRecordTyRow elems "&"
     VariantTy items -> prettyExtLabeledItems items Nothing (line <> "|") ":"
@@ -949,6 +958,7 @@ prettyPrecPrimCon con = case con of
   LabelCon name -> atPrec ArgPrec $ "##" <> p name
   ExplicitDict _ _ -> atPrec ArgPrec $ "ExplicitDict"
   DictHole _ e -> atPrec LowestPrec $ "synthesize" <+> pApp e
+  HandlerHole _ e -> atPrec LowestPrec $ "synthesize" <+> pApp e
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -16,7 +16,8 @@ module QueryType (
   litType, lamExprTy,
   numNaryPiArgs, naryLamExprType, specializedFunType,
   oneEffect, projectionIndices, sourceNameType, typeBinOp, typeUnOp,
-  isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict
+  isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict,
+  instantiateHandlerType,
   ) where
 
 import Control.Category ((>>>))
@@ -334,11 +335,12 @@ instance HasType Atom where
     Con con -> getTypePrimCon con
     TC _ -> return TyKind
     Eff _ -> return EffKind
-    -- TODO(alex): validate
-    EffOp _ _ (EffectOpType _ ty) -> substM ty
     TypeCon _ _ _ -> return TyKind
     DictCon dictExpr -> getTypeE dictExpr
     DictTy (DictType _ _ _) -> return TyKind
+    -- TODO(alex): check correctness
+    HandlerDictCon d -> getTypeE d
+    HandlerDictTy _ -> return TyKind
     LabeledRow _ -> return LabeledRowKind
     RecordTy _ -> return TyKind
     VariantTy _ -> return TyKind
@@ -420,6 +422,7 @@ getTypePrimCon con = case con of
   LabelCon _   -> return $ TC $ LabelType
   ExplicitDict dictTy _ -> substM dictTy
   DictHole _ ty -> substM ty
+  HandlerHole _ ty -> substM ty
 
 dictExprType :: DictExpr i -> TypeQueryM i o (DictType o)
 dictExprType e = case e of
@@ -479,6 +482,13 @@ typeTabApp tabTy xs = go tabTy $ toList xs
 
 instance HasType DictExpr where
   getTypeE e = DictTy <$> dictExprType e
+
+instance HasType HandlerDictExpr where
+  getTypeE (HandlerDictExpr handlerName _ _) = do
+    handlerName' <- substM handlerName
+    (HandlerDef effName _ _ _ _ _ _) <- lookupHandlerDef handlerName'
+    (EffectDef effSourceName _) <- lookupEffectDef effName
+    return (HandlerDictTy $ HandlerDictType effSourceName effName)
 
 instance HasType Expr where
   getTypeE expr = case expr of
@@ -615,6 +625,11 @@ getTypePrimOp op = case op of
   OutputStreamPtr ->
     return $ BaseTy $ hostPtrTy $ hostPtrTy $ Scalar Word8Type
     where hostPtrTy ty = PtrType (Heap CPU, ty)
+  Perform hndDict i -> do
+    HandlerDictTy (HandlerDictType _ effName) <- getTypeE hndDict
+    EffectDef _ ops <- lookupEffectDef effName
+    let (_, EffectOpType _pol lamTy) = ops !! i
+    return lamTy
   ProjMethod dict i -> do
     DictTy (DictType _ className params) <- getTypeE dict
     def@(ClassDef _ _ paramBs classBs methodTys) <- lookupClassDef className
@@ -636,7 +651,15 @@ getTypePrimOp op = case op of
     TC (RefType h _) -> TC . RefType h <$> substM vty
     ty -> error $ "Not a reference type: " ++ pprint ty
   Resume retTy _ -> substM retTy
-  Handle _ _ -> throw NotImplementedErr "getTypePrimOp.Handle"  -- TODO(alex): implement
+  Handle (HandlerDictCon hde) _ -> do
+    HandlerDictExpr hndName r args <- substM hde
+    instantiateHandlerType hndName r args
+  Handle _ _ -> error "Handler did not have literal dict as first arg"
+
+instantiateHandlerType :: EnvReader m => HandlerName n -> Atom n -> [Atom n] -> m n (Type n)
+instantiateHandlerType hndName r args = do
+  HandlerDef _ rb bs _effs retTy _ _ <- lookupHandlerDef hndName
+  applySubst (rb @> (SubstVal r) <.> bs @@> (map SubstVal args)) retTy
 
 getSuperclassDicts :: ClassDef n -> Atom n -> [Atom n]
 getSuperclassDicts (ClassDef _ _ _ (SuperclassBinders classBs _) _) dict =

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -490,10 +490,13 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   Con con -> Con <$> (inline traversePrimCon) simplifyAtom con
   TC tc -> TC <$> (inline traversePrimTC) simplifyAtom tc
   Eff eff -> Eff <$> substM eff
-  EffOp eff idx ty -> EffOp <$> substM eff <*> pure idx <*> substM ty  -- TODO(alex): check correctness
   TypeCon _ _ _ -> substM atom
   DictCon d -> DictCon <$> substM d
   DictTy  t -> DictTy  <$> substM t
+  -- TODO(alex): check correctness
+  HandlerDictCon d -> HandlerDictCon <$> substM d
+  HandlerDictTy  t -> HandlerDictTy  <$> substM t
+  --
   RecordTy _ -> substM atom >>= cheapNormalize >>= \atom' -> case atom' of
     StaticRecordTy items -> StaticRecordTy <$> dropSubst (mapM simplifyAtom items)
     _ -> error $ "Failed to simplify a record with a dynamic label: " ++ pprint atom'

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -26,7 +26,7 @@ module Syntax (
     fieldRowElemsFromList, prependFieldRowElem, extRowAsFieldRowElems, fieldRowElemsAsExtRow,
     pattern StaticRecordTy, pattern RecordTyWithElems,
     Expr (..), Atom (..), Arrow (..), PrimTC (..), Abs (..),
-    DictExpr (..), DictType (..),
+    DictExpr (..), DictType (..), HandlerDictExpr (..), HandlerDictType (..),
     PrimExpr (..), PrimCon (..), LitVal (..), PtrLitVal (..), PtrSnapshot (..),
     AlwaysEqual (..),
     PrimEffect (..), PrimOp (..), PrimHof (..),

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -250,6 +250,7 @@ transposeOp op ct = case op of
   ToEnum _ _            -> notLinear
   ThrowException _      -> notLinear
   OutputStreamPtr       -> notLinear
+  Perform _ _           -> unreachable
   ProjMethod _ _        -> unreachable
   ExplicitApply _ _     -> unreachable
   MonoLiteral _         -> unreachable
@@ -286,6 +287,8 @@ transposeAtom atom ct = case atom of
   TabLam _        -> notTangent
   DictCon _       -> notTangent
   DictTy _        -> notTangent
+  HandlerDictCon _ -> notTangent  -- TODO(alex): check correctness
+  HandlerDictTy _ -> notTangent   -- TODO(alex): check correctness
   TypeCon _ _ _   -> notTangent
   LabeledRow _    -> notTangent
   RecordTy _      -> notTangent
@@ -295,7 +298,6 @@ transposeAtom atom ct = case atom of
   DepPairTy _     -> notTangent
   TC _            -> notTangent
   Eff _           -> notTangent
-  EffOp _ _ _     -> notTangent  -- TODO(alex): check correctness
   ACase _ _ _     -> error "Unexpected ACase"
   BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
@@ -362,6 +364,7 @@ transposeCon con ct = case con of
   ConRef _       -> notTangent
   ExplicitDict _ _ -> notTangent
   DictHole _ _ -> notTangent
+  HandlerHole _ _ -> notTangent
   where notTangent = error $ "Not a tangent atom: " ++ pprint (Con con)
 
 notImplemented :: HasCallStack => a

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -73,7 +73,9 @@ data PrimCon e =
       | ConRef (PrimCon e)
       -- Misc hacks
       | ExplicitDict e e  -- Dict type, method. Used in prelude for `run_accum`.
-      | DictHole (AlwaysEqual SrcPosCtx) e -- Only used during type inference
+      -- Only used during type inference
+      | DictHole (AlwaysEqual SrcPosCtx) e
+      | HandlerHole (AlwaysEqual SrcPosCtx) e  -- e is HandlerDictTy
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 newtype AlwaysEqual a = AlwaysEqual a
@@ -98,6 +100,7 @@ data PrimOp e =
       | ThrowException e             -- Catchable exceptions (unlike `ThrowError`)
       | Resume e e                   -- Resume from effect handler (type, arg)
       | Handle e e                   -- Call a handler (handler def, body)
+      | Perform e Int                -- Call an effect operation (handler dict) (op #)
       -- References
       | IndexRef e e
       | ProjRef Int e

--- a/tests/algeff-tests.dx
+++ b/tests/algeff-tests.dx
@@ -53,6 +53,24 @@ def checkFloatNonNegative (x:Float) : {Exn} Float =
   check $ x >= 0.0
   x
 
+-- catch_ \_.
+--   checkFloatNonNegative (3.14)
+-- > Compiler bug!
+-- > Please report this at github.com/google-research/dex-lang/issues
+-- >
+-- > Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+-- > CallStack (from HasCallStack):
+-- >   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+
+-- catch_ \_.
+--   checkFloatNonNegative (-1.0)
+-- > Compiler bug!
+-- > Please report this at github.com/google-research/dex-lang/issues
+-- >
+-- > Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+-- > CallStack (from HasCallStack):
+-- >   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+
 effect Counter
   def inc : Unit -> Unit
 


### PR DESCRIPTION
This is to be merged into #1058 (not main)

This removes `EffOp` and replaces it with a `Perform` PrimOp and ensures that our examples fail inside `Imp.hs`.