### PR TITLE
Account for the cost of TabCon emitted after loop unrolling

### DIFF
--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -46,6 +46,14 @@ x = for i:(Fin 4). [0, 0, 0, ordinal i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0
 "basic destination passing for scalar array literals"
 -- CHECK-LABEL: basic destination passing for scalar array literals
 
-%passes opt lower
+%passes lower
 _ = for i:(Fin 50). [1, 2, 3]
 -- CHECK-NOT: alloc
+
+"no excessive nested unrolling"
+-- CHECK-LABEL: no excessive nested unrolling
+
+%passes opt
+_ = for i:(Fin 20) j:(Fin 4). ordinal j
+-- CHECK: [0, 1, 2, 3]
+-- CHECK-NOT: [0, 1, 2, 3]


### PR DESCRIPTION
Unrolling loops with large TabCons is a bad idea and #1009 was supposed to prevent that. But I forgot to account for the TabCon that we emit after unrolling a loop, so `for i:(Fin 10000) j:(Fin 4). ordinal j` ended up unrolling the `[0, 1, 2, 3]` literal introduced by unrolling the `j` loop 10000 times.