### PR TITLE
Don't emit Fin Ix dicts in the emitIx pass

### DIFF
--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -99,6 +99,9 @@ instance HasEmitIx DictExpr where
   emitIxE _ = error "unhandled dict!"
 instance HasEmitIx Atom where
   emitIxE = \case
+    -- We don't emit the Fin dicts, since they're small and built in,
+    -- so they don't need to be simplified.
+    DictCon (IxFin n) -> DictCon . IxFin <$> emitIxE n
     DictCon de -> do
       de' <- emitIxDict de
       dictTy' <- getType de'


### PR DESCRIPTION
There's no point in host those out of the types. The Ix simplification pass doesn't simplify them anyway, since they're builtin and already pre-simplified. They're also all over the place, so leaving them be ends up speeding up the compiler.