### PR TITLE
Rewrite misc/build-web-index in Python and make it complain loudly if a document has no title

### DIFF
--- a/lib/complex.dx
+++ b/lib/complex.dx
@@ -1,3 +1,5 @@
+'# Complex number support
+
 data Complex = MkComplex Float Float  -- real, imaginary
 
 instance HasAllClose Complex

--- a/makefile
+++ b/makefile
@@ -264,7 +264,7 @@ dither-data: $(dither-data)
 run-examples/dither: dither-data
 update-examples/dither: dither-data
 
-tests: opt-tests unit-tests lower-tests quine-tests repl-test module-tests
+tests: opt-tests unit-tests lower-tests quine-tests repl-test module-tests doc-format-test
 
 # Keep the unit tests in their own working directory too, due to
 # https://github.com/commercialhaskell/stack/issues/4977
@@ -273,6 +273,9 @@ unit-tests:
 
 opt-tests: just-build
 	misc/file-check tests/opt-tests.dx $(dex) -O script
+
+doc-format-test: $(doc-files) $(example-files) $(lib-files)
+	python3 misc/build-web-index "$(doc-files)" "$(example-files)" "$(lib-files)" > /dev/null
 
 quine-tests: $(quine-test-targets)
 
@@ -396,7 +399,7 @@ pages/lib/%.html: lib/%.dx
 	$(dex) script $^ --outfmt html > $@
 
 pages/index.md: $(doc-files) $(example-files) $(lib-files)
-	misc/build-web-index "$(doc-files)" "$(example-files)" "$(lib-files)" > $@
+	python3 misc/build-web-index "$(doc-files)" "$(example-files)" "$(lib-files)" > $@
 
 ${pages-doc-files}:pages/%.html: doc/%.dx
 	mkdir -p pages

--- a/misc/build-web-index
+++ b/misc/build-web-index
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env python3
 
 # This script constructs a Markdown file (on standard output) that constitutes
 # an index of all web-rendered pages of Dex examples, documentation, and
@@ -17,33 +17,42 @@
 # detect when a file lacks such a title and fail loudly, instead of just
 # omitting that file from the index.
 
-set -e
+import re
+import sys
 
-# The non-quotation is intentional: I am trying to get bash to split on words so
-# that `grep` takes the arguments as separate even though they were passed as
-# one thing to this script.
-docs=$1
-examples=$2
-libraries=$3
+def file_block(files):
+  for fname in files:
+    if fname.startswith("doc/"):
+      link_name = fname[len("doc/"):]
+    else:
+      link_name = fname
+    with open(fname, 'r') as f:
+      line = f.readline()
+      title = re.match(r"' *# ?(.*)", line)
+      if title:
+        print(f"- [{fname}]({link_name}.html) {title.group(1)}")
+      else:
+        raise ValueError(f"First line of file {fname} was not a title (top-level Markdown heading)")
 
-echo "# InDex"; echo ""
+def main():
+  docs, examples, libraries = sys.argv[1:4]
 
-echo "## Documentation"; echo ""
+  print("# InDex"); print("")
 
-grep -F "'# " $docs \
- | sed -e 's/^doc\/\(.*\).dx/- [doc\/\1.dx](\1.html)/' \
- | sed -e "s/'#//"
+  print("## Documentation"); print("")
 
-echo ""; echo "## Examples"; echo ""
+  file_block(docs.split())
 
-grep -F "'# " $examples \
- | sed -e 's/^\(.*\).dx/- [\1.dx](\1.html)/' \
- | sed -e "s/'#//"
+  print(""); print("## Examples"); print("")
 
-echo ""; echo "## Libraries"; echo ""
+  file_block(examples.split())
 
-echo "- [lib/prelude.dx](prelude.html): The Dex Prelude (automatically imported)"
+  print(""); print("## Libraries"); print("")
 
-grep -F "'# " $libraries \
- | sed -e 's/^\(.*\).dx/- [\1.dx](\1.html)/' \
- | sed -e "s/'#//"
+  print("- [lib/prelude.dx](prelude.html): The Dex Prelude (automatically imported)")
+
+  file_block(libraries.split())
+
+
+if __name__ == '__main__':
+  main()


### PR DESCRIPTION
Add a test to the Makefile (and therefore to CI) checking that every decoument has a title, so that they are all included in the auto-generated InDex.

Add a title to `lib/complex.dx` so it is included in same.