### PR TITLE
Example: Monte Carlo tree search for two-player games

### DIFF
--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -1,0 +1,345 @@
+' ## Monte Carlo Tree Search
+MCTS is part of the decision engine behind the notable AlphaGo program.
+It uses the expected outcome as a heuristic for tree searching.
+Here we implement the variant with minimax search and upper
+confidence bound for trees (uct).
+This demo implements a doubly-linked tree structure as a Dex array,
+and traverses its branches by indexing.
+- [reference](http://www.incompleteideas.net/609%20dropbox/other%20readings%20and%20resources/MCTS-survey.pdf)
+- Use safe-names-dev build
+
+def (+!) {a} [Ix a] (n:a) (m:Int) : a = ((ordinal n) + m)@_
+def xor (a:Bool) (b:Bool) : Bool = ((not a) && b) || (a && (not b))
+
+' ### Tree types
+
+data  Node nodeIx a =
+  Branch content:a parent:(Maybe nodeIx) children:(List (nodeIx))
+
+def Tree (nodeIx:Type) (a:Type) [Ix nodeIx] : Type =
+  (nodeIx=>(Maybe (Node nodeIx a)) & nodeIx)
+  -- Node array, and pointer to last used node.
+
+def root {nodeIx a} (tree:Tree nodeIx a) : nodeIx =
+  0@_ -- Convention
+
+def isLeaf {node a} ((Branch _ _ children):Node node a) : Bool = 
+  list_length children == 0
+
+def isRoot {node a} ((Branch _ parent _):Node node a) : Bool =
+  is_nothing parent
+
+def initTree {a} (maxSize:Int) (defaultContent:a)
+  : Tree (Fin maxSize) a =
+  root = Branch defaultContent Nothing (AsList 0 [])
+  nothings = for i. Nothing
+  initArray = yield_state nothings \ref. ref!(0@_) := (Just root)
+  (initArray, 0@_)
+
+' ### Game and Node utilities
+
+def Game (state:Type) (move:Type) : Type =
+  {
+    possibleMoves : state -> (List move) &
+    winOrLose : state -> Bool &
+    update : state -> move -> state &
+    gameOver : state -> Bool &
+  }
+
+def NodeStats (state:Type) : Type = 
+  (Float & Int & Int & state)
+  -- (average wins, #visit, level, state)
+
+def node_win_visit_stats {nodeIx state} (node:(Node nodeIx (NodeStats state)))
+  : (Float & Int) =
+  (Branch stats _ _) = node
+  (wins, visits, _, _) = stats
+  (wins, visits)
+
+def node_is_visited {nodeIx state} (node:(Node nodeIx (NodeStats state)))
+  : Bool =
+  (_, visits) = node_win_visit_stats node
+  visits > 0
+
+def node_state {nodeIx state} (node:(Node nodeIx (NodeStats state))) : state =
+  (Branch stats _ _) = node
+  (_, _, _, s) = stats
+  s
+
+def node_level {nodeIx state} (node:(Node nodeIx (NodeStats state))) : Int =
+  (Branch stats _ _) = node
+  (_, _, level, _) = stats
+  level
+
+' ### MCTS functions
+
+' Let $n$ be a node. The reward $Q(n)$ summarizes the performance of $n$'s subtree.
+$N(n)$ is the number of visits of $n$. $n_p$ is the parent of node $n$.
+The upper confidence bound for trees is a metric that balances
+exploration vs exploitation, which are weighed by $1:\sqrt{2}$ here.
+The upper confidence bound for trees of node $n$ is
+$$UCT(n) = \frac{Q(n)}{N(n)} + \sqrt{2\frac{ln(N(n_p))}{N(n)}}$$
+
+def uct (win:Float) (n:Int) (parent_n:Int) : Float = 
+  -- wins stored at every node are w.r.t to the max_player
+  win / (i_to_f n) + sqrt (2.0 / (i_to_f n) * (log (i_to_f parent_n)))
+
+'Recursively find the most promising leaf (measured by UCT) to rollout next.
+
+def mcts_select {move state nodeIx}
+    (game: Game state move) (tree: Tree nodeIx (NodeStats state)) (key: Key)
+    : nodeIx = 
+    arr = fst tree
+
+    yield_state (root tree) \ref. iter \i.
+      node = from_just arr.(get ref)
+      if isLeaf node
+        then
+          Done ()
+        else
+          (Branch stats _ children_list) = node
+          (AsList _ children) = children_list
+          fully_expanded = all for i.
+            node_is_visited $ from_just arr.(children.i)
+          if not fully_expanded
+            then
+              criterion = \child.
+                not $ node_is_visited $ from_just arr.child
+              (AsList _ unvisited) = filter criterion children 
+              ref := unvisited.(rand_idx key)
+              Done ()
+            else
+              (_, p_visits) = node_win_visit_stats node
+              -- minimax
+              is_max_player = is_even $ node_level node
+              selector = if is_max_player then argmax else argmin
+              best_child = selector for i.
+                child = from_just arr.(children.i)
+                (win, visits) = node_win_visit_stats child
+                uct win visits p_visits
+              ref := children.best_child
+              Continue
+
+' Expand the tree (in-place) by adding states one-move away from the current state.
+
+def expand {move state nodeIx h}
+    (game: Game state move)
+    (treeRef: Ref h (Tree nodeIx (NodeStats state)))
+    (node: nodeIx) : {State h} Unit =
+    -- assume `node` is a leaf node (base) and has a non-terminal state (base_state)
+
+    -- extract info about the base node
+    base_node = from_just $ get (fst_ref treeRef)!node
+    (Branch base_stats base_parent _) = base_node
+    (_, _, base_level, base_state) = base_stats
+
+    -- prepare child nodes
+    (AsList n base_moves) = (get_at #possibleMoves game) base_state
+    child_nodes = for i.
+      new_move = base_moves.i
+      new_state = (get_at #update game) base_state new_move
+      new_stats = (0, 0, base_level + 1, new_state)
+      Branch new_stats (Just node) (to_list [])
+
+    -- write to the tree
+    new_node = get (snd_ref treeRef)
+    base_children_ix = for i:(Fin n). new_node +! (1 + ordinal i)
+    -- update base's children list
+    new_base_node = Branch base_stats base_parent (to_list base_children_ix)
+    (fst_ref treeRef)!node := Just new_base_node
+    -- insert every child
+    for i.
+      child_ix = base_children_ix.i
+      (fst_ref treeRef)!child_ix := Just child_nodes.i
+    snd_ref treeRef := new_node +! n
+
+' Simulate the game starting at a given state until the game terminates and
+return the simulation result.
+
+def rollout {move state}
+    (game: Game state move)
+    (key: Key) (currState: state) : Bool =
+    -- output is w.r.t. current player
+    with_state currState \ref. iter \i.
+      curr_state = get ref
+      (AsList _ new_moves) = (get_at #possibleMoves game) curr_state
+      -- ^ should've been in the else block, but the compiler complains
+      if (get_at #gameOver game) curr_state
+        then
+          -- #winOrLose is w.r.t. the last player
+          result = (get_at #winOrLose game) curr_state
+          Done $ xor (is_even i) result
+        else
+        -- rollout policy: uniform random
+          new_move = new_moves.(rand_idx (hash key i))
+          ref := (get_at #update game) curr_state new_move
+          Continue
+
+' Update the record of a node and its chain of ancestors,
+based on the simulation result.
+
+def backpropagate {move state nodeIx h} [Eq nodeIx] 
+    (game: Game state move)
+    (treeRef: Ref h (Tree nodeIx (NodeStats state)))
+    (node: nodeIx) (newResult: Float) : {State h} Unit =
+    -- newResult: win or lose w.r.t curr_player @node
+    currRoot = 0@nodeIx
+    leaf_min_player = get (fst_ref treeRef)!node |>
+      from_just |> node_level |> is_odd
+    maxResult = if leaf_min_player 
+                    then (1. - newResult)
+                    else newResult
+
+    -- collect itself and all ancestors
+    ancestors_list = yieldAccum (ListMonoid nodeIx) \ls.
+      with_state node \nodeRef. iter \_.
+        append ls (get nodeRef)
+        curr_node = from_just $ get (fst_ref treeRef)!(get nodeRef)
+        (Branch _ curr_parent _) = curr_node
+        if is_nothing curr_parent || currRoot == (get nodeRef)
+          then Done ()
+          else
+            nodeRef := from_just curr_parent
+            Continue
+
+    -- update win and loss counts
+    (AsList _ ancestors) = ancestors_list
+    for i.
+      -- unpack
+      ancestor = from_just $ get (fst_ref treeRef)!(ancestors.i)
+      (Branch stats parent children) = ancestor
+      (wins, visits, level, state) = stats
+      -- compute
+      (new_wins, new_visits) = (wins + maxResult, visits + 1)
+      -- pack
+      new_stats = (new_wins, new_visits, level, state)
+      (fst_ref treeRef)!(ancestors.i) := Just (Branch new_stats parent children)
+    ()
+
+' Wrap up the procedure for taking one sample and extend the tree.
+
+def mcts_sample {move state nodeIx} [Eq nodeIx]
+    (game: Game state move) (key: Key)
+    (tree: Tree nodeIx (NodeStats state))
+    : Tree nodeIx (NodeStats state) =
+    [key1, key2] = split_key key
+    leaf_ix = mcts_select game tree key1
+    leaf = from_just (fst tree).leaf_ix
+    -- todo: this is a copy of the array for every sampling
+    yield_state tree \treeRef.
+      if not $ (get_at #gameOver game) $ node_state leaf then
+        expand game treeRef leaf_ix
+      num_leaf_rollouts = 10
+      result = yieldAccum (AddMonoid Float) \c.
+        for i:(Fin num_leaf_rollouts).
+          key' = ixkey key i
+          c += if rollout game key' $ node_state leaf 
+            then 1. / (i_to_f num_leaf_rollouts)
+            else 0.
+      backpropagate game treeRef leaf_ix result
+
+' ### Toy game: Count 21
+This is a simple two-player game. Starting from 0, each player in turn chooses
+to add 1 or 2 to the current sum. The player who reaches 21 wins.
+
+Count21State = Int
+Count21Move = Int
+Count21 : Game Count21State Count21Move = {
+  possibleMoves = \sum. to_list [1,2],
+  winOrLose = \sum. sum == 21,
+  update = \sum move. sum + move,
+  gameOver = \sum. sum >= 21,
+}
+
+' #### Approximate winning chances by sampling
+In theory, multiples of three are bad positions for the current player,
+since the opponent has a winning strategy by always choosing
+(3 - move by the current player). Otherwise, the current player
+has a winning strategy.
+
+key = new_key 0
+
+def test (key:Key) (initState:Int) : (Float & Int) = 
+  init_node_stats : NodeStats Count21State = (0, 0, 0, initState)
+  -- (0 wins, 0 visits, level 0, game state)
+  start_tree = initTree 70 init_node_stats
+  end_tree = fold start_tree \i:(Fin 50).
+    mcts_sample Count21 (ixkey key i)
+  node_win_visit_stats $ from_just (fst end_tree).(root end_tree)
+
+test key 21
+> (0, 50)
+test key 20
+> (46, 50)
+test key 19
+> (45, 50)
+test key 18
+> (1, 50)
+test key 17
+> (39, 50)
+test key 16
+> (39, 50)
+test key 15
+> (8, 50)
+test key 14
+> (34, 50)
+test key 13
+> (31, 50)
+test key 12
+> (25, 50)
+
+' With fixed number (50) of samples, fully explored trees
+(`initState` close to 21) yields extreme win/visits ratios.\
+On the other hand, large trees need more samples to converge.
+
+' #### A closer look at the game tree
+Say the current sum is 17,
+the winning move for the current player is to add 1.
+In the following tree, we see adding 1 (the second node)
+is indeed considered a more promising choice by `uct`
+and enjoys more traffic than its sibiling (adding 2, the third node).
+
+init_node_stats : NodeStats Count21State = (0, 0, 0, 17)
+start_tree = initTree 15 init_node_stats
+end_tree = fold start_tree \i:(Fin 50).
+  mcts_sample Count21 (ixkey key i)
+
+end_tree
+> ( [ (Just (Branch (39, (50, (0, 17))) Nothing (AsList 2 [(1@Fin 15), (2@Fin 15)])))
+> , (Just (Branch (38, (44, (1, 18))) (Just (0@Fin 15)) (AsList 2 [ (3@Fin 15)
+>                                                               , (4@Fin 15) ])))
+> , (Just (Branch (0, (5, (1, 19))) (Just (0@Fin 15)) (AsList 2 [ (5@Fin 15)
+>                                                             , (6@Fin 15) ])))
+> , (Just (Branch (1, (1, (2, 19))) (Just (1@Fin 15)) (AsList 2 [ (9@Fin 15)
+>                                                             , (10@Fin 15) ])))
+> , (Just (Branch (37, (42, (2, 20))) (Just (1@Fin 15)) (AsList 2 [ (11@Fin 15)
+>                                                               , (12@Fin 15) ])))
+> , (Just (Branch (0, (1, (2, 20))) (Just (2@Fin 15)) (AsList 2 [ (7@Fin 15)
+>                                                             , (8@Fin 15) ])))
+> , (Just (Branch (0, (3, (2, 21))) (Just (2@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (0, (0, (3, 21))) (Just (5@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (0, (0, (3, 22))) (Just (5@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (0, (0, (3, 20))) (Just (3@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (0, (0, (3, 21))) (Just (3@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (37, (37, (3, 21))) (Just (4@Fin 15)) (AsList 0 [])))
+> , (Just (Branch (0, (4, (3, 22))) (Just (4@Fin 15)) (AsList 0 [])))
+> , Nothing
+> , Nothing ]
+> , (12@Fin 15) )
+
+-- def test_ucts {nodeIx state}
+--   (tree: Tree nodeIx (NodeStats state))
+--   : nodeIx => Maybe Float =
+--   for i.
+--     case (fst tree).i of
+--       Nothing -> Nothing
+--       Just node ->
+--         (Branch stats parent _) = node
+--         case parent of
+--           Nothing -> Nothing
+--           Just parent_ix ->
+--             (_, p_n) = node_win_visit_stats $ from_just $ (fst tree).parent_ix
+--             (w, n) = node_win_visit_stats node
+--             Just $ uct w n p_n
+-- ucts = test_ucts end_tree
+-- for i. (i, ucts.i, (fst end_tree).i)

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -184,31 +184,24 @@ def mcts_backpropagate {move state node_ix h} [Eq node_ix]
                     then (1. - newResult)
                     else newResult
 
-    -- collect itself and all ancestors
-    ancestors_list = yield_accum (ListMonoid node_ix) \ls.
-      with_state node \node_ref. iter \_.
-        append ls (get node_ref)
-        curr_node = from_just $ get (fst_ref tree_ref)!(get node_ref)
-        (Branch _ curr_parent _) = curr_node
-        if is_nothing curr_parent || (0@node_ix) == (get node_ref)
-          then Done ()
-          else
-            node_ref := from_just curr_parent
-            Continue
-
-    -- update win and loss counts
-    (AsList _ ancestors) = ancestors_list
-    for i.
-      -- unpack
-      ancestor = from_just $ get (fst_ref tree_ref)!(ancestors.i)
-      (Branch stats parent children) = ancestor
+    with_state node \node_ref. iter \_.
+      -- update win and loss counts
+      --- unpack
+      curr_node = from_just $ get (fst_ref tree_ref)!(get node_ref)
+      (Branch stats parent children) = curr_node
       (wins, visits, level, state) = stats
-      -- compute
+      --- compute
       (new_wins, new_visits) = (wins + maxResult, visits + 1)
-      -- pack
+      --- pack
       new_stats = (new_wins, new_visits, level, state)
-      (fst_ref tree_ref)!(ancestors.i) := Just (Branch new_stats parent children)
-    ()
+      (fst_ref tree_ref)!(get node_ref) := Just (Branch new_stats parent children)
+
+      -- find the parent of the current node
+      if is_nothing parent || (0@node_ix) == (get node_ref)
+        then Done ()
+        else
+          node_ref := from_just parent
+          Continue
 
 ' Wrap up the procedure for taking one sample and extend the tree.
 

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -47,11 +47,11 @@ def Game (state:Type) (move:Type) : Type =
   }
 
 def NodeStats (state:Type) : Type = 
-  (Int & Int & Nat & state)
-  -- (#win, #visit, level, state)
+  (Nat & Nat & Nat & state)
+  -- (#winning rollouts for max/first player, #visit, level, state)
 
 def node_win_visit_stats {node_ix state} (node:(Node node_ix (NodeStats state)))
-  : (Int & Int) =
+  : (Nat & Nat) =
   (Branch stats _ _) = node
   (wins, visits, _, _) = stats
   (wins, visits)
@@ -80,9 +80,9 @@ $N(n)$ is the number of visits of $n$. $n_p$ is the parent of node $n$.
 The upper confidence bound for trees of node $n$ is
 $$UCT(n) = \frac{Q(n)}{N(n)} + \sqrt{2\frac{ln(N(n_p))}{N(n)}}$$
 
-def uct (win:Int) (n:Int) (parent_n:Int) : Float = 
+def uct (win:Nat) (n:Nat) (parent_n:Nat) : Float =
   -- wins stored at every node are w.r.t to the max_player
-  (i_to_f win) / (i_to_f n) + sqrt (2.0 / (i_to_f n) * (log (i_to_f parent_n)))
+  (n_to_f win) / (n_to_f n) + sqrt (2.0 / (n_to_f n) * (log (n_to_f parent_n)))
 
 'Recursively find the most promising leaf (measured by UCT) to rollout next.
 
@@ -180,24 +180,20 @@ based on the simulation result.
 def mcts_backpropagate {move state node_ix h} [Eq node_ix] 
     (game: Game state move)
     (tree_ref: Ref h (Tree node_ix (NodeStats state)))
-    (node: node_ix) (new_rollout_wins: Int) : {State h} Unit =
-    -- newResult: win or lose w.r.t curr_player @node
-    leaf_min_player = get (fst_ref tree_ref)!node |>
-      from_just |> node_level |> is_odd
-    rollouts_per_sample = n_to_i ROLLOUTS_PER_SAMPLE
-    max_result = if leaf_min_player 
-                    then (rollouts_per_sample - new_rollout_wins)
-                    else new_rollout_wins
+    (node: node_ix) (new_rollout_wins: Nat) : {State h} Unit =
+    -- new_rollout_wins: #wins w.r.t max player
 
     with_state node \node_ref. iter \_.
       -- update win and loss counts
-      --- unpack
+      -- -unpack
       curr_node = from_just $ get (fst_ref tree_ref)!(get node_ref)
       (Branch stats parent children) = curr_node
       (wins, visits, level, state) = stats
-      --- compute
-      (new_wins, new_visits) = (wins + max_result, visits + rollouts_per_sample)
-      --- pack
+      -- -compute
+      new_wins = wins + new_rollout_wins
+      new_visits = visits + 1  -- Todo: or to add ROLLOUTS_PER_SAMPLE
+
+      -- -pack
       new_stats = (new_wins, new_visits, level, state)
       (fst_ref tree_ref)!(get node_ref) := Just (Branch new_stats parent children)
 
@@ -223,15 +219,17 @@ def mcts_sample {move state node_ix} [Eq node_ix]
       if not $ (get_at #game_over game) $ node_state leaf then
         mcts_expand game tree_ref leaf_ix
 
-    num_wins = yield_accum (AddMonoid Int) \c.
+    leaf_min_player = leaf |> node_level |> is_odd
+    max_player_wins = yield_accum (AddMonoid Nat) \c.
       for i:(Fin ROLLOUTS_PER_SAMPLE).
         key' = ixkey key i
-        c += if mcts_rollout game key' $ node_state leaf 
-          then 1
-          else 0
+        leaf_result = mcts_rollout game key' $ node_state leaf
+                  -- w.r.t. the current player
+        max_rollout_wins = b_to_n $ xor leaf_min_player leaf_result
+        c += max_rollout_wins
 
     yield_state tree' \tree_ref.
-      mcts_backpropagate game tree_ref leaf_ix num_wins
+      mcts_backpropagate game tree_ref leaf_ix max_player_wins
 
 ' ## Toy game: Count 21
 This is a simple two-player game. Two players in turn choose
@@ -254,36 +252,36 @@ has a winning strategy.
 
 key = new_key 0
 
-def test (key:Key) (current_state:Nat) : (Int & Int) = 
+def test (key:Key) (current_state:Nat) : (Nat & Nat) =
   init_node_stats : NodeStats Count21State = 
     (0, 0, 0, current_state)
   -- (0 wins, 0 visits, level 0, game state)
-  tree_size = MAX_TREE_SIZE
-  start_tree = init_tree tree_size init_node_stats
+  start_tree = init_tree MAX_TREE_SIZE init_node_stats
   end_tree = fold start_tree \i:(Fin SAMPLES).
     mcts_sample Count21 (ixkey key i)
   node_win_visit_stats $ from_just (fst end_tree).(root_of end_tree)
 
+
 test key 21
-> (0., 50)
+> (0, 50)
 test key 20
-> (45.5, 50)
+> (485, 50)
 test key 19
-> (45., 50)
+> (490, 50)
 test key 18
-> (2.3, 50)
+> (23, 50)
 test key 17
-> (40., 50)
+> (475, 50)
 test key 16
-> (38.8, 50)
+> (468, 50)
 test key 15
-> (29.9, 50)
+> (69, 50)
 test key 14
-> (32.2, 50)
+> (451, 50)
 test key 13
-> (33.7, 50)
+> (389, 50)
 test key 12
-> (30.9, 50)
+> (286, 50)
 
 ' We fix number of samples (SAMPLES=50) and rollouts (ROLLOUTS_PER_SAMPLE=10). Fully explored 
 trees (`current_state` close to 21) yields extreme win/visits ratios. 
@@ -302,19 +300,24 @@ end_tree = fold start_tree \i:(Fin 50).
   mcts_sample Count21 (ixkey key i)
 
 end_tree
-> ( [ (Just (Branch (40., (50, (0, 17))) Nothing (AsList 2 [ (1@(Fin 15)), (2@(Fin 15)) ])))
-> , (Just (Branch (38.4, (43, (1, 18))) (Just (0@(Fin 15))) (AsList 2 [ (5@(Fin 15)), (6@(Fin 15)) ])))
-> , (Just (Branch (0.8, (6, (1, 19))) (Just (0@(Fin 15))) (AsList 2 [ (3@(Fin 15)), (4@(Fin 15)) ])))
-> , (Just (Branch (0.5, (1, (2, 20))) (Just (2@(Fin 15))) (AsList 2 [ (11@(Fin 15)), (12@(Fin 15)) ])))
-> , (Just (Branch (0., (4, (2, 21))) (Just (2@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (0.8, (1, (2, 19))) (Just (1@(Fin 15))) (AsList 2 [ (7@(Fin 15)), (8@(Fin 15)) ])))
-> , (Just (Branch (36.8, (41, (2, 20))) (Just (1@(Fin 15))) (AsList 2 [ (9@(Fin 15)), (10@(Fin 15)) ])))
-> , (Just (Branch (0., (0, (3, 20))) (Just (5@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (0., (0, (3, 21))) (Just (5@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (36., (36, (3, 21))) (Just (6@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (-0., (4, (3, 22))) (Just (6@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (0., (0, (3, 21))) (Just (3@(Fin 15))) (AsList 0 [])))
-> , (Just (Branch (0., (0, (3, 22))) (Just (3@(Fin 15))) (AsList 0 [])))
+> ( [ (Just (Branch (475, (50, (0, 17))) Nothing (AsList 2 [ (1@(Fin 15))
+>                                                      , (2@(Fin 15)) ])))
+> , (Just (Branch (464, (48, (1, 18))) (Just (0@(Fin 15))) (AsList 2 [ (5@(Fin 15))
+>                                                                  , (6@(Fin 15)) ])))
+> , (Just (Branch (3, (1, (1, 19))) (Just (0@(Fin 15))) (AsList 2 [ (3@(Fin 15))
+>                                                               , (4@(Fin 15)) ])))
+> , (Just (Branch (0, (0, (2, 20))) (Just (2@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0, (0, (2, 21))) (Just (2@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (8, (1, (2, 19))) (Just (1@(Fin 15))) (AsList 2 [ (7@(Fin 15))
+>                                                               , (8@(Fin 15)) ])))
+> , (Just (Branch (448, (46, (2, 20))) (Just (1@(Fin 15))) (AsList 2 [ (9@(Fin 15))
+>                                                                  , (10@(Fin 15)) ])))
+> , (Just (Branch (0, (0, (3, 20))) (Just (5@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0, (0, (3, 21))) (Just (5@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (440, (44, (3, 21))) (Just (6@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0, (1, (3, 22))) (Just (6@(Fin 15))) (AsList 0 [])))
+> , Nothing
+> , Nothing
 > , Nothing
 > , Nothing ]
-> , (12@(Fin 15)) )
+> , (10@(Fin 15)) )

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -1,99 +1,95 @@
 ' ## Monte Carlo Tree Search
-MCTS is part of the decision engine behind the notable AlphaGo program.
-It uses the expected outcome as a heuristic for tree searching.
-Here we implement the variant with minimax search and upper
-confidence bound for trees (uct).
+MCTS is the decision engine for the notable AlphaGo program.
+It samples rollouts to guide tree search. 
+The nice thing is Dex can in theory automatically parallelize leaf rollouts.
+
+' We implement a variant of MCTS with minimax search and upper
+confidence bound for trees (uct) for the two-player mini-game `Count21`. 
 This demo implements a doubly-linked tree structure as a Dex array,
 and traverses its branches by indexing.
-- [reference](http://www.incompleteideas.net/609%20dropbox/other%20readings%20and%20resources/MCTS-survey.pdf)
-- Use safe-names-dev build
+[reference](http://www.incompleteideas.net/609%20dropbox/other%20readings%20and%20resources/MCTS-survey.pdf)
 
-def (+!) {a} [Ix a] (n:a) (m:Int) : a = ((ordinal n) + m)@_
+def (+|) {a} [Ix a] (n:a) (m:Nat) : a = ((ordinal n) + m)@a
 def xor (a:Bool) (b:Bool) : Bool = ((not a) && b) || (a && (not b))
 
 ' ### Tree types
 
-data  Node nodeIx a =
-  Branch content:a parent:(Maybe nodeIx) children:(List (nodeIx))
+data Node node_ix a =
+  Branch content:a parent:(Maybe node_ix) children:(List (node_ix))
 
-def Tree (nodeIx:Type) (a:Type) [Ix nodeIx] : Type =
-  (nodeIx=>(Maybe (Node nodeIx a)) & nodeIx)
+def Tree (node_ix:Type) (a:Type) [Ix node_ix] : Type =
+  (node_ix=>(Maybe (Node node_ix a)) & node_ix)
   -- Node array, and pointer to last used node.
 
-def root {nodeIx a} (tree:Tree nodeIx a) : nodeIx =
-  0@_ -- Convention
+def root_of {node_ix a} (tree:Tree node_ix a) : node_ix = 0@node_ix
 
-def isLeaf {node a} ((Branch _ _ children):Node node a) : Bool = 
+def is_leaf {node a} ((Branch _ _ children):Node node a) : Bool = 
   list_length children == 0
 
-def isRoot {node a} ((Branch _ parent _):Node node a) : Bool =
-  is_nothing parent
-
-def initTree {a} (maxSize:Int) (defaultContent:a)
-  : Tree (Fin maxSize) a =
-  root = Branch defaultContent Nothing (AsList 0 [])
-  nothings = for i. Nothing
-  initArray = yield_state nothings \ref. ref!(0@_) := (Just root)
-  (initArray, 0@_)
+def init_tree {a} (max_size:Nat) (default_content:a): Tree (Fin max_size) a =
+  root = Branch default_content Nothing (AsList 0 [])
+  nothings = for i:(Fin max_size). Nothing
+  init_array = yield_state nothings \ref. ref!(0@_) := (Just root)
+  (init_array, 0@_)
 
 ' ### Game and Node utilities
 
 def Game (state:Type) (move:Type) : Type =
   {
-    possibleMoves : state -> (List move) &
-    winOrLose : state -> Bool &
+    possible_moves : state -> (List move) &
+    win_or_lose : state -> Bool &
     update : state -> move -> state &
-    gameOver : state -> Bool &
+    game_over : state -> Bool &
   }
 
 def NodeStats (state:Type) : Type = 
-  (Float & Int & Int & state)
-  -- (average wins, #visit, level, state)
+  (Float & Nat & Nat & state)
+  -- (win ratio or reward, #visit, level, state)
 
-def node_win_visit_stats {nodeIx state} (node:(Node nodeIx (NodeStats state)))
-  : (Float & Int) =
+def node_win_visit_stats {node_ix state} (node:(Node node_ix (NodeStats state)))
+  : (Float & Nat) =
   (Branch stats _ _) = node
   (wins, visits, _, _) = stats
   (wins, visits)
 
-def node_is_visited {nodeIx state} (node:(Node nodeIx (NodeStats state)))
+def node_is_visited {node_ix state} (node:(Node node_ix (NodeStats state)))
   : Bool =
   (_, visits) = node_win_visit_stats node
   visits > 0
 
-def node_state {nodeIx state} (node:(Node nodeIx (NodeStats state))) : state =
+def node_state {node_ix state} (node:(Node node_ix (NodeStats state))) : state =
   (Branch stats _ _) = node
   (_, _, _, s) = stats
   s
 
-def node_level {nodeIx state} (node:(Node nodeIx (NodeStats state))) : Int =
+def node_level {node_ix state} (node:(Node node_ix (NodeStats state))) : Nat =
   (Branch stats _ _) = node
   (_, _, level, _) = stats
   level
 
 ' ### MCTS functions
 
-' Let $n$ be a node. The reward $Q(n)$ summarizes the performance of $n$'s subtree.
+' Let $n$ be a node. The upper confidence bound for trees (UCT) is a heuristic 
+that balances exploration and exploitation, weighed by $1:\sqrt{2}$ here.
+The reward $Q(n)$ summarizes the performance of $n$'s subtree.
 $N(n)$ is the number of visits of $n$. $n_p$ is the parent of node $n$.
-The upper confidence bound for trees is a metric that balances
-exploration vs exploitation, which are weighed by $1:\sqrt{2}$ here.
 The upper confidence bound for trees of node $n$ is
 $$UCT(n) = \frac{Q(n)}{N(n)} + \sqrt{2\frac{ln(N(n_p))}{N(n)}}$$
 
-def uct (win:Float) (n:Int) (parent_n:Int) : Float = 
+def uct (win:Float) (n:Nat) (parent_n:Nat) : Float = 
   -- wins stored at every node are w.r.t to the max_player
-  win / (i_to_f n) + sqrt (2.0 / (i_to_f n) * (log (i_to_f parent_n)))
+  win / (n_to_f n) + sqrt (2.0 / (n_to_f n) * (log (n_to_f parent_n)))
 
 'Recursively find the most promising leaf (measured by UCT) to rollout next.
 
-def mcts_select {move state nodeIx}
-    (game: Game state move) (tree: Tree nodeIx (NodeStats state)) (key: Key)
-    : nodeIx = 
+def mcts_select {move state node_ix}
+    (game: Game state move) (tree: Tree node_ix (NodeStats state)) (key: Key)
+    : node_ix = 
     arr = fst tree
 
-    yield_state (root tree) \ref. iter \i.
+    yield_state (root_of tree) \ref. iter \i.
       node = from_just arr.(get ref)
-      if isLeaf node
+      if is_leaf node
         then
           Done ()
         else
@@ -122,19 +118,19 @@ def mcts_select {move state nodeIx}
 
 ' Expand the tree (in-place) by adding states one-move away from the current state.
 
-def expand {move state nodeIx h}
+def mcts_expand {move state node_ix h}
     (game: Game state move)
-    (treeRef: Ref h (Tree nodeIx (NodeStats state)))
-    (node: nodeIx) : {State h} Unit =
+    (tree_ref: Ref h (Tree node_ix (NodeStats state)))
+    (node: node_ix) : {State h} Unit =
     -- assume `node` is a leaf node (base) and has a non-terminal state (base_state)
 
     -- extract info about the base node
-    base_node = from_just $ get (fst_ref treeRef)!node
+    base_node = from_just $ get (fst_ref tree_ref)!node
     (Branch base_stats base_parent _) = base_node
     (_, _, base_level, base_state) = base_stats
 
     -- prepare child nodes
-    (AsList n base_moves) = (get_at #possibleMoves game) base_state
+    (AsList n base_moves) = (get_at #possible_moves game) base_state
     child_nodes = for i.
       new_move = base_moves.i
       new_state = (get_at #update game) base_state new_move
@@ -142,113 +138,115 @@ def expand {move state nodeIx h}
       Branch new_stats (Just node) (to_list [])
 
     -- write to the tree
-    new_node = get (snd_ref treeRef)
-    base_children_ix = for i:(Fin n). new_node +! (1 + ordinal i)
+    new_node = get (snd_ref tree_ref)
+    base_children_ix = for i:(Fin n). new_node +| (1 + ordinal i)
     -- update base's children list
     new_base_node = Branch base_stats base_parent (to_list base_children_ix)
-    (fst_ref treeRef)!node := Just new_base_node
+    (fst_ref tree_ref)!node := Just new_base_node
     -- insert every child
     for i.
       child_ix = base_children_ix.i
-      (fst_ref treeRef)!child_ix := Just child_nodes.i
-    snd_ref treeRef := new_node +! n
+      (fst_ref tree_ref)!child_ix := Just child_nodes.i
+    snd_ref tree_ref := new_node +| n
 
 ' Simulate the game starting at a given state until the game terminates and
 return the simulation result.
 
-def rollout {move state}
+def mcts_rollout {move state}
     (game: Game state move)
-    (key: Key) (currState: state) : Bool =
+    (key: Key) (curr_state: state) : Bool =
     -- output is w.r.t. current player
-    with_state currState \ref. iter \i.
-      curr_state = get ref
-      (AsList _ new_moves) = (get_at #possibleMoves game) curr_state
-      -- ^ should've been in the else block, but the compiler complains
-      if (get_at #gameOver game) curr_state
+    with_state curr_state \ref. iter \i.
+      curr_state' = get ref
+      if (get_at #game_over game) curr_state'
         then
-          -- #winOrLose is w.r.t. the last player
-          result = (get_at #winOrLose game) curr_state
+          -- #win_or_lose is w.r.t. the last player
+          result = (get_at #win_or_lose game) curr_state'
           Done $ xor (is_even i) result
         else
-        -- rollout policy: uniform random
+          (AsList _ new_moves) = (get_at #possible_moves game) curr_state'
+          -- rollout policy: uniform random
           new_move = new_moves.(rand_idx (hash key i))
-          ref := (get_at #update game) curr_state new_move
+          ref := (get_at #update game) curr_state' new_move
           Continue
 
 ' Update the record of a node and its chain of ancestors,
 based on the simulation result.
 
-def backpropagate {move state nodeIx h} [Eq nodeIx] 
+def mcts_backpropagate {move state node_ix h} [Eq node_ix] 
     (game: Game state move)
-    (treeRef: Ref h (Tree nodeIx (NodeStats state)))
-    (node: nodeIx) (newResult: Float) : {State h} Unit =
+    (tree_ref: Ref h (Tree node_ix (NodeStats state)))
+    (node: node_ix) (newResult: Float) : {State h} Unit =
     -- newResult: win or lose w.r.t curr_player @node
-    currRoot = 0@nodeIx
-    leaf_min_player = get (fst_ref treeRef)!node |>
+    leaf_min_player = get (fst_ref tree_ref)!node |>
       from_just |> node_level |> is_odd
     maxResult = if leaf_min_player 
                     then (1. - newResult)
                     else newResult
 
     -- collect itself and all ancestors
-    ancestors_list = yieldAccum (ListMonoid nodeIx) \ls.
-      with_state node \nodeRef. iter \_.
-        append ls (get nodeRef)
-        curr_node = from_just $ get (fst_ref treeRef)!(get nodeRef)
+    ancestors_list = yield_accum (ListMonoid node_ix) \ls.
+      with_state node \node_ref. iter \_.
+        append ls (get node_ref)
+        curr_node = from_just $ get (fst_ref tree_ref)!(get node_ref)
         (Branch _ curr_parent _) = curr_node
-        if is_nothing curr_parent || currRoot == (get nodeRef)
+        if is_nothing curr_parent || (0@node_ix) == (get node_ref)
           then Done ()
           else
-            nodeRef := from_just curr_parent
+            node_ref := from_just curr_parent
             Continue
 
     -- update win and loss counts
     (AsList _ ancestors) = ancestors_list
     for i.
       -- unpack
-      ancestor = from_just $ get (fst_ref treeRef)!(ancestors.i)
+      ancestor = from_just $ get (fst_ref tree_ref)!(ancestors.i)
       (Branch stats parent children) = ancestor
       (wins, visits, level, state) = stats
       -- compute
       (new_wins, new_visits) = (wins + maxResult, visits + 1)
       -- pack
       new_stats = (new_wins, new_visits, level, state)
-      (fst_ref treeRef)!(ancestors.i) := Just (Branch new_stats parent children)
+      (fst_ref tree_ref)!(ancestors.i) := Just (Branch new_stats parent children)
     ()
 
 ' Wrap up the procedure for taking one sample and extend the tree.
 
-def mcts_sample {move state nodeIx} [Eq nodeIx]
+-- slow: every sample makes two copies of the tree array
+def mcts_sample {move state node_ix} [Eq node_ix]
     (game: Game state move) (key: Key)
-    (tree: Tree nodeIx (NodeStats state))
-    : Tree nodeIx (NodeStats state) =
+    (tree: Tree node_ix (NodeStats state))
+    : Tree node_ix (NodeStats state) =
     [key1, key2] = split_key key
     leaf_ix = mcts_select game tree key1
     leaf = from_just (fst tree).leaf_ix
-    -- todo: this is a copy of the array for every sampling
-    yield_state tree \treeRef.
-      if not $ (get_at #gameOver game) $ node_state leaf then
-        expand game treeRef leaf_ix
-      num_leaf_rollouts = 10
-      result = yieldAccum (AddMonoid Float) \c.
-        for i:(Fin num_leaf_rollouts).
-          key' = ixkey key i
-          c += if rollout game key' $ node_state leaf 
-            then 1. / (i_to_f num_leaf_rollouts)
-            else 0.
-      backpropagate game treeRef leaf_ix result
+
+    tree' = yield_state tree \tree_ref.
+      if not $ (get_at #game_over game) $ node_state leaf then
+        mcts_expand game tree_ref leaf_ix
+
+    num_leaf_rollouts = 10
+    result = yield_accum (AddMonoid Float) \c.
+      for i:(Fin num_leaf_rollouts).
+        key' = ixkey key i
+        c += if mcts_rollout game key' $ node_state leaf 
+          then 1. / (n_to_f num_leaf_rollouts)
+          else 0.
+
+    yield_state tree' \tree_ref.
+      mcts_backpropagate game tree_ref leaf_ix result
 
 ' ### Toy game: Count 21
-This is a simple two-player game. Starting from 0, each player in turn chooses
-to add 1 or 2 to the current sum. The player who reaches 21 wins.
+This is a simple two-player game. Two players in turn chooses
+between 1 and 2 to add to the current sum, starting at 0. Whoever reaches 21 wins.
 
-Count21State = Int
-Count21Move = Int
+Count21State = Nat
+Count21Move = Nat
 Count21 : Game Count21State Count21Move = {
-  possibleMoves = \sum. to_list [1,2],
-  winOrLose = \sum. sum == 21,
-  update = \sum move. sum + move,
-  gameOver = \sum. sum >= 21,
+  possible_moves = \sum:Count21State. to_list $ map unsafe_i_to_n [1,2],
+  win_or_lose = \sum. sum == unsafe_i_to_n 21,
+  update = \sum:Count21State move. sum + move,
+  game_over = \sum. sum >= unsafe_i_to_n 21,
 }
 
 ' #### Approximate winning chances by sampling
@@ -259,87 +257,67 @@ has a winning strategy.
 
 key = new_key 0
 
-def test (key:Key) (initState:Int) : (Float & Int) = 
-  init_node_stats : NodeStats Count21State = (0, 0, 0, initState)
+def test (key:Key) (current_state:Nat) : (Float & Nat) = 
+  init_node_stats : NodeStats Count21State = 
+    (0., unsafe_i_to_n 0, unsafe_i_to_n 0, current_state)
   -- (0 wins, 0 visits, level 0, game state)
-  start_tree = initTree 70 init_node_stats
+  tree_size = unsafe_i_to_n 70
+  start_tree = init_tree tree_size init_node_stats
   end_tree = fold start_tree \i:(Fin 50).
     mcts_sample Count21 (ixkey key i)
-  node_win_visit_stats $ from_just (fst end_tree).(root end_tree)
+  node_win_visit_stats $ from_just (fst end_tree).(root_of end_tree)
 
 test key 21
-> (0, 50)
+> (0., 50)
 test key 20
-> (46, 50)
+> (45.5, 50)
 test key 19
-> (45, 50)
+> (45., 50)
 test key 18
-> (1, 50)
+> (2.3, 50)
 test key 17
-> (39, 50)
+> (40., 50)
 test key 16
-> (39, 50)
+> (38.8, 50)
 test key 15
-> (8, 50)
+> (29.9, 50)
 test key 14
-> (34, 50)
+> (32.2, 50)
 test key 13
-> (31, 50)
+> (33.7, 50)
 test key 12
-> (25, 50)
+> (30.9, 50)
 
-' With fixed number (50) of samples, fully explored trees
-(`initState` close to 21) yields extreme win/visits ratios.\
-On the other hand, large trees need more samples to converge.
+' We fix number of samples (50) and rollouts (10 per sample). Fully explored 
+trees (`current_state` close to 21) yields extreme win/visits ratios. 
+We also verify that the current player is disadvantaged when the current state 
+is a multiple of three.
 
 ' #### A closer look at the game tree
-Say the current sum is 17,
-the winning move for the current player is to add 1.
-In the following tree, we see adding 1 (the second node)
-is indeed considered a more promising choice by `uct`
-and enjoys more traffic than its sibiling (adding 2, the third node).
+Say the current sum is 17, the winning move for the current player is to add 1.
+In the following tree, we see that adding 1 (the second node) is indeed 
+considered a more promising choice by `uct` and sees more rollouts than 
+the alternative (adding 2, the third node).
 
 init_node_stats : NodeStats Count21State = (0, 0, 0, 17)
-start_tree = initTree 15 init_node_stats
+start_tree = init_tree 15 init_node_stats
 end_tree = fold start_tree \i:(Fin 50).
   mcts_sample Count21 (ixkey key i)
 
 end_tree
-> ( [ (Just (Branch (39, (50, (0, 17))) Nothing (AsList 2 [(1@Fin 15), (2@Fin 15)])))
-> , (Just (Branch (38, (44, (1, 18))) (Just (0@Fin 15)) (AsList 2 [ (3@Fin 15)
->                                                               , (4@Fin 15) ])))
-> , (Just (Branch (0, (5, (1, 19))) (Just (0@Fin 15)) (AsList 2 [ (5@Fin 15)
->                                                             , (6@Fin 15) ])))
-> , (Just (Branch (1, (1, (2, 19))) (Just (1@Fin 15)) (AsList 2 [ (9@Fin 15)
->                                                             , (10@Fin 15) ])))
-> , (Just (Branch (37, (42, (2, 20))) (Just (1@Fin 15)) (AsList 2 [ (11@Fin 15)
->                                                               , (12@Fin 15) ])))
-> , (Just (Branch (0, (1, (2, 20))) (Just (2@Fin 15)) (AsList 2 [ (7@Fin 15)
->                                                             , (8@Fin 15) ])))
-> , (Just (Branch (0, (3, (2, 21))) (Just (2@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (0, (0, (3, 21))) (Just (5@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (0, (0, (3, 22))) (Just (5@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (0, (0, (3, 20))) (Just (3@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (0, (0, (3, 21))) (Just (3@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (37, (37, (3, 21))) (Just (4@Fin 15)) (AsList 0 [])))
-> , (Just (Branch (0, (4, (3, 22))) (Just (4@Fin 15)) (AsList 0 [])))
+> ( [ (Just (Branch (40., (50, (0, 17))) Nothing (AsList 2 [ (1@(Fin 15)), (2@(Fin 15)) ])))
+> , (Just (Branch (38.4, (43, (1, 18))) (Just (0@(Fin 15))) (AsList 2 [ (5@(Fin 15)), (6@(Fin 15)) ])))
+> , (Just (Branch (0.8, (6, (1, 19))) (Just (0@(Fin 15))) (AsList 2 [ (3@(Fin 15)), (4@(Fin 15)) ])))
+> , (Just (Branch (0.5, (1, (2, 20))) (Just (2@(Fin 15))) (AsList 2 [ (11@(Fin 15)), (12@(Fin 15)) ])))
+> , (Just (Branch (0., (4, (2, 21))) (Just (2@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0.8, (1, (2, 19))) (Just (1@(Fin 15))) (AsList 2 [ (7@(Fin 15)), (8@(Fin 15)) ])))
+> , (Just (Branch (36.8, (41, (2, 20))) (Just (1@(Fin 15))) (AsList 2 [ (9@(Fin 15)), (10@(Fin 15)) ])))
+> , (Just (Branch (0., (0, (3, 20))) (Just (5@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0., (0, (3, 21))) (Just (5@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (36., (36, (3, 21))) (Just (6@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (-0., (4, (3, 22))) (Just (6@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0., (0, (3, 21))) (Just (3@(Fin 15))) (AsList 0 [])))
+> , (Just (Branch (0., (0, (3, 22))) (Just (3@(Fin 15))) (AsList 0 [])))
 > , Nothing
 > , Nothing ]
-> , (12@Fin 15) )
-
--- def test_ucts {nodeIx state}
---   (tree: Tree nodeIx (NodeStats state))
---   : nodeIx => Maybe Float =
---   for i.
---     case (fst tree).i of
---       Nothing -> Nothing
---       Just node ->
---         (Branch stats parent _) = node
---         case parent of
---           Nothing -> Nothing
---           Just parent_ix ->
---             (_, p_n) = node_win_visit_stats $ from_just $ (fst tree).parent_ix
---             (w, n) = node_win_visit_stats node
---             Just $ uct w n p_n
--- ucts = test_ucts end_tree
--- for i. (i, ucts.i, (fst end_tree).i)
+> , (12@(Fin 15)) )

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -12,6 +12,10 @@ and traverses its branches by indexing.
 def (+|) {a} [Ix a] (n:a) (m:Nat) : a = ((ordinal n) + m)@a
 def xor (a:Bool) (b:Bool) : Bool = ((not a) && b) || (a && (not b))
 
+MAX_TREE_SIZE:Nat = 70
+SAMPLES:Nat = 50
+ROLLOUTS_PER_SAMPLE:Nat = 10
+
 ' ## Tree types
 
 data Node node_ix a =
@@ -43,11 +47,11 @@ def Game (state:Type) (move:Type) : Type =
   }
 
 def NodeStats (state:Type) : Type = 
-  (Float & Nat & Nat & state)
-  -- (win ratio or reward, #visit, level, state)
+  (Int & Int & Nat & state)
+  -- (#win, #visit, level, state)
 
 def node_win_visit_stats {node_ix state} (node:(Node node_ix (NodeStats state)))
-  : (Float & Nat) =
+  : (Int & Int) =
   (Branch stats _ _) = node
   (wins, visits, _, _) = stats
   (wins, visits)
@@ -76,9 +80,9 @@ $N(n)$ is the number of visits of $n$. $n_p$ is the parent of node $n$.
 The upper confidence bound for trees of node $n$ is
 $$UCT(n) = \frac{Q(n)}{N(n)} + \sqrt{2\frac{ln(N(n_p))}{N(n)}}$$
 
-def uct (win:Float) (n:Nat) (parent_n:Nat) : Float = 
+def uct (win:Int) (n:Int) (parent_n:Int) : Float = 
   -- wins stored at every node are w.r.t to the max_player
-  win / (n_to_f n) + sqrt (2.0 / (n_to_f n) * (log (n_to_f parent_n)))
+  (i_to_f win) / (i_to_f n) + sqrt (2.0 / (i_to_f n) * (log (i_to_f parent_n)))
 
 'Recursively find the most promising leaf (measured by UCT) to rollout next.
 
@@ -176,13 +180,14 @@ based on the simulation result.
 def mcts_backpropagate {move state node_ix h} [Eq node_ix] 
     (game: Game state move)
     (tree_ref: Ref h (Tree node_ix (NodeStats state)))
-    (node: node_ix) (newResult: Float) : {State h} Unit =
+    (node: node_ix) (new_rollout_wins: Int) : {State h} Unit =
     -- newResult: win or lose w.r.t curr_player @node
     leaf_min_player = get (fst_ref tree_ref)!node |>
       from_just |> node_level |> is_odd
-    maxResult = if leaf_min_player 
-                    then (1. - newResult)
-                    else newResult
+    rollouts_per_sample = n_to_i ROLLOUTS_PER_SAMPLE
+    max_result = if leaf_min_player 
+                    then (rollouts_per_sample - new_rollout_wins)
+                    else new_rollout_wins
 
     with_state node \node_ref. iter \_.
       -- update win and loss counts
@@ -191,7 +196,7 @@ def mcts_backpropagate {move state node_ix h} [Eq node_ix]
       (Branch stats parent children) = curr_node
       (wins, visits, level, state) = stats
       --- compute
-      (new_wins, new_visits) = (wins + maxResult, visits + 1)
+      (new_wins, new_visits) = (wins + max_result, visits + rollouts_per_sample)
       --- pack
       new_stats = (new_wins, new_visits, level, state)
       (fst_ref tree_ref)!(get node_ref) := Just (Branch new_stats parent children)
@@ -218,16 +223,15 @@ def mcts_sample {move state node_ix} [Eq node_ix]
       if not $ (get_at #game_over game) $ node_state leaf then
         mcts_expand game tree_ref leaf_ix
 
-    num_leaf_rollouts = 10
-    result = yield_accum (AddMonoid Float) \c.
-      for i:(Fin num_leaf_rollouts).
+    num_wins = yield_accum (AddMonoid Int) \c.
+      for i:(Fin ROLLOUTS_PER_SAMPLE).
         key' = ixkey key i
         c += if mcts_rollout game key' $ node_state leaf 
-          then 1. / (n_to_f num_leaf_rollouts)
-          else 0.
+          then 1
+          else 0
 
     yield_state tree' \tree_ref.
-      mcts_backpropagate game tree_ref leaf_ix result
+      mcts_backpropagate game tree_ref leaf_ix num_wins
 
 ' ## Toy game: Count 21
 This is a simple two-player game. Two players in turn choose
@@ -250,13 +254,13 @@ has a winning strategy.
 
 key = new_key 0
 
-def test (key:Key) (current_state:Nat) : (Float & Nat) = 
+def test (key:Key) (current_state:Nat) : (Int & Int) = 
   init_node_stats : NodeStats Count21State = 
-    (0., 0, 0, current_state)
+    (0, 0, 0, current_state)
   -- (0 wins, 0 visits, level 0, game state)
-  tree_size = 70
+  tree_size = MAX_TREE_SIZE
   start_tree = init_tree tree_size init_node_stats
-  end_tree = fold start_tree \i:(Fin 50).
+  end_tree = fold start_tree \i:(Fin SAMPLES).
     mcts_sample Count21 (ixkey key i)
   node_win_visit_stats $ from_just (fst end_tree).(root_of end_tree)
 
@@ -281,7 +285,7 @@ test key 13
 test key 12
 > (30.9, 50)
 
-' We fix number of samples (50) and rollouts (10 per sample). Fully explored 
+' We fix number of samples (SAMPLES=50) and rollouts (ROLLOUTS_PER_SAMPLE=10). Fully explored 
 trees (`current_state` close to 21) yields extreme win/visits ratios. 
 We also verify that the current player is disadvantaged when the current state 
 is a multiple of three.

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -237,16 +237,16 @@ def mcts_sample {move state node_ix} [Eq node_ix]
       mcts_backpropagate game tree_ref leaf_ix result
 
 ' ## Toy game: Count 21
-This is a simple two-player game. Two players in turn chooses
+This is a simple two-player game. Two players in turn choose
 between 1 and 2 to add to the current sum, starting at 0. Whoever reaches 21 wins.
 
 Count21State = Nat
 Count21Move = Nat
 Count21 : Game Count21State Count21Move = {
-  possible_moves = \sum:Count21State. to_list $ map unsafe_i_to_n [1,2],
-  win_or_lose = \sum. sum == unsafe_i_to_n 21,
+  possible_moves = \sum:Count21State. to_list [1,2],
+  win_or_lose = \sum. sum == 21,
   update = \sum:Count21State move. sum + move,
-  game_over = \sum. sum >= unsafe_i_to_n 21,
+  game_over = \sum. sum >= 21,
 }
 
 ' ### Approximate winning chances by sampling
@@ -259,9 +259,9 @@ key = new_key 0
 
 def test (key:Key) (current_state:Nat) : (Float & Nat) = 
   init_node_stats : NodeStats Count21State = 
-    (0., unsafe_i_to_n 0, unsafe_i_to_n 0, current_state)
+    (0., 0, 0, current_state)
   -- (0 wins, 0 visits, level 0, game state)
-  tree_size = unsafe_i_to_n 70
+  tree_size = 70
   start_tree = init_tree tree_size init_node_stats
   end_tree = fold start_tree \i:(Fin 50).
     mcts_sample Count21 (ixkey key i)

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -1,4 +1,4 @@
-' ## Monte Carlo Tree Search
+' # Monte Carlo Tree Search
 MCTS is the decision engine for the notable AlphaGo program.
 It samples rollouts to guide tree search. 
 The nice thing is Dex can in theory automatically parallelize leaf rollouts.
@@ -12,7 +12,7 @@ and traverses its branches by indexing.
 def (+|) {a} [Ix a] (n:a) (m:Nat) : a = ((ordinal n) + m)@a
 def xor (a:Bool) (b:Bool) : Bool = ((not a) && b) || (a && (not b))
 
-' ### Tree types
+' ## Tree types
 
 data Node node_ix a =
   Branch content:a parent:(Maybe node_ix) children:(List (node_ix))
@@ -32,7 +32,7 @@ def init_tree {a} (max_size:Nat) (default_content:a): Tree (Fin max_size) a =
   init_array = yield_state nothings \ref. ref!(0@_) := (Just root)
   (init_array, 0@_)
 
-' ### Game and Node utilities
+' ## Game and Node utilities
 
 def Game (state:Type) (move:Type) : Type =
   {
@@ -67,7 +67,7 @@ def node_level {node_ix state} (node:(Node node_ix (NodeStats state))) : Nat =
   (_, _, level, _) = stats
   level
 
-' ### MCTS functions
+' ## MCTS functions
 
 ' Let $n$ be a node. The upper confidence bound for trees (UCT) is a heuristic 
 that balances exploration and exploitation, weighed by $1:\sqrt{2}$ here.
@@ -236,7 +236,7 @@ def mcts_sample {move state node_ix} [Eq node_ix]
     yield_state tree' \tree_ref.
       mcts_backpropagate game tree_ref leaf_ix result
 
-' ### Toy game: Count 21
+' ## Toy game: Count 21
 This is a simple two-player game. Two players in turn chooses
 between 1 and 2 to add to the current sum, starting at 0. Whoever reaches 21 wins.
 
@@ -249,7 +249,7 @@ Count21 : Game Count21State Count21Move = {
   game_over = \sum. sum >= unsafe_i_to_n 21,
 }
 
-' #### Approximate winning chances by sampling
+' ### Approximate winning chances by sampling
 In theory, multiples of three are bad positions for the current player,
 since the opponent has a winning strategy by always choosing
 (3 - move by the current player). Otherwise, the current player
@@ -293,7 +293,7 @@ trees (`current_state` close to 21) yields extreme win/visits ratios.
 We also verify that the current player is disadvantaged when the current state 
 is a multiple of three.
 
-' #### A closer look at the game tree
+' ### A closer look at the game tree
 Say the current sum is 17, the winning move for the current player is to add 1.
 In the following tree, we see that adding 1 (the second node) is indeed 
 considered a more promising choice by `uct` and sees more rollouts than 

--- a/makefile
+++ b/makefile
@@ -209,7 +209,7 @@ example-names := \
   isomorphisms fluidsim \
   sgd psd kernelregression nn \
   quaternions manifold-gradients schrodinger tutorial \
-  latex linear-maps dither
+  latex linear-maps dither mcts
 # TODO: re-enable
 # fft vega-plotting
 


### PR DESCRIPTION
The nice thing about MCTS in Dex is we can automatically parallelize leaf rollouts in `def mcts_sample`. The not-so-nice thing is we copy the entire tree array for each sample in `mcts_sample`. Well, we can edit the tree in place by passing in a tree_ref, but I am not sure if that prohibits parallel leaf rollouts.

#926 for defining instances looks neat! I am envious that I can't use `given` when defining functions (yet?)