### PR TITLE
Perform loop invariant code motion (and DCE) after lowering

### DIFF
--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -839,10 +839,13 @@ typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
   Seq _ ixDict carry f -> do
     ixTy <- ixTyFromDict =<< substM ixDict
     carryTy' <- getTypeE carry
+    let badCarry = throw TypeErr $ "Seq carry should be a product of raw references, got: " ++ pprint carryTy'
+    case carryTy' of
+      ProdTy refTys -> forM_ refTys \case RawRefTy _ -> return (); _ -> badCarry
+      _ -> badCarry
     Pi (PiType (PiBinder b argTy PlainArrow) eff UnitTy) <- getTypeE f
     checkAlphaEq (PairTy (ixTypeType ixTy) carryTy') argTy
     declareEffs =<< liftHoistExcept (hoist b eff)
-    RawRefTy _ <- return carryTy'  -- We might need allow products of references too.
     return carryTy'
   RememberDest d body -> do
     dTy@(RawRefTy _) <- getTypeE d

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -37,7 +37,7 @@ module Name (
   pattern JustB, pattern NothingB,
   toConstAbs, toConstAbsPure, PrettyE, PrettyB, ShowE, ShowV, ShowB,
   runScopeReaderT, runScopeReaderM, runSubstReaderT, liftSubstReaderT,
-  liftScopeReaderT, liftScopeReaderM,
+  liftScopeReaderT, liftScopeReaderM, tryExtDistinct,
   ScopeReaderT (..), SubstReaderT (..),
   lookupSubstM, dropSubst, extendSubst, fmapNames, fmapNamesM, traverseNames,
   MonadKind, MonadKind1, MonadKind2,
@@ -309,6 +309,12 @@ extendSubst frag cont = do
   env <- (<>>frag) <$> getSubst
   withSubst env cont
 {-# INLINE extendSubst #-}
+
+tryExtDistinct :: (ScopeReader m, BindsNames b) => b n l -> m n (Maybe (DistinctEvidence l))
+tryExtDistinct b = do
+  scope <- unsafeGetScope
+  return $ fst <$> extendIfDistinct scope (toScopeFrag b)
+{-# INLINE tryExtDistinct #-}
 
 -- === extending envs with name-only substitutions ===
 

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -539,6 +539,11 @@ evalUExpr expr = do
   evalBlock typed
 {-# SCC evalUExpr #-}
 
+whenOpt :: Topper m => a -> (a -> m n a) -> m n a
+whenOpt x act = getConfig <&> optLevel >>= \case
+  NoOptimize -> return x
+  Optimize   -> act x
+
 evalBlock :: (Topper m, Mut n) => Block n -> m n (Atom n)
 evalBlock typed = do
   eopt <- checkPass EarlyOptPass $ earlyOptimize typed
@@ -546,16 +551,16 @@ evalBlock typed = do
   simplifiedBlock <- checkPass SimpPass $ simplifyTopBlock synthed
   evalRequiredSpecializations simplifiedBlock
   SimplifiedBlock simp recon <- return simplifiedBlock
-  opt <- (fmap optLevel getConfig) >>= \case
-    Optimize   -> checkPass OptPass $ optimize simp
-    NoOptimize -> return simp
+  opt <- whenOpt simp $ checkPass OptPass . optimize
   result <- case opt of
     AtomicBlock result -> return result
     _ -> do
       explicitIx <- emitIx opt
       instIx <- simplifyIx explicitIx
       lowered <- checkPass LowerPass $ lowerFullySequential instIx
-      evalBackend lowered
+      lopt <- whenOpt lowered $ checkPass LowerOptPass .
+        (dceIxDestBlock >=> hoistLoopInvariant)
+      evalBackend lopt
   applyRecon recon result
 {-# SCC evalBlock #-}
 
@@ -708,7 +713,10 @@ checkPass name cont = do
     return result
 #ifdef DEX_DEBUG
   logTop $ MiscLog $ "Running checks"
-  let allowedEffs = case name of LowerPass -> OneEffect IOEffect; _ -> mempty
+  let allowedEffs = case name of
+                      LowerPass    -> OneEffect IOEffect
+                      LowerOptPass -> OneEffect IOEffect
+                      _            -> mempty
   {-# SCC afterPassTypecheck #-} (liftExcept =<<) $ liftEnvReaderT $
     withAllowedEffects allowedEffs $ checkTypesM result
   logTop $ MiscLog $ "Checks passed"

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -1483,12 +1483,15 @@ instance GenericB LamBinder where
 
 instance BindsAtMostOneName LamBinder AtomNameC where
   LamBinder b _ _ _ @> x = b @> x
+  {-# INLINE (@>) #-}
 
 instance BindsOneName LamBinder AtomNameC where
   binderName (LamBinder b _ _ _) = binderName b
+  {-# INLINE binderName #-}
 
 instance HasNameHint (LamBinder n l) where
   getNameHint (LamBinder b _ _ _) = getNameHint b
+  {-# INLINE getNameHint #-}
 
 instance ProvesExt  LamBinder
 instance BindsNames LamBinder
@@ -1567,12 +1570,15 @@ instance GenericB PiBinder where
 
 instance BindsAtMostOneName PiBinder AtomNameC where
   PiBinder b _ _ @> x = b @> x
+  {-# INLINE (@>) #-}
 
 instance BindsOneName PiBinder AtomNameC where
   binderName (PiBinder b _ _) = binderName b
+  {-# INLINE binderName #-}
 
 instance HasNameHint (PiBinder n l) where
   getNameHint (PiBinder b _ _) = getNameHint b
+  {-# INLINE getNameHint #-}
 
 instance ProvesExt  PiBinder
 instance BindsNames PiBinder
@@ -1902,7 +1908,9 @@ instance AlphaHashableE DeclBinding
 instance GenericB Decl where
   type RepB Decl = AtomBinderP DeclBinding
   fromB (Let b binding) = b :> binding
+  {-# INLINE fromB #-}
   toB   (b :> binding) = Let b binding
+  {-# INLINE toB #-}
 
 instance SinkableB Decl
 instance HoistableB  Decl
@@ -1912,6 +1920,14 @@ instance AlphaEqB Decl
 instance AlphaHashableB Decl
 instance ProvesExt  Decl
 instance BindsNames Decl
+
+instance BindsAtMostOneName Decl AtomNameC where
+  Let b _ @> x = b @> x
+  {-# INLINE (@>) #-}
+
+instance BindsOneName Decl AtomNameC where
+  binderName (Let b _) = binderName b
+  {-# INLINE binderName #-}
 
 instance Semigroup (SynthCandidates n) where
   SynthCandidates xs ys <> SynthCandidates xs' ys' =

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -350,7 +350,7 @@ data LogLevel = LogNothing | PrintEvalTime | PrintBench String
 data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
 
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
-              | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval | LowerPass
+              | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval | LowerOptPass | LowerPass
               | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass
                 deriving (Ord, Eq, Bounded, Enum, Generic)
 
@@ -362,7 +362,7 @@ instance Show PassName where
     LLVMOpt  -> "llvmopt" ; AsmPass   -> "asm"
     JAXPass  -> "jax"   ; JAXSimpPass -> "jsimp"; ResultPass -> "result"
     LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo";
-    LowerPass -> "lower" ;
+    LowerOptPass -> "lower-opt"; LowerPass -> "lower"
     EarlyOptPass -> "early-opt"; OptPass -> "opt"
 
 data EnvQuery =

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -57,3 +57,18 @@ _ = for i:(Fin 50). [1, 2, 3]
 _ = for i:(Fin 20) j:(Fin 4). ordinal j
 -- CHECK: [0, 1, 2, 3]
 -- CHECK-NOT: [0, 1, 2, 3]
+
+"alloc hoisting"
+-- CHECK-LABEL: alloc hoisting
+
+%passes lower-opt
+_ = for i:(Fin 10).
+  n = ordinal i + 2
+  for j:(Fin 4). sum for k:(Fin n). ordinal j
+-- The alloc for the (ordinal i + 2)-sized array should happen in the i loop,
+-- not in the j loop
+-- CHECK: [[n:v#[0-9]+]]:Word32 = %iadd {{.*}} 0x2
+-- CHECK-NOT: seq
+-- CHECK: alloc {{.*}}Fin{{.*}}[[n]]
+-- CHECK: seq
+-- CHECK: seq


### PR DESCRIPTION
Most importantly, to lift allocs of arrays that have stable (but not necessarily statically known) shapes out of the hot inner loops. This dramatically improves the performance (40x !) of the `conv` benchmark when it is not specialized on the `size` parameter (you can replace the `3` by `sum [3]` and see for yourself).