### PR TITLE
Print the effect row along the Pi type

### DIFF
--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -336,7 +336,10 @@ instance Pretty (PiType n) where
     prettyBody = case body of
       Pi subpi -> pretty subpi
       _ -> pLowest body
-    in prettyBinder <> (group $ line <> p arr <+> prettyBody)
+    prettyEff = case eff of
+      Pure -> space
+      _    -> space <> pretty eff <> space
+    in prettyBinder <> (group $ line <> p arr <> prettyEff <> prettyBody)
 
 instance Pretty (TabPiType n) where
   pretty (TabPiType (b :> IxType ty _) body) = let


### PR DESCRIPTION
For some reason we weren't printing the effect rows, at all! This led to a fairly long debugging session for me, when the type checker complained that `Nat -> Nat != Nat -> Nat`, because the first type was actually `Nat -> {IO} Nat`...