### PR TITLE
Add an ADT to represent the different kinds of projections

### DIFF
--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -991,7 +991,7 @@ builtinNames = M.fromList
   , ("toEnum"    , OpExpr $ ToEnum () ())
   , ("outputStreamPtr", OpExpr $ OutputStreamPtr)
   , ("newtype"    , ConExpr $ Newtype () ())
-  , ("projNewtype", OpExpr $ ProjNewtype ())
+  , ("projNewtype", OpExpr $ ProjBaseNewtype ())
   , ("projMethod0", OpExpr $ ProjMethod () 0)
   , ("projMethod1", OpExpr $ ProjMethod () 1)
   , ("projMethod2", OpExpr $ ProjMethod () 2)

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -162,11 +162,11 @@ prepareFunctionForExport' cc f = do
                   offset <- foldM iadd (IdxRepVal 0) =<< mapM (uncurry imul) (zip strides ords)
                   wrapScalarNewtypes eltTy =<< unsafePtrLoad =<< ptrOffset basePtr offset
 
-              indexSetSizeFin n = unwrapNewtype <$> projectIxFinMethod 0 n
+              indexSetSizeFin n = unwrapBaseNewtype <$> projectIxFinMethod 0 n
               ordinalFin n ix = do
                 Lam (LamExpr b body) <- projectIxFinMethod 1 n
                 ordNat <- emitBlock =<< applySubst (b@>SubstVal ix) body
-                return $ unwrapNewtype ordNat
+                return $ unwrapBaseNewtype ordNat
               dup x = (x, x)
 
     toExportType :: Fallible m => Type n -> m (ExportType n)

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -316,7 +316,8 @@ seqLICM !nextProj !top !topDestNames !lb !reg decls ans = case decls of
                     Let bn (DeclBinding _ _ (Op (AllocDest _))) ->
                       ( nextProj + 1
                       , binderName bn : sinkList topDestNames
-                      , SubstVal $ ProjectElt (nextProj NE.:| [1]) $ withExtEvidence reg' $ sink $ binderName lb')
+                      , SubstVal $ ProjectElt (ProjectProduct nextProj NE.:| [ProjectProduct 1]) $
+                          withExtEvidence reg' $ sink $ binderName lb')
                     _ -> (nextProj, sinkList topDestNames, Rename $ sink $ binderName b')
           HoistFailure _ -> moveOn
         _ -> moveOn

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -282,6 +282,12 @@ instance PrettyPrec (Atom n) where
 instance Pretty (BoxPtr n) where
   pretty (BoxPtr ptrptr sb) = pretty (ptrptr, sb)
 
+instance Pretty Projection where
+  pretty = \case
+    UnwrapCompoundNewtype -> "uc"
+    UnwrapBaseNewtype -> "ub"
+    ProjectProduct i -> p i
+
 prettyRecordTyRow :: FieldRowElems n -> Doc ann -> DocPrec ann
 prettyRecordTyRow elems separator = do
   atPrec ArgPrec $ align $ group $ braces $ (prefix <>) $

--- a/src/lib/Serialize.hs
+++ b/src/lib/Serialize.hs
@@ -66,7 +66,7 @@ getDexString (Con (Newtype _ (DepPair _ xs _))) = case tryParseStringContent xs 
       TabLam (TabLamExpr i body) <- return tabAtom
       FinConst n <- return $ binderType i
       Block _ (Nest offDecl (Nest loadDecl Empty)) (Var result) <- return body
-      Let v1 (DeclBinding _ _ (Op (PtrOffset (Var ptrName) (ProjectElt (0 NE.:| [0]) i')))) <- return offDecl
+      Let v1 (DeclBinding _ _ (Op (PtrOffset (Var ptrName) (ProjectElt (UnwrapBaseNewtype NE.:| [UnwrapBaseNewtype]) i')))) <- return offDecl
       guard $ binderName i == i'
       Let r (DeclBinding _ _ loadExpr) <- return loadDecl
       guard $ binderName r == result

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -146,7 +146,7 @@ data PrimOp e =
       -- Pointer to the stdout-like output stream
       | OutputStreamPtr
       -- Odds, ends and hacks.
-      | ProjNewtype e     -- shouldn't appear after inference
+      | ProjBaseNewtype e     -- shouldn't appear after inference
       | ProjMethod e Int  -- project a method from the dict
       | ExplicitApply e e
       | MonoLiteral e

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -216,7 +216,7 @@ def catLists {a} (xs:List a) (ys:List a) : List a =
 def listToTable {a} ((AsList n xs): List a) : (Fin n)=>a = xs
 
 :t listToTable
-> ((a:Type) ?-> (v#0:(List a)) -> (Fin (ProjectElt [0, 0] v#0)) => a)
+> ((a:Type) ?-> (v#0:(List a)) -> (Fin (ProjectElt [0, uc] v#0)) => a)
 
 :p
   l = AsList _ [1, 2, 3]
@@ -228,7 +228,7 @@ def listToTable2 {a} (l: List a) : (Fin (list_length l))=>a =
   xs
 
 :t listToTable2
-> ((a:Type) ?-> (l:(List a)) -> (Fin (ProjectElt [0, 0] l)) => a)
+> ((a:Type) ?-> (l:(List a)) -> (Fin (ProjectElt [0, uc] l)) => a)
 
 :p
   l = AsList _ [1, 2, 3]


### PR DESCRIPTION
Our current approach (using integers) was simple, but it was erasing lots of information. For example 0 could mean that we're taking a first element of a product type, but it could also mean that we're unwrapping a newtype. This change adds an ADT to start distinguishing between a few different kinds of projections, namely: product projections and two flavors of newtype projections: base and compound newtype unwraps. The difference between them is pretty arbitrary and corresponds to what the newtype erasure pass will eliminate (only compound newtypes). The set of base newtype is small and currently is only `Nat` and `Fin`.