### PR TITLE
Add LICM for `for` loops

### DIFF
--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -559,7 +559,7 @@ evalBlock typed = do
       instIx <- simplifyIx explicitIx
       lowered <- checkPass LowerPass $ lowerFullySequential instIx
       lopt <- whenOpt lowered $ checkPass LowerOptPass .
-        (dceIxDestBlock >=> hoistLoopInvariant)
+        (dceIxDestBlock >=> hoistLoopInvariantIxDest)
       evalBackend lopt
   applyRecon recon result
 {-# SCC evalBlock #-}

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -27,7 +27,7 @@ m' = m ** m
 -- CHECK-LABEL: basic destination passing for scalar array literals
 
 %passes lower
-_ = for i:(Fin 50). [1, 2, 3]
+_ = for i:(Fin 50). [ordinal i, 2, 3]
 -- CHECK-NOT: alloc
 
 -- === Loop unrolling ===
@@ -87,3 +87,12 @@ _ = for i:(Fin 10).
 -- CHECK: alloc {{.*}}Fin{{.*}}[[n]]
 -- CHECK: seq
 -- CHECK: seq
+
+"loop hoisting"
+-- CHECK-LABEL: loop hoisting
+
+%passes opt
+_ = for i:(Fin 20) j:(Fin 4). ordinal j
+-- CHECK-NOT: for
+-- CHECK: [[x:v#[0-9]+]]:{{.*}} = [0, 1, 2, 3]
+-- CHECK: for {{.*}}:{{.*}}. [[x]]


### PR DESCRIPTION
Hoisting loops becomes difficult once we transition to the lowered IR (mostly due to destination passing), so if we want to hoist loop-invariant loops, we have to do it before lowering.