### PR TITLE
Educational: built-in `map` primitive

### DIFF
--- a/src/lib/AbstractSyntax.hs
+++ b/src/lib/AbstractSyntax.hs
@@ -494,6 +494,10 @@ expr = propagateSrcE expr' where
         UApp (mkApp (ns $ fromString rangeName) (ns UHole)) lim
   expr' (CLambda args body) =
     dropSrcE <$> liftM2 buildLam (concat <$> mapM argument args) (block body)
+  expr' (CMap fun array) = do
+    fun' <- expr fun
+    array' <- expr array
+    return $ UMap fun' array'
   expr' (CFor KView indices body) =
     dropSrcE <$> (buildTabLam <$> mapM patOptAnn indices <*> block body)
   expr' (CFor kind indices body) = do

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -777,6 +777,7 @@ typeCheckPrimOp op = case op of
 
 typeCheckPrimHof :: Typer m => PrimHof (Atom i) -> m i o (Type o)
 typeCheckPrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
+  Map f -> getTypeE f
   For _ ixDict f -> do
     ixTy <- ixTyFromDict =<< substM ixDict
     Pi (PiType (PiBinder b argTy PlainArrow) eff eltTy) <- getTypeE f

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -114,6 +114,7 @@ data Group'
   | CPrefix SourceName Group -- covers unary - and unary + among others
   | CPostfix SourceName Group
   | CLambda [Group] CBlock  -- The arguments do not have Juxtapose at the top level
+  | CMap Group Group -- unary fun, array
   | CFor ForKind [Group] CBlock -- also for_, rof, rof_, view
   | CCase Group [(Group, CBlock)] -- scrutinee, alternatives
   | CIf Group CBlock (Maybe CBlock)
@@ -559,6 +560,14 @@ cLam = do
   body <- cBlock
   return $ CLambda bs body
 
+cMap :: Parser Group'
+cMap = do
+  keyWord MapKW
+  fun <- cGroupNoJuxt
+  keyWord OverKW
+  array <- cGroup
+  return $ CMap fun array
+
 cFor :: Parser Group'
 cFor = do
   kw <- forKW
@@ -704,6 +713,7 @@ leafGroupNoBrackets = do
     _ | isDigit next -> (    CNat   <$> natLit
                          <|> CFloat <$> doubleLit)
     '\\' -> cLam
+    'm'  -> cMap <|> CIdentifier <$> anyName
     -- For exprs include view, for, rof, for_, rof_
     'v'  -> cFor  <|> CIdentifier <$> anyName
     'f'  -> cFor  <|> CIdentifier <$> anyName

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -943,6 +943,69 @@ checkOrInferRho (WithSrcE pos expr) reqTy = do
       Infer   -> inferULam Pure uLamExpr
     ixTy <- asIxType ty'
     matchRequirement $ TabLam $ TabLamExpr (b':>ixTy) body'
+  UMap fun array -> do
+    argElemVar <- liftM Var $ freshInferenceName (TC TypeKind)
+    resElemVar <- liftM Var $ freshInferenceName (TC TypeKind)
+    funTy <- naryNonDepPiType PlainArrow Pure [argElemVar] resElemVar
+    fun' <- checkOrInferRho fun (Check funTy)
+
+    arrayReqTy <- case reqTy of
+      Check (TabPi (TabPiType (b:>ixTy) resElemTy)) -> do
+        -- TODO: Throw a graceful error if `resElemTy` depends on `b`.
+        let resElemTy' = ignoreHoistFailure $ hoist b resElemTy
+        constrainEq resElemVar resElemTy'
+        liftM (Check . TabPi) $ nonDepTabPiType ixTy argElemVar
+      Check _ -> return Infer
+      Infer -> return Infer
+    array' <- checkOrInferRho array arrayReqTy
+
+    -- Construct the `TabLam` for `Map`. This should probably not be done here
+    -- alongside the inference code; perhaps `AbstractSyntax.hs` would be a
+    -- better place for this. However, if we replaced replaced the `fun` and
+    -- `array` arguments to `UMap` with a `UTabLam`, this would make typing
+    -- failures less informative at the source code level (since the source code
+    -- contains concrete syntax for `fun` and `array`, but not for the
+    -- constructed `UTabLam`.) The cleanest alternative, however, would probably
+    -- be to place the construction of the `TabLam` (or of an equivalent block
+    -- paired with binders for its free variables) in `Lower.hs` or `Imp.hs`.
+    -- However, at that point we would require the expressions in the block
+    -- (including the expressions in the decls inside the block) to be
+    -- simplified; and the `TabApp` and `App` expressions below are apparently
+    -- not simplified.
+    TabPi (TabPiType (bA:>ixTy) argElemTy) <- getType array'
+    -- TODO: Throw a graceful error if `argElemTy` depends on `bA`.
+    let argElemTy' = ignoreHoistFailure $ hoist bA argElemTy
+    -- NOTE: In the definition of `arrayReqTy` we have already introduced a
+    -- constaint for `resElemVar`; but we still need to constrain `argElemVar`.
+    -- (Additionally `resElemVar` should also be constrained by the
+    -- `matchRequirement` below, but this is not the case for `argElemVar`.)
+    constrainEq argElemVar argElemTy'
+    Pi (PiType (PiBinder bF _ _) _ resElemTy) <- getType fun'
+    -- TODO: Throw a graceful error if `resElemTy` depends on `bF`.
+    let resElemTy' = ignoreHoistFailure $ hoist bF resElemTy
+
+    f <- withFreshBinder noHint ixTy \b0 -> do
+      let binder = b0:>ixTy
+      -- I am having trouble getting the following to work when trying to use a
+      -- single call to `withFreshBinders` (plural!) only. The problem appears
+      -- to be that `withFreshBinders` does not make available evidence of
+      -- `Distinct` for the intermediate scope, i.e. the scope that has `b1` but
+      -- not `b2`. Without this evidence, `sink fun'` in the let-block below is
+      -- not valid.
+      body <- withFreshBinder noHint (sink argElemTy') \b1 ->
+        withFreshBinder noHint (sink resElemTy') \b2 ->
+          let indexName = binderName b0
+              argElem = TabApp (sink array') $ (Var indexName) :| []
+              declArgElem = Let b1 (DeclBinding PlainLet (sink argElemTy') argElem)
+              funApp = App (sink fun') $ (Var $ binderName b1) :| []
+              declResElem = Let b2 (DeclBinding PlainLet (sink resElemTy') funApp)
+              ann = BlockAnn (sink resElemTy') Pure
+              block = Block ann (Nest declArgElem (Nest declResElem Empty)) (Var $ binderName b2)
+          in return block
+      return $ TabLam $ TabLamExpr binder body
+
+    result <- liftM Var $ emit $ Hof $ Map f
+    matchRequirement result
   UFor dir (UForExpr b body) -> do
     allowedEff <- getAllowedEffects
     let uLamExpr = ULamExpr PlainArrow b body

--- a/src/lib/Lexing.hs
+++ b/src/lib/Lexing.hs
@@ -69,11 +69,14 @@ data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
              | ViewKW | ImportKW | ForeignKW | NamedInstanceKW
              | EffectKW | HandlerKW | JmpKW | CtlKW | ReturnKW | ResumeKW
              | CustomLinearizationKW | CustomLinearizationSymbolicKW
+             | MapKW | OverKW
   deriving (Enum)
 
 keyWordToken :: KeyWord -> String
 keyWordToken = \case
   DefKW           -> "def"
+  MapKW           -> "map_"
+  OverKW          -> "over_"
   ForKW           -> "for"
   RofKW           -> "rof"
   For_KW          -> "for_"

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -662,6 +662,8 @@ instance PrettyPrec (UExpr' n) where
                              <+> nest 2 (pLowest body)
       where kw = case dir of Fwd -> "for"
                              Rev -> "rof"
+    UMap fun array -> atPrec LowestPrec $ "map_"  <+> nest 2 (pLowest fun)
+                                      <+> "over_" <+> nest 2 (pLowest array)
     UPi piType -> prettyPrec piType
     UTabPi piType -> prettyPrec piType
     UDecl declExpr -> prettyPrec declExpr

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -698,6 +698,7 @@ getTypePrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
     Pi (PiType (PiBinder b _ _) _ eltTy) <- getTypeE f
     ixTy <- ixTyFromDict =<< substM dict
     return $ TabTy (b:>ixTy) eltTy
+  Map f -> getTypeE f
   While _ -> return UnitTy
   Linearize f -> do
     Pi (PiType (PiBinder binder a PlainArrow) Pure b) <- getTypeE f
@@ -797,6 +798,7 @@ exprEffects expr = case expr of
     _ -> return Pure
   Hof hof -> case hof of
     For _ _ f     -> functionEffs f
+    Map _         -> return Pure
     While body    -> functionEffs body
     Linearize _   -> return Pure  -- Body has to be a pure function
     Transpose _   -> return Pure  -- Body has to be a pure function

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -839,6 +839,9 @@ projectDictMethod d i = do
 
 simplifyHof :: Emits o => Hof i -> SimplifyM i o (Atom o)
 simplifyHof hof = case hof of
+  Map f -> do
+    f' <- simplifyAtom f
+    liftM Var $ emit $ Hof $ Map f'
   For d ixDict lam -> do
     ixTy@(IxType _ ixDict') <- ixTyFromDict =<< substM ixDict
     (lam', Abs b recon) <- simplifyLam lam

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -207,6 +207,8 @@ instance SourceRenamableE UExpr' where
     UDecl (UDeclExpr decl rest) ->
       sourceRenameB decl \decl' ->
         UDecl <$> UDeclExpr decl' <$> sourceRenameE rest
+    UMap fun array -> UMap <$> sourceRenameE fun
+                           <*> sourceRenameE array
     UFor d (UForExpr pat body) ->
       sourceRenameB pat \pat' ->
         UFor d <$> UForExpr pat' <$> sourceRenameE body

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -158,6 +158,7 @@ traversePrimOp = inline traverse
 
 data PrimHof e =
         For ForAnn e e        -- ix dict, body lambda
+      | Map e                 -- body tab-lambda
       | While e
       | RunReader e e
       | RunWriter (Maybe e) (BaseMonoidP e) e

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -93,6 +93,7 @@ data UExpr' (n::S) =
  | UTabPi  (UTabPiExpr n)
  | UTabApp (UExpr n) (UExpr n)
  | UDecl (UDeclExpr n)
+ | UMap (UExpr n) (UExpr n)
  | UFor Direction (UForExpr n)
  | UCase (UExpr n) [UAlt n]
  | UHole

--- a/tests/mymap.dx
+++ b/tests/mymap.dx
@@ -1,0 +1,22 @@
+def my_map {a:Type} {b:Type} {n:Type} [Ix n]
+    (f:a -> b)
+    (x:n => a) : n => b =
+  for i:n. f x.i
+
+x0 = [1, 2, 3, 4, 5]
+
+my_map (\x. x+x) x0
+map_ (\x. x+x) over_ x0
+
+my_map (\x. 2*x) x0
+map_ (\x. 2*x) over_ x0
+
+my_map (\x. 2*x) (x0 + x0)
+map_ (\x. 2*x) over_ (x0 + x0)
+-- The following is also parsed as `map_ (\x. 2*x) over_ (x0 + x0)` ... not
+-- intentionally so.
+map_ (\x. 2*x) over_ x0 + x0
+
+my_map (\x. 2*x) x0 + x0
+(map_ (\x. 2*x) over_ x0) + x0
+


### PR DESCRIPTION
This is educational work.
DO NOT MERGE.

Implement a built-in `map` primitive for mapping a function over an array.
