### PR TITLE
Rename DataConTag to SumTag

### DIFF
--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -712,8 +712,11 @@ typeCheckPrimOp op = case op of
     unless (0 <= i && i < length labelTys) $ throw TypeErr "Invalid variant index"
     e |: (labelTys !! i)
     return ty'
-  DataConTag x -> do
-    TypeCon _ _ _ <- getTypeE x
+  SumTag x -> do
+    getTypeE x >>= \case
+      TypeCon _ _ _ -> return ()
+      SumTy _ -> return ()
+      xTy -> throw TypeErr $ "SumTag expected a data-type or a sum type, got: " ++ pprint xTy
     return TagRepTy
   ToEnum t x -> do
     x |: Word8Ty

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -987,7 +987,7 @@ builtinNames = M.fromList
   , ("ptrOffset", OpExpr $ PtrOffset () ())
   , ("ptrLoad"  , OpExpr $ PtrLoad ())
   , ("ptrStore" , OpExpr $ PtrStore () ())
-  , ("dataConTag", OpExpr $ DataConTag ())
+  , ("dataConTag", OpExpr $ SumTag ())
   , ("toEnum"    , OpExpr $ ToEnum () ())
   , ("outputStreamPtr", OpExpr $ OutputStreamPtr)
   , ("newtype"    , ConExpr $ Newtype () ())

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -500,7 +500,8 @@ toImpOp maybeDest op = case op of
         ans <- emitInstr $ IPrimOp $ Select p' x' y'
         returnVal =<< toScalarAtom ans
       _ -> unsupported
-  DataConTag con -> case con of
+  SumTag con -> case con of
+    Con (SumCon _ tag _) -> returnVal $ TagRepVal $ fromIntegral tag
     Con (SumAsProd _ tag _) -> returnVal tag
     Con (Newtype _ (Con (SumCon _ tag _))) -> returnVal $ TagRepVal $ fromIntegral tag
     Con (Newtype _ (Con (SumAsProd _ tag _))) -> returnVal tag

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -401,7 +401,7 @@ linearizeOp op = case op of
   IOAlloc _ _            -> emitZeroT
   IOFree _               -> emitZeroT
   ThrowError _           -> emitZeroT
-  DataConTag _           -> emitZeroT
+  SumTag _               -> emitZeroT
   ToEnum _ _             -> emitZeroT
   TabCon ty xs -> do
     ty' <- substM ty

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -627,7 +627,7 @@ getTypePrimOp op = case op of
     diff <- labeledRowDifference' full (NoExt types')
     return $ SumTy [ VariantTy $ NoExt types', VariantTy diff ]
   VariantMake ty _ _ _ -> substM ty
-  DataConTag _ -> return TagRepTy
+  SumTag _ -> return TagRepTy
   ToEnum t _ -> substM t
   SumToVariant x -> getTypeE x >>= \case
     SumTy cases -> return $ VariantTy $ NoExt $ foldMap (labeledSingleton "c") cases

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -247,7 +247,7 @@ transposeOp op ct = case op of
   IOAlloc _ _           -> notLinear
   IOFree _              -> notLinear
   ThrowError   _        -> notLinear
-  DataConTag _          -> notLinear
+  SumTag _              -> notLinear
   ToEnum _ _            -> notLinear
   ThrowException _      -> notLinear
   OutputStreamPtr       -> notLinear

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -137,7 +137,7 @@ data PrimOp e =
       -- type, label, how deeply shadowed, payload
       | VariantMake e Label Int e
       -- Ask which constructor was used, as its Word8 index
-      | DataConTag e
+      | SumTag e
       -- Create an enum (payload-free ADT) from a Word8
       | ToEnum e e
       -- Converts sum types returned by primitives to variant-types that


### PR DESCRIPTION
The newtype simplification pass will replace multi-constructor data types with sum types, so we need to allow those too.