### PR TITLE
Change the syntax of instance definitions to put the binders at the end, separated by the new `given` keyword

### DIFF
--- a/examples/brownian_motion.dx
+++ b/examples/brownian_motion.dx
@@ -124,7 +124,7 @@ interface HasStandardNormal a:Type
 
 instance HasStandardNormal Float32
   rand_normal = randn
-instance {a n} [HasStandardNormal a] HasStandardNormal (n=>a)
+instance HasStandardNormal (n=>a) given {a n} [HasStandardNormal a]
   rand_normal = \key.
     for i. rand_normal (ixkey key i)
 
@@ -142,11 +142,11 @@ interface [HasStandardNormal v] HasBrownianSheet a:Type v:Type
                       -- tolerance -> key -> input -> output
   sample_brownian_sheet : Float -> Key -> a -> v
 
-instance {v} [HasStandardNormal v, VSpace v] HasBrownianSheet Float v
+instance HasBrownianSheet Float v given {v} [HasStandardNormal v, VSpace v]
   sample_brownian_sheet = \tol k x.
     sample_brownian_motion tol rand_normal k x
 
-instance {a v} [VSpace v, HasBrownianSheet a v] HasBrownianSheet (a & Float) v
+instance HasBrownianSheet (a & Float) v given {a v} [VSpace v, HasBrownianSheet a v]
   sample_brownian_sheet = \tol k (xa, xb).
     -- the call to `sample_brownian_sheet` below will recurse
     -- until the input is one-dimensional.

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -27,7 +27,7 @@ data FenceAndPosts n [Ix n] =
   Fence n
   Posts (Post n)
 
-instance {a} Ix (FenceAndPosts a)
+instance Ix (FenceAndPosts a) given {a}
   size = 2 * size a + 1
   ordinal = \i. case i of
     Fence j -> 2 * ordinal j + 1
@@ -37,10 +37,10 @@ instance {a} Ix (FenceAndPosts a)
       True  -> Fence $ unsafe_from_ordinal _ (intdiv2 o)
       False -> Posts $ unsafe_from_ordinal _ (intdiv2 o)
 
-instance {a} NonEmpty (FenceAndPosts a)
+instance NonEmpty (FenceAndPosts a) given {a}
   first_ix = unsafe_from_ordinal _ 0
 
-instance {a} [Eq a] Eq (FenceAndPosts a)
+instance Eq (FenceAndPosts a) given {a} [Eq a]
   (==) = \x y. case x of
     Fence x -> case y of
       Fence y -> x == y
@@ -63,12 +63,12 @@ that doesn't contain the first element.
 data AllButFirst n [NonEmpty n] =
   MkAllButFirst n
 
-instance {a} Ix (AllButFirst a)
+instance Ix (AllButFirst a) given {a}
   size = unsafe_nat_diff (size a) 1
   ordinal = \(MkAllButFirst i). ordinal i
   unsafe_from_ordinal = \o. MkAllButFirst $ unsafe_from_ordinal _ o
 
-instance {a} Subset (AllButFirst a) a
+instance Subset (AllButFirst a) a given {a}
   inject' = \x. unsafe_from_ordinal _ ((ordinal x) + 1)
   project' = \x. case (ordinal x) > 0 of
     True -> unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
@@ -76,7 +76,7 @@ instance {a} Subset (AllButFirst a) a
   unsafe_project' = \x.
     unsafe_from_ordinal _ (unsafe_nat_diff (ordinal x) 1)
 
-instance {a} [Eq a] Eq (AllButFirst a)
+instance Eq (AllButFirst a) given {a} [Eq a]
   (==) = \(MkAllButFirst x) (MkAllButFirst y). x == y
 
 '#### Test AllButFirst

--- a/examples/isomorphisms.dx
+++ b/examples/isomorphisms.dx
@@ -194,7 +194,7 @@ def abcToTuple {a b c} : Iso {a:a & b:b & c:c} (c&b&a) =
   fwd = \({a, b, c}). (c, b, a)
   bwd = \(c, b, a). {a, b, c}
   MkIso {fwd, bwd}
-instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n & b:m & c:q}
+instance Ix {a:n & b:m & c:q} given {n m q} [Ix n, Ix m, Ix q]
   size = size n * size m * size q
   ordinal = ordinal <<< app_iso abcToTuple
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abcToTuple
@@ -203,7 +203,7 @@ def bcToPair {b c} : Iso {b:b & c:c} (c&b) =
   fwd = \({b, c}). (c, b)
   bwd = \(c, b). {b, c}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {b:n & c:m}
+instance Ix {b:n & c:m} given {n m} [Ix n, Ix m]
   size = size n * size m
   ordinal = ordinal <<< app_iso bcToPair
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso bcToPair
@@ -266,7 +266,7 @@ def abcToEither {a b c} : Iso {a:a | b:b | c:c} (a|(b|c)) =
       Left  y -> {|b=y|}
       Right y -> {|c=y|}
   MkIso {fwd, bwd}
-instance {n m q} [Ix n, Ix m, Ix q] Ix {a:n | b:m | c:q}
+instance Ix {a:n | b:m | c:q} given {n m q} [Ix n, Ix m, Ix q]
   size = size n + size m + size q
   ordinal = ordinal <<< app_iso abcToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abcToEither
@@ -279,7 +279,7 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Left x  -> {|a=x|}
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
+instance Ix {a:n | b:m} given {n m} [Ix n, Ix m]
   size = size n + size m
   ordinal = ordinal <<< app_iso abToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToEither
@@ -292,7 +292,7 @@ def acToEither {a c} : Iso {a:a | c:c} (a|c) =
     Left x  -> {|a=x|}
     Right x -> {|c=x|}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {a:n | c:m}
+instance Ix {a:n | c:m} given {n m} [Ix n, Ix m]
   size = size n + size m
   ordinal = ordinal <<< app_iso acToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso acToEither

--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -50,7 +50,7 @@ instance HasDeterminant ScalarMap
   transpose' = id
   identity' = MkScalarMap 1.0
 
-instance {v} [Mul v, VSpace v] LinearEndo ScalarMap v
+instance LinearEndo ScalarMap v given {v} [Mul v, VSpace v]
   apply =  \(MkScalarMap a) b. a .* b
   diag =   \(MkScalarMap a).   a .* one
   solve' = \(MkScalarMap a) b. b / a
@@ -64,31 +64,31 @@ instance Arbitrary ScalarMap
 data DiagMap n [Ix n] =
   MkDiagMap (n=>Float)
 
-instance {n} HasDeterminant (DiagMap n)
+instance HasDeterminant (DiagMap n) given {n}
   determinant' = \(MkDiagMap x). prod x
   transposeType = n=>Float
   transpose' = id
   identity' = MkDiagMap one
 
-instance {n v} [Mul v, VSpace v] LinearEndo (DiagMap n) (n=>v)
+instance LinearEndo (DiagMap n) (n=>v) given {n v} [Mul v, VSpace v]
   apply =  \(MkDiagMap x) y. for i. x.i .* y.i
   diag =   \(MkDiagMap a).   for i. a.i .* one
   solve' = \(MkDiagMap a) b. for i. b.i / a.i
 
-instance {n} Arbitrary (DiagMap n)
+instance Arbitrary (DiagMap n) given {n}
   arb = \k. MkDiagMap $ arb k
 
 
 '### Full-rank matrices.
 I didn't use a newtype for these, but I'm not sure if that's the right call.
 
-instance {n} HasDeterminant (n=>n=>Float)
+instance HasDeterminant (n=>n=>Float) given {n}
   determinant' = determinant
   transposeType = n=>n=>Float
   transpose' = transpose
   identity' = eye
 
-instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
+instance LinearEndo (n=>n=>Float) (n=>v) given {n v} [Mul v, VSpace v]
   apply = \x y. for i. sum for j. x.i.j .* y.j
   diag = \x. for i. x.i.i .* one
   solve' = solve
@@ -99,18 +99,18 @@ instance {n v} [Mul v, VSpace v] LinearEndo (n=>n=>Float) (n=>v)
 data LowerTriMap n [Ix n] =
   MkLowerTriMap ((i:n)=>(..i)=>Float)
 
-instance {n} HasDeterminant (LowerTriMap n)
+instance HasDeterminant (LowerTriMap n) given {n}
   determinant' = \(MkLowerTriMap x). prod $ lower_tri_diag x
   transposeType = UpperTriMat n Float
   transpose' = error "Can't transpose to different types yet."
   identity' = MkLowerTriMap for i j. select (ordinal i == ordinal j) one zero
 
-instance {n v} [Mul v, VSpace v] LinearEndo (LowerTriMap n) (n=>v)
+instance LinearEndo (LowerTriMap n) (n=>v) given {n v} [Mul v, VSpace v]
   apply  = \(MkLowerTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
   diag   = \(MkLowerTriMap x).   for i. x.i.(unsafe_project _ i) .* one
   solve' = \(MkLowerTriMap x).   forward_substitute x
 
-instance {n} Arbitrary (LowerTriMap n)
+instance Arbitrary (LowerTriMap n) given {n}
   arb = \k. MkLowerTriMap $ arb k
 
 
@@ -119,18 +119,18 @@ instance {n} Arbitrary (LowerTriMap n)
 data UpperTriMap n [Ix n] =
   MkUpperTriMap ((i:n)=>(i..)=>Float)
 
-instance {n} HasDeterminant (UpperTriMap n)
+instance HasDeterminant (UpperTriMap n) given {n}
   determinant' = \(MkUpperTriMap x). prod $ upper_tri_diag x
   transposeType = LowerTriMat n Float
   transpose' = error "Can't transpose to different types yet."
   identity' = MkUpperTriMap for i j. select (0 == ordinal j) one zero
 
-instance {n v} [Mul v, VSpace v] LinearEndo (UpperTriMap n) (n=>v)
+instance LinearEndo (UpperTriMap n) (n=>v) given {n v} [Mul v, VSpace v]
   apply  = \(MkUpperTriMap x) y. for i. sum for j. x.i.j .* y.(inject _ j)
   diag   = \(MkUpperTriMap x).   for i. x.i.(0@_) .* one
   solve' = \(MkUpperTriMap x).   backward_substitute x
 
-instance {n} Arbitrary (UpperTriMap n)
+instance Arbitrary (UpperTriMap n) given {n}
   arb = \k. MkUpperTriMap $ arb k
 
 
@@ -139,7 +139,7 @@ instance {n} Arbitrary (UpperTriMap n)
 data SkewSymmetricMap n [Ix n] =
   MkSkewSymMap ((i:n)=>(..<i)=>Float)
 
-instance {n} HasDeterminant (SkewSymmetricMap n)
+instance HasDeterminant (SkewSymmetricMap n) given {n}
   determinant' = case is_odd (size n) of
     True -> zero
     False -> \(MkSkewSymMap a).
@@ -149,14 +149,14 @@ instance {n} HasDeterminant (SkewSymmetricMap n)
   transpose' = \(MkSkewSymMap x). MkSkewSymMap (-x)
   identity' = error "Skew symmetric matrices can't represent the identity map."
 
-instance {n v} [Mul v, VSpace v] LinearEndo (SkewSymmetricMap n) (n=>v)
+instance LinearEndo (SkewSymmetricMap n) (n=>v) given {n v} [Mul v, VSpace v]
   apply  = \(MkSkewSymMap x) y. skew_symmetric_prod x y
   diag   = \(MkSkewSymMap x).   zero
   solve' = \(MkSkewSymMap x) y.
     dense_rep = skew_symmetric_prod x eye  -- Fall back to naive algorithm
     solve dense_rep y
 
-instance {n} Arbitrary (SkewSymmetricMap n)
+instance Arbitrary (SkewSymmetricMap n) given {n}
   arb = \k. MkSkewSymMap $ arb k
 
 
@@ -172,7 +172,7 @@ interface HasStandardNormal a:Type
 
 instance HasStandardNormal Float32
   randNormal = randn
-instance {a n} [HasStandardNormal a] HasStandardNormal (n=>a)
+instance HasStandardNormal (n=>a) given {a n} [HasStandardNormal a]
   randNormal = \key.
     for i. randNormal (ixkey key i)
 

--- a/examples/manifold-gradients.dx
+++ b/examples/manifold-gradients.dx
@@ -75,7 +75,7 @@ point $x$ as both the tangent space, and as a local chart.
 instance of a TangentSpace for vector spaces. In this case, we view the tangent
 space at $x$ to be just a copy of the vector space, centred on $x$.
 
-instance {a} [VSpace a] TangentSpace a a
+instance TangentSpace a a given {a} [VSpace a]
   tangentExponentialMap = \ p v . p + v
   tangentLogarithmMap = \ p q . q - p
 

--- a/examples/regression.dx
+++ b/examples/regression.dx
@@ -72,7 +72,7 @@ def lrToEither {a b} : Iso {left:a | right:b} (a|b) =
     Left x  -> {|left=x|}
     Right x -> {|right=x|}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {left:n | right:m}
+instance Ix {left:n | right:m} given {n m} [Ix n, Ix m] 
   size = size n + size m
   ordinal = ordinal <<< app_iso lrToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso lrToEither

--- a/examples/tutorial.dx
+++ b/examples/tutorial.dx
@@ -587,14 +587,14 @@ tableMean' [(1.0, 0.5), (0.5, 0.8)]
 ' tuple types.
 
 ' ```
-instance {v w} [Add v, Add w] Add (v & w)
+instance Add (v & w) given {v w} [Add v, Add w]
   add = \(x1,x2) (y1, y2). (x1 + y1, x2 + y2)
   zero = (zero, zero)
  
-instance {v w} [Sub v, Sub w] Sub (v & w)
+instance Sub (v & w) given {v w} [Sub v, Sub w]
   sub = \(x1,x2) (y1, y2). (x1 - y1, x2 - y2)
  
-instance {v w} [VSpace v, VSpace w] VSpace (v & w)
+instance VSpace (v & w) given {v w} [VSpace v, VSpace w]
   scale_vec = \s (x, y). (scale_vec s x, scale_vec s y)
 
 '## More Fashion MNist

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -70,7 +70,7 @@ def transpose_lower_to_upper_no_diag {n v}
 
 '## Type-shifting inequalities between indices
 
-instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIx m) (LowerTriIx n)
+instance Subset (LowerTriIx m) (LowerTriIx n) given {m n} [Ix n, Ix m, Subset m n]
   inject' = \(MkLowerTriIx i j).
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
@@ -88,7 +88,7 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIx m) (LowerTriIx n)
     j'' = unsafe_project m j'
     MkLowerTriIx i' $ unsafe_project _ j''
 
-instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIx m) (UpperTriIx n)
+instance Subset (UpperTriIx m) (UpperTriIx n) given {m n} [Ix n, Ix m, Subset m n]
   inject' = \(MkUpperTriIx i j).
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
@@ -106,7 +106,7 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIx m) (UpperTriIx n)
     j'' = unsafe_project m j'
     MkUpperTriIx i' $ unsafe_project _ j''
 
-instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIxExc m) (LowerTriIxExc n)
+instance Subset (LowerTriIxExc m) (LowerTriIxExc n) given {m n} [Ix n, Ix m, Subset m n]
   inject' = \(MkLowerTriIxExc i j).
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j
@@ -124,7 +124,7 @@ instance {m n} [Ix n, Ix m, Subset m n] Subset (LowerTriIxExc m) (LowerTriIxExc 
     j'' = unsafe_project m j'
     MkLowerTriIxExc i' $ unsafe_project _ j''
 
-instance {m n} [Ix n, Ix m, Subset m n] Subset (UpperTriIxExc m) (UpperTriIxExc n)
+instance Subset (UpperTriIxExc m) (UpperTriIxExc n) given {m n} [Ix n, Ix m, Subset m n]
   inject' = \(MkUpperTriIxExc i j).
     i' = inject n i
     j' = unsafe_project _ $ inject n $ inject m j

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -217,10 +217,10 @@ instance Add Unit
 instance Sub Unit
   sub = \x y. ()
 
-instance {n a} [Add a] Add (n->a)
+instance Add (n->a) given {n a} [Add a]
   add = \f g. \x. (f x) + (g x)
   zero = \x. zero
-instance {n a} [Sub a] Sub (n->a)
+instance Sub (n->a) given {n a} [Sub a]
   sub = \f g. \x. (f x) - (g x)
 
 '#### Mul
@@ -269,7 +269,7 @@ instance Mul Unit
   mul = \x y. ()
   one = ()
 
-instance {n a} [Mul a] Mul (n->a)
+instance Mul (n->a) given {n a} [Mul a]
   mul = \f g. \x. (f x) * (g x)
   one = \x. one
 
@@ -350,22 +350,22 @@ data RangeTo q:Type i:q = UnsafeMkRangeTo Nat
 -- `(..<i)` parses as `RangeToExc _ i`
 data RangeToExc q:Type i:q = UnsafeMkRangeToExc Nat
 
-instance {q:Type} {i:q} [Ix q] Ix (RangeFrom q i)
+instance Ix (RangeFrom q i) given {q:Type} {i:q} [Ix q]
   size = unsafe_nat_diff (size q) (ordinal i)
   ordinal = \(UnsafeMkRangeFrom j). j
   unsafe_from_ordinal = \j. UnsafeMkRangeFrom j
 
-instance {q:Type} {i:q} [Ix q] Ix (RangeFromExc q i)
+instance Ix (RangeFromExc q i) given {q:Type} {i:q} [Ix q]
   size = unsafe_nat_diff (size q) (ordinal i + 1)
   ordinal = \(UnsafeMkRangeFromExc j). j
   unsafe_from_ordinal = \j. UnsafeMkRangeFromExc j
 
-instance {q:Type} {i:q} [Ix q] Ix (RangeTo q i)
+instance Ix (RangeTo q i) given {q:Type} {i:q} [Ix q]
   size = ordinal i + 1
   ordinal = \(UnsafeMkRangeTo j). j
   unsafe_from_ordinal = \j. UnsafeMkRangeTo j
 
-instance {q:Type} {i:q} [Ix q] Ix (RangeToExc q i)
+instance Ix (RangeToExc q i) given {q:Type} {i:q} [Ix q]
   size = ordinal i
   ordinal = \(UnsafeMkRangeToExc j). j
   unsafe_from_ordinal = \j. UnsafeMkRangeToExc j
@@ -379,37 +379,37 @@ def iota (n:Type) [Ix n] : n=>Nat = view i. ordinal i
 
 '## Arithmetic instances for table types
 
-instance {a n} [Add a] Add (n=>a)
+instance Add (n=>a) given {a n} [Add a]
   add = \xs ys. for i. xs.i + ys.i
   zero = for _. zero
-instance {a n} [Sub a] Sub (n=>a)
+instance Sub (n=>a) given {a n} [Sub a]
   sub = \xs ys. for i. xs.i - ys.i
 
-instance {a n} [Add a] Add ((i:n) => (i..) => a)  -- Upper triangular tables
+instance Add ((i:n) => (i..) => a) given {a n} [Add a]  -- Upper triangular tables
   add = \xs ys. for i. xs.i + ys.i
   zero = for _. zero
-instance {a n} [Sub a] Sub ((i:n) => (i..) => a)  -- Upper triangular tables
+instance Sub ((i:n) => (i..) => a) given {a n} [Sub a]  -- Upper triangular tables
   sub = \xs ys. for i. xs.i - ys.i
 
-instance {a n} [Add a] Add ((i:n) => (..i) => a)  -- Lower triangular tables
+instance Add ((i:n) => (..i) => a) given {a n} [Add a]  -- Lower triangular tables
   add = \xs ys. for i. xs.i + ys.i
   zero = for _. zero
-instance {a n} [Sub a] Sub ((i:n) => (..i) => a)  -- Lower triangular tables
+instance Sub ((i:n) => (..i) => a) given {a n} [Sub a]  -- Lower triangular tables
   sub = \xs ys. for i. xs.i - ys.i
 
-instance {a n} [Add a] Add ((i:n) => (..<i) => a)
+instance Add ((i:n) => (..<i) => a) given {a n} [Add a]
   add = \xs ys. for i. xs.i + ys.i
   zero = for _. zero
-instance {a n} [Sub a] Sub ((i:n) => (..<i) => a)
+instance Sub ((i:n) => (..<i) => a) given {a n} [Sub a]
   sub = \xs ys. for i. xs.i - ys.i
 
-instance {a n} [Add a] Add ((i:n) => (i<..) => a)
+instance Add ((i:n) => (i<..) => a) given {a n} [Add a]
   add = \xs ys. for i. xs.i + ys.i
   zero = for _. zero
-instance {a n} [Sub a] Sub ((i:n) => (i<..) => a)
+instance Sub ((i:n) => (i<..) => a) given {a n} [Sub a]
   sub = \xs ys. for i. xs.i - ys.i
 
-instance {a n} [Mul a] Mul (n=>a)
+instance Mul (n=>a) given {a n} [Mul a]
   mul = \xs ys. for i. xs.i * ys.i
   one = for _. one
 
@@ -421,14 +421,14 @@ def fst {a b} ((x, _): (a & b)) : a = x
 def snd {a b} ((_, y): (a & b)) : b = y
 def swap {a b} ((x, y):(a&b)) : (b&a) = (y, x)
 
-instance {a b} [Add a, Add b] Add (a & b)
+instance Add (a & b) given {a b} [Add a, Add b]
   add = \(a, b) (c, d). ( (a + c), (b + d))
   zero = (zero, zero)
 
-instance {a b} [Sub a, Sub b] Sub (a & b)
+instance Sub (a & b) given {a b} [Sub a, Sub b]
   sub = \(a, b) (c, d). ( (a - c), (b - d))
 
-instance {a b} [Ix a, Ix b] Ix (a & b)
+instance Ix (a & b) given {a b} [Ix a, Ix b]
   size = size a * size b
   ordinal = \(i, j). (ordinal i * size b) + ordinal j
   unsafe_from_ordinal = \o.
@@ -455,25 +455,25 @@ def neg  {a} [VSpace a] (v:a) : a = (-1.0) .* v
 instance VSpace Float
   scale_vec = \x y. x * y
 
-instance {a n} [VSpace a] VSpace (n=>a)
+instance VSpace (n=>a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance {a b} [VSpace a, VSpace b] VSpace (a & b)
+instance VSpace (a & b) given {a b} [VSpace a, VSpace b]
   scale_vec = \ s (a, b) . (scale_vec s a, scale_vec s b)
 
-instance {a n} [VSpace a] VSpace ((i:n) => (..i) => a)
+instance VSpace ((i:n) => (..i) => a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance {a n} [VSpace a] VSpace ((i:n) => (i..) => a)
+instance VSpace ((i:n) => (i..) => a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance {a n} [VSpace a] VSpace ((i:n) => (..<i) => a)
+instance VSpace ((i:n) => (..<i) => a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance {a n} [VSpace a] VSpace ((i:n) => (i<..) => a)
+instance VSpace ((i:n) => (i<..) => a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance {a n} [VSpace a] VSpace (n->a)
+instance VSpace (n->a) given {a n} [VSpace a]
   scale_vec = \s f. \x. s .* (f x)
 
 instance VSpace Unit
@@ -548,7 +548,7 @@ data (|) a b =
   Left  a
   Right b
 
-instance {a b} [Ix a, Ix b] Ix (a | b)
+instance Ix (a | b) given {a b} [Ix a, Ix b]
   size = size a + size b
   ordinal = \i. case i of
     Left ai  -> ordinal ai
@@ -580,7 +580,7 @@ def i_to_n (x:Int) : Maybe Nat =
 
 data Post segment:Type = UnsafeMkPost Nat
 
-instance {segment} [Ix segment] Ix (Post segment)
+instance Ix (Post segment) given {segment} [Ix segment]
   size = size segment + 1
   ordinal = \(UnsafeMkPost i). i
   unsafe_from_ordinal = \i. UnsafeMkPost i
@@ -597,7 +597,7 @@ interface [Ix n] NonEmpty n
 def last_ix {n} [NonEmpty n] : n =
   unsafe_from_ordinal _ $ unsafe_i_to_n $ n_to_i (size n) - 1
 
-instance {n} [Ix n] NonEmpty (Post n)
+instance NonEmpty (Post n) given {n} [Ix n]
   first_ix = unsafe_from_ordinal (Post n) 0
 
 instance NonEmpty Unit
@@ -618,7 +618,7 @@ interface Monoid a
 
 def (<>) {a} [Monoid a] : a -> a -> a = mcombine
 
-instance {a n} [Monoid a] Monoid (n=>a)
+instance Monoid (n=>a) given {a n} [Monoid a]
   mempty = for i. mempty
   mcombine = \x y. for i. mcombine x.i y.i
 
@@ -630,11 +630,11 @@ named-instance OrMonoid : Monoid Bool
   mempty = False
   mcombine = (||)
 
-named-instance AddMonoid : (a:Type) [Add a] Monoid a
+named-instance AddMonoid : Monoid a given (a:Type) [Add a]
   mempty = zero
   mcombine = add
 
-named-instance MulMonoid : (a:Type) [Mul a] Monoid a
+named-instance MulMonoid : Monoid a given (a:Type) [Mul a]
   mempty = one
   mcombine = mul
 
@@ -652,7 +652,7 @@ data AccumMonoidData h w =
 interface AccumMonoid h w
   getAccumMonoidData : AccumMonoidData h w
 
-instance {n h w} [Ix n] [am : AccumMonoid h w] AccumMonoid h (n=>w)
+instance AccumMonoid h (n=>w) given {n h w} [Ix n] [am : AccumMonoid h w]
   getAccumMonoidData =
     (UnsafeMkAccumMonoidData b bm) = %projMethod0 am
     UnsafeMkAccumMonoidData b bm
@@ -787,7 +787,7 @@ instance Eq Bool
 instance Eq Unit
   (==) = \x y. True
 
-instance {a b} [Eq a, Eq b] Eq (a | b)
+instance Eq (a | b) given {a b} [Eq a, Eq b]
   (==) = \x y. case x of
     Left x -> case y of
       Left y -> x == y
@@ -796,7 +796,7 @@ instance {a b} [Eq a, Eq b] Eq (a | b)
       Left y -> False
       Right y -> x == y
 
-instance {a} [Eq a] Eq (Maybe a)
+instance Eq (Maybe a) given {a} [Eq a]
   (==) = \x y. case x of
     Just x -> case y of
       Just y -> x == y
@@ -840,10 +840,10 @@ instance Ord Unit
   (>) = \x y. False
   (<) = \x y. False
 
-instance {a b} [Eq a, Eq b] Eq (a & b)
+instance Eq (a & b) given {a b} [Eq a, Eq b]
   (==) = \(x1,x2) (y1,y2). x1 == y1 && x2 == y2
 
-instance {a b} [Ord a, Ord b] Ord (a & b)
+instance Ord (a & b) given {a b} [Ord a, Ord b]
   (>) = \(x1,x2) (y1,y2). x1 > y1 || (x1 == y1 && x2 > y2)
   (<) = \(x1,x2) (y1,y2). x1 < y1 || (x1 == y1 && x2 < y2)
 
@@ -859,10 +859,10 @@ instance Ord Nat
   (<) = \x y. nat_to_rep x < nat_to_rep y
 
 -- TODO: we want Eq and Ord for all index sets, not just `Fin n`
-instance {n} Eq (Fin n)
+instance Eq (Fin n) given {n}
   (==) = \x y. ordinal x == ordinal y
 
-instance {n} Ord (Fin n)
+instance Ord (Fin n) given {n}
   (>) = \x y. ordinal x > ordinal y
   (<) = \x y. ordinal x < ordinal y
 
@@ -873,7 +873,7 @@ instance Ix Bool
     True -> 1
   unsafe_from_ordinal = \i. i > 0
 
-instance {a} [Ix a] Ix (Maybe a)
+instance Ix (Maybe a) given {a} [Ix a]
   size = size a + 1
   ordinal = \i. case i of
     Just ai -> ordinal ai
@@ -886,18 +886,18 @@ instance {a} [Ix a] Ix (Maybe a)
 instance NonEmpty Bool
   first_ix = unsafe_from_ordinal _ 0
 
-instance {a b} [NonEmpty a, NonEmpty b] NonEmpty (a & b)
+instance NonEmpty (a & b) given {a b} [NonEmpty a, NonEmpty b]
   first_ix = unsafe_from_ordinal _ 0
 
-instance {a b} [Ix b, NonEmpty a] NonEmpty (a|b)
+instance NonEmpty (a|b) given {a b} [Ix b, NonEmpty a]
   first_ix = unsafe_from_ordinal _ 0
 
 -- The below instance is valid, but causes "multiple candidate dictionaries"
 -- errors if both Left and Right are NonEmpty.
--- instance {a b} [Ix a, NonEmpty b] NonEmpty (a|b)
+-- instance NonEmpty (a|b) given {a b} [Ix a, NonEmpty b]
 --  first_ix = unsafe_from_ordinal _ 0
 
-instance {a} [Ix a] NonEmpty (Maybe a)
+instance NonEmpty (Maybe a) given {a} [Ix a]
   first_ix = unsafe_from_ordinal _ 0
 
 def scan {a b n} [Ix n] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
@@ -924,12 +924,12 @@ instance Monoid Ordering
       GT -> GT
       EQ -> y
 
-instance {a n} [Eq a] Eq (n=>a)
+instance Eq (n=>a) given {a n} [Eq a]
   (==) = \xs ys.
     yield_accum AndMonoid \ref.
       for i. ref += xs.i == ys.i
 
-instance {a n} [Ord a] Ord (n=>a)
+instance Ord (n=>a) given {a n} [Ord a]
   (>) = \xs ys.
     f: Ordering =
         fold EQ $ \i c. c <> (compare xs.i ys.i)
@@ -955,7 +955,7 @@ def unsafe_project {a} (a_sub:Type) [Subset a_sub a] (x:a) : a_sub =
 def inject {a_sub} (a:Type) [Subset a_sub a] (x:a_sub) : a =
   inject' x
 
-instance {a b c} [Subset a b, Subset b c] Subset a c
+instance Subset a c given {a b c} [Subset a b, Subset b c]
   inject' = \x. inject c $ inject b x
   project' = \x. case project b x of
     Nothing -> Nothing
@@ -965,7 +965,7 @@ instance {a b c} [Subset a b, Subset b c] Subset a c
 def unsafe_project_rangefrom {q:Type} {i:q} [Ix q] (j:q) : RangeFrom q i =
   UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
 
-instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
+instance Subset (RangeFrom q i) q given {q:Type} {i:q} [Ix q]
   inject' = \(UnsafeMkRangeFrom j).
     unsafe_from_ordinal _ $ j + ordinal i
   project' = \j.
@@ -976,7 +976,7 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeFrom q i) q
       else Just $ UnsafeMkRangeFrom $ unsafe_nat_diff j' i'
   unsafe_project' = \j. UnsafeMkRangeFrom $ unsafe_nat_diff (ordinal j) (ordinal i)
 
-instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
+instance Subset (RangeFromExc q i) q given {q:Type} {i:q} [Ix q]
   inject' = \(UnsafeMkRangeFromExc j).
     unsafe_from_ordinal _ $ j + ordinal i + 1
   project' = \j.
@@ -988,7 +988,7 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeFromExc q i) q
   unsafe_project' = \j.
     UnsafeMkRangeFromExc $ unsafe_nat_diff (ordinal j) (ordinal i + 1)
 
-instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
+instance Subset (RangeTo q i) q given {q:Type} {i:q} [Ix q]
   inject' = \(UnsafeMkRangeTo j). unsafe_from_ordinal _ j
   project' = \j.
     j' = ordinal j
@@ -998,7 +998,7 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeTo q i) q
       else Just $ UnsafeMkRangeTo j'
   unsafe_project' = \j. UnsafeMkRangeTo (ordinal j)
 
-instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
+instance Subset (RangeToExc q i) q given {q:Type} {i:q} [Ix q]
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
   project' = \j.
     j' = ordinal j
@@ -1008,7 +1008,7 @@ instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) q
       else Just $ UnsafeMkRangeToExc j'
   unsafe_project' = \j. UnsafeMkRangeToExc (ordinal j)
 
-instance {q:Type} {i:q} [Ix q] Subset (RangeToExc q i) (RangeTo q i)
+instance Subset (RangeToExc q i) (RangeTo q i) given {q:Type} {i:q} [Ix q]
   inject' = \(UnsafeMkRangeToExc j). unsafe_from_ordinal _ j
   project' = \j.
     j' = ordinal j
@@ -1142,7 +1142,7 @@ instance Storable Nat
   load  = \(MkPtr ptr)  . rep_to_nat $ load (MkPtr ptr)
   storage_size = storage_size NatRep
 
-instance {a} Storable (Ptr a)
+instance Storable (Ptr a) given {a}
   store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internal_cast %PtrPtr ptr) x
   load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internal_cast %PtrPtr ptr)
   storage_size = 8  -- TODO: something more portable?
@@ -1203,7 +1203,7 @@ def mod {a} [Add a, Integral a] (x:a) (y:a) : a = rem (y + rem x y) y
 
 '## Table Operations
 
-instance {a n} [Floating a] Floating (n=>a)
+instance Floating (n=>a) given {a n} [Floating a]
   exp    = map exp
   exp2   = map exp2
   log    = map log
@@ -1357,19 +1357,19 @@ instance HasDefaultTolerance Float64
   atol = f_to_f64 0.00000001
   rtol = f_to_f64 0.00001
 
-instance {a b} [HasDefaultTolerance a, HasDefaultTolerance b,
-                HasAllClose a, HasAllClose b] HasAllClose (a & b)
+instance HasAllClose (a & b) given {a b} [ HasDefaultTolerance a, HasDefaultTolerance b
+                                         , HasAllClose a, HasAllClose b] 
   allclose = \atol rtol (a, b) (c, d). (a ~~ c) && (b ~~ d)
 
-instance {a b} [HasDefaultTolerance a, HasDefaultTolerance b] HasDefaultTolerance (a & b)
+instance HasDefaultTolerance (a & b) given {a b} [HasDefaultTolerance a, HasDefaultTolerance b]
   atol = (atol, atol)
   rtol = (rtol, rtol)
 
-instance {n t} [HasAllClose t] HasAllClose (n=>t)
+instance HasAllClose (n=>t) given {n t} [HasAllClose t]
   allclose = \atol rtol a b.
     all for i:n. allclose atol.i rtol.i a.i b.i
 
-instance {n t} [HasDefaultTolerance t] HasDefaultTolerance (n=>t)
+instance HasDefaultTolerance (n=>t) given {n t} [HasDefaultTolerance t]
   atol = for i. atol
   rtol = for i. rtol
 
@@ -1390,7 +1390,7 @@ def check_deriv (f:Float->Float) (x:Float) : Bool =
 data List a =
   AsList n:Nat elements:(Fin n => a)
 
-instance {a} [Eq a] Eq (List a)
+instance Eq (List a) given {a} [Eq a]
   (==) = \(AsList nx xs) (AsList ny ys).
     if nx /= ny
       then False
@@ -1404,7 +1404,7 @@ def to_list {n a} (xs:n=>a) : List a =
   n' = size n
   AsList _ $ unsafe_cast_table (Fin n') xs
 
-instance {a} Monoid (List a)
+instance Monoid (List a) given {a}
   mempty = AsList _ []
   mcombine = \x y.
     (AsList nx xs) = x
@@ -1416,7 +1416,7 @@ instance {a} Monoid (List a)
         True  -> xs.(unsafe_from_ordinal _ i')
         False -> ys.(unsafe_from_ordinal _ $ unsafe_nat_diff i' nx)
 
-named-instance ListMonoid : (a:Type) Monoid (List a)
+named-instance ListMonoid : Monoid (List a) given (a:Type)
   mempty = mempty
   mcombine = mcombine
 
@@ -1646,7 +1646,7 @@ instance Show Float64
     (n, ptr) = showFloat64 x
     string_from_char_ptr n $ MkPtr ptr
 
-instance {a b} [Show a, Show b] Show (a & b)
+instance Show (a & b) given {a b} [Show a, Show b]
   show = \(a, b). "(" <> show a <> ", " <> show b <> ")"
 
 '### Parse interface
@@ -2046,7 +2046,7 @@ interface [VSpace v] InnerProd v
 instance InnerProd Float
   inner_prod = \x y. x * y
 
-instance {a n} [InnerProd a] InnerProd (n=>a)
+instance InnerProd (n=>a) given {a n} [InnerProd a]
   inner_prod = \x y. sum for i. inner_prod x.i y.i
 
 
@@ -2068,27 +2068,27 @@ instance Arbitrary Int32
 instance Arbitrary Nat
   arb = \key. f_to_n $ randn key * 5.0
 
-instance {n a} [Arbitrary a] Arbitrary (n=>a)
+instance Arbitrary (n=>a) given {n a} [Arbitrary a]
   arb = \key. for i. arb $ ixkey key i
 
-instance {n a} [Arbitrary a] Arbitrary ((i:n)=>(..<i) => a)
+instance Arbitrary ((i:n)=>(..<i) => a) given {n a} [Arbitrary a]
   arb = \x. for i. arb $ new_key (ordinal i)
 
-instance {n a} [Arbitrary a] Arbitrary ((i:n)=>(..i) => a)
+instance Arbitrary ((i:n)=>(..i) => a) given {n a} [Arbitrary a]
   arb = \x. for i. arb $ new_key (ordinal i)
 
-instance {n a} [Arbitrary a] Arbitrary ((i:n)=>(i..) => a)
+instance Arbitrary ((i:n)=>(i..) => a) given {n a} [Arbitrary a]
   arb = \x. for i. arb $ new_key (ordinal i)
 
-instance {n a} [Arbitrary a] Arbitrary ((i:n)=>(i<..) => a)
+instance Arbitrary ((i:n)=>(i<..) => a) given {n a} [Arbitrary a]
   arb = \x. for i. arb $ new_key (ordinal i)
 
-instance {a b} [Arbitrary a, Arbitrary b] Arbitrary (a & b)
+instance Arbitrary (a & b) given {a b} [Arbitrary a, Arbitrary b]
   arb = \key.
     [k1, k2] = split_key key
     (arb k1, arb k2)
 
-instance {n} Arbitrary (Fin n)
+instance Arbitrary (Fin n) given {n}
   arb = rand_idx
 
 '## Ord on Arrays
@@ -2170,7 +2170,7 @@ def lexical_order {n} [Ord n]
             True -> Continue
             False -> Done False
 
-instance {n} [Ord n] Ord (List n)
+instance Ord (List n) given {n} [Ord n]
   (>) = lexical_order (>) (>)
   (<) = lexical_order (<) (<)
 
@@ -2440,7 +2440,7 @@ def assert (b:Bool) : {Except} Unit =
 
 '### Misc instances that require `error`
 
-instance {a b} Subset a (a|b)
+instance Subset a (a|b) given {a b}
   inject' = \x. Left x
   project' = \x. case x of
     Left  y -> Just y
@@ -2449,7 +2449,7 @@ instance {a b} Subset a (a|b)
     Left  x -> x
     Right x -> error "Can't project Right branch to Left branch"
 
-instance {a b} Subset a (b|a)
+instance Subset a (b|a) given {a b}
   inject' = \x. Right x
   project' = \x. case x of
     Left  x -> Nothing
@@ -2483,12 +2483,12 @@ def reversed_digits_to_int {a b} [Ix a, Ix b] (digits: a=>b) : Nat =
     next_base = cur_base * base
     (next_k, next_base)
 
-instance {a b} [Ix a, Ix b] Ix (a=>b)
+instance Ix (a=>b) given {a b} [Ix a, Ix b]
   -- 0@a is the least significant digit,
   -- while (size a - 1)@a is the most significant digit.
   size = intpow (size b) (size a)
   ordinal             = reversed_digits_to_int
   unsafe_from_ordinal = int_to_reversed_digits
 
-instance {a b} [Ix a, NonEmpty b] NonEmpty (a=>b)
+instance NonEmpty (a=>b) given {a b} [Ix a, NonEmpty b]
   first_ix = unsafe_from_ordinal _ 0

--- a/lib/set.dx
+++ b/lib/set.dx
@@ -57,7 +57,7 @@ def to_set {n a} [Ord a] (xs:n=>a) : Set a =
 
 def set_size {a} ((UnsafeAsSet n _):Set a) : Nat = n
 
-instance {a} [Eq a] Eq (Set a)
+instance Eq (Set a) given {a} [Eq a]
   (==) = \(UnsafeAsSet _ xs) (UnsafeAsSet _ ys).
     (AsList _ xs) == (AsList _ ys)
 
@@ -87,12 +87,12 @@ def set_intersect {a}
 data StringSetIx l:(Set String) =
   MkSetIx Nat   -- TODO: Use (Fin (setSize l)) instead.
 
-instance {set} Ix (StringSetIx set)
+instance Ix (StringSetIx set) given {set}
   size = set_size set
   ordinal = \(MkSetIx i). i
   unsafe_from_ordinal = \k. MkSetIx k
 
-instance {set} Eq (StringSetIx set)
+instance Eq (StringSetIx set) given {set}
   (==) = \ix1 ix2. ordinal ix1 == ordinal ix2
 
 -- Todo: Add an interface for converting to and from integer indices.

--- a/lib/stats.dx
+++ b/lib/stats.dx
@@ -22,11 +22,11 @@ rather than relying on monoid reduction using `add`.
 
 data LogSpace f = Exp f
 
-instance {f} [Add f] Mul (LogSpace f)
+instance Mul (LogSpace f) given {f} [Add f]
   mul = \(Exp la) (Exp lb). Exp $ la + lb
   one = Exp zero
 
-instance {f} [Sub f] Fractional (LogSpace f)
+instance Fractional (LogSpace f) given {f} [Sub f]
   divide = \(Exp la) (Exp lb). Exp $ la - lb
 
 instance Arbitrary (LogSpace Float)
@@ -50,7 +50,7 @@ def log_add_exp {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] (la:f
         then la + log1p (exp (lb - la))
         else lb + log1p (exp (la - lb))
 
-instance {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f] Add (LogSpace f)
+instance Add (LogSpace f) given {f} [Floating f, Add f, Sub f, Mul f, Fractional f, Ord f]
   add = \(Exp la) (Exp lb). Exp $ log_add_exp la lb
   zero = Exp (zero - (divide one zero))
 

--- a/misc/dex.el
+++ b/misc/dex.el
@@ -10,7 +10,7 @@
     ("^'\\(.\\|\n.\\)*\n\n"  . font-lock-comment-face)
     ("\\w+:"                 . font-lock-comment-face)
     ("^:\\w*"                . font-lock-preprocessor-face)
-    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bdo\\b\\|\\bview\\b\\|\\bimport\\b\\|\\bforeign\\b" .
+    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bgiven\\b\\|\\bdo\\b\\|\\bview\\b\\|\\bimport\\b\\|\\bforeign\\b" .
            font-lock-keyword-face)
     ("--o"                               . font-lock-variable-name-face)
     ("[-.,!$^&*:~+/=<>|?\\\\]"           . font-lock-variable-name-face)

--- a/src/lib/Lexing.hs
+++ b/src/lib/Lexing.hs
@@ -65,7 +65,8 @@ checkNotKeyword p = try $ do
 
 data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
              | DataKW | InterfaceKW
-             | InstanceKW | IfKW | ThenKW | ElseKW | DoKW
+             | InstanceKW | GivenKW
+             | IfKW | ThenKW | ElseKW | DoKW
              | ViewKW | ImportKW | ForeignKW | NamedInstanceKW
              | EffectKW | HandlerKW | JmpKW | CtlKW | ReturnKW | ResumeKW
              | CustomLinearizationKW | CustomLinearizationSymbolicKW
@@ -87,6 +88,7 @@ keyWordToken = \case
   InterfaceKW     -> "interface"
   InstanceKW      -> "instance"
   NamedInstanceKW -> "named-instance"
+  GivenKW         -> "given"
   DoKW            -> "do"
   ViewKW          -> "view"
   ImportKW        -> "import"

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -1107,10 +1107,14 @@ instance Pretty CDecl' where
   pretty (CDef name args Nothing blk) =
     "def " <> fromString name <> " " <> pArg args <> " ="
       <> nest 2 (hardline <> p blk)
-  pretty (CInstance header methods name) =
-    case name of
-      Nothing  -> "instance " <> p header <> prettyLines methods
-      (Just n) -> "named-instance " <> p n <+> p header <> prettyLines methods
+  pretty (CInstance header givens methods name) =
+    name' <> p header <> givens' <> prettyLines methods where
+    name' = case name of
+      Nothing  -> "instance "
+      (Just n) -> "named-instance " <> p n <> " "
+    givens' = case givens of
+      (WithSrc _ CEmpty) -> ""
+      _ -> " given" <+> p givens <> " "
   pretty (CExpr e) = p e
 
 instance Pretty CBlock where

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -552,7 +552,7 @@ def wbToEither {a b} : Iso {weights:a | biases:b} (a|b) =
     Right x -> {|biases=x|}
   MkIso {fwd, bwd}
 
-instance {n m} [Ix n, Ix m] Ix {weights:n | biases:m}
+instance Ix {weights:n | biases:m} given {n m} [Ix n, Ix m]
   size = size n + size m
   ordinal = ordinal <<< app_iso wbToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso wbToEither

--- a/tests/record-variant-tests.dx
+++ b/tests/record-variant-tests.dx
@@ -313,7 +313,7 @@ def abToPair {a b} : Iso {a:a & b:b} (b&a) =
   fwd = \({a, b}). (b, a)
   bwd = \(b, a). {a, b}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {a:n & b:m}
+instance Ix {a:n & b:m} given {n m} [Ix n, Ix m]
   size = size n * size m
   ordinal = ordinal <<< app_iso abToPair
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToPair
@@ -345,7 +345,7 @@ def abToEither {a b} : Iso {a:a | b:b} (a|b) =
     Left x  -> {|a=x|}
     Right x -> {|b=x|}
   MkIso {fwd, bwd}
-instance {n m} [Ix n, Ix m] Ix {a:n | b:m}
+instance Ix {a:n | b:m} given {n m} [Ix n, Ix m]
   size = size n + size m
   ordinal = ordinal <<< app_iso abToEither
   unsafe_from_ordinal = unsafe_from_ordinal _ >>> rev_iso abToEither

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -96,9 +96,9 @@ def deriveDFromF {a} [F a] (x:a) : Int = d_ x
 -- Overlapping instances
 instance A Int
   a_ = \x. 1
-instance {n a} [A a] A (n=>a)
+instance A (n=>a) given {n a} [A a]
   a_ = \x. a_ x.(0@_)
-instance {n} A (n=>Int)
+instance A (n=>Int) given {n}
   a_ = \x. 0
 
 -- There are two derivations for n=>Int
@@ -124,11 +124,11 @@ interface Eq' a
 interface [Eq' a] Ord' a
   ord : a -> Int
 
-instance {n} Eq' (n=>Int)
+instance Eq' (n=>Int) given {n}
   eq = const 2
-instance {n a} [Eq' a] Eq' (n=>a)
+instance Eq' (n=>a) given {n a} [Eq' a]
   eq = const 3
-instance {n a} [Ord' a] Ord' (n=>a)
+instance Ord' (n=>a) given {n a} [Ord' a]
   ord = const 4
 
 -- Simplifiable constraints should be accepted
@@ -192,7 +192,7 @@ def q4 {a5} (x : a5) : MyPairOfXs a5 = (x, x)
 -- Check automatic quantification for interfaces
 interface AutoQuant a
   dummy : Int
-instance {a} AutoQuant (MyPairOfXs a)
+instance AutoQuant (MyPairOfXs a) given {a}
   dummy = 1
 
 -- Should be able to quantify nested constraints


### PR DESCRIPTION
Update the corpus to the new syntax.

Fixes #926.