### PR TITLE
Use ObjectLinkingLayer on macOS

### DIFF
--- a/src/lib/LLVM/Link.hs
+++ b/src/lib/LLVM/Link.hs
@@ -26,7 +26,11 @@ import qualified LLVM.Shims
 
 data Linker = Linker
   { linkerExecutionSession :: OrcJIT.ExecutionSession
+#ifdef darwin_HOST_OS
+  , linkerLinkLayer        :: OrcJIT.ObjectLinkingLayer
+#else
   , linkerLinkLayer        :: OrcJIT.RTDyldObjectLinkingLayer
+#endif
   , _linkerTargetMachine   :: Target.TargetMachine
    -- We ought to just need the link layer and the mangler but but llvm-hs
    -- requires a full `IRCompileLayer` for incidental reasons. TODO: fix.
@@ -50,7 +54,11 @@ createLinker = do
   -- TODO: should this be a parameter to `createLinker` instead?
   tm <- LLVM.Shims.newDefaultHostTargetMachine
   s         <- OrcJIT.createExecutionSession
+#ifdef darwin_HOST_OS
+  linkLayer <- OrcJIT.createObjectLinkingLayer s
+#else
   linkLayer <- OrcJIT.createRTDyldObjectLinkingLayer s
+#endif
   dylib     <- OrcJIT.createJITDylib s "main_dylib"
   compileLayer <- OrcJIT.createIRCompileLayer s linkLayer tm
   OrcJIT.addDynamicLibrarySearchGeneratorForCurrentProcess compileLayer dylib

--- a/src/lib/LLVM/Shims.hs
+++ b/src/lib/LLVM/Shims.hs
@@ -56,7 +56,13 @@ newTargetMachine (Target.Target targetFFI) triple cpu features
 -- TODO: Consider changing the linking layer, as suggested in:
 --       http://llvm.1065342.n5.nabble.com/llvm-dev-ORC-JIT-Weekly-5-td135203.html
 newDefaultHostTargetMachine :: IO Target.TargetMachine
-newDefaultHostTargetMachine = LLVM.Shims.newHostTargetMachine R.PIC CM.Large CGO.Aggressive
+newDefaultHostTargetMachine = LLVM.Shims.newHostTargetMachine R.PIC cm CGO.Aggressive
+  where
+#if darwin_HOST_OS
+    cm = CM.Small
+#else
+    cm = CM.Large
+#endif
 
 newHostTargetMachine :: R.Model -> CM.Model -> CGO.Level -> IO Target.TargetMachine
 newHostTargetMachine relocModel codeModel cgoLevel = do

--- a/stack-macos.yaml
+++ b/stack-macos.yaml
@@ -11,7 +11,7 @@ packages:
 
 extra-deps:
   - github: llvm-hs/llvm-hs
-    commit: d694c1a0d8941591dffb8c2f7877712e04ab3e7e
+    commit: 423220bffac4990d019fc088c46c5f25310d5a33
     subdirs:
       - llvm-hs
       - llvm-hs-pure

--- a/stack.yaml
+++ b/stack.yaml
@@ -11,7 +11,7 @@ packages:
 
 extra-deps:
   - github: llvm-hs/llvm-hs
-    commit: d694c1a0d8941591dffb8c2f7877712e04ab3e7e
+    commit: 423220bffac4990d019fc088c46c5f25310d5a33
     subdirs:
       - llvm-hs
       - llvm-hs-pure


### PR DESCRIPTION
ObjectLinkingLayer is an OrcJIT interface to the new JITLink LLVM library. It's supposed to be able to handle much more than the old RuntimeDyld system, like relocations for code using the small code model (see [this](https://llvm.org/docs/JITLink.html#runtimedyld) for a list of restriction).

Unfortunately, we're still on LLVM 12 and at that time the support for ELF relations in ObjectLinkingLayer (which are used on Linux) were rather limited, so we can't always used it as a default. But the macOS (or really MachO) support was much farther along, so we should be able to already make the switch. We can likely remove the conditionals once we update to LLVM 15.