### PR TITLE
Remove handler dict ADTs from Lowering

### DIFF
--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -288,8 +288,6 @@ instance HasEmitIx FieldRowElem
 instance HasEmitIx DataDefParams
 instance HasEmitIx DeclBinding
 instance HasEmitIx IxType
-instance HasEmitIx HandlerDictExpr
-instance HasEmitIx HandlerDictType
 
 instance (HasEmitIx ann, Color c, ToBinding ann c) => HasEmitIxB (BinderP c ann) where
   emitIxB (b:>ann) cont = do


### PR DESCRIPTION
They were removed in #1072, which was merged into `main` after the last CI run in #1074.