### PR TITLE
Don't execute :p and :html commands when loading libraries.

### DIFF
--- a/lib/diagram.dx
+++ b/lib/diagram.dx
@@ -230,24 +230,29 @@ render_scaled_svg = \d. render_svg d (compute_bounds d)
 move_x : Float -> Diagram -> Diagram = \x. move_xy (x, 0.0)
 move_y : Float -> Diagram -> Diagram = \y. move_xy (0.0, y)
 
-' A Demo showing all kind of features
-```
-mydiagram : Diagram =
-    (  (circle 7.0 |> move_xy (20.0, 20.0) |> setFillColor blue |> setStrokeColor red)
-    <> (circle 5.0 |> move_xy (40.0, 41.0))
-    <> (rect  10.0 20.0 |> move_xy (5.0, 10.0) |> setStrokeColor red)
-    <> (text "DexLang"  |> move_xy (30.0, 10.0) |> setStrokeColor green)
-    <> (pointDiagram |> move_xy (15.0, 5.0) |> setStrokeColor red)
-    )
-:html renderScaledSVG mydiagram
-```
+'## Demos
 
-' Another demo that shows things are all center aligned:
-```
-concentric_diagram : Diagram = (
-     (rect 2.0 2.0 |> setFillColor red)
-  <> (circle 1.0 |> setFillColor blue)
-  <> (text "DexLang" |> setStrokeColor white)
-) |> move_xy (5.0, 5.0)
-:html renderScaledSVG concentric_diagram
-```
+'A generic diagram
+
+:html
+  mydiagram : Diagram = (
+     (circle 7.0 |> move_xy (20.0, 20.0)
+       |> set_fill_color blue |> set_stroke_color red)
+  <> (circle 5.0 |> move_xy (40.0, 41.0))
+  <> (rect  10.0 20.0 |> move_xy (5.0, 10.0) |> set_stroke_color red)
+  <> (text "DexLang"  |> move_xy (30.0, 10.0) |> set_stroke_color green)
+  <> (point_diagram |> move_xy (15.0, 5.0) |> set_stroke_color red)
+  )
+  render_scaled_svg mydiagram
+> <html output>
+
+'Another diagram, showing things are all center aligned
+
+:html
+  concentric_diagram : Diagram = (
+       (rect 2.0 2.0 |> set_fill_color red)
+    <> (circle 1.0 |> set_fill_color blue)
+    <> (text "DexLang" |> set_stroke_color white)
+  ) |> move_xy (5.0, 5.0)
+  render_scaled_svg concentric_diagram
+> <html output>

--- a/makefile
+++ b/makefile
@@ -216,6 +216,8 @@ test-names = uexpr-tests adt-tests type-tests cast-tests eval-tests show-tests \
 
 doc-names = conditionals functions
 
+lib-names = complex fft netpbm plot sort diagram linalg parser png set stats
+
 benchmark-names = \
   fused_sum gaussian jvp_matmul matmul_big matmul_small matvec_big matvec_small \
   poly vjp_matmul
@@ -224,10 +226,12 @@ quine-test-targets = \
   $(test-names:%=run-tests/%) \
   $(example-names:%=run-examples/%) \
   $(doc-names:%=run-doc/%) \
+  $(lib-names:%=run-lib/%) \
   $(benchmark-names:%=run-bench-tests/%)
 
 update-test-targets    = $(test-names:%=update-tests/%)
 update-doc-targets     = $(doc-names:%=update-doc/%)
+update-lib-targets     = $(lib-names:%=update-lib/%)
 update-example-targets = $(example-names:%=update-examples/%)
 
 t10k-images-idx3-ubyte-sha256 = 346e55b948d973a97e58d2351dde16a484bd415d4595297633bb08f03db6a073
@@ -289,6 +293,8 @@ run-tests/%: tests/%.dx just-build
 	misc/check-quine $< $(dex) -O script
 run-doc/%: doc/%.dx just-build
 	misc/check-quine $< $(dex) script
+run-lib/%: lib/%.dx just-build
+	misc/check-quine $< $(dex) script
 run-examples/%: examples/%.dx just-build
 	misc/check-quine $< $(dex) -O script
 # This runs the benchmark in test mode, which means we're checking
@@ -318,13 +324,17 @@ update-lower-vectorize-tests: just-build
 update-%: export DEX_ALLOW_CONTRACTIONS=0
 update-%: export DEX_TEST_MODE=t
 
-update-all: $(update-test-targets) $(update-example-targets)
+update-all: $(update-test-targets) $(update-doc-targets) $(update-lib-targets) $(update-example-targets)
 
 update-tests/%: tests/%.dx just-build
 	$(dex) script $< > $<.tmp
 	mv $<.tmp $<
 
 update-doc/%: doc/%.dx just-build
+	$(dex) script $< > $<.tmp
+	mv $<.tmp $<
+
+update-lib/%: lib/%.dx just-build
 	$(dex) script $< > $<.tmp
 	mv $<.tmp $<
 

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -212,7 +212,7 @@ evalSourceBlock' :: (Topper m, Mut n) => ModuleSourceName -> SourceBlock -> m n 
 evalSourceBlock' mname block = case sbContents block of
   EvalUDecl decl -> execUDecl mname decl
   Command cmd expr -> case cmd of
-    EvalExpr fmt -> do
+    EvalExpr fmt -> when (mname == Main) do
       annExpr <- case fmt of
         Printed -> return expr
         RenderHtml -> return $ addTypeAnn expr $ referTo "String"


### PR DESCRIPTION
This tweak allows libraries to be literate programs with embedded examples, because the example will only run when rendering the library with `dex script`, not when loading it for use.

Also uncomment embedded examples in the `diagram` library, and add libraries to quine tests to make sure all their embedded examples execute without error.