### PR TITLE
Run ghcup before building dex on macOS

### DIFF
--- a/.github/workflows/haskell-ci.yaml
+++ b/.github/workflows/haskell-ci.yaml
@@ -31,16 +31,12 @@ jobs:
     - name: Checkout the repository
       uses: actions/checkout@v2
 
-    - name: Install system dependencies
-      run: |
-        ${{ matrix.install_deps }}
-        echo "${{ matrix.path_extension }}" >> $GITHUB_PATH
-
     - name: Cache
       uses: actions/cache@v2
       with:
         path: |
           ~/.stack
+          ~/.ghcup/ghc/8.10.7
           $GITHUB_WORKSPACE/.stack-work
           $GITHUB_WORKSPACE/.stack-work-test
           $GITHUB_WORKSPACE/examples/t10k-images-idx3-ubyte
@@ -48,6 +44,12 @@ jobs:
 
         key: ${{ runner.os }}-v5-${{ hashFiles('**/*.cabal', 'stack*.yaml') }}
         restore-keys: ${{ runner.os }}-v5-
+
+    - name: Install system dependencies
+      run: |
+        ${{ matrix.install_deps }}
+        if [[ "$OSTYPE" == "darwin"* ]]; then ghcup install ghc 8.10.7; fi
+        echo "${{ matrix.path_extension }}" >> $GITHUB_PATH
 
     # This step is a workaround.
     # See issue for context: https://github.com/actions/cache/issues/445


### PR DESCRIPTION
On the macOS runners stack seems to be installed via ghcup. The first time we run `make build`, the ghcup wrapper seems to want to install GHC 8.10.7, which leads to cache errors during subsequent stack invocations. I have no clue what's going on, but this seems to be enough to fix it.