### PR TITLE
Propagate more name hints.

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -50,7 +50,7 @@ sumUsingPolys lim (Abs i body) = do
       Just poly' -> return $ Abs i' poly'
       Nothing -> throw NotImplementedErr $
         "Algebraic simplification failed to model index computations: " ++ pprint body'
-  limName <- emitAtomToName lim
+  limName <- emitAtomToName noHint lim
   emitPolynomial $ sum limName sumAbs
 
 mul :: Polynomial n-> Polynomial n -> Polynomial n

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -368,7 +368,7 @@ linearizeExpr expr = case expr of
         resultTyWithTangent <- PairTy <$> substM resultTy
                                       <*> tangentFunType resultTangentType
         (ans, linLam) <- fromPair =<< buildCase e' resultTyWithTangent \i x -> do
-          x' <- emitAtomToName x
+          x' <- emitAtomToName noHint x
           Abs b body <- return $ alts !! i
           extendSubst (b @> x') $ withTangentFunAsLambda $ linearizeBlock body
         return $ WithTangent ans do

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -188,7 +188,7 @@ transposeExpr expr ct = case expr of
       False -> do
         e' <- substNonlin e
         void $ buildCase e' UnitTy \i v -> do
-          v' <- emitAtomToName v
+          v' <- emitAtomToName noHint v
           Abs b body <- return $ alts !! i
           extendSubst (b @> RenameNonlin v') do
             transposeBlock body (sink ct)

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -113,3 +113,11 @@ _ = for i:(Fin 20) j:(Fin 4). ordinal j
 %passes opt
 (2 > 1 || 4 < 5) && 6 == 6
 -- CHECK: (1| () |)@(Bool)
+
+-- Testing user name preservation
+
+%passes simp
+:p
+  unmistakable_name = for i:(Fin 10). 2 * ordinal i
+  for j. unmistakable_name.j
+-- CHECK: unmista


### PR DESCRIPTION
This change tries to increase the distance that user-supplied names make it through compiler passes.  It's far from complete, but suffices to get simplification to preserve the name given in the checked-in test case, which it didn't before.

The place where user-supplied names come from is decls (that were present in the source program).  Such a name names the value returned from the RHS of that decl.  So, this PR collects the name hint from a decl undergoing processing, passes it to the function processing the RHS, and tweaks said function to, if it emits a decl representing the value of that RHS, propagate said name hint to that emission.

Why do this now?  Because I want to write unit tests for the upcoming occurrence analysis that query the occurrence-analyzed IR for the annotation that goes with a variable of interest, and I want to name that variable using the surface name that appears in the string in the unit test.