### PR TITLE
Responding to reviewer comments on algeff typechecking

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1252,7 +1252,7 @@ ptrOffset x i = emitOp $ PtrOffset x i
 
 unsafePtrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
 unsafePtrLoad x = do
-  lam <- liftEmitBuilder $ buildLam noHint PlainArrow UnitTy (oneEffect IOEffect) \_ ->
+  lam <- liftEmitBuilder $ buildLam noHint PlainArrow UnitTy (OneEffect IOEffect) \_ ->
     emitOp . PtrLoad =<< sinkM x
   liftM Var $ emit $ Hof $ RunIO $ lam
 

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -36,7 +36,6 @@ import Types.Core
 import Syntax
 import Name
 import PPrint ()
-import Core (lookupHandlerDef)
 
 -- === top-level API ===
 
@@ -260,8 +259,6 @@ instance HasType Atom where
       params' <- mapM substM params
       checkArgTys paramBs params'
       return TyKind
-    HandlerDictCon dictExpr -> getTypeE dictExpr
-    HandlerDictTy (HandlerDictType _ _) -> return TyKind
     LabeledRow elems -> checkFieldRowElems elems $> LabeledRowKind
     RecordTy elems -> checkFieldRowElems elems $> TyKind
     VariantTy row -> checkLabeledRow row $> TyKind
@@ -324,6 +321,13 @@ instance HasType Expr where
     Op   op  -> typeCheckPrimOp op
     Hof  hof -> typeCheckPrimHof hof
     Case e alts resultTy effs -> checkCase e alts resultTy effs
+    -- TODO(alex): actually check something here? this is a QueryType copy/paste
+    Handle hndName [] body -> do
+      hndName' <- substM hndName
+      r <- getTypeE body
+      instantiateHandlerType hndName' r []
+    -- TODO(alex): implement
+    Handle _ _ _  -> error "not implemented"
 
 instance HasType Block where
   getTypeE (Block NoBlockAnn Empty expr) = do
@@ -408,14 +412,6 @@ dictExprType e = case e of
 
 instance HasType DictExpr where
   getTypeE e = DictTy <$> dictExprType e
-
--- TODO(alex): copied from QueryType, need to actually _check_ things.
-instance HasType HandlerDictExpr where
-  getTypeE (HandlerDictExpr handlerName _ _) = do
-    handlerName' <- substM handlerName
-    (HandlerDef effName _ _ _ _ _ _) <- lookupHandlerDef handlerName'
-    (EffectDef effSourceName _) <- lookupEffectDef effName
-    return (HandlerDictTy $ HandlerDictType effSourceName effName)
 
 instance HasType DepPairType where
   getTypeE (DepPairType b ty) = do
@@ -533,7 +529,6 @@ typeCheckPrimCon con = case con of
     method |: methodTy
     return dictTy'
   DictHole _ ty -> checkTypeE TyKind ty
-  HandlerHole _ ty -> checkTypeE TyKind ty
 
 typeCheckPrimOp :: Typer m => PrimOp (Atom i) -> m i o (Type o)
 typeCheckPrimOp op = case op of
@@ -721,9 +716,9 @@ typeCheckPrimOp op = case op of
   OutputStreamPtr ->
     return $ BaseTy $ hostPtrTy $ hostPtrTy $ Scalar Word8Type
     where hostPtrTy ty = PtrType (Heap CPU, ty)
-  Perform hndDict i -> do
-    HandlerDictTy (HandlerDictType _ effName) <- getTypeE hndDict
-    EffectDef _ ops <- lookupEffectDef effName
+  Perform eff i -> do
+    Eff (OneEffect (UserEffect effName)) <- return eff
+    EffectDef _ ops <- substM effName >>= lookupEffectDef
     let (_, EffectOpType _pol lamTy) = ops !! i
     return lamTy
   ProjMethod dict i -> do
@@ -761,11 +756,6 @@ typeCheckPrimOp op = case op of
   -- TODO(alex): check the argument
   Resume retTy _argTy -> do
     checkTypeE TyKind retTy
-  -- TODO(alex): actually _check_ things (this is QueryType c&p)
-  Handle (HandlerDictCon hde) _ -> do
-    HandlerDictExpr hndName r args <- substM hde
-    instantiateHandlerType hndName r args
-  Handle _ _ -> error "Handler did not have literal dict as first arg"
 
 typeCheckPrimHof :: Typer m => PrimHof (Atom i) -> m i o (Type o)
 typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
@@ -1114,7 +1104,7 @@ instance CheckableE EffectRow where
     substM effRow
 
 declareEff :: Typer m => Effect o -> m i o ()
-declareEff eff = declareEffs $ oneEffect eff
+declareEff eff = declareEffs $ OneEffect eff
 
 declareEffs :: Typer m => EffectRow o -> m i o ()
 declareEffs effs = do
@@ -1204,7 +1194,7 @@ checkFFIFunTypeM (NaryPiType (NonEmptyNest b bs) eff resultTy) = do
   argTy <- checkScalar $ binderType b
   case bs of
     Empty -> do
-      assertEq eff (oneEffect IOEffect) ""
+      assertEq eff (OneEffect IOEffect) ""
       resultTys <- checkScalarOrPairType resultTy
       let cc = case length resultTys of
                  0 -> error "Not implemented"

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -304,6 +304,7 @@ instance BindsEnv LamBinder where
                    (Just $ sink effects)
 
 instance BindsEnv PiBinder where
+  toEnvFrag :: Distinct l => PiBinder n l -> EnvFrag n l
   toEnvFrag (PiBinder b ty arr) =
     withExtEvidence b do
       let binding = toBinding $ sink $ PiBinding arr ty

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -52,6 +52,8 @@ traverseExprDefault expr = confuseGHC >>= \_ -> case expr of
   Hof hof -> Hof  <$> mapM tge hof
   Case scrut alts resultTy effs ->
     Case <$> tge scrut <*> mapM traverseAlt alts <*> tge resultTy <*> substM effs
+  Handle hndName args body ->
+    Handle <$> substM hndName <*> mapM tge args <*> tge body
 
 traverseAtomDefault :: GenericTraverser s => Atom i -> GenericTraverserM s i o (Atom o)
 traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
@@ -91,10 +93,6 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   DictCon dictExpr -> DictCon <$> tge dictExpr
   DictTy (DictType sn cn params) ->
     DictTy <$> (DictType sn <$> substM cn <*> mapM tge params)
-  HandlerDictCon (HandlerDictExpr v r args) ->
-    HandlerDictCon <$> (HandlerDictExpr <$> substM v <*> tge r <*> mapM tge args)
-  HandlerDictTy (HandlerDictType sn effName) -> HandlerDictTy <$>
-    (HandlerDictType sn <$> substM effName)
   LabeledRow elems -> LabeledRow <$> traverseGenericE elems
   RecordTy elems -> RecordTy <$> traverseGenericE elems
   VariantTy ext -> VariantTy <$> traverseExtLabeledItems ext

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -384,6 +384,7 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
                  void $ extendSubst (b @> SubstVal (sink xs)) $
                    translateBlock (Just $ sink dest) body
             destToAtom dest
+  Handle _ _ _ -> error "handlers should be gone by now"
   where
     notASimpExpr = error $ "not a simplified expression: " ++ pprint expr
     returnVal atom = case maybeDest of

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -95,10 +95,6 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   TC  tc  -> TC  <$> mapM rec tc
   DictCon _ -> substM atom
   DictTy  _ -> substM atom
-  -- TODO(alex): check correctness
-  HandlerDictCon _ -> substM atom
-  HandlerDictTy  _ -> substM atom
-  --
   Eff _ -> substM atom
   TypeCon sn defName (DataDefParams params dicts) -> do
     defName' <- substM defName
@@ -167,6 +163,8 @@ evalExpr expr = case expr of
       extendSubst (b @> SubstVal UnitTy) $
         evalBlock body
     _ -> error $ "Not implemented: " ++ pprint expr
+  -- TODO(alex): implement
+  Handle _ _ _ -> error $ "Not implemented: " ++ pprint expr
 {-# SCC evalExpr #-}
 
 evalOp :: Interp m => Op i -> m i o (Atom o)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -264,10 +264,6 @@ linearizeAtom atom = case atom of
           extendSubst (b@>i) $ linearizeBlock body
   DictCon _ -> notImplemented
   DictTy _  -> notImplemented
-  -- TODO(alex): check correctness
-  HandlerDictCon _ -> notImplemented
-  HandlerDictTy _ -> notImplemented
-  --
   DepPair _ _ _     -> notImplemented
   TypeCon _ _ _   -> emitZeroT
   LabeledRow _    -> emitZeroT
@@ -377,6 +373,7 @@ linearizeExpr expr = case expr of
           extendSubst (b @> x') $ withTangentFunAsLambda $ linearizeBlock body
         return $ WithTangent ans do
           applyLinToTangents $ sink linLam
+  Handle _ _ _ -> error "handlers should be gone by now"
 
 linearizeOp :: Emits o => Op i -> LinM i o Atom Atom
 linearizeOp op = case op of
@@ -538,7 +535,6 @@ linearizePrimCon con = case con of
   ConRef _       -> error "Unexpected ref"
   ExplicitDict  _ _ -> error "Unexpected ExplicitDict"
   DictHole _ _ -> error "Unexpected DictHole"
-  HandlerHole _ _ -> error "Unexpected HandlerHole"
   where emitZeroT = withZeroT $ substM $ Con con
 
 linearizeHof :: Emits o => Hof i -> LinM i o Atom Atom

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -265,8 +265,6 @@ instance HasDCE Effect
 instance HasDCE EffectOpType
 instance HasDCE DictExpr
 instance HasDCE DictType
-instance HasDCE HandlerDictExpr
-instance HasDCE HandlerDictType
 instance HasDCE FieldRowElems
 instance HasDCE FieldRowElem
 instance HasDCE DataDefParams

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -165,6 +165,8 @@ instance PrettyPrec (Expr n) where
     atPrec LowestPrec $ "remember" <+> pApp d <+> prettyLam ("\\" <> p b <> ".") effs body
   prettyPrec (Hof hof) = prettyPrec hof
   prettyPrec (Case e alts _ effs) = prettyPrecCase "case" e alts effs
+  prettyPrec (Handle v args body) =
+      atPrec LowestPrec $ p v <+> p args <+> prettyLam "\\_." Pure body
 
 prettyPrecCase :: PrettyE e => Doc ann -> Atom n -> [AltP e n] -> EffectRow n -> DocPrec ann
 prettyPrecCase name e alts effs = atPrec LowestPrec $
@@ -231,14 +233,6 @@ instance Pretty (DictType n) where
   pretty (DictType classSourceName _ params) =
     p classSourceName <+> spaced params
 
-instance Pretty (HandlerDictExpr n) where
-  pretty (HandlerDictExpr name r args) =
-    "HandlerDictExpr" <+> p name <+> p r <+> p args
-
-instance Pretty (HandlerDictType n) where
-  pretty (HandlerDictType handlerSourceName effectName) =
-    "HandlerDictType" <+> p handlerSourceName <+> p effectName
-
 instance Pretty (DepPairType n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (DepPairType n) where
   prettyPrec (DepPairType b rhs) =
@@ -273,8 +267,6 @@ instance PrettyPrec (Atom n) where
       _  -> atPrec LowestPrec $ pAppArg (p name) params
     DictCon d -> atPrec LowestPrec $ p d
     DictTy  t -> atPrec LowestPrec $ p t
-    HandlerDictCon d -> atPrec LowestPrec $ p d
-    HandlerDictTy  t -> atPrec LowestPrec $ p t
     LabeledRow elems -> prettyRecordTyRow elems "?"
     RecordTy elems -> prettyRecordTyRow elems "&"
     VariantTy items -> prettyExtLabeledItems items Nothing (line <> "|") ":"
@@ -958,7 +950,6 @@ prettyPrecPrimCon con = case con of
   LabelCon name -> atPrec ArgPrec $ "##" <> p name
   ExplicitDict _ _ -> atPrec ArgPrec $ "ExplicitDict"
   DictHole _ e -> atPrec LowestPrec $ "synthesize" <+> pApp e
-  HandlerHole _ e -> atPrec LowestPrec $ "synthesize" <+> pApp e
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -795,8 +795,8 @@ exprEffects expr = case expr of
       return $ deleteEff ExceptionEffect effs
     Seq _ _ _ f   -> functionEffs f
     RememberDest _ f -> functionEffs f
-    where ioEff = (OneEffect IOEffect :: EffectRow o)
-          maybeIO d = case d of Just _ -> (<>ioEff); Nothing -> id
+    where maybeIO :: Maybe (Atom i) -> (EffectRow o -> EffectRow o)
+          maybeIO d = case d of Just _ -> (<>OneEffect IOEffect); Nothing -> id
   Case _ _ _ effs -> substM effs
   Handle v _ body -> do
     HandlerDef eff _ _ _ _ _ _ <- substM v >>= lookupHandlerDef

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -15,7 +15,7 @@ module QueryType (
   instantiateNaryPi, instantiateDepPairTy, instantiatePi, instantiateTabPi,
   litType, lamExprTy,
   numNaryPiArgs, naryLamExprType, specializedFunType,
-  oneEffect, projectionIndices, sourceNameType, typeBinOp, typeUnOp,
+  projectionIndices, sourceNameType, typeBinOp, typeUnOp,
   isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict,
   instantiateHandlerType,
   ) where
@@ -211,11 +211,8 @@ specializedFunType (AppSpecialization f ab) = liftEnvReaderM $
         return $ NaryPiType allBs effs resultTy
       _ -> error "should only be specializing top-level functions"
 
-oneEffect :: Effect n -> EffectRow n
-oneEffect eff = EffectRow (S.singleton eff) Nothing
-
 userEffect :: EffectName n -> Atom n
-userEffect v = Eff (oneEffect (UserEffect v))
+userEffect v = Eff (OneEffect (UserEffect v))
 
 projectionIndices :: (Fallible1 m, EnvReader m) => Type n -> m n [[Int]]
 projectionIndices ty = case ty of
@@ -338,9 +335,6 @@ instance HasType Atom where
     TypeCon _ _ _ -> return TyKind
     DictCon dictExpr -> getTypeE dictExpr
     DictTy (DictType _ _ _) -> return TyKind
-    -- TODO(alex): check correctness
-    HandlerDictCon d -> getTypeE d
-    HandlerDictTy _ -> return TyKind
     LabeledRow _ -> return LabeledRowKind
     RecordTy _ -> return TyKind
     VariantTy _ -> return TyKind
@@ -422,7 +416,6 @@ getTypePrimCon con = case con of
   LabelCon _   -> return $ TC $ LabelType
   ExplicitDict dictTy _ -> substM dictTy
   DictHole _ ty -> substM ty
-  HandlerHole _ ty -> substM ty
 
 dictExprType :: DictExpr i -> TypeQueryM i o (DictType o)
 dictExprType e = case e of
@@ -483,13 +476,6 @@ typeTabApp tabTy xs = go tabTy $ toList xs
 instance HasType DictExpr where
   getTypeE e = DictTy <$> dictExprType e
 
-instance HasType HandlerDictExpr where
-  getTypeE (HandlerDictExpr handlerName _ _) = do
-    handlerName' <- substM handlerName
-    (HandlerDef effName _ _ _ _ _ _) <- lookupHandlerDef handlerName'
-    (EffectDef effSourceName _) <- lookupEffectDef effName
-    return (HandlerDictTy $ HandlerDictType effSourceName effName)
-
 instance HasType Expr where
   getTypeE expr = case expr of
     App f xs -> do
@@ -502,6 +488,17 @@ instance HasType Expr where
     Op   op  -> getTypePrimOp op
     Hof  hof -> getTypePrimHof hof
     Case _ _ resultTy _ -> substM resultTy
+    Handle hndName [] body -> do
+      hndName' <- substM hndName
+      r <- getTypeE body
+      instantiateHandlerType hndName' r []
+    -- TODO(alex): implement
+    Handle _ _ _  -> error "not implemented"
+
+instantiateHandlerType :: EnvReader m => HandlerName n -> Atom n -> [Atom n] -> m n (Type n)
+instantiateHandlerType hndName r args = do
+  HandlerDef _ rb bs _effs retTy _ _ <- lookupHandlerDef hndName
+  applySubst (rb @> (SubstVal r) <.> bs @@> (map SubstVal args)) retTy
 
 getTypePrimOp :: PrimOp (Atom i) -> TypeQueryM i o (Type o)
 getTypePrimOp op = case op of
@@ -625,9 +622,9 @@ getTypePrimOp op = case op of
   OutputStreamPtr ->
     return $ BaseTy $ hostPtrTy $ hostPtrTy $ Scalar Word8Type
     where hostPtrTy ty = PtrType (Heap CPU, ty)
-  Perform hndDict i -> do
-    HandlerDictTy (HandlerDictType _ effName) <- getTypeE hndDict
-    EffectDef _ ops <- lookupEffectDef effName
+  Perform eff i -> do
+    Eff (OneEffect (UserEffect effName)) <- return eff
+    EffectDef _ ops <- substM effName >>= lookupEffectDef
     let (_, EffectOpType _pol lamTy) = ops !! i
     return lamTy
   ProjMethod dict i -> do
@@ -651,15 +648,6 @@ getTypePrimOp op = case op of
     TC (RefType h _) -> TC . RefType h <$> substM vty
     ty -> error $ "Not a reference type: " ++ pprint ty
   Resume retTy _ -> substM retTy
-  Handle (HandlerDictCon hde) _ -> do
-    HandlerDictExpr hndName r args <- substM hde
-    instantiateHandlerType hndName r args
-  Handle _ _ -> error "Handler did not have literal dict as first arg"
-
-instantiateHandlerType :: EnvReader m => HandlerName n -> Atom n -> [Atom n] -> m n (Type n)
-instantiateHandlerType hndName r args = do
-  HandlerDef _ rb bs _effs retTy _ _ <- lookupHandlerDef hndName
-  applySubst (rb @> (SubstVal r) <.> bs @@> (map SubstVal args)) retTy
 
 getSuperclassDicts :: ClassDef n -> Atom n -> [Atom n]
 getSuperclassDicts (ClassDef _ _ _ (SuperclassBinders classBs _) _) dict =
@@ -778,18 +766,18 @@ exprEffects expr = case expr of
       getTypeSubst ref >>= \case
         RefTy (Var h) _ ->
           return $ case m of
-            MGet      -> oneEffect (RWSEffect State  $ Just h)
-            MPut    _ -> oneEffect (RWSEffect State  $ Just h)
-            MAsk      -> oneEffect (RWSEffect Reader $ Just h)
+            MGet      -> OneEffect (RWSEffect State  $ Just h)
+            MPut    _ -> OneEffect (RWSEffect State  $ Just h)
+            MAsk      -> OneEffect (RWSEffect Reader $ Just h)
             -- XXX: We don't verify the base monoid. See note about RunWriter.
-            MExtend _ _ -> oneEffect (RWSEffect Writer $ Just h)
+            MExtend _ _ -> OneEffect (RWSEffect Writer $ Just h)
         _ -> error "References must have reference type"
-    ThrowException _ -> return $ oneEffect ExceptionEffect
-    IOAlloc  _ _  -> return $ oneEffect IOEffect
-    IOFree   _    -> return $ oneEffect IOEffect
-    PtrLoad  _    -> return $ oneEffect IOEffect
-    PtrStore _ _  -> return $ oneEffect IOEffect
-    Place    _ _  -> return $ oneEffect IOEffect
+    ThrowException _ -> return $ OneEffect ExceptionEffect
+    IOAlloc  _ _  -> return $ OneEffect IOEffect
+    IOFree   _    -> return $ OneEffect IOEffect
+    PtrLoad  _    -> return $ OneEffect IOEffect
+    PtrStore _ _  -> return $ OneEffect IOEffect
+    Place    _ _  -> return $ OneEffect IOEffect
     _ -> return Pure
   Hof hof -> case hof of
     For _ _ f     -> functionEffs f
@@ -807,8 +795,12 @@ exprEffects expr = case expr of
       return $ deleteEff ExceptionEffect effs
     Seq _ _ _ f   -> functionEffs f
     RememberDest _ f -> functionEffs f
-    where maybeIO d = case d of Just _ -> (<>oneEffect IOEffect); Nothing -> id
+    where ioEff = (OneEffect IOEffect :: EffectRow o)
+          maybeIO d = case d of Just _ -> (<>ioEff); Nothing -> id
   Case _ _ _ effs -> substM effs
+  Handle v _ body -> do
+    HandlerDef eff _ _ _ _ _ _ <- substM v >>= lookupHandlerDef
+    deleteEff (UserEffect eff) <$> getEffectsImpl body
 
 instance HasEffectsE Block where
   getEffectsImpl (Block (BlockAnn _ effs) _ _) = substM effs

--- a/src/lib/RawName.hs
+++ b/src/lib/RawName.hs
@@ -25,6 +25,7 @@ import Data.Coerce
 import Data.Store
 import Data.Text.Prettyprint.Doc  hiding (nest)
 import GHC.Generics (Generic)
+import Data.String
 
 -- === RawName ===
 
@@ -149,6 +150,9 @@ instance HasNameHint RawName where
 
 instance HasNameHint String where
   getNameHint = hintFromString
+
+instance IsString NameHint where
+  fromString = hintFromString
 
 hintFromString :: String -> NameHint
 hintFromString s = NameHint $ goFromString (nameRepBits - 8) zeroBits s'

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -210,6 +210,8 @@ simplifyExpr expr = confuseGHC >>= \_ -> case expr of
                   buildBlock $ simplifyBlock body
             liftM Var $ emit $ Case e' alts' resultTy' eff'
           False -> defuncCase e' alts resultTy'
+  -- TODO(alex): implement
+  Handle _ _ _ -> error "Not implemented"
 
 caseComputingEffs
   :: forall m n. (MonadFail1 m, EnvReader m)
@@ -493,10 +495,6 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   TypeCon _ _ _ -> substM atom
   DictCon d -> DictCon <$> substM d
   DictTy  t -> DictTy  <$> substM t
-  -- TODO(alex): check correctness
-  HandlerDictCon d -> HandlerDictCon <$> substM d
-  HandlerDictTy  t -> HandlerDictTy  <$> substM t
-  --
   RecordTy _ -> substM atom >>= cheapNormalize >>= \atom' -> case atom' of
     StaticRecordTy items -> StaticRecordTy <$> dropSubst (mapM simplifyAtom items)
     _ -> error $ "Failed to simplify a record with a dynamic label: " ++ pprint atom'

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -26,7 +26,7 @@ module Syntax (
     fieldRowElemsFromList, prependFieldRowElem, extRowAsFieldRowElems, fieldRowElemsAsExtRow,
     pattern StaticRecordTy, pattern RecordTyWithElems,
     Expr (..), Atom (..), Arrow (..), PrimTC (..), Abs (..),
-    DictExpr (..), DictType (..), HandlerDictExpr (..), HandlerDictType (..),
+    DictExpr (..), DictType (..),
     PrimExpr (..), PrimCon (..), LitVal (..), PtrLitVal (..), PtrSnapshot (..),
     AlwaysEqual (..),
     PrimEffect (..), PrimOp (..), PrimHof (..),
@@ -119,6 +119,7 @@ module Syntax (
     pattern NothingAtom, pattern JustAtom, pattern AtomicBlock,
     pattern BoolTy, pattern FalseAtom, pattern TrueAtom,
     pattern SISourceName, pattern SIInternalName,
+    pattern OneEffect,
     (-->), (?-->), (--@), (==>)) where
 
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -699,7 +699,7 @@ checkPass name cont = do
     return result
 #ifdef DEX_DEBUG
   logTop $ MiscLog $ "Running checks"
-  let allowedEffs = case name of LowerPass -> singletonEffRow IOEffect; _ -> mempty
+  let allowedEffs = case name of LowerPass -> OneEffect IOEffect; _ -> mempty
   {-# SCC afterPassTypecheck #-} (liftExcept =<<) $ liftEnvReaderT $
     withAllowedEffects allowedEffs $ checkTypesM result
   logTop $ MiscLog $ "Checks passed"

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -191,6 +191,7 @@ transposeExpr expr ct = case expr of
           extendSubst (b @> RenameNonlin v') do
             transposeBlock body (sink ct)
           return UnitVal
+  Handle _ _ _ -> error "handlers should be gone by now"
 
 transposeOp :: Emits o => Op i -> Atom o -> TransposeM i o ()
 transposeOp op ct = case op of
@@ -261,7 +262,6 @@ transposeOp op ct = case op of
   VectorIota _          -> unreachable
   VectorSubref _ _ _    -> unreachable
   Resume _ _            -> notLinear
-  Handle _ _            -> notLinear
   where
     notLinear = error $ "Can't transpose a non-linear operation: " ++ pprint op
     unreachable = error $ "Shouldn't appear in transposition: " ++ pprint op
@@ -287,8 +287,6 @@ transposeAtom atom ct = case atom of
   TabLam _        -> notTangent
   DictCon _       -> notTangent
   DictTy _        -> notTangent
-  HandlerDictCon _ -> notTangent  -- TODO(alex): check correctness
-  HandlerDictTy _ -> notTangent   -- TODO(alex): check correctness
   TypeCon _ _ _   -> notTangent
   LabeledRow _    -> notTangent
   RecordTy _      -> notTangent
@@ -364,7 +362,6 @@ transposeCon con ct = case con of
   ConRef _       -> notTangent
   ExplicitDict _ _ -> notTangent
   DictHole _ _ -> notTangent
-  HandlerHole _ _ -> notTangent
   where notTangent = error $ "Not a tangent atom: " ++ pprint (Con con)
 
 notImplemented :: HasCallStack => a

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -75,7 +75,6 @@ data PrimCon e =
       | ExplicitDict e e  -- Dict type, method. Used in prelude for `run_accum`.
       -- Only used during type inference
       | DictHole (AlwaysEqual SrcPosCtx) e
-      | HandlerHole (AlwaysEqual SrcPosCtx) e  -- e is HandlerDictTy
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 newtype AlwaysEqual a = AlwaysEqual a
@@ -99,8 +98,7 @@ data PrimOp e =
       | ThrowError e                 -- Hard error (parameterized by result type)
       | ThrowException e             -- Catchable exceptions (unlike `ThrowError`)
       | Resume e e                   -- Resume from effect handler (type, arg)
-      | Handle e e                   -- Call a handler (handler def, body)
-      | Perform e Int                -- Call an effect operation (handler dict) (op #)
+      | Perform e Int                -- Call an effect operation (effect name) (op #)
       -- References
       | IndexRef e e
       | ProjRef Int e
@@ -218,6 +216,10 @@ pattern Pure :: OrdV name => EffectRowP name n
 pattern Pure <- ((\(EffectRow effs t) -> (S.null effs, t)) -> (True, Nothing))
   where Pure = EffectRow mempty Nothing
 
+pattern OneEffect :: OrdV name => EffectP name n -> EffectRowP name n
+pattern OneEffect eff <- ((\(EffectRow effs t) -> (S.toList effs, t)) -> ([eff], Nothing))
+  where OneEffect eff = EffectRow (S.singleton eff) Nothing
+
 instance OrdV name => Semigroup (EffectRowP name n) where
   EffectRow effs t <> EffectRow effs' t' =
     EffectRow (S.union effs effs') newTail
@@ -234,9 +236,6 @@ instance OrdV name => Monoid (EffectRowP name n) where
 extendEffRow :: OrdV name => S.Set (EffectP name n) -> EffectRowP name n -> EffectRowP name n
 extendEffRow effs (EffectRow effs' t) = EffectRow (effs <> effs') t
 {-# INLINE extendEffRow #-}
-
-singletonEffRow :: EffectP name n -> EffectRowP name n
-singletonEffRow eff = EffectRow (S.singleton eff) Nothing
 
 data Arrow =
    PlainArrow

--- a/tests/algeff-tests.dx
+++ b/tests/algeff-tests.dx
@@ -53,23 +53,23 @@ def checkFloatNonNegative (x:Float) : {Exn} Float =
   check $ x >= 0.0
   x
 
--- catch_ \_.
---   checkFloatNonNegative (3.14)
--- > Compiler bug!
--- > Please report this at github.com/google-research/dex-lang/issues
--- >
--- > Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
--- > CallStack (from HasCallStack):
--- >   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+catch_ \_.
+  checkFloatNonNegative (3.14)
+> Compiler bug!
+> Please report this at github.com/google-research/dex-lang/issues
+>
+> Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+> CallStack (from HasCallStack):
+>   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
 
--- catch_ \_.
---   checkFloatNonNegative (-1.0)
--- > Compiler bug!
--- > Please report this at github.com/google-research/dex-lang/issues
--- >
--- > Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
--- > CallStack (from HasCallStack):
--- >   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+catch_ \_.
+  checkFloatNonNegative (-1.0)
+> Compiler bug!
+> Please report this at github.com/google-research/dex-lang/issues
+>
+> Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+> CallStack (from HasCallStack):
+>   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
 
 effect Counter
   def inc : Unit -> Unit

--- a/tests/algeff-tests.dx
+++ b/tests/algeff-tests.dx
@@ -58,18 +58,18 @@ catch_ \_.
 > Compiler bug!
 > Please report this at github.com/google-research/dex-lang/issues
 >
-> Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+> Not implemented
 > CallStack (from HasCallStack):
->   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+>   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
 
 catch_ \_.
   checkFloatNonNegative (-1.0)
 > Compiler bug!
 > Please report this at github.com/google-research/dex-lang/issues
 >
-> Expected scalar, got: (HandlerDictExpr catch_ Float32 [])
+> Not implemented
 > CallStack (from HasCallStack):
->   error, called at src/lib/Imp.hs:1515:8 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Imp
+>   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
 
 effect Counter
   def inc : Unit -> Unit


### PR DESCRIPTION
Rather than just pushing to the other PR, I'm leaving this here to be considered individually. After our discussion Thursday morning, we decided to keep the handler implementation details out of the IR and instead:

1. Remove `HandlerDict{Ty,Type,Con}` and `HandlerDictHole`
2. Promote `Handle` to an `Expr` that is to be removed by Simplify

This adds two things worth calling out for the general compiler:

1. `oneEffect` is now a pattern synonym `OneEffect` and `singletonEffectRow` has been removed.
3. `NameHint` now has an `IsString` instance.