### PR TITLE
Add a role system and use it to guide generalization

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -56,6 +56,7 @@ library
                      , Err
                      , Export
                      , GenericTraversal
+                     , Generalize
                      , Imp
                      , Interpreter
                      , Inference

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -190,7 +190,7 @@ def ctc {vocab time position} [Eq time, Eq vocab]
         logits.(unsafe_from_ordinal _ (ordinal t)).(unsafe_from_ordinal _ (ordinal v))
       labels' = view p:position'.
         unsafe_from_ordinal _ (ordinal labels.(unsafe_from_ordinal _ (ordinal p)))
-      
+
       ctc_non_empty blank' logits' labels'
     else zero
 

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -226,6 +226,7 @@ instance ( SubstB Name frag, HoistableB frag, OutFrag frag
     return ans
   {-# INLINE buildScoped #-}
 
+-- TODO: derive this instead
 instance ( SubstB Name frag, HoistableB frag, OutFrag frag
          , ExtOutMap Env frag, Fallible m)
          => EnvExtender (DoubleBuilderT frag m) where
@@ -1133,9 +1134,6 @@ zipNest _ _ Empty = Empty
 zipNest f (x:t) (Nest b rest) = Nest (f x b) $ zipNest f t rest
 zipNest _ _ _ = error "List too short!"
 
-zipPiBinders :: [Arrow] -> Nest Binder i i' -> Nest PiBinder i i'
-zipPiBinders = zipNest \arr (b :> ty) -> PiBinder b ty arr
-
 emitMethod
   :: (Mut n, TopBuilder m)
   => NameHint -> ClassName n -> [Bool] -> Int -> m n (Name MethodNameC n)
@@ -1153,6 +1151,9 @@ makeMethodGetter className explicit methodIdx = liftBuilder do
     let dictTy = DictTy $ DictType sourceName (sink className') (map Var params)
     buildPureLam noHint ClassArrow dictTy \dict ->
       emitOp $ ProjMethod (Var dict) methodIdx
+  where
+    zipPiBinders :: [Arrow] -> Nest RoleBinder i i' -> Nest PiBinder i i'
+    zipPiBinders = zipNest \arr (RoleBinder b ty _) -> PiBinder b ty arr
 
 emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> Atom n -> m n (Name TyConNameC n)
 emitTyConName dataDefName tyConAtom = do

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -414,7 +414,7 @@ dictExprType e = case e of
   SuperclassProj d i -> do
     DictTy (DictType _ className params) <- getTypeE d
     ClassDef _ _ bs superclasses _ <- lookupClassDef className
-    checkedApplyNaryAbs (Abs bs (superclassTypes superclasses !! i)) params
+    checkedApplyNaryAbs (Abs (toBinderNest bs) (superclassTypes superclasses !! i)) params
   IxFin n -> do
     n' <- checkTypeE NatTy n
     liftM DictTy $ ixDictType $ TC $ Fin n'
@@ -1089,14 +1089,14 @@ checkedInstantiateDataDef
   => DataDef n -> DataDefParams n -> m n [DataConDef n]
 checkedInstantiateDataDef (DataDef _ (DataDefBinders bs1 bs2) cons)
                           (DataDefParams xs1 xs2) = do
-  fromListE <$> checkedApplyNaryAbs (Abs (bs1 >>> bs2) (ListE cons)) (xs1 <> xs2)
+  fromListE <$> checkedApplyNaryAbs (Abs (toBinderNest bs1 >>> bs2) (ListE cons)) (xs1 <> xs2)
 
 checkedApplyClassParams
   :: (EnvReader m, Fallible1 m) => ClassDef n -> [Type n]
   -> m n (Abs SuperclassBinders (ListE MethodType) n)
 checkedApplyClassParams (ClassDef _ _ bs superclassBs methodTys) params = do
   let body = Abs superclassBs (ListE methodTys)
-  checkedApplyNaryAbs (Abs bs body) params
+  checkedApplyNaryAbs (Abs (toBinderNest bs) body) params
 
 -- TODO: Subst all at once, not one at a time!
 checkedApplyNaryAbs :: (EnvReader m, Fallible1 m, SinkableE e, SubstE AtomSubstVal e)

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -27,6 +27,7 @@ import Control.Monad.Identity
 import Control.Monad.Reader
 import Control.Monad.Writer.Strict hiding (Alt)
 import Control.Monad.State
+import qualified Control.Monad.State.Strict as SS
 import qualified Data.Map.Strict       as M
 
 import Name
@@ -269,6 +270,20 @@ instance (Monad m, ExtOutMap Env decls, OutFrag decls)
           return (ans, catOutFrags (toScope env') decls d, env')
   {-# INLINE refreshAbs #-}
 
+instance ( Monad m, ExtOutMap Env d1, ExtOutMap Env d2
+         , OutFrag d1, OutFrag d2, SubstB Name d1, HoistableB d1)
+         => EnvExtender (DoubleInplaceT Env d1 d2 m) where
+  refreshAbs ab cont = do
+    (ans, decls) <- UnsafeMakeDoubleInplaceT do
+      SS.StateT \s@(topScope, _) -> do
+        (ans, (_, decls)) <- refreshAbs ab \b e -> do
+          flip SS.runStateT (topScope, emptyOutFrag) $
+            unsafeRunDoubleInplaceT $ cont b e
+        return ((ans, decls), s)
+    unsafeEmitDoubleInplaceTHoisted decls
+    return ans
+  {-# INLINE refreshAbs #-}
+
 -- === Typeclasses for syntax ===
 
 -- TODO: unify this with `HasNames` by parameterizing by the thing you bind,
@@ -319,6 +334,14 @@ instance BindsEnv TopEnvFrag where
 
 instance BindsEnv EnvFrag where
   toEnvFrag frag = frag
+  {-# INLINE toEnvFrag #-}
+
+instance BindsEnv RoleBinder where
+  toEnvFrag (RoleBinder b ty _) = toEnvFrag (PiBinder b ty PlainArrow)
+  {-# INLINE toEnvFrag #-}
+
+instance BindsEnv RolePiBinder where
+  toEnvFrag (RolePiBinder b ty arr _) = toEnvFrag (PiBinder b ty arr)
   {-# INLINE toEnvFrag #-}
 
 instance BindsEnv (RecSubstFrag Binding) where

--- a/src/lib/Generalize.hs
+++ b/src/lib/Generalize.hs
@@ -1,0 +1,231 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Generalize (generalizeArgs, generalizeIxDict, Generalized) where
+
+import Control.Monad
+import Control.Category ((>>>))
+
+import Syntax
+import Inference
+import QueryType
+import Name
+import Err
+import MTL1
+import LabeledItems
+
+type Generalized (e::E) (n::S) = (Abs (Nest Binder) e n, [Atom n])
+
+generalizeIxDict :: EnvReader m => Dict n -> m n (Generalized Dict n)
+generalizeIxDict dict = liftGeneralizerM do
+  dict' <- sinkM dict
+  dictTy <- getType dict'
+  dictTyGeneralized <- generalizeType dictTy
+  liftEnvReaderM $ generalizeDict dictTyGeneralized dict'
+{-# INLINE generalizeIxDict #-}
+
+generalizeArgs ::EnvReader m => Nest PiBinder n l -> [Atom n] -> m n (Generalized (ListE Atom) n)
+generalizeArgs reqTys allArgs =  liftGeneralizerM $ runSubstReaderT idSubst do
+  PairE (Abs reqTys' UnitE) (ListE allArgs') <- sinkM $ PairE (Abs reqTys UnitE) (ListE allArgs)
+  ListE <$> go reqTys' allArgs'
+  where
+    go ::Nest PiBinder i i' -> [Atom n] -> SubstReaderT AtomSubstVal GeneralizerM i n [Atom n]
+    go Empty [] = return []
+    go (Nest (PiBinder b ty _) bs) (arg:args) = do
+      ty' <- substM ty
+      arg' <- case ty' of
+        TyKind   -> liftSubstReaderT $ generalizeType arg
+        DictTy _ -> generalizeDict ty' arg
+        _ -> return arg
+      args'' <- extendSubst (b@>SubstVal arg') $ go bs args
+      return $ arg' : args''
+    go _ _ = error "zip error"
+{-# INLINE generalizeArgs #-}
+
+-- === generalizer monad plumbing ===
+
+data GeneralizationEmission n l = GeneralizationEmission (Binder n l) (Atom n)
+type GeneralizationEmissions = RNest GeneralizationEmission
+
+newtype GeneralizerM n a = GeneralizerM {
+  runGeneralizerM' :: DoubleInplaceT Env GeneralizationEmissions UnitB HardFailM n a }
+  deriving (Functor, Applicative, Monad, MonadFail, Fallible, ScopeReader, EnvReader, EnvExtender)
+
+liftGeneralizerM
+  :: EnvReader m
+  => (forall l. DExt n l => GeneralizerM l (e l))
+  -> m n (Generalized e n)
+liftGeneralizerM cont = do
+  env <- unsafeGetEnv
+  Distinct <- getDistinct
+  Abs emissions (DoubleInplaceTResult UnitB e) <- return $ runHardFail $
+    runDoubleInplaceT env $ runGeneralizerM' cont
+  let (bs, vals) = hoistGeneralizationVals (unRNest emissions)
+  return (Abs bs e, vals)
+  where
+    -- TODO: something not O(N^2)
+    hoistGeneralizationVals :: Nest GeneralizationEmission n l -> (Nest Binder n l, [Atom n])
+    hoistGeneralizationVals Empty = (Empty, [])
+    hoistGeneralizationVals (Nest (GeneralizationEmission b val) bs) = do
+      let (bs', vals) = hoistGeneralizationVals bs
+      case hoist b (ListE vals) of
+        HoistSuccess (ListE vals') -> (Nest b bs', val:vals')
+        HoistFailure _ -> error "should't happen"
+{-# INLINE liftGeneralizerM #-}
+
+-- XXX: the supplied type may be more general than the type of the atom!
+emitGeneralizationParameter :: Type n -> Atom n -> GeneralizerM n (AtomName n)
+emitGeneralizationParameter ty val = GeneralizerM do
+  Abs b v <- return $ newName noHint
+  let emission = Abs (RNest REmpty (GeneralizationEmission (b:>ty) val)) v
+  emitDoubleInplaceTHoisted emission >>= \case
+    Nothing -> error $ "expected atom to be hoistable " ++ pprint val
+    Just v' -> return v'
+
+-- === actual generalization traversal ===
+
+-- Given a type (an Atom of type `Type`), abstracts over all data components
+generalizeType :: Type n -> GeneralizerM n (Type n)
+generalizeType ty = traverseTyParams ty \paramRole paramReqTy param -> case paramRole of
+  TypeParam -> generalizeType param
+  DictParam -> generalizeDict paramReqTy param
+  DataParam -> do
+    paramTyGeneralized <- getType param >>= generalizeType
+    Var <$> emitGeneralizationParameter paramTyGeneralized param
+
+-- === role-aware type traversal ===
+
+-- This traverses the type parameters, with knowledge of their roles and
+-- expected types. It's used here for generalization, but it may also be useful
+-- for other operations on types, like newtype stripping.
+
+traverseTyParams
+  :: (EnvReader m, EnvExtender m)
+  => Atom n
+  -> (forall l . DExt n l => ParamRole -> Type l -> Atom l -> m l (Atom l))
+  -> m n (Atom n)
+traverseTyParams ty f = getDistinct >>= \Distinct -> case ty of
+  TypeCon sn def (DataDefParams ordinaryParams dictParams) -> do
+    Abs roleBinders UnitE <- getDataDefRoleBinders def
+    params' <- traverseRoleBinders f roleBinders (ordinaryParams ++ dictParams)
+    let (ordinaryParams', dictParams') = splitAt (length ordinaryParams) params'
+    return $ TypeCon sn def $ DataDefParams ordinaryParams' dictParams'
+  DictTy (DictType sn name params) -> do
+    Abs paramRoles UnitE <- getClassRoleBinders name
+    params' <- traverseRoleBinders f paramRoles params
+    return $ DictTy $ DictType sn name params'
+  TabPi (TabPiType (b:>(IxType iTy d)) resultTy) -> do
+    iTy' <- f TypeParam TyKind iTy
+    dictTy <- ignoreFallibleT1 $ DictTy <$> ixDictType iTy'
+    d'   <- f DictParam dictTy d
+    withFreshBinder (getNameHint b) (toBinding iTy') \b' -> do
+      resultTy' <- applySubst (b@>binderName b') resultTy >>= f TypeParam TyKind
+      return $ TabTy (b':>IxType iTy' d') resultTy'
+  RecordTy  elems -> RecordTy  <$> traverserseFieldRowElemTypes (f TypeParam TyKind) elems
+  VariantTy (Ext elems Nothing) -> do
+    elems' <- traverse (f TypeParam TyKind) elems
+    return $ VariantTy $ Ext elems' Nothing
+  TC tc -> TC <$> case tc of
+    BaseType b -> return $ BaseType b
+    ProdType tys -> ProdType <$> forM tys \t -> f TypeParam TyKind t
+    SumType  tys -> SumType  <$> forM tys \t -> f TypeParam TyKind t
+    Nat -> return Nat
+    Fin n -> Fin <$> f DataParam NatTy n
+    RefType _ _ -> error "not implemented" -- how should we handle the ParamRole for the heap parameter?
+    TypeKind         -> return TypeKind
+    EffectRowKind    -> return EffectRowKind
+    LabeledRowKindTC -> return LabeledRowKindTC
+    LabelType        -> return LabelType
+  _ -> error $ "Not implemented: " ++ pprint ty
+{-# INLINE traverseTyParams #-}
+
+traverseRoleBinders
+  :: forall m n n'. EnvReader m
+  => (forall l . DExt n l => ParamRole -> Type l -> Atom l -> m l (Atom l))
+  ->  Nest RoleBinder n n' -> [Atom n] -> m n [Atom n]
+traverseRoleBinders f allBinders allParams =
+  runSubstReaderT idSubst $ go allBinders allParams
+  where
+    go :: forall i i'. Nest RoleBinder i i' -> [Atom n]
+       -> SubstReaderT AtomSubstVal m i n [Atom n]
+    go Empty [] = return []
+    go (Nest (RoleBinder b ty role) bs) (param:params) = do
+      ty' <- substM ty
+      Distinct <- getDistinct
+      param' <- liftSubstReaderT $ f role ty' param
+      params'' <- extendSubst (b@>SubstVal param') $ go bs params
+      return $ param' : params''
+    go _ _ = error "zip error"
+{-# INLINE traverseRoleBinders #-}
+
+
+traverserseFieldRowElemTypes :: Monad m => (Type n -> m (Type n)) -> FieldRowElems n -> m (FieldRowElems n)
+traverserseFieldRowElemTypes f els = fieldRowElemsFromList <$> traverse checkElem elemList
+  where
+    elemList = fromFieldRowElems els
+    checkElem = \case
+      StaticFields items -> StaticFields <$> traverse f items
+      DynField _ _ -> error "shouldn't have dynamic fields post-simplification"
+      DynFields _  -> error "shouldn't have dynamic fields post-simplification"
+
+-- traverseLabeledRow
+--   :: Monad m
+--   => (Type n -> m (Type n))
+--   -> LabeledItems (Type n)
+--   -> m (LabeledItems (Type n))
+-- traverseLabeledRow f (items rest) = undefined
+-- {-# INLINE traverseLabeledRow #-}
+
+-- traverseLabeledRow (Ext items rest) = do
+--   mapM_ (|: TyKind) items
+--   forM_ rest \name -> do
+--     name' <- lookupSubstM name
+--     ty <- atomBindingType <$> lookupEnv name'
+--     checkAlphaEq LabeledRowKind ty
+
+
+-- checkLabeledRow :: Typer m => ExtLabeledItems (Type i) (AtomName i) -> m i o ()
+-- checkLabeledRow (Ext items rest) = do
+--   mapM_ (|: TyKind) items
+--   forM_ rest \name -> do
+--     name' <- lookupSubstM name
+--     ty <- atomBindingType <$> lookupEnv name'
+--     checkAlphaEq LabeledRowKind ty
+
+getDataDefRoleBinders :: EnvReader m => DataDefName n -> m n (Abs (Nest RoleBinder) UnitE n)
+getDataDefRoleBinders def = do
+  DataDef _ (DataDefBinders bs dictBs) _ <- lookupDataDef def
+  let bs' = fmapNest (\(b:>ty) -> RoleBinder b ty DictParam) dictBs
+  return $ Abs (bs >>> bs') UnitE
+{-# INLINE getDataDefRoleBinders #-}
+
+getClassRoleBinders :: EnvReader m => ClassName n -> m n (Abs (Nest RoleBinder) UnitE n)
+getClassRoleBinders def = do
+  ClassDef _ _ bs _ _ <- lookupClassDef def
+  return $ Abs bs UnitE
+{-# INLINE getClassRoleBinders #-}
+
+-- === instances ===
+
+instance GenericB GeneralizationEmission where
+  type RepB GeneralizationEmission = BinderP AtomNameC (PairE Type Atom)
+  fromB (GeneralizationEmission (b:>ty) x) = b :> PairE ty x
+  toB   (b :> PairE ty x) = GeneralizationEmission (b:>ty) x
+
+instance SubstB Name GeneralizationEmission
+instance HoistableB  GeneralizationEmission
+instance ProvesExt   GeneralizationEmission
+instance BindsNames  GeneralizationEmission
+instance SinkableB   GeneralizationEmission
+
+instance BindsEnv GeneralizationEmission where
+  toEnvFrag (GeneralizationEmission b _) = toEnvFrag b
+  {-# INLINE toEnvFrag #-}
+
+instance ExtOutMap Env GeneralizationEmissions where
+  extendOutMap bindings emissions =
+    bindings `extendOutMap` toEnvFrag emissions
+  {-# INLINE extendOutMap #-}

--- a/src/lib/MTL1.hs
+++ b/src/lib/MTL1.hs
@@ -12,7 +12,7 @@ module MTL1 (
     StateT1, pattern StateT1, runStateT1, evalStateT1, MonadState1,
     MaybeT1 (..), runMaybeT1, ReaderT1 (..), runReaderT1,
     ScopedT1, pattern ScopedT1, runScopedT1,
-    FallibleT1, runFallibleT1
+    FallibleT1, runFallibleT1, ignoreFallibleT1
   ) where
 
 import Control.Monad.Reader
@@ -289,6 +289,13 @@ runFallibleT1 m =
     Right ans -> return $ Success ans
     Left errs -> return $ Failure errs
 {-# INLINE runFallibleT1 #-}
+
+ignoreFallibleT1 :: Monad1 m => FallibleT1 m n a -> m n a
+ignoreFallibleT1 m =
+  runFallibleT1 m >>= \case
+    Success x -> return x
+    Failure e -> error $ pprint e
+{-# INLINE ignoreFallibleT1 #-}
 
 instance Monad1 m => MonadFail (FallibleT1 m n) where
   fail s = throw MonadFailErr s

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -512,6 +512,9 @@ instance Pretty (DataConDef n) where
   pretty (DataConDef name repTy _) =
     p name <+> ":" <+> p repTy
 
+instance Pretty (RoleBinder n l) where
+  pretty (RoleBinder b ty _) = p (b:>ty)
+
 instance Pretty (ClassDef n) where
   pretty (ClassDef classSourceName methodNames params superclasses methodTys) =
     "Class:" <+> pretty classSourceName <+> pretty methodNames
@@ -519,6 +522,9 @@ instance Pretty (ClassDef n) where
          line <> "parameter biners:" <+> pretty params <>
          line <> "superclasses:" <+> pretty (superclassTypes superclasses) <>
          line <> "methods:" <+> pretty methodTys)
+
+instance Pretty (RolePiBinder n l) where
+  pretty (RolePiBinder b ty _ _) = p (b:>ty)
 
 instance Pretty (InstanceDef n) where
   pretty (InstanceDef className bs params _) =

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -758,9 +758,9 @@ instance HasType Block where
 getClassTy :: ClassDef n -> Type n
 getClassTy (ClassDef _ _ bs _ _) = go bs
   where
-    go :: Nest Binder n l -> Type n
+    go :: Nest RoleBinder n l -> Type n
     go Empty = TyKind
-    go (Nest (b:>ty) rest) = Pi $ PiType (PiBinder b ty PlainArrow) Pure $ go rest
+    go (Nest (RoleBinder b ty _) rest) = Pi $ PiType (PiBinder b ty PlainArrow) Pure $ go rest
 
 ixTyFromDict :: EnvReader m => Atom n -> m n (IxType n)
 ixTyFromDict dict = do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -25,11 +25,11 @@ import Err
 import Name
 import Core
 import Builder
+import Generalize
 import Syntax
 import Optimize (peepholeOp)
 import CheckType (CheckableE (..), isData)
-import Util ( enumerate, foldMapM, restructure, toSnocList
-            , splitAtExact, SnocList, snoc, emptySnocList)
+import Util (enumerate, foldMapM, restructure, splitAtExact)
 import QueryType
 import CheapReduction
 import Linearize
@@ -376,68 +376,9 @@ determineSpecializationSpec fname staticArgs = do
     TopFunBound (NaryPiType bs _ _) _ -> do
       (PairB staticArgBinders _) <- return $
         splitNestAt (length staticArgs) (nonEmptyToNest bs)
-      (ab, extraArgs) <- liftEnvReaderM $ generalizeDataComponentsNest staticArgBinders staticArgs
+      (ab, extraArgs) <- generalizeArgs staticArgBinders staticArgs
       return (AppSpecialization fname ab, extraArgs)
     _ -> error "should only be specializing top functions"
-
-type Generalized (e::E) (n::S) = (Abs (Nest Binder) e n, [Atom n])
-
-generalizeDataComponentsNest
-  :: Nest PiBinder n l  -- fully-general argument types expected
-  -> [Atom n]           -- current specialization requested
-  -> EnvReaderM n (Generalized (ListE Atom) n)  -- slightly more general specialization proposed
-generalizeDataComponentsNest bs xs = do
-  Distinct <- getDistinct
-  runSubstReaderT idSubst $ generalizeDataComponentsNestRec (Abs bs UnitE) xs emptyGeneralizationAccum
-
--- Generalization binders, generalized types, new args. The new args match the binders.
-type GeneralizationAccum n l = (RNest Binder n l, SnocList (Type l), SnocList (Atom n))
-
-emptyGeneralizationAccum :: GeneralizationAccum n n
-emptyGeneralizationAccum = (REmpty, emptySnocList, emptySnocList)
-
-generalizeDataComponentsNestRec
-  :: DExt n l
-  => EmptyAbs (Nest PiBinder) i
-  -> [Type n]
-  -> GeneralizationAccum n l
-  -> SubstReaderT AtomSubstVal EnvReaderM i l (Generalized (ListE Type) n)
-generalizeDataComponentsNestRec (Abs Empty UnitE) [] (newBs, generalizedArgs, newArgs) =
-  return (Abs (unRNest newBs) (ListE (toList generalizedArgs)), toList newArgs)
-generalizeDataComponentsNestRec (Abs (Nest b bs) UnitE) (x:xs) accum = do
-  let (newBs, generalizedArgs, newArgs) = accum
-  ty <- substM (binderType b)
-  (ab, newerArgs) <- liftSubstReaderT do
-    x' <- sinkM x
-    case ty of
-      TyKind -> generalizeType x'
-      DictTy dTy -> do
-        xGeneral <- generalizeInstance dTy x'
-        return (Abs Empty xGeneral, [])
-      _ -> error "not implemented"
-  let ListE newerArgs' = ignoreHoistFailure $ hoist newBs $ ListE newerArgs
-  refreshAbs ab \newerBs x' -> do
-    extendSubst (b @> SubstVal x') do
-      let newAccum = ( newBs >>> toRNest newerBs
-                     -- TODO: avoid mapping `sink` over the full list of args here
-                     , fmap sink generalizedArgs `snoc` x'
-                     , newArgs <> toSnocList newerArgs')
-      generalizeDataComponentsNestRec (Abs bs UnitE) xs newAccum
-generalizeDataComponentsNestRec _ _ _ = error "length mismatch"
-
-generalizeType :: Type n -> EnvReaderM n (Generalized Type n)
-generalizeType (TC (Fin n)) = do
-  withFreshBinder noHint NatTy \b -> do
-    let bs = Nest (b:>NatTy) Empty
-    let generalizedTy = TC $ Fin $ Var $ binderName b
-    let args = [n]
-    return (Abs bs generalizedTy, args)
-generalizeType ty = return (Abs Empty ty, [])
-
-generalizeInstance :: DictType n -> Atom n -> EnvReaderM n (Atom n)
-generalizeInstance (DictType "Ix" _ [TC (Fin n)]) (DictCon (IxFin _)) =
-  return $ DictCon (IxFin n)
-generalizeInstance _ x = return x
 
 getSpecializedFunction :: HoistingTopBuilder m => SpecializationSpec n -> m n (AtomName n)
 getSpecializedFunction s = do

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -19,7 +19,7 @@
 {-# LANGUAGE DefaultSignatures #-}
 
 module Syntax (
-    Type, Kind, BaseType (..), ScalarBaseType (..), Except,
+    Type, Kind, Dict, BaseType (..), ScalarBaseType (..), Except,
     EffectP (..), Effect, UEffect, RWS (..), EffectRowP (..), EffectRow, UEffectRow,
     Binder, Block (..), BlockAnn (..), Decl (..), Decls, DeclBinding (..),
     FieldRowElem (..), FieldRowElems, fromFieldRowElems,
@@ -31,7 +31,7 @@ module Syntax (
     AlwaysEqual (..),
     PrimEffect (..), PrimOp (..), PrimHof (..),
     LamBinding (..), LamBinder (..), LamExpr (..),
-    PiBinding (..), PiBinder (..),
+    PiBinding (..), PiBinder (..), RoleBinder (..), RolePiBinder (..), ParamRole (..),
     PiType (..), DepPairType (..), LetAnn (..),
     BinOp (..), UnOp (..), CmpOp (..), SourceMap (..), SourceNameDef (..), LitProg,
     ForAnn, Val, Op, Con, Hof, TC, SuperclassBinders (..),
@@ -40,7 +40,7 @@ module Syntax (
     SynthCandidates (..), Env (..), TopEnv (..), ModuleEnv (..), SerializedEnv (..),
     ImportStatus (..), emptyModuleEnv,
     ModuleSourceName (..), LoadedModules (..), LoadedObjects (..), Cache (..),
-    BindsEnv (..), BindsOneAtomName (..), AtomNameBinder,
+    BindsEnv (..), BindsOneAtomName (..), AtomNameBinder, toBinder, toBinderNest,
     AltP, Alt, AtomBinding (..),
     SolverBinding (..), TopFunBinding (..), SpecializationSpec (..),
     SubstE (..), SubstB (..), Ptr, PtrType,


### PR DESCRIPTION
The idea is that each parameter to a type constructor, class, or instance, must have one of three roles:
  1. type parameter role        (parameters of type `Type`)
  2. data parameter role        (parameters that are runtime-representable)
  3. dictionary parameter role  (parameters of type `DictTy _`)

When we generalize the arguments for a function specialization, we handle parameters according to their role. Data parameters become additional runtime arguments. Type parameters are traversed recursively. And dictionary parameters are generalized according to the required more general type.

For example, imagine we want to generalize the application of `sum : {a} [Ix a] (a=>Float) -> Float` applied to `(Fin 10)` and `IxFinInstance 10`. We traverse the type parameter, `Fin 10`, and find that it has a data parameter, `n:Nat`, which is instantiated at `10` here. We generalize it to `n`, so we have `\n:Nat. sum (Fin n)`. Then we consider the dictionary, `IxFinInstance 10`. With `sum` specialized at `Fin n` instead of `Fin 10`, we now require that the dictionary has type `Ix (Fin n)` instead of `Ix (Fin (10))`. We assume (and require) that instances are parametric in data parameters, so we know that we can use the same synthesis tree and we just need to update the parameters. We swap out data parameters in the instance for inference variables, `IxFinInstance ?1`, and unify the type, `Ix (Fin ?1)`, with the required `Ix (Fin n)`, which is solved by `?1 = n`. We end up generating a generalized-specialized top-level function defined by `\n. sum (Fin n) (IxFinInstance n)` as we hoped.

This change generalizes the function `generalizeType` which previously just special-cased `Fin n` and `Ix (Fin n)` and didn't handle other types and classes at all. It also lets us hoist more general ix dictionaries (e.g. `\n. Ix (Fin n)` instead of `Ix (Fin 10)`, `Ix (Fin 13)`, etc.), which should produce more cache hits, and makes it more reasonable to emit them to the top level.

With this change, we're formalizing two restrictions which were previously just unimplemented/crashy holes in the compiler:
  1. instances must be parametric over all data arguments. You can't define an instance like `Ix (Fin 10)`. It has to be `{n:Nat} (Ix (Fin n))` instead.
  2. type constructor parameters must be one of type/data/dict, so we can't have, e.g., functions as type constructor parameters.

This commit doesn't actually enforce these invariants - either the parametricity or the data/dict/type constraint on type parameters. We should do that as a follow-up.