### PR TITLE
Add unsafe_project method to Subset interface and use it to clean up linalg.

### DIFF
--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -70,7 +70,9 @@ instance {a} Ix (AllButFirst a)
 
 instance {a} Subset (AllButFirst a) a
   inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
-  can_project' = \x. ordinal x > 0
+  project' = \x. case (ordinal x) > 0 of
+    True -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
+    False -> Nothing
   unsafe_project' = \x.
     unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
 
@@ -85,6 +87,10 @@ all $ for i:(AllButFirst (Unit | Fin 2)).
 
 all $ for i:(AllButFirst (Bool | Bool)).
   Just i == (project _ $ inject (Bool | Bool) i)
+> True
+
+all $ for i:(AllButFirst (Bool | Bool)).
+  i == (unsafe_project _ $ inject (Bool | Bool) i)
 > True
 
 for i:(AllButFirst (Bool | Bool)).

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -70,9 +70,9 @@ instance {a} Ix (AllButFirst a)
 
 instance {a} Subset (AllButFirst a) a
   inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
-  project' = \x. case ordinal x == 0 of
-    True  -> Nothing
-    False -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
+  can_project' = \x. ordinal x > 0
+  unsafe_project' = \x.
+    unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
 
 instance {a} [Eq a] Eq (AllButFirst a)
   (==) = \(MkAllButFirst x) (MkAllButFirst y). x == y

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -107,7 +107,7 @@ instance {n} HasDeterminant (LowerTriMap n)
 
 instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMap n) (n=>v)
   apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
-  diag   = \(MkLowerTriMap x).   for i. x.i.(unsafe_cast i) .* one
+  diag   = \(MkLowerTriMap x).   for i. x.i.(unsafe_project _ i) .* one
   solve' = \(MkLowerTriMap x).   forward_substitute x
 
 instance {n} Arbitrary (LowerTriMap n)

--- a/examples/psd.dx
+++ b/examples/psd.dx
@@ -21,7 +21,7 @@ psd : N=>N=>Float =
 def padLowerTriMat {n v} [Add v] (mat:LowerTriMat n v) : n=>n=>v =
   for i j.
     if (ordinal j)<=(ordinal i)
-      then mat.i.(unsafe_cast j)
+      then mat.i.(unsafe_project _ j)
       else zero
 
 l = chol psd

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -15,7 +15,7 @@ def refl_more {n} [Ix n] (i:n) : (i..) = unsafe_project _ i
 def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.(refl_more i)
 def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.(refl_less i)
 
-def is_last {n} [Ix n] (x:n) : Bool = ordinal x + 1 == size n
+def is_last {n} [Ix n] (x:n) : Bool = (ordinal x + 1) == size n
 
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -15,7 +15,7 @@ def refl_more {n} [Ix n] (i:n) : (i..) = unsafe_project _ i
 def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.(refl_more i)
 def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.(refl_less i)
 
-def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
+def is_last {n} [Ix n] (x:n) : Bool = ordinal x + 1 == size n
 
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -3,15 +3,6 @@
 - LU Decomposition
 - Matrix Inversion
 
-def unsafe_cast {a m} [Ix a, Ix m] (d:a) : m = unsafe_from_ordinal m (ordinal d)
-
-'The three functions below are safe because one can't produce an element of type n
-if there isn't at least one possible value in its type. So being able
-to produce x to call this function is proof that `n` is non-empty,
-even though we don't use the `NonEmpty` constraint.
-
-def first_ix_of {n} [Ix n] (x:n) : n = unsafe_from_ordinal n 0
-def last_ix_of  {n} [Ix n] (x:n) : n = unsafe_from_ordinal n (unsafe_nat_diff (size n) 1)
 def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
 
 '## Triangular matrices
@@ -19,16 +10,11 @@ def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
 def LowerTriMat (n:Type) [Ix n] (v:Type) : Type = (i:n)=>(..i)=>v
 def UpperTriMat (n:Type) [Ix n] (v:Type) : Type = (i:n)=>(i..)=>v
 
-def refl_less {n} [Ix n] (i:n) : (..i) =
-  from_just $ project _ i
+def refl_less {n} [Ix n] (i:n) : (..i) = unsafe_project _ i
+def refl_more {n} [Ix n] (i:n) : (i..) = unsafe_project _ i
 
-def refl_more {n} [Ix n] (i:n) : (i..) =
-  from_just $ project _ i
-
-def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v =
-  view i. u.i.(refl_more i)
-def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v =
-  view i. l.i.(refl_less i)
+def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.(refl_more i)
+def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.(refl_less i)
 
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero
@@ -46,22 +32,22 @@ data UpperTriIxExc n = MkUpperTriIxExc i:n j:(i<..)
 -- TODO: Put these in instances of an Isomorphism interface?
 def transpose_upper_ix {n} [Ix n] (i:n) (j:(i..)) : LowerTriIx n =
   j' = inject n j
-  i' = from_just $ project _ i
+  i' = unsafe_project _ i
   MkLowerTriIx j' i'
 
 def transpose_lower_ix {n} [Ix n] (i:n) (j:(..i)) : UpperTriIx n =
   j' = inject n j
-  i' = from_just $ project _ i
+  i' = unsafe_project _ i
   MkUpperTriIx j' i'
 
 def transpose_upper_ix_exc {n} [Ix n] (i:n) (j:(i<..)) : LowerTriIxExc n =
   j' = inject n j
-  i' = from_just $ project _ i
+  i' = unsafe_project _ i
   MkLowerTriIxExc j' i'
 
 def transpose_lower_ix_exc {n} [Ix n] (i:n) (j:(..<i)) : UpperTriIxExc n =
   j' = inject n j
-  i' = from_just $ project _ i
+  i' = unsafe_project _ i
   MkUpperTriIxExc j' i'
 
 def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
@@ -86,76 +72,72 @@ def transpose_lower_to_upper_no_diag {n v}
 instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIx m) (LowerTriIx n)
   inject' = \(MkLowerTriIx i j).
     i' = inject n i
-    j' = from_just $ project _ $ inject n $ inject m j
+    j' = unsafe_project _ $ inject n $ inject m j
     MkLowerTriIx i' j'
-  project' = \(MkLowerTriIx i j). 
-    case project m i of
-      Nothing -> Nothing
-      (Just i') ->
-        j' = inject n j
-        j'' = from_just $ project m j'
-        Just $ MkLowerTriIx i' $ from_just $ project _ j''
+  can_project' = \(MkLowerTriIx i j). can_project m i
+  unsafe_project' = \(MkLowerTriIx i j).
+    i' = unsafe_project m i
+    j' = inject n j
+    j'' = unsafe_project m j'
+    MkLowerTriIx i' $ unsafe_project _ j''
 
 instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIx m) (UpperTriIx n)
   inject' = \(MkUpperTriIx i j).
     i' = inject n i
-    j' = from_just $ project _ $ inject n $ inject m j
+    j' = unsafe_project _ $ inject n $ inject m j
     MkUpperTriIx i' j'
-  project' = \(MkUpperTriIx i j). 
-    case project m i of
-      Nothing -> Nothing
-      (Just i') ->
-        j' = inject n j
-        j'' = from_just $ project m j'
-        Just $ MkUpperTriIx i' $ from_just $ project _ j''
+  can_project' = \(MkUpperTriIx i j). can_project m i
+  unsafe_project' = \(MkUpperTriIx i j).
+    i' = unsafe_project m i
+    j' = inject n j
+    j'' = unsafe_project m j'
+    MkUpperTriIx i' $ unsafe_project _ j''
 
 instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIxExc m) (LowerTriIxExc n)
   inject' = \(MkLowerTriIxExc i j).
     i' = inject n i
-    j' = from_just $ project _ $ inject n $ inject m j
+    j' = unsafe_project _ $ inject n $ inject m j
     MkLowerTriIxExc i' j'
-  project' = \(MkLowerTriIxExc i j). 
-    case project m i of
-      Nothing -> Nothing
-      (Just i') ->
-        j' = inject n j
-        j'' = from_just $ project m j'
-        Just $ MkLowerTriIxExc i' $ from_just $ project _ j''
+  can_project' = \(MkLowerTriIxExc i j). can_project m i
+  unsafe_project' = \(MkLowerTriIxExc i j).
+    i' = unsafe_project m i
+    j' = inject n j
+    j'' = unsafe_project m j'
+    MkLowerTriIxExc i' $ unsafe_project _ j''
 
 instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIxExc m) (UpperTriIxExc n)
   inject' = \(MkUpperTriIxExc i j).
     i' = inject n i
-    j' = from_just $ project _ $ inject n $ inject m j
+    j' = unsafe_project _ $ inject n $ inject m j
     MkUpperTriIxExc i' j'
-  project' = \(MkUpperTriIxExc i j). 
-    case project m i of
-      Nothing -> Nothing
-      (Just i') ->
-        j' = inject n j
-        j'' = from_just $ project m j'
-        Just $ MkUpperTriIxExc i' $ from_just $ project _ j''
+  can_project' = \(MkUpperTriIxExc i j). can_project m i
+  unsafe_project' = \(MkUpperTriIxExc i j).
+    i' = unsafe_project m i
+    j' = inject n j
+    j'' = unsafe_project m j'
+    MkUpperTriIxExc i' $ unsafe_project _ j''
 
 '## Chaining inequalities between indices
 
 def relax_ii {n} {p:n} [Ix n] (i:(p ..)) (j:(.. p)) : LowerTriIx n =
   i' = inject n i
   j' = inject n j
-  MkLowerTriIx i' $ from_just $ project _ j'
+  MkLowerTriIx i' $ unsafe_project _ j'
 
 def relax_ei {n} {p:n} [Ix n] (i:(p<..)) (j:(.. p)) : LowerTriIxExc n =
   i' = inject n i
   j' = inject n j
-  MkLowerTriIxExc i' $ from_just $ project _ j'
+  MkLowerTriIxExc i' $ unsafe_project _ j'
 
 def relax_ie {n} {p:n} [Ix n] (i:(p ..)) (j:(..<p)) : LowerTriIxExc n =
   i' = inject n i
   j' = inject n j
-  MkLowerTriIxExc i' $ from_just $ project _ j'
+  MkLowerTriIxExc i' $ unsafe_project _ j'
 
 def relax_ee {n} {p:n} [Ix n] (i:(p<..)) (j:(..<p)) : LowerTriIxExc n =
   i' = inject n i
   j' = inject n j
-  MkLowerTriIxExc i' $ from_just $ project _ j'
+  MkLowerTriIxExc i' $ unsafe_project _ j'
 
 '## Linalg helpers
 
@@ -207,7 +189,7 @@ def chol {n} (x:n=>n=>Float) : LowerTriMat n Float =
         then
           mat i j := sqrt a
         else
-          b = get $ mat j' (from_just $ project (..j') j')
+          b = get $ mat j' (refl_less j')
           mat i j := a / b
 
 '## Permutations
@@ -280,7 +262,7 @@ def lu {n} (a: n=>n=>Float) :
     for j:n.
       for i:(..j).
         s = sum for k:(..i).
-          (MkUpperTriIx k2 _) = transpose_lower_ix i k
+          (MkUpperTriIx k2 _)  = transpose_lower_ix i k
           (MkUpperTriIx k3 j3) = transpose_lower_ix j k2
           ukj = get $ upper_tri_mat uRef k3 j3
           (MkLowerTriIx i4 k4) = inject _ $ MkLowerTriIx i k

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -3,7 +3,6 @@
 - LU Decomposition
 - Matrix Inversion
 
-def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
 
 '## Triangular matrices
 
@@ -15,6 +14,8 @@ def refl_more {n} [Ix n] (i:n) : (i..) = unsafe_project _ i
 
 def upper_tri_diag {n v} (u:UpperTriMat n v) : n=>v = view i. u.i.(refl_more i)
 def lower_tri_diag {n v} (l:LowerTriMat n v) : n=>v = view i. l.i.(refl_less i)
+
+def is_last {n} [Ix n] (x:n) : Bool = ((ordinal x) + 1) == size n
 
 def lower_tri_identity {a n} [Ix n, Add a, Mul a] : LowerTriMat n a =
   for i j. select (is_last j) one zero
@@ -74,7 +75,13 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIx m) (LowerTriIx n)
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
     MkLowerTriIx i' j'
-  can_project' = \(MkLowerTriIx i j). can_project m i
+  project' = \(MkLowerTriIx i j).
+    case project m i of
+      Nothing -> Nothing
+      (Just i') ->
+        j' = inject n j
+        j'' = unsafe_project m j'
+        Just $ MkLowerTriIx i' $ unsafe_project _ j''
   unsafe_project' = \(MkLowerTriIx i j).
     i' = unsafe_project m i
     j' = inject n j
@@ -86,7 +93,13 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIx m) (UpperTriIx n)
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
     MkUpperTriIx i' j'
-  can_project' = \(MkUpperTriIx i j). can_project m i
+  project' = \(MkUpperTriIx i j).
+    case project m i of
+      Nothing -> Nothing
+      (Just i') ->
+        j' = inject n j
+        j'' = unsafe_project m j'
+        Just $ MkUpperTriIx i' $ unsafe_project _ j''
   unsafe_project' = \(MkUpperTriIx i j).
     i' = unsafe_project m i
     j' = inject n j
@@ -98,7 +111,13 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIxExc m) (LowerTriIxExc 
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
     MkLowerTriIxExc i' j'
-  can_project' = \(MkLowerTriIxExc i j). can_project m i
+  project' = \(MkLowerTriIxExc i j).
+    case project m i of
+      Nothing -> Nothing
+      (Just i') ->
+        j' = inject n j
+        j'' = unsafe_project m j'
+        Just $ MkLowerTriIxExc i' $ unsafe_project _ j''
   unsafe_project' = \(MkLowerTriIxExc i j).
     i' = unsafe_project m i
     j' = inject n j
@@ -110,7 +129,13 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIxExc m) (UpperTriIxExc 
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
     MkUpperTriIxExc i' j'
-  can_project' = \(MkUpperTriIxExc i j). can_project m i
+  project' = \(MkUpperTriIxExc i j).
+    case project m i of
+      Nothing -> Nothing
+      (Just i') ->
+        j' = inject n j
+        j'' = unsafe_project m j'
+        Just $ MkUpperTriIxExc i' $ unsafe_project _ j''
   unsafe_project' = \(MkUpperTriIxExc i j).
     i' = unsafe_project m i
     j' = inject n j
@@ -213,7 +238,7 @@ def swap_in_place {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Un
   signRef := -(get signRef)
 
 def perm_to_table {n} ((perm, _):Permutation n) : n=>n = perm
-def perm_sign    {n} ((_, sign):Permutation n) : PermutationSign = sign
+def perm_sign     {n} ((_, sign):Permutation n) : PermutationSign = sign
 
 
 '## LU decomposition functions
@@ -222,7 +247,7 @@ def pivotize {n} (a:n=>n=>Float) : Permutation n =
   -- Gives a row permutation that makes Gaussian elimination more stable.
   yield_state identity_permutation \permRef.
     for j:n.
-      row_with_largest = argmin for i:(j..). (-(abs a.(inject n i).j))
+      row_with_largest = argmax for i:(j..). abs a.(inject n i).j
       if (ordinal j) /= (ordinal row_with_largest) then
         swap_in_place permRef j (inject n row_with_largest)
 
@@ -233,7 +258,6 @@ def lu {n} (a: n=>n=>Float) :
   permutation = pivotize a
   a = apply_permutation permutation a
 
-  -- TODO Why is this type annotation needed?
   init_lower : (LowerTriMat n Float) = lower_tri_identity
   init_upper = zero
 
@@ -242,7 +266,7 @@ def lu {n} (a: n=>n=>Float) :
     uRef = snd_ref stateRef
 
   -- For reference, here's code to compute the LU decomposition
-  -- without dependent tables (i.e. with standard flat matrices):
+  -- with standard flat matrices:
   --  for j:n.
   --    for i:(..j).
   --      i = inject _ i

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -895,17 +895,12 @@ instance {a n} [Ord a] Ord (n=>a)
 '## Subset class
 
 interface Subset a_sub a
-  inject'              : a_sub -> a
-  can_project' a_sub a : a -> Bool
-  unsafe_project'      : a -> a_sub
-
-def can_project {a} (a_sub:Type) [Subset a_sub a] (x:a) : Bool =
-  can_project' a_sub a x
+  inject'         : a_sub -> a
+  project'        : a -> Maybe a_sub
+  unsafe_project' : a -> a_sub
 
 def project {a} (a_sub:Type) [Subset a_sub a] (x:a) : Maybe a_sub =
-  case can_project a_sub x of
-    True  -> Just $ unsafe_project' x
-    False -> Nothing
+  project' x
 
 def unsafe_project {a} (a_sub:Type) [Subset a_sub a] (x:a) : a_sub =
   unsafe_project' x
@@ -915,38 +910,65 @@ def inject {a_sub} (a:Type) [Subset a_sub a] (x:a_sub) : a =
 
 instance {a b c} [Subset a b, Subset b c] Subset a c
   inject' = \x. inject c $ inject b x
-  can_project' = \x. case can_project b x of
-    False -> False
-    True -> can_project a $ unsafe_project b x
+  project' = \x. case project b x of
+    Nothing -> Nothing
+    Just y -> project a y
   unsafe_project' = \x. unsafe_project a $ unsafe_project b x
+
+def unsafe_project_rangefrom {q:Type} {i:q} [Ix q] (j:q) : RangeFrom q i =
+  UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
   inject' = \(UnsafeMkRangeFrom j).
     unsafe_from_ordinal _ $ j + ordinal i
-  can_project' = \j. ordinal j >= ordinal i
-  unsafe_project' = \j.
-    UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' < i'
+      then Nothing
+      else Just $ UnsafeMkRangeFrom $ unsafe_nat_diff j' i'
+  unsafe_project' = \j. UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
   inject' = \(UnsafeMkRangeFromExc j).
     unsafe_from_ordinal _ $ j + ordinal i + 1
-  can_project' = \j. ordinal j > ordinal i
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' <= i'
+      then Nothing
+      else Just $ UnsafeMkRangeFromExc $ unsafe_nat_diff j' (i' + 1)
   unsafe_project' = \j.
-    UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) (ordinal i + 1)
+    UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) ((ordinal i) + 1)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
   inject' = \(UnsafeMkRangeTo j). unsafe_from_ordinal _ j
-  can_project' = \j. ordinal j <= ordinal j
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' > i'
+      then Nothing
+      else Just $ UnsafeMkRangeTo j'
   unsafe_project' = \j. UnsafeMkRangeTo (ordinal j)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
-  can_project' = \j. ordinal j < ordinal i
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' >= i'
+      then Nothing
+      else Just $ UnsafeMkRangeToExc j'
   unsafe_project' = \j. UnsafeMkRangeToExc (ordinal j)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) (RangeTo q i)
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
-  can_project' = \j. ordinal j < ordinal i
+  project' = \j.
+    j' = ordinal j
+    i' = ordinal i
+    if j' >= i'
+      then Nothing
+      else Just $ UnsafeMkRangeToExc j'
   unsafe_project' = \j. UnsafeMkRangeToExc (ordinal j)
 
 '## Elementary/Special Functions
@@ -2371,21 +2393,21 @@ def assert (b:Bool) : {Except} Unit =
 
 instance {a b} Subset a (a|b)
   inject' = \x. Left x
-  can_project' = \x. case x of
-    Left  x -> True
-    Right x -> False
+  project' = \x. case x of
+    Left  y -> Just y
+    Right x -> Nothing
   unsafe_project' = \x. case x of
     Left  x -> x
-    Right x -> todo   -- Impossible
+    Right x -> error "Can't project Right branch to Left branch"
 
 instance {a b} Subset a (b|a)
   inject' = \x. Right x
-  can_project' = \x. case x of
-    Left  x -> False
-    Right x -> True
+  project' = \x. case x of
+    Left  x -> Nothing
+    Right y -> Just y
   unsafe_project' = \x. case x of
     Left  x -> todo   -- Impossible
-    Right x -> x
+    Right x -> error "Can't project Left branch to Right branch"
 
 
 '## Testing Helpers

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2406,9 +2406,8 @@ instance {a b} Subset a (b|a)
     Left  x -> Nothing
     Right y -> Just y
   unsafe_project' = \x. case x of
-    Left  x -> todo   -- Impossible
-    Right x -> error "Can't project Left branch to Right branch"
-
+    Left  x -> error "Can't project Left branch to Right branch"
+    Right x -> x
 
 '## Testing Helpers
 

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -939,7 +939,7 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
       then Nothing
       else Just $ UnsafeMkRangeFromExc $ unsafe_nat_diff j' (i' + 1)
   unsafe_project' = \j.
-    UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) ((ordinal i) + 1)
+    UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) (ordinal i + 1)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
   inject' = \(UnsafeMkRangeTo j). unsafe_from_ordinal _ j
@@ -2389,7 +2389,7 @@ def throw {a} (_:Unit) : {Except} a =
 def assert (b:Bool) : {Except} Unit =
   if not b then throw ()
 
-'### Misc instances that require `todo`
+'### Misc instances that require `error`
 
 instance {a b} Subset a (a|b)
   inject' = \x. Left x

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -895,79 +895,59 @@ instance {a n} [Ord a] Ord (n=>a)
 '## Subset class
 
 interface Subset a_sub a
-  inject' : a_sub -> a
-  project' : a -> Maybe a_sub
+  inject'              : a_sub -> a
+  can_project' a_sub a : a -> Bool
+  unsafe_project'      : a -> a_sub
+
+def can_project {a} (a_sub:Type) [Subset a_sub a] (x:a) : Bool =
+  can_project' a_sub a x
 
 def project {a} (a_sub:Type) [Subset a_sub a] (x:a) : Maybe a_sub =
-  project' x
+  case can_project a_sub x of
+    True  -> Just $ unsafe_project' x
+    False -> Nothing
+
+def unsafe_project {a} (a_sub:Type) [Subset a_sub a] (x:a) : a_sub =
+  unsafe_project' x
 
 def inject {a_sub} (a:Type) [Subset a_sub a] (x:a_sub) : a =
   inject' x
 
 instance {a b c} [Subset a b, Subset b c] Subset a c
   inject' = \x. inject c $ inject b x
-  project' = \x. case project b x of
-    Nothing -> Nothing
-    Just y -> project a y
-
-instance {a b} Subset a (a|b)
-  inject' = \x. Left x
-  project' = \x. case x of
-    Left  x -> Just x
-    Right x -> Nothing
-
-instance {a b} Subset a (b|a)
-  inject' = \x. Right x
-  project' = \x. case x of
-    Left  x -> Nothing
-    Right x -> Just x
+  can_project' = \x. case can_project b x of
+    False -> False
+    True -> can_project a $ unsafe_project b x
+  unsafe_project' = \x. unsafe_project a $ unsafe_project b x
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
   inject' = \(UnsafeMkRangeFrom j).
     unsafe_from_ordinal _ $ j + ordinal i
-  project' = \j.
-    j' = ordinal j
-    i' = ordinal i
-    if j' < i'
-      then Nothing
-      else Just $ UnsafeMkRangeFrom $ unsafe_nat_diff j' i'
+  can_project' = \j. ordinal j >= ordinal i
+  unsafe_project' = \j.
+    UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
   inject' = \(UnsafeMkRangeFromExc j).
     unsafe_from_ordinal _ $ j + ordinal i + 1
-  project' = \j.
-    j' = ordinal j
-    i' = ordinal i
-    if j' <= i'
-      then Nothing
-      else Just $ UnsafeMkRangeFromExc $ unsafe_nat_diff j' (i' + 1)
+  can_project' = \j. ordinal j > ordinal i
+  unsafe_project' = \j.
+    UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) (ordinal i + 1)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
   inject' = \(UnsafeMkRangeTo j). unsafe_from_ordinal _ j
-  project' = \j.
-    j' = ordinal j
-    i' = ordinal i
-    if j' > i'
-      then Nothing
-      else Just $ UnsafeMkRangeTo j'
+  can_project' = \j. ordinal j <= ordinal j
+  unsafe_project' = \j. UnsafeMkRangeTo (ordinal j)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
-  project' = \j.
-    j' = ordinal j
-    i' = ordinal i
-    if j' >= i'
-      then Nothing
-      else Just $ UnsafeMkRangeToExc j'
+  can_project' = \j. ordinal j < ordinal i
+  unsafe_project' = \j. UnsafeMkRangeToExc (ordinal j)
 
 instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) (RangeTo q i)
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
-  project' = \j.
-    j' = ordinal j
-    i' = ordinal i
-    if j' >= i'
-      then Nothing
-      else Just $ UnsafeMkRangeToExc j'
+  can_project' = \j. ordinal j < ordinal i
+  unsafe_project' = \j. UnsafeMkRangeToExc (ordinal j)
 
 '## Elementary/Special Functions
 This is more or less the standard [LibM fare](https://en.wikipedia.org/wiki/C_mathematical_functions).
@@ -2386,6 +2366,26 @@ def throw {a} (_:Unit) : {Except} a =
 
 def assert (b:Bool) : {Except} Unit =
   if not b then throw ()
+
+'### Misc instances that require `todo`
+
+instance {a b} Subset a (a|b)
+  inject' = \x. Left x
+  can_project' = \x. case x of
+    Left  x -> True
+    Right x -> False
+  unsafe_project' = \x. case x of
+    Left  x -> x
+    Right x -> todo   -- Impossible
+
+instance {a b} Subset a (b|a)
+  inject' = \x. Right x
+  can_project' = \x. case x of
+    Left  x -> False
+    Right x -> True
+  unsafe_project' = \x. case x of
+    Left  x -> todo   -- Impossible
+    Right x -> x
 
 
 '## Testing Helpers

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1073,3 +1073,9 @@ first_ix :: (Fin 0 & Unit)
 
 project Unit (inject (Unit | Fin 2) ())
 > (Just ())
+
+project Unit (inject (Unit | Fin 2) (0@(Fin 2)))
+> Nothing
+
+unsafe_project Unit (inject (Unit | Fin 2) ())
+> ()

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1079,3 +1079,6 @@ project Unit (inject (Unit | Fin 2) (0@(Fin 2)))
 
 unsafe_project Unit (inject (Unit | Fin 2) ())
 > ()
+
+unsafe_project Unit (inject (Fin 2 | Unit) ())
+> ()

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -46,7 +46,7 @@ grad (\x. snd $ sign_and_log_determinant [[x]]) 2.0
 def padLowerTriMat {n v} [Add v] (mat:LowerTriMat n v) : n=>n=>v =
   for i j.
     if (ordinal j)<=(ordinal i)
-      then mat.i.(unsafe_cast j)
+      then mat.i.(unsafe_project _ j)
       else zero
 
 lower : LowerTriMat (Fin 4) Float = arb $ new_key 0


### PR DESCRIPTION
Almost every usage of `project` looked `fromJust $ project`.  This PR lets us replace all of those with `unsafe_project`, hopefully lessening the performance hit compared to unsafe indexing.