### PR TITLE
Add an `IR` type parameter to the core/simplified IR

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -279,6 +279,7 @@ foreign-library Dex
   ghc-options:         -Wall
                        -fPIC
                        -optP-Wno-nonportable-include-path
+                       -Wno-unticked-promoted-constructors
   default-language:    Haskell2010
   default-extensions:  BlockArguments
                      , DataKinds

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -28,7 +28,7 @@ import Data.Map.Strict    qualified as M
 import Data.ByteString    qualified as BS
 import Data.Text.Encoding qualified as T
 
-import Syntax  hiding (sizeOf)
+import Syntax  hiding (sizeOf, CAtom)
 import TopLevel
 import Name
 import PPrint
@@ -50,7 +50,7 @@ type ExportNativeFunctionAddr = FunPtr () -- points to executable code
 type NativeFunctionTable = M.Map ExportNativeFunctionAddr ExportNativeFunction
 
 data AtomEx where
-  AtomEx :: Atom n -> AtomEx
+  AtomEx :: Atom CoreIR n -> AtomEx
 
 dexCreateContext :: IO (Ptr Context)
 dexCreateContext = do

--- a/src/Dex/Foreign/Serialize.hs
+++ b/src/Dex/Foreign/Serialize.hs
@@ -18,7 +18,7 @@ import Foreign.Ptr
 import Foreign.Storable
 
 import Name
-import Syntax
+import Syntax hiding (CAtom)
 import Serialize (pprintVal)
 
 import Dex.Foreign.Context
@@ -78,7 +78,7 @@ dexToCAtom atomPtr resultPtr = do
   AtomEx atom <- fromStablePtr atomPtr
   scalarAtomToCAtom atom
   where
-    scalarAtomToCAtom :: Atom n -> IO CInt
+    scalarAtomToCAtom :: Atom CoreIR n -> IO CInt
     scalarAtomToCAtom atom = case atom of
       Con con -> case con of
         Lit l          -> poke resultPtr (CLit l) $> 1

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -25,7 +25,7 @@ import Err
 import MTL1
 import QueryType
 
-type PolyName = Name AtomNameC
+type PolyName = SAtomName
 type PolyBinder = NameBinder AtomNameC
 
 type Constant = Rational
@@ -42,8 +42,8 @@ newtype Polynomial (n::S) =
 -- This is the main entrypoint. Doing polynomial math sometimes lets
 -- us compute sums in closed form. This tries to compute
 -- `\sum_{i=0}^(lim-1) body`. `i`, `lim`, and `body` should all have type `Nat`.
-sumUsingPolys :: (Builder m, Fallible1 m, Emits n)
-              => Atom n -> Abs Binder Block n -> m n (Atom n)
+sumUsingPolys :: (Builder SimpIR m, Fallible1 m, Emits n)
+              => SAtom n -> Abs (Binder SimpIR) SBlock n -> m n (SAtom n)
 sumUsingPolys lim (Abs i body) = do
   sumAbs <- refreshAbs (Abs i body) \(i':>_) body' -> do
     blockAsPoly body' >>= \case
@@ -112,15 +112,15 @@ _showPoly (Polynomial p) =
 -- === core expressions as polynomials ===
 
 type PolySubstVal = SubstVal AtomNameC (MaybeE Polynomial)
-type BlockTraverserM i o a = SubstReaderT PolySubstVal (MaybeT1 BuilderM) i o a
+type BlockTraverserM i o a = SubstReaderT PolySubstVal (MaybeT1 (BuilderM SimpIR)) i o a
 
 blockAsPoly
   :: (EnvExtender m, EnvReader m)
-  => Block n -> m n (Maybe (Polynomial n))
+  => SBlock n -> m n (Maybe (Polynomial n))
 blockAsPoly (Block _ decls result) =
   liftBuilder $ runMaybeT1 $ runSubstReaderT idSubst $ blockAsPolyRec decls result
 
-blockAsPolyRec :: Nest Decl i i' -> Atom i' -> BlockTraverserM i o (Polynomial o)
+blockAsPolyRec :: Nest (Decl SimpIR) i i' -> SAtom i' -> BlockTraverserM i o (Polynomial o)
 blockAsPolyRec decls result = case decls of
   Empty -> atomAsPoly result
   Nest (Let b (DeclBinding _ _ expr)) restDecls -> do
@@ -128,13 +128,13 @@ blockAsPolyRec decls result = case decls of
     extendSubst (b@>SubstVal p) $ blockAsPolyRec restDecls result
 
   where
-    atomAsPoly :: Atom i -> BlockTraverserM i o (Polynomial o)
+    atomAsPoly :: SAtom i -> BlockTraverserM i o (Polynomial o)
     atomAsPoly = \case
       Var v       -> varAsPoly v
       IdxRepVal i -> return $ poly [((fromIntegral i) % 1, mono [])]
       _ -> empty
 
-    varAsPoly :: AtomName i -> BlockTraverserM i o (Polynomial o)
+    varAsPoly :: SAtomName i -> BlockTraverserM i o (Polynomial o)
     varAsPoly v = getSubst <&> (!v) >>= \case
       SubstVal NothingE   -> empty
       SubstVal (JustE cp) -> return cp
@@ -144,7 +144,7 @@ blockAsPolyRec decls result = case decls of
           IdxRepTy -> return $ poly [(1, mono [(v', 1)])]
           _ -> empty
 
-    exprAsPoly :: Expr i -> BlockTraverserM i o (Polynomial o)
+    exprAsPoly :: SExpr i -> BlockTraverserM i o (Polynomial o)
     exprAsPoly e = case e of
       Atom a -> atomAsPoly a
       Op (BinOp op x y) -> case op of
@@ -167,7 +167,7 @@ blockAsPolyRec decls result = case decls of
 -- coefficients. This is why we have to find the least common multiples and do the
 -- accumulation over numbers multiplied by that LCM. We essentially do fixed point
 -- fractional math here.
-emitPolynomial :: (Emits n, Builder m) => Polynomial n -> m n (Atom n)
+emitPolynomial :: (Emits n, Builder SimpIR m) => Polynomial n -> m n (SAtom n)
 emitPolynomial (Polynomial p) = do
   let constLCM = asAtom $ foldl lcm 1 $ fmap (denominator . snd) $ toList p
   monoAtoms <- flip traverse (toList p) $ \(m, c) -> do
@@ -181,12 +181,12 @@ emitPolynomial (Polynomial p) = do
     --       because it might be causing overflows due to all arithmetic being shifted.
     asAtom = IdxRepVal . fromInteger
 
-emitMonomial :: (Emits n, Builder m) => Monomial n -> m n (Atom n)
+emitMonomial :: (Emits n, Builder SimpIR m) => Monomial n -> m n (SAtom n)
 emitMonomial (Monomial m) = do
   varAtoms <- forM (toList m) \(v, e) -> ipow (Var v) e
   foldM imul (IdxRepVal 1) varAtoms
 
-ipow :: (Emits n, Builder m) => Atom n -> Int -> m n (Atom n)
+ipow :: (Emits n, Builder SimpIR m) => SAtom n -> Int -> m n (SAtom n)
 ipow x i = foldM imul (IdxRepVal 1) (replicate i x)
 
 -- === instances ===

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -88,49 +88,49 @@ import Core
 -- === Ordinary (local) builder class ===
 
 class (EnvReader m, EnvExtender m, Fallible1 m)
-      => Builder (m::MonadKind1) where
-  emitDecl :: Emits n => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
+      => Builder (r::IR) (m::MonadKind1) | m -> r where
+  emitDecl :: Emits n => NameHint -> LetAnn -> Expr r n -> m n (AtomName r n)
 
-class Builder m => ScopableBuilder (m::MonadKind1) where
+class Builder r m => ScopableBuilder (r::IR) (m::MonadKind1) where
   buildScoped
     :: SinkableE e
     => (forall l. (Emits l, DExt n l) => m l (e l))
-    -> m n (Abs (Nest Decl) e n)
+    -> m n (Abs (Nest (Decl r)) e n)
 
-type Builder2 (m :: MonadKind2) = forall i. Builder (m i)
-type ScopableBuilder2 (m :: MonadKind2) = forall i. ScopableBuilder (m i)
+type Builder2         (r::IR) (m :: MonadKind2) = forall i. Builder         r (m i)
+type ScopableBuilder2 (r::IR) (m :: MonadKind2) = forall i. ScopableBuilder r (m i)
 
-emit :: (Builder m, Emits n) => Expr n -> m n (AtomName n)
+emit :: (Builder r m, Emits n) => Expr r n -> m n (AtomName r n)
 emit expr = emitDecl noHint PlainLet expr
 {-# INLINE emit #-}
 
-emitHinted :: (Builder m, Emits n) => NameHint -> Expr n -> m n (AtomName n)
+emitHinted :: (Builder r m, Emits n) => NameHint -> Expr r n -> m n (AtomName r n)
 emitHinted hint expr = emitDecl hint PlainLet expr
 {-# INLINE emitHinted #-}
 
-emitOp :: (Builder m, Emits n) => Op n -> m n (Atom n)
+emitOp :: (Builder r m, Emits n) => Op r n -> m n (Atom r n)
 emitOp op = Var <$> emit (Op op)
 {-# INLINE emitOp #-}
 
-emitUnOp :: (Builder m, Emits n) => UnOp -> Atom n -> m n (Atom n)
+emitUnOp :: (Builder r m, Emits n) => UnOp -> Atom r n -> m n (Atom r n)
 emitUnOp op x = emitOp $ UnOp op x
 
-emitBlock :: (Builder m, Emits n) => Block n -> m n (Atom n)
+emitBlock :: (Builder r m, Emits n) => Block r n -> m n (Atom r n)
 emitBlock (Block _ decls result) = emitDecls decls result
 
-emitDecls :: (Builder m, Emits n, SubstE Name e, SinkableE e)
-          => Nest Decl n l -> e l -> m n (e n)
+emitDecls :: (Builder r m, Emits n, SubstE Name e, SinkableE e)
+          => Nest (Decl r) n l -> e l -> m n (e n)
 emitDecls decls result = runSubstReaderT idSubst $ emitDecls' decls result
 
-emitDecls' :: (Builder m, Emits o, SubstE Name e, SinkableE e)
-           => Nest Decl i i' -> e i' -> SubstReaderT Name m i o (e o)
+emitDecls' :: (Builder r m, Emits o, SubstE Name e, SinkableE e)
+           => Nest (Decl r) i i' -> e i' -> SubstReaderT Name m i o (e o)
 emitDecls' Empty e = substM e
 emitDecls' (Nest (Let b (DeclBinding ann _ expr)) rest) e = do
   expr' <- substM expr
   v <- emitDecl (getNameHint b) ann expr'
   extendSubst (b @> v) $ emitDecls' rest e
 
-emitAtomToName :: (Builder m, Emits n) => NameHint -> Atom n -> m n (AtomName n)
+emitAtomToName :: (Builder r m, Emits n) => NameHint -> Atom r n -> m n (AtomName r n)
 emitAtomToName _ (Var v) = return v
 emitAtomToName hint x = emitHinted hint (Atom x)
 
@@ -154,19 +154,18 @@ liftTopBuilderHoisted cont = do
   Distinct <- getDistinct
   return $ runHardFail $ runTopBuilderT env $ localTopBuilder cont
 
-newtype DoubleBuilderT (topEmissions::B) (m::MonadKind) (n::S) (a:: *) =
-  DoubleBuilderT { runDoubleBuilderT' :: DoubleInplaceT Env topEmissions BuilderEmissions m n a }
+newtype DoubleBuilderT (r::IR) (topEmissions::B) (m::MonadKind) (n::S) (a:: *) =
+  DoubleBuilderT { runDoubleBuilderT' :: DoubleInplaceT Env topEmissions (BuilderEmissions r) m n a }
   deriving ( Functor, Applicative, Monad, MonadFail, Fallible
-           , CtxReader, MonadIO, Catchable, MonadReader r)
+           , CtxReader, MonadIO, Catchable, MonadReader r')
 
 deriving instance (ExtOutMap Env frag, HoistableB frag, OutFrag frag, Fallible m)
-                  => ScopeReader (DoubleBuilderT frag m)
+                  => ScopeReader (DoubleBuilderT r frag m)
 
-type DoubleBuilder = DoubleBuilderT TopEnvFrag HardFailM
-
+type DoubleBuilder r = DoubleBuilderT r TopEnvFrag HardFailM
 
 liftDoubleBuilderTNoEmissions
-  :: (EnvReader m, Fallible m') => DoubleBuilderT UnitB m' n a -> m n (m' a)
+  :: (EnvReader m, Fallible m') => DoubleBuilderT r UnitB m' n a -> m n (m' a)
 liftDoubleBuilderTNoEmissions cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
@@ -182,7 +181,7 @@ liftDoubleBuilderTNoEmissions cont = do
 liftDoubleBuilderT
   :: ( EnvReader m, Fallible m', SinkableE e, SubstE Name e
      , ExtOutMap Env frag, OutFrag frag)
-  => (forall l. DExt n l => DoubleBuilderT frag m' l (e l))
+  => (forall l. DExt n l => DoubleBuilderT r frag m' l (e l))
   -> m n (m' (Abs frag e n))
 liftDoubleBuilderT cont = do
   env <- unsafeGetEnv
@@ -193,7 +192,7 @@ runDoubleBuilderT
   :: ( Distinct n, Fallible m, SinkableE e, SubstE Name e
      , ExtOutMap Env frag, OutFrag frag)
   => Env n
-  -> (forall l. DExt n l => DoubleBuilderT frag m l (e l))
+  -> (forall l. DExt n l => DoubleBuilderT r frag m l (e l))
   -> m (Abs frag e n)
 runDoubleBuilderT env cont = do
   Abs envFrag (DoubleInplaceTResult REmpty e) <-
@@ -201,23 +200,23 @@ runDoubleBuilderT env cont = do
   return $ Abs envFrag e
 
 instance (ExtOutMap Env f, OutFrag f, SubstB Name f, HoistableB f, Fallible m)
-  => HoistingTopBuilder f (DoubleBuilderT f m) where
+  => HoistingTopBuilder f (DoubleBuilderT r f m) where
   emitHoistedEnv ab = DoubleBuilderT $ emitDoubleInplaceTHoisted ab
   {-# INLINE emitHoistedEnv #-}
   canHoistToTop e = DoubleBuilderT $ canHoistToTopDoubleInplaceT e
   {-# INLINE canHoistToTop #-}
 
-instance (ExtOutMap Env frag, HoistableB frag, OutFrag frag, Fallible m) => EnvReader (DoubleBuilderT frag m) where
+instance (ExtOutMap Env frag, HoistableB frag, OutFrag frag, Fallible m) => EnvReader (DoubleBuilderT r frag m) where
   unsafeGetEnv = DoubleBuilderT $ liftDoubleInplaceT $ unsafeGetEnv
 
 instance ( SubstB Name frag, HoistableB frag, OutFrag frag
          , ExtOutMap Env frag, Fallible m)
-        => Builder (DoubleBuilderT frag m) where
+        => Builder r (DoubleBuilderT r frag m) where
   emitDecl hint ann e = DoubleBuilderT $ liftDoubleInplaceT $ runBuilderT' $ emitDecl hint ann e
 
 instance ( SubstB Name frag, HoistableB frag, OutFrag frag
          , ExtOutMap Env frag, Fallible m)
-         => ScopableBuilder (DoubleBuilderT frag m) where
+         => ScopableBuilder r (DoubleBuilderT r frag m) where
   -- TODO: find a safe API for DoubleInplaceT sufficient to implement this
   buildScoped cont = DoubleBuilderT do
     (ans, decls) <- UnsafeMakeDoubleInplaceT $
@@ -238,7 +237,7 @@ instance ( SubstB Name frag, HoistableB frag, OutFrag frag
 -- TODO: derive this instead
 instance ( SubstB Name frag, HoistableB frag, OutFrag frag
          , ExtOutMap Env frag, Fallible m)
-         => EnvExtender (DoubleBuilderT frag m) where
+         => EnvExtender (DoubleBuilderT r frag m) where
   refreshAbs ab cont = DoubleBuilderT do
     (ans, decls) <- UnsafeMakeDoubleInplaceT do
       StateT \s@(topScope, _) -> do
@@ -296,21 +295,21 @@ addInstanceSynthCandidate :: TopBuilder m => ClassName n -> InstanceName n -> m 
 addInstanceSynthCandidate className instanceName =
   emitSynthCandidates $ SynthCandidates [] (M.singleton className [instanceName])
 
-emitAtomRules :: TopBuilder m => AtomName n -> AtomRules n -> m n ()
+emitAtomRules :: TopBuilder m => AtomName r n -> AtomRules n -> m n ()
 emitAtomRules v rules = emitNamelessEnv $
   TopEnvFrag emptyOutFrag $ mempty { fragCustomRules = CustomRules $ M.singleton v rules }
 
-emitTopLet :: (Mut n, TopBuilder m) => NameHint -> LetAnn -> Expr n -> m n (AtomName n)
+emitTopLet :: (Mut n, TopBuilder m) => NameHint -> LetAnn -> Expr r n -> m n (AtomName r n)
 emitTopLet hint letAnn expr = do
   ty <- getType expr
-  emitBinding hint $ AtomNameBinding $ LetBound  (DeclBinding letAnn ty expr)
+  emitBinding hint $ AtomNameBinding $ unsafeCoerceIRE $ LetBound (DeclBinding letAnn ty expr)
 
 emitImpFunBinding :: (Mut n, TopBuilder m) => NameHint -> ImpFunction n -> m n (ImpFunName n)
 emitImpFunBinding hint f = emitBinding hint $ ImpFunBinding f
 
 emitSpecialization
   :: (Mut n, TopBuilder m)
-  => SpecializationSpec n -> m n (AtomName n)
+  => SpecializationSpec n -> m n (AtomName r n)
 emitSpecialization s = do
   let hint = getNameHint s
   specializedTy <- specializedFunType s
@@ -342,39 +341,43 @@ extendLoadedObjects name ptr = do
 extendCache :: TopBuilder m => Cache n -> m n ()
 extendCache cache = emitPartialTopEnvFrag $ mempty {fragCache = cache}
 
-extendImpCache :: TopBuilder m => AtomName n -> ImpFunName n -> m n ()
+extendImpCache :: TopBuilder m => AtomName r n -> ImpFunName n -> m n ()
 extendImpCache fSimp fImp =
   extendCache $ mempty { impCache = eMapSingleton fSimp fImp }
 
-queryImpCache :: EnvReader m => AtomName n -> m n (Maybe (ImpFunName n))
+queryImpCache :: EnvReader m => AtomName r n -> m n (Maybe (ImpFunName n))
 queryImpCache v = do
   cache <- impCache <$> getCache
   return $ lookupEMap cache v
 
-emitLoweredFun :: (Mut n, TopBuilder m) => NameHint -> NaryLamExpr n -> m n (AtomName n)
+emitLoweredFun :: (Mut n, TopBuilder m) => NameHint -> NaryLamExpr SimpIR n -> m n (AtomName r n)
 emitLoweredFun hint f = do
   fTy <- naryLamExprType f
   emitBinding hint $ AtomNameBinding $ TopFunBound fTy (LoweredTopFun f)
 
-extendSpecializationCache :: TopBuilder m => SpecializationSpec n -> AtomName n -> m n ()
+extendSpecializationCache :: TopBuilder m => SpecializationSpec n -> AtomName r n -> m n ()
 extendSpecializationCache specialization f =
   extendCache $ mempty { specializationCache = eMapSingleton specialization f }
 
-querySpecializationCache :: EnvReader m => SpecializationSpec n -> m n (Maybe (AtomName n))
+querySpecializationCache :: EnvReader m => SpecializationSpec n -> m n (Maybe (AtomName r n))
 querySpecializationCache specialization = do
   cache <- specializationCache <$> getCache
   return $ lookupEMap cache specialization
 
-extendIxDictCache :: TopBuilder m => AbsDict n -> Name SpecializedDictNameC n -> m n ()
+extendIxDictCache :: TopBuilder m => AbsDict r n -> Name SpecializedDictNameC n -> m n ()
 extendIxDictCache absDict name =
-  extendCache $ mempty { ixDictCache = eMapSingleton absDict name }
+  extendCache $ mempty { ixDictCache = eMapSingleton (unsafeCoerceRAbsDict absDict) name }
 
-queryIxDictCache :: EnvReader m => AbsDict n -> m n (Maybe (Name SpecializedDictNameC n))
-queryIxDictCache v = do
+queryIxDictCache :: EnvReader m => AbsDict r n -> m n (Maybe (Name SpecializedDictNameC n))
+queryIxDictCache d = do
   cache <- ixDictCache <$> getCache
-  return $ lookupEMap cache v
+  return $ lookupEMap cache (unsafeCoerceRAbsDict d)
 
-finishSpecializedDict :: (Mut n, TopBuilder m) => SpecDictName n -> [NaryLamExpr n] -> m n ()
+unsafeCoerceRAbsDict :: AbsDict r n -> AbsDict r' n
+unsafeCoerceRAbsDict (Abs bs e) = Abs bs' (unsafeCoerceIRE e)
+  where bs' = fmapNest (\(b:>ty) -> b :> unsafeCoerceIRE ty) bs
+
+finishSpecializedDict :: (Mut n, TopBuilder m) => SpecDictName n -> [NaryLamExpr SimpIR n] -> m n ()
 finishSpecializedDict name methods =
   emitPartialTopEnvFrag $ mempty {fragFinishSpecializedDict = toSnocList [(name, methods)]}
 
@@ -467,7 +470,7 @@ runTopBuilderT bindings cont = do
   liftM snd $ runInplaceT bindings $ runTopBuilderT' $ cont
 {-# INLINE runTopBuilderT #-}
 
-type TopBuilder2 (m :: MonadKind2) = forall i. TopBuilder (m i)
+type TopBuilder2 (r::IR) (m :: MonadKind2) = forall i. TopBuilder (m i)
 
 instance (SinkableE e, HoistableState e, TopBuilder m) => TopBuilder (StateT1 e m) where
   emitBinding hint binding = lift11 $ emitBinding hint binding
@@ -480,17 +483,17 @@ instance (SinkableE e, HoistableState e, TopBuilder m) => TopBuilder (StateT1 e 
 
 -- === BuilderT ===
 
-type BuilderEmissions = RNest Decl
+type BuilderEmissions r = RNest (Decl r)
 
-newtype BuilderT (m::MonadKind) (n::S) (a:: *) =
-  BuilderT { runBuilderT' :: InplaceT Env BuilderEmissions m n a }
+newtype BuilderT (r::IR) (m::MonadKind) (n::S) (a:: *) =
+  BuilderT { runBuilderT' :: InplaceT Env (BuilderEmissions r) m n a }
   deriving ( Functor, Applicative, Monad, MonadTrans1, MonadFail, Fallible
            , CtxReader, ScopeReader, Alternative, Searcher
-           , MonadWriter w, MonadReader r)
+           , MonadWriter w, MonadReader r')
 
-type BuilderM = BuilderT HardFailM
+type BuilderM (r::IR) = BuilderT r HardFailM
 
-liftBuilderT :: (Fallible m, EnvReader m') => BuilderT m n a -> m' n (m a)
+liftBuilderT :: (Fallible m, EnvReader m') => BuilderT r m n a -> m' n (m a)
 liftBuilderT cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
@@ -499,15 +502,15 @@ liftBuilderT cont = do
     return result
 {-# INLINE liftBuilderT #-}
 
-liftBuilder :: EnvReader m => BuilderM n a -> m n a
+liftBuilder :: EnvReader m => BuilderM r n a -> m n a
 liftBuilder cont = liftM runHardFail $ liftBuilderT cont
 {-# INLINE liftBuilder #-}
 
 -- TODO: This should not fabricate Emits evidence!!
 -- XXX: this uses unsafe functions in its implementations. It should be safe to
 -- use, but be careful changing it.
-liftEmitBuilder :: (Builder m, SinkableE e, SubstE Name e)
-                => BuilderM n (e n) -> m n (e n)
+liftEmitBuilder :: (Builder r m, SinkableE e, SubstE Name e)
+                => BuilderM r n (e n) -> m n (e n)
 liftEmitBuilder cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
@@ -515,7 +518,7 @@ liftEmitBuilder cont = do
   Emits <- fabricateEmitsEvidenceM
   emitDecls (unsafeCoerceB $ unRNest decls) result
 
-instance Fallible m => ScopableBuilder (BuilderT m) where
+instance Fallible m => ScopableBuilder r (BuilderT r m) where
   buildScoped cont = BuilderT do
     Abs rdecls e <- locallyMutableInplaceT $
       runBuilderT' do
@@ -525,68 +528,68 @@ instance Fallible m => ScopableBuilder (BuilderT m) where
     return $ Abs (unRNest rdecls) e
   {-# INLINE buildScoped #-}
 
-newtype BuilderDeclEmission (n::S) (l::S) = BuilderDeclEmission (Decl n l)
-instance ExtOutMap Env BuilderDeclEmission where
+newtype BuilderDeclEmission (r::IR) (n::S) (l::S) = BuilderDeclEmission (Decl r n l)
+instance ExtOutMap Env (BuilderDeclEmission r) where
   extendOutMap env (BuilderDeclEmission d) = env `extendOutMap` toEnvFrag d
   {-# INLINE extendOutMap #-}
-instance ExtOutFrag BuilderEmissions BuilderDeclEmission where
+instance ExtOutFrag (BuilderEmissions r) (BuilderDeclEmission r) where
   extendOutFrag rn (BuilderDeclEmission d) = RNest rn d
   {-# INLINE extendOutFrag #-}
 
-instance Fallible m => Builder (BuilderT m) where
+instance Fallible m => Builder r (BuilderT r m) where
   emitDecl hint ann expr = do
     ty <- getType expr
     BuilderT $ freshExtendSubInplaceT hint \b ->
       (BuilderDeclEmission $ Let b $ DeclBinding ann ty expr, binderName b)
   {-# INLINE emitDecl #-}
 
-instance Fallible m => EnvReader (BuilderT m) where
+instance Fallible m => EnvReader (BuilderT r m) where
   unsafeGetEnv = BuilderT $ getOutMapInplaceT
   {-# INLINE unsafeGetEnv #-}
 
-instance Fallible m => EnvExtender (BuilderT m) where
+instance Fallible m => EnvExtender (BuilderT r m) where
   refreshAbs ab cont = BuilderT $ refreshAbs ab \b e -> runBuilderT' $ cont b e
   {-# INLINE refreshAbs #-}
 
-instance (SinkableV v, ScopableBuilder m) => ScopableBuilder (SubstReaderT v m i) where
+instance (SinkableV v, ScopableBuilder r m) => ScopableBuilder r (SubstReaderT v m i) where
   buildScoped cont = SubstReaderT $ ReaderT \env ->
     buildScoped $
       runReaderT (runSubstReaderT' cont) (sink env)
   {-# INLINE buildScoped #-}
 
-instance (SinkableV v, Builder m) => Builder (SubstReaderT v m i) where
+instance (SinkableV v, Builder r m) => Builder r (SubstReaderT v m i) where
   emitDecl hint ann expr = SubstReaderT $ lift $ emitDecl hint ann expr
   {-# INLINE emitDecl #-}
 
-instance (SinkableE e, ScopableBuilder m) => ScopableBuilder (OutReaderT e m) where
+instance (SinkableE e, ScopableBuilder r m) => ScopableBuilder r (OutReaderT e m) where
   buildScoped cont = OutReaderT $ ReaderT \env ->
     buildScoped do
       env' <- sinkM env
       runReaderT (runOutReaderT' cont) env'
   {-# INLINE buildScoped #-}
 
-instance (SinkableE e, Builder m) => Builder (OutReaderT e m) where
+instance (SinkableE e, Builder r m) => Builder r (OutReaderT e m) where
   emitDecl hint ann expr =
     OutReaderT $ lift $ emitDecl hint ann expr
   {-# INLINE emitDecl #-}
 
-instance (SinkableE e, ScopableBuilder m) => ScopableBuilder (ReaderT1 e m) where
+instance (SinkableE e, ScopableBuilder r m) => ScopableBuilder r (ReaderT1 e m) where
   buildScoped cont = ReaderT1 $ ReaderT \env ->
     buildScoped do
       env' <- sinkM env
       runReaderT (runReaderT1' cont) env'
   {-# INLINE buildScoped #-}
 
-instance (SinkableE e, Builder m) => Builder (ReaderT1 e m) where
+instance (SinkableE e, Builder r m) => Builder r (ReaderT1 e m) where
   emitDecl hint ann expr =
     ReaderT1 $ lift $ emitDecl hint ann expr
   {-# INLINE emitDecl #-}
 
-instance (SinkableE e, HoistableState e, Builder m) => Builder (StateT1 e m) where
+instance (SinkableE e, HoistableState e, Builder r m) => Builder r (StateT1 e m) where
   emitDecl hint ann expr = lift11 $ emitDecl hint ann expr
   {-# INLINE emitDecl #-}
 
-instance (SinkableE e, HoistableState e, ScopableBuilder m) => ScopableBuilder (StateT1 e m) where
+instance (SinkableE e, HoistableState e, ScopableBuilder r m) => ScopableBuilder r (StateT1 e m) where
   buildScoped cont = StateT1 \s -> do
     Abs decls (e `PairE` s') <- buildScoped $ liftM toPairE $ runStateT1 cont =<< sinkM s
     let s'' = hoistState s decls s'
@@ -600,7 +603,7 @@ instance (SinkableE e, HoistableState e, HoistingTopBuilder frag m)
   canHoistToTop e = lift11 $ canHoistToTop e
   {-# INLINE canHoistToTop #-}
 
-instance Builder m => Builder (MaybeT1 m) where
+instance Builder r m => Builder r (MaybeT1 m) where
   emitDecl hint ann expr = lift11 $ emitDecl hint ann expr
   {-# INLINE emitDecl #-}
 
@@ -635,24 +638,24 @@ newtype WrapWithEmits n r =
 -- === lambda-like things ===
 
 buildBlock
-  :: ScopableBuilder m
-  => (forall l. (Emits l, DExt n l) => m l (Atom l))
-  -> m n (Block n)
+  :: ScopableBuilder r m
+  => (forall l. (Emits l, DExt n l) => m l (Atom r l))
+  -> m n (Block r n)
 buildBlock cont = buildScoped (cont >>= withType) >>= computeAbsEffects >>= absToBlock
 
-withType :: (EnvReader m, HasType e) => e l -> m l ((e `PairE` Type) l)
+withType :: (EnvReader m, HasType r e) => e l -> m l ((e `PairE` Type r) l)
 withType e = do
   ty <- {-# SCC blockTypeNormalization #-} cheapNormalize =<< getType e
   return $ e `PairE` ty
 {-# INLINE withType #-}
 
-makeBlock :: Nest Decl n l -> EffectRow l -> Atom l -> Type l -> Block n
+makeBlock :: Nest (Decl r) n l -> EffectRow l -> Atom r l -> Type r l -> Block r n
 makeBlock decls effs atom ty = Block (BlockAnn ty' effs') decls atom where
   ty' = ignoreHoistFailure $ hoist decls ty
   effs' = ignoreHoistFailure $ hoist decls effs
 {-# INLINE makeBlock #-}
 
-absToBlockInferringTypes :: EnvReader m => Abs (Nest Decl) Atom n -> m n (Block n)
+absToBlockInferringTypes :: EnvReader m => Abs (Nest (Decl r)) (Atom r) n -> m n (Block r n)
 absToBlockInferringTypes ab = liftEnvReaderM do
   abWithEffs <-  computeAbsEffects ab
   refreshAbs abWithEffs \decls (effs `PairE` result) -> do
@@ -661,7 +664,7 @@ absToBlockInferringTypes ab = liftEnvReaderM do
       absToBlock $ Abs decls (effs `PairE` (result `PairE` ty))
 {-# INLINE absToBlockInferringTypes #-}
 
-absToBlock :: (Fallible m) => Abs (Nest Decl) (EffectRow `PairE` (Atom `PairE` Type)) n -> m (Block n)
+absToBlock :: (Fallible m) => Abs (Nest (Decl r)) (EffectRow `PairE` (Atom r `PairE` Type r)) n -> m (Block r n)
 absToBlock (Abs decls (effs `PairE` (result `PairE` ty))) = do
   let msg = "Block:" <> nest 1 (prettyBlock decls result) <> line
             <> group ("Of type:" <> nest 2 (line <> pretty ty)) <> line
@@ -671,20 +674,20 @@ absToBlock (Abs decls (effs `PairE` (result `PairE` ty))) = do
   return $ Block (BlockAnn ty' effs') decls result
 {-# INLINE absToBlock #-}
 
-buildPureLam :: ScopableBuilder m
-             => NameHint -> Arrow -> Type n
-             -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-             -> m n (Atom n)
+buildPureLam :: ScopableBuilder r m
+             => NameHint -> Arrow -> Type r n
+             -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+             -> m n (Atom r n)
 buildPureLam hint arr ty body = do
   buildLamGeneral hint arr ty (const $ return Pure) \v -> do
     Distinct <- getDistinct
     body v
 
 buildTabLam
-  :: ScopableBuilder m
-  => NameHint -> IxType n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: ScopableBuilder r m
+  => NameHint -> IxType r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 buildTabLam hint ty fBody = do
   withFreshBinder hint ty \b -> do
     let v = binderName b
@@ -692,33 +695,33 @@ buildTabLam hint ty fBody = do
     return $ TabLam $ TabLamExpr (b:>ty) body
 
 buildLam
-  :: ScopableBuilder m
-  => NameHint -> Arrow -> Type n -> EffectRow n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: ScopableBuilder r m
+  => NameHint -> Arrow -> Type r n -> EffectRow n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 buildLam hint arr ty eff body = buildLamGeneral hint arr ty (const $ sinkM eff) body
 
-buildNullaryLam :: ScopableBuilder m
+buildNullaryLam :: ScopableBuilder r m
                 => EffectRow n
-                -> (forall l. (Emits l, DExt n l) => m l (Atom l))
-                -> m n (Atom n)
+                -> (forall l. (Emits l, DExt n l) => m l (Atom r l))
+                -> m n (Atom r n)
 buildNullaryLam effs cont = buildLam noHint PlainArrow UnitTy effs \_ -> cont
 
-buildNullaryPi :: Builder m
+buildNullaryPi :: Builder r m
                => EffectRow n
-               -> (forall l. DExt n l => m l (Type l))
-               -> m n (Type n)
+               -> (forall l. DExt n l => m l (Type r l))
+               -> m n (Type r n)
 buildNullaryPi effs cont =
   Pi <$> buildPi noHint PlainArrow UnitTy \_ -> do
     resultTy <- cont
     return (sink effs, resultTy)
 
 buildLamGeneral
-  :: ScopableBuilder m
-  => NameHint -> Arrow -> Type n
-  -> (forall l.           DExt n l  => AtomName l -> m l (EffectRow l))
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: ScopableBuilder r m
+  => NameHint -> Arrow -> Type r n
+  -> (forall l.           DExt n l  => AtomName r l -> m l (EffectRow l))
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 buildLamGeneral hint arr ty fEff fBody = do
   withFreshBinder hint (LamBinding arr ty) \b -> do
     let v = binderName b
@@ -728,10 +731,10 @@ buildLamGeneral hint arr ty fEff fBody = do
 
 -- Body must be an Atom because otherwise the nullary case would require
 -- emitting decls into the enclosing scope.
-buildPureNaryLam :: ScopableBuilder m
-                 => EmptyAbs (Nest PiBinder) n
-                 -> (forall l. DExt n l => [AtomName l] -> m l (Atom l))
-                 -> m n (Atom n)
+buildPureNaryLam :: ScopableBuilder r m
+                 => EmptyAbs (Nest (PiBinder r)) n
+                 -> (forall l. DExt n l => [AtomName r l] -> m l (Atom r l))
+                 -> m n (Atom r n)
 buildPureNaryLam (EmptyAbs Empty) cont = do
   Distinct <- getDistinct
   cont []
@@ -744,20 +747,20 @@ buildPureNaryLam (EmptyAbs (Nest (PiBinder b ty arr) rest)) cont = do
       cont (x':xs)
 buildPureNaryLam _ _ = error "impossible"
 
-buildPi :: (Fallible1 m, Builder m)
-        => NameHint -> Arrow -> Type n
-        -> (forall l. DExt n l => AtomName l -> m l (EffectRow l, Type l))
-        -> m n (PiType n)
+buildPi :: (Fallible1 m, Builder r m)
+        => NameHint -> Arrow -> Type r n
+        -> (forall l. DExt n l => AtomName r l -> m l (EffectRow l, Type r l))
+        -> m n (PiType r n)
 buildPi hint arr ty body = do
   withFreshPiBinder hint (PiBinding arr ty) \b -> do
     (effs, resultTy) <- body $ binderName b
     return $ PiType b effs resultTy
 
 buildNaryPi
-  :: Builder m
-  => EmptyAbs (Nest Binder) n
-  -> (forall l. (Distinct l, DExt n l) => [AtomName l] -> m l (Type l))
-  -> m n (Type n)
+  :: Builder r m
+  => EmptyAbs (Nest (Binder r)) n
+  -> (forall l. (Distinct l, DExt n l) => [AtomName r l] -> m l (Type r l))
+  -> m n (Type r n)
 buildNaryPi (Abs Empty UnitE) cont = do
   Distinct <- getDistinct
   cont []
@@ -768,8 +771,8 @@ buildNaryPi (Abs (Nest (b:>ty) bs) UnitE) cont = do
     return (Pure, piTy)
 
 buildNonDepPi :: EnvReader m
-              => NameHint -> Arrow -> Type n -> EffectRow n -> Type n
-              -> m n (PiType n)
+              => NameHint -> Arrow -> Type r n -> EffectRow n -> Type r n
+              -> m n (PiType r n)
 buildNonDepPi hint arr argTy effs resultTy = liftBuilder do
   argTy' <- sinkM argTy
   buildPi hint arr argTy' \_ -> do
@@ -789,7 +792,7 @@ buildAbs hint binding cont = do
     body <- cont $ binderName b
     return $ Abs (b:>binding) body
 
-varsAsBinderNest :: EnvReader m => [AtomName n] -> m n (EmptyAbs (Nest Binder) n)
+varsAsBinderNest :: EnvReader m => [AtomName r n] -> m n (EmptyAbs (Nest (Binder r)) n)
 varsAsBinderNest [] = return $ EmptyAbs Empty
 varsAsBinderNest (v:vs) = do
   rest <- varsAsBinderNest vs
@@ -797,10 +800,10 @@ varsAsBinderNest (v:vs) = do
   Abs b (Abs bs UnitE) <- return $ abstractFreeVar v rest
   return $ EmptyAbs (Nest (b:>ty) bs)
 
-typesAsBinderNest :: EnvReader m => [Type n] -> m n (EmptyAbs (Nest Binder) n)
+typesAsBinderNest :: EnvReader m => [Type r n] -> m n (EmptyAbs (Nest (Binder r)) n)
 typesAsBinderNest types = liftEnvReaderM $ go types
   where
-    go :: forall n. [Type n] -> EnvReaderM n (EmptyAbs (Nest Binder) n)
+    go :: forall r n. [Type r n] -> EnvReaderM n (EmptyAbs (Nest (Binder r)) n)
     go tys = case tys of
       [] -> return $ Abs Empty UnitE
       ty:rest -> withFreshBinder noHint ty \b -> do
@@ -816,10 +819,10 @@ singletonBinderNest hint ann = do
   return $ EmptyAbs (Nest (b:>ann) Empty)
 
 buildNaryAbs
-  :: ( ScopableBuilder m, SinkableE e, SubstE Name e, SubstE AtomSubstVal e, HoistableE e
-     , BindsOneAtomName b, BindsEnv b, SubstB Name b)
+  :: ( ScopableBuilder r m, SinkableE e, SubstE Name e, SubstE (AtomSubstVal r) e, HoistableE e
+     , BindsOneAtomName r b, BindsEnv b, SubstB Name b)
   => EmptyAbs (Nest b) n
-  -> (forall l. DExt n l => [AtomName l] -> m l (e l))
+  -> (forall l. DExt n l => [AtomName r l] -> m l (e l))
   -> m n (Abs (Nest b) e n)
 buildNaryAbs (Abs n UnitE) body = do
   a <- liftBuilder $ buildNaryAbsRec [] n
@@ -828,8 +831,8 @@ buildNaryAbs (Abs n UnitE) body = do
 {-# INLINE buildNaryAbs #-}
 
 buildNaryAbsRec
-  :: (BindsOneAtomName b, BindsEnv b, SubstB Name b)
-  => [AtomName n] -> Nest b n l -> BuilderM n (Abs (Nest b) (ListE AtomName) n)
+  :: (BindsOneAtomName r b, BindsEnv b, SubstB Name b)
+  => [AtomName r n] -> Nest b n l -> BuilderM r n (Abs (Nest b) (ListE (AtomName r)) n)
 buildNaryAbsRec ns x = confuseGHC >>= \_ -> case x of
   Empty -> return $ Abs Empty $ ListE $ reverse ns
   Nest b bs -> do
@@ -839,10 +842,10 @@ buildNaryAbsRec ns x = confuseGHC >>= \_ -> case x of
 
 -- TODO: probably deprectate this version in favor of `buildNaryLamExpr`
 buildNaryLam
-  :: (ScopableBuilder m, Emits n)
-  => EmptyAbs (Nest Binder) n
-  -> (forall l. (Emits l, Distinct l, DExt n l) => [AtomName l] -> m l (Atom l))
-  -> m n (Atom n)
+  :: (ScopableBuilder r m, Emits n)
+  => EmptyAbs (Nest (Binder r)) n
+  -> (forall l. (Emits l, Distinct l, DExt n l) => [AtomName r l] -> m l (Atom r l))
+  -> m n (Atom r n)
 buildNaryLam binderNest body = do
   naryAbs <- buildNaryAbs binderNest \vs ->
     buildBlock $ body $ map sink vs
@@ -850,23 +853,23 @@ buildNaryLam binderNest body = do
     AtomicBlock atom -> return atom
     block -> emitBlock block
   where
-    naryAbsToNaryLam :: Abs (Nest Binder) Block n -> Block n
+    naryAbsToNaryLam :: Abs (Nest (Binder r)) (Block r) n -> Block r n
     naryAbsToNaryLam (Abs binders block) = case binders of
       Empty -> block
       Nest (b:>ty) bs ->
         AtomicBlock $ Lam $ LamExpr (LamBinder b ty PlainArrow Pure) $
           naryAbsToNaryLam $ Abs bs block
 
-asNaryLam :: EnvReader m => NaryPiType n -> Atom n -> m n (NaryLamExpr n)
+asNaryLam :: EnvReader m => NaryPiType r n -> Atom r n -> m n (NaryLamExpr r n)
 asNaryLam ty f = liftBuilder do
   buildNaryLamExpr ty \xs ->
     naryApp (sink f) (map Var $ toList xs)
 
 buildNaryLamExpr
-  :: ScopableBuilder m
-  => NaryPiType n
-  -> (forall l. (Emits l, Distinct l, DExt n l) => NonEmpty (AtomName l) -> m l (Atom l))
-  -> m n (NaryLamExpr n)
+  :: ScopableBuilder r m
+  => NaryPiType r n
+  -> (forall l. (Emits l, Distinct l, DExt n l) => NonEmpty (AtomName r l) -> m l (Atom r l))
+  -> m n (NaryLamExpr r n)
 buildNaryLamExpr (NaryPiType (NonEmptyNest b bs) eff resultTy) cont =
   case bs of
     Empty -> do
@@ -883,10 +886,10 @@ buildNaryLamExpr (NaryPiType (NonEmptyNest b bs) eff resultTy) cont =
       return $ NaryLamExpr (NonEmptyNest b' (Nest bnext' rest')) eff' body'
 
 buildAlt
-  :: ScopableBuilder m
-  => Type n
-  -> (forall l. (Distinct l, Emits l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (Alt n)
+  :: ScopableBuilder r m
+  => Type r n
+  -> (forall l. (Distinct l, Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (Alt r n)
 buildAlt ty body = do
   buildAbs noHint ty \x ->
     buildBlock do
@@ -894,10 +897,10 @@ buildAlt ty body = do
       body $ sink x
 
 buildUnaryAtomAlt
-  :: ScopableBuilder m
-  => Type n
-  -> (forall l. (Distinct l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (AltP Atom n)
+  :: ScopableBuilder r m
+  => Type r n
+  -> (forall l. (Distinct l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (AltP r (Atom r) n)
 buildUnaryAtomAlt ty body = do
   buildAbs noHint ty \v -> do
     Distinct <- getDistinct
@@ -905,10 +908,10 @@ buildUnaryAtomAlt ty body = do
 
 -- TODO: consider a version with nonempty list of alternatives where we figure
 -- out the result type from one of the alts rather than providing it explicitly
-buildCase :: (Emits n, ScopableBuilder m)
-          => Atom n -> Type n
-          -> (forall l. (Emits l, DExt n l) => Int -> Atom l -> m l (Atom l))
-          -> m n (Atom n)
+buildCase :: (Emits n, ScopableBuilder r m)
+          => Atom r n -> Type r n
+          -> (forall l. (Emits l, DExt n l) => Int -> Atom r l -> m l (Atom r l))
+          -> m n (Atom r n)
 buildCase scrut resultTy indexedAltBody = do
   case trySelectBranch scrut of
     Just (i, arg) -> do
@@ -925,11 +928,11 @@ buildCase scrut resultTy indexedAltBody = do
         return (Abs b' body, ignoreHoistFailure $ hoist b' eff')
       liftM Var $ emit $ Case scrut alts resultTy $ mconcat effs
 
-buildSplitCase :: (Emits n, ScopableBuilder m)
-               => LabeledItems (Type n) -> Atom n -> Type n
-               -> (forall l. (Emits l, DExt n l) => Atom l -> m l (Atom l))
-               -> (forall l. (Emits l, DExt n l) => Atom l -> m l (Atom l))
-               -> m n (Atom n)
+buildSplitCase :: (Emits n, ScopableBuilder r m)
+               => LabeledItems (Type r n) -> Atom r n -> Type r n
+               -> (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
+               -> (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
+               -> m n (Atom r n)
 buildSplitCase tys scrut resultTy match fallback = do
   split <- emitOp $ VariantSplit tys scrut
   buildCase split resultTy \i v ->
@@ -939,10 +942,10 @@ buildSplitCase tys scrut resultTy match fallback = do
       _ -> error "should only have two cases"
 
 buildEffLam
-  :: ScopableBuilder m
-  => RWS -> NameHint -> Type n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: ScopableBuilder r m
+  => RWS -> NameHint -> Type r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 buildEffLam rws hint ty body = do
   eff <- getAllowedEffects
   buildLam noHint PlainArrow TyKind Pure \h -> do
@@ -959,10 +962,10 @@ buildEffLam rws hint ty body = do
       return $ Lam $ LamExpr (LamBinder b ty' PlainArrow effs) body'
 
 buildForAnn
-  :: (Emits n, ScopableBuilder m)
-  => NameHint -> ForAnn -> IxType n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: (Emits n, ScopableBuilder r m)
+  => NameHint -> ForAnn -> IxType r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 buildForAnn hint ann ixTy@(IxType iTy ixDict) body = do
   lam <- withFreshBinder hint ixTy \b -> do
     let v = binderName b
@@ -971,13 +974,13 @@ buildForAnn hint ann ixTy@(IxType iTy ixDict) body = do
     return $ Lam $ LamExpr (LamBinder b iTy PlainArrow effs) body'
   liftM Var $ emit $ Hof $ For ann ixDict lam
 
-buildFor :: (Emits n, ScopableBuilder m)
-         => NameHint -> Direction -> IxType n
-         -> (forall l. (Emits l, DExt n l) => AtomName l -> m l (Atom l))
-         -> m n (Atom n)
+buildFor :: (Emits n, ScopableBuilder r m)
+         => NameHint -> Direction -> IxType r n
+         -> (forall l. (Emits l, DExt n l) => AtomName r l -> m l (Atom r l))
+         -> m n (Atom r n)
 buildFor hint dir ty body = buildForAnn hint dir ty body
 
-unzipTab :: (Emits n, Builder m) => Atom n -> m n (Atom n, Atom n)
+unzipTab :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n, Atom r n)
 unzipTab tab = do
   TabTy (_:>ixTy) _ <- getType tab
   fsts <- liftEmitBuilder $ buildTabLam noHint ixTy \i ->
@@ -987,29 +990,29 @@ unzipTab tab = do
   return (fsts, snds)
 
 emitRunWriter
-  :: (Emits n, ScopableBuilder m)
-  => NameHint -> Type n -> BaseMonoid n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: (Emits n, ScopableBuilder r m)
+  => NameHint -> Type r n -> BaseMonoid r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 emitRunWriter hint accTy bm body = do
   lam <- buildEffLam Writer hint accTy \h ref -> body h ref
   liftM Var $ emit $ Hof $ RunWriter Nothing bm lam
 
 emitRunState
-  :: (Emits n, ScopableBuilder m)
-  => NameHint -> Atom n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: (Emits n, ScopableBuilder r m)
+  => NameHint -> Atom r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 emitRunState hint initVal body = do
   stateTy <- getType initVal
   lam <- buildEffLam State hint stateTy \h ref -> body h ref
   liftM Var $ emit $ Hof $ RunState Nothing initVal lam
 
 emitRunReader
-  :: (Emits n, ScopableBuilder m)
-  => NameHint -> Atom n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> AtomName l -> m l (Atom l))
-  -> m n (Atom n)
+  :: (Emits n, ScopableBuilder r m)
+  => NameHint -> Atom r n
+  -> (forall l. (Emits l, DExt n l) => AtomName r l -> AtomName r l -> m l (Atom r l))
+  -> m n (Atom r n)
 emitRunReader hint r body = do
   rTy <- getType r
   lam <- buildEffLam Reader hint rTy \h ref -> body h ref
@@ -1017,7 +1020,7 @@ emitRunReader hint r body = do
 
 -- === vector space (ish) type class ===
 
-zeroAt :: HasCallStack => Builder m => Type n -> m n (Atom n)
+zeroAt :: HasCallStack => Builder r m => Type r n -> m n (Atom r n)
 zeroAt ty = case ty of
   BaseTy bt  -> return $ Con $ Lit $ zeroLit bt
   ProdTy tys -> ProdVal <$> mapM zeroAt tys
@@ -1034,18 +1037,18 @@ zeroAt ty = case ty of
       Scalar Float32Type -> Float32Lit 0.0
       _                  -> unreachable
 
-zeroLike :: (HasCallStack, HasType e, Builder m) => e n -> m n (Atom n )
+zeroLike :: (HasCallStack, HasType r e, Builder r m) => e n -> m n (Atom r n )
 zeroLike x = zeroAt =<< getType x
 
-tangentType :: EnvReader m => Type n -> m n (Type n)
+tangentType :: EnvReader m => Type r n -> m n (Type r n)
 tangentType ty = maybeTangentType ty >>= \case
   Just tanTy -> return tanTy
   Nothing -> error $ "can't differentiate wrt type: " ++ pprint ty
 
-maybeTangentType :: EnvReader m => Type n -> m n (Maybe (Type n))
+maybeTangentType :: EnvReader m => Type r n -> m n (Maybe (Type r n))
 maybeTangentType ty = liftEnvReaderT $ maybeTangentType' ty
 
-maybeTangentType' :: Type n -> EnvReaderT Maybe n (Type n)
+maybeTangentType' :: Type r n -> EnvReaderT Maybe n (Type r n)
 maybeTangentType' ty = case ty of
   StaticRecordTy items -> StaticRecordTy <$> mapM rec items
   -- TODO: Delete this case! This is a hack!
@@ -1065,22 +1068,22 @@ maybeTangentType' ty = case ty of
   _ -> empty
   where rec = maybeTangentType'
 
-fromNewtypeWrapper :: (EnvReader m, Fallible1 m) => Type n -> m n (Type n)
+fromNewtypeWrapper :: (EnvReader m, Fallible1 m) => Type r n -> m n (Type r n)
 fromNewtypeWrapper ty = do
   TypeCon _ defName params <- return ty
   def <- lookupDataDef defName
   [con] <- instantiateDataDef def params
   -- Single field constructors are represented by their field
   DataConDef _ wrappedTy [_] <- return con
-  return wrappedTy
+  return $ unsafeCoerceIRE wrappedTy
 
-tangentBaseMonoidFor :: Builder m => Type n -> m n (BaseMonoid n)
+tangentBaseMonoidFor :: Builder r m => Type r n -> m n (BaseMonoid r n)
 tangentBaseMonoidFor ty = do
   zero <- zeroAt ty
   adder <- liftEmitBuilder $ buildLam noHint PlainArrow ty Pure \v -> updateAddAt $ Var v
   return $ BaseMonoid zero adder
 
-addTangent :: (Emits n, Builder m) => Atom n -> Atom n -> m n (Atom n)
+addTangent :: (Emits n, Builder r m) => Atom r n -> Atom r n -> m n (Atom r n)
 addTangent x y = do
   getType x >>= \case
     StaticRecordTy tys -> do
@@ -1099,19 +1102,19 @@ addTangent x y = do
     ty -> notTangent ty
     where notTangent ty = error $ "Not a tangent type: " ++ pprint ty
 
-updateAddAt :: (Emits n, Builder m) => Atom n -> m n (Atom n)
+updateAddAt :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n)
 updateAddAt x = liftEmitBuilder do
   ty <- getType x
   buildLam noHint PlainArrow ty Pure \v -> addTangent (sink x) (Var v)
 
 -- === builder versions of common top-level emissions ===
 
-litValToPointerlessAtom :: (Mut n, TopBuilder m) => LitVal -> m n (Atom n)
+litValToPointerlessAtom :: (Mut n, TopBuilder m) => LitVal -> m n (Atom r n)
 litValToPointerlessAtom litval = case litval of
   PtrLit val -> Var <$> emitPtrLit (getNameHint @String "ptr") val
   _          -> return $ Con $ Lit litval
 
-emitPtrLit :: (Mut n, TopBuilder m) => NameHint -> PtrLitVal -> m n (AtomName n)
+emitPtrLit :: (Mut n, TopBuilder m) => NameHint -> PtrLitVal -> m n (AtomName r n)
 emitPtrLit hint p@(PtrLitVal ty _) = do
   ptrName <- emitBinding hint $ PtrBinding p
   emitBinding hint $ AtomNameBinding $ PtrLitBound ty ptrName
@@ -1144,11 +1147,11 @@ emitInstanceDef :: (Mut n, TopBuilder m) => InstanceDef n -> m n (Name InstanceN
 emitInstanceDef instanceDef@(InstanceDef className _ _ _) = do
   emitBinding (getNameHint className) $ InstanceBinding instanceDef
 
-emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> Atom n -> m n (Name DataConNameC n)
+emitDataConName :: (Mut n, TopBuilder m) => DataDefName n -> Int -> Atom r n -> m n (Name DataConNameC n)
 emitDataConName dataDefName conIdx conAtom = do
   DataDef _ _ dataCons <- lookupDataDef dataDefName
   let (DataConDef name _ _) = dataCons !! conIdx
-  emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx conAtom
+  emitBinding (getNameHint name) $ DataConBinding dataDefName conIdx (unsafeCoerceIRE conAtom)
 
 zipNest :: (forall ii ii'. a -> b ii ii' -> b' ii ii')
         -> [a]
@@ -1166,7 +1169,7 @@ emitMethod hint classDef explicit idx = do
   f <- Var <$> emitTopLet hint PlainLet (Atom getter)
   emitBinding hint $ MethodBinding classDef idx f
 
-makeMethodGetter :: EnvReader m => Name ClassNameC n -> [Bool] -> Int -> m n (Atom n)
+makeMethodGetter :: EnvReader m => Name ClassNameC n -> [Bool] -> Int -> m n (Atom r n)
 makeMethodGetter className explicit methodIdx = liftBuilder do
   className' <- sinkM className
   ClassDef sourceName _ paramBs _ _ <- getClassDef className'
@@ -1176,12 +1179,13 @@ makeMethodGetter className explicit methodIdx = liftBuilder do
     buildPureLam noHint ClassArrow dictTy \dict ->
       emitOp $ ProjMethod (Var dict) methodIdx
   where
-    zipPiBinders :: [Arrow] -> Nest RolePiBinder i i' -> Nest PiBinder i i'
-    zipPiBinders = zipNest \arr (RolePiBinder b ty _ _) -> PiBinder b ty arr
+    zipPiBinders :: [Arrow] -> Nest (RolePiBinder r') i i' -> Nest (PiBinder r) i i'
+    zipPiBinders = zipNest \arr (RolePiBinder b ty _ _) -> PiBinder b (unsafeCoerceIRE ty) arr
 
-emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> Atom n -> m n (Name TyConNameC n)
+emitTyConName :: (Mut n, TopBuilder m) => DataDefName n -> Atom r n -> m n (Name TyConNameC n)
 emitTyConName dataDefName tyConAtom = do
-  emitBinding (getNameHint dataDefName) $ TyConBinding dataDefName tyConAtom
+  let tyConAtom' = unsafeCoerceIRE tyConAtom
+  emitBinding (getNameHint dataDefName) $ TyConBinding dataDefName tyConAtom'
 
 getDataCon :: EnvReader m => Name DataConNameC n -> m n (DataDefName n, Int)
 getDataCon v = do
@@ -1195,7 +1199,7 @@ getClassDef classDefName = do
 
 -- === builder versions of common local ops ===
 
-fLitLike :: (Builder m, Emits n) => Double -> Atom n -> m n (Atom n)
+fLitLike :: (Builder r m, Emits n) => Double -> Atom r n -> m n (Atom r n)
 fLitLike x t = do
   ty <- getType t
   case ty of
@@ -1203,93 +1207,93 @@ fLitLike x t = do
     BaseTy (Scalar Float32Type) -> return $ Con $ Lit $ Float32Lit $ realToFrac x
     _ -> error "Expected a floating point scalar"
 
-neg :: (Builder m, Emits n) => Atom n -> m n (Atom n)
+neg :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 neg x = emitOp $ UnOp FNeg x
 
-add :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+add :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 add x y = emitOp $ BinOp FAdd x y
 
 -- TODO: Implement constant folding for fixed-width integer types as well!
-iadd :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+iadd :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 iadd (Con (Lit l)) y | getIntLit l == 0 = return y
 iadd x (Con (Lit l)) | getIntLit l == 0 = return x
 iadd x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (+) x y
 iadd x y = emitOp $ BinOp IAdd x y
 
-mul :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+mul :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 mul x y = emitOp $ BinOp FMul x y
 
-imul :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+imul :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 imul   (Con (Lit l)) y               | getIntLit l == 1 = return y
 imul x                 (Con (Lit l)) | getIntLit l == 1 = return x
 imul x@(Con (Lit _)) y@(Con (Lit _))                    = return $ applyIntBinOp (*) x y
 imul x y = emitOp $ BinOp IMul x y
 
-sub :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+sub :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 sub x y = emitOp $ BinOp FSub x y
 
-isub :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+isub :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 isub x (Con (Lit l)) | getIntLit l == 0 = return x
 isub x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp (-) x y
 isub x y = emitOp $ BinOp ISub x y
 
-select :: (Builder m, Emits n) => Atom n -> Atom n -> Atom n -> m n (Atom n)
+select :: (Builder r m, Emits n) => Atom r n -> Atom r n -> Atom r n -> m n (Atom r n)
 select (Con (Lit (Word8Lit p))) x y = return $ if p /= 0 then x else y
 select p x y = emitOp $ Select p x y
 
-div' :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+div' :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 div' x y = emitOp $ BinOp FDiv x y
 
-idiv :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+idiv :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 idiv x (Con (Lit l)) | getIntLit l == 1 = return x
 idiv x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntBinOp div x y
 idiv x y = emitOp $ BinOp IDiv x y
 
-irem :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+irem :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 irem x y = emitOp $ BinOp IRem x y
 
-fpow :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+fpow :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 fpow x y = emitOp $ BinOp FPow x y
 
-flog :: (Builder m, Emits n) => Atom n -> m n (Atom n)
+flog :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 flog x = emitOp $ UnOp Log x
 
-ilt :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+ilt :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 ilt x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (<) x y
 ilt x y = emitOp $ BinOp (ICmp Less) x y
 
-ieq :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+ieq :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 ieq x@(Con (Lit _)) y@(Con (Lit _)) = return $ applyIntCmpOp (==) x y
 ieq x y = emitOp $ BinOp (ICmp Equal) x y
 
-fromPair :: (Builder m, Emits n) => Atom n -> m n (Atom n, Atom n)
+fromPair :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n, Atom r n)
 fromPair pair = do
   ~[x, y] <- getUnpacked pair
   return (x, y)
 
-getProj :: (Builder m, Emits n) => Int -> Atom n -> m n (Atom n)
+getProj :: (Builder r m, Emits n) => Int -> Atom r n -> m n (Atom r n)
 getProj i x = do
   xs <- getUnpacked x
   return $ xs !! i
 
-getFst :: (Builder m, Emits n) => Atom n -> m n (Atom n)
+getFst :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 getFst p = fst <$> fromPair p
 
-getSnd :: (Builder m, Emits n) => Atom n -> m n (Atom n)
+getSnd :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 getSnd p = snd <$> fromPair p
 
 -- the rightmost index is applied first
-getNaryProjRef :: (Builder m, Emits n) => [Int] -> Atom n -> m n (Atom n)
+getNaryProjRef :: (Builder r m, Emits n) => [Int] -> Atom r n -> m n (Atom r n)
 getNaryProjRef [] ref = return ref
 getNaryProjRef (i:is) ref = getProjRef i =<< getNaryProjRef is ref
 
-getProjRef :: (Builder m, Emits n) => Int -> Atom n -> m n (Atom n)
+getProjRef :: (Builder r m, Emits n) => Int -> Atom r n -> m n (Atom r n)
 getProjRef i r = emitOp $ ProjRef i r
 
 -- XXX: getUnpacked must reduce its argument to enforce the invariant that
 -- ProjectElt atoms are always fully reduced (to avoid type errors between two
 -- equivalent types spelled differently).
-getUnpacked :: (Fallible1 m, EnvReader m) => Atom n -> m n [Atom n]
+getUnpacked :: (Fallible1 m, EnvReader m) => Atom r n -> m n [Atom r n]
 getUnpacked atom = do
   atom' <- cheapNormalize atom
   ty <- getType atom'
@@ -1297,57 +1301,57 @@ getUnpacked atom = do
   return $ idxs <&> flip getProjection atom'
 {-# SCC getUnpacked #-}
 
-emitUnpacked :: (Builder m, Emits n) => Atom n -> m n [AtomName n]
+emitUnpacked :: (Builder r m, Emits n) => Atom r n -> m n [AtomName r n]
 emitUnpacked tup = do
   xs <- getUnpacked tup
   forM xs \x -> emit $ Atom x
 
-unwrapBaseNewtype :: Atom n -> Atom n
+unwrapBaseNewtype :: Atom r n -> Atom r n
 unwrapBaseNewtype = getProjection [UnwrapBaseNewtype]
 {-# INLINE unwrapBaseNewtype #-}
 
-unwrapCompoundNewtype :: Atom n -> Atom n
+unwrapCompoundNewtype :: Atom r n -> Atom r n
 unwrapCompoundNewtype = getProjection [UnwrapCompoundNewtype]
 {-# INLINE unwrapCompoundNewtype #-}
 
-app :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+app :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 app x i = Var <$> emit (App x (i:|[]))
 
-naryApp :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
+naryApp :: (Builder r m, Emits n) => Atom r n -> [Atom r n] -> m n (Atom r n)
 naryApp = naryAppHinted noHint
 {-# INLINE naryApp #-}
 
-naryAppHinted :: (Builder m, Emits n)
-  => NameHint -> Atom n -> [Atom n] -> m n (Atom n)
+naryAppHinted :: (Builder r m, Emits n)
+  => NameHint -> Atom r n -> [Atom r n] -> m n (Atom r n)
 naryAppHinted hint f xs = case nonEmpty xs of
   Nothing -> return f
   Just xs' -> Var <$> emitHinted hint (App f xs')
 
-tabApp :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+tabApp :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 tabApp x i = Var <$> emit (TabApp x (i:|[]))
 
-naryTabApp :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
+naryTabApp :: (Builder r m, Emits n) => Atom r n -> [Atom r n] -> m n (Atom r n)
 naryTabApp = naryTabAppHinted noHint
 {-# INLINE naryTabApp #-}
 
-naryTabAppHinted :: (Builder m, Emits n)
-  => NameHint -> Atom n -> [Atom n] -> m n (Atom n)
+naryTabAppHinted :: (Builder r m, Emits n)
+  => NameHint -> Atom r n -> [Atom r n] -> m n (Atom r n)
 naryTabAppHinted hint f xs = case nonEmpty xs of
   Nothing -> return f
   Just xs' -> Var <$> emitHinted hint (TabApp f xs')
 
-indexRef :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+indexRef :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 indexRef ref i = emitOp $ IndexRef ref i
 
-naryIndexRef :: (Builder m, Emits n) => Atom n -> [Atom n] -> m n (Atom n)
+naryIndexRef :: (Builder r m, Emits n) => Atom r n -> [Atom r n] -> m n (Atom r n)
 naryIndexRef ref is = foldM indexRef ref is
 
-ptrOffset :: (Builder m, Emits n) => Atom n -> Atom n -> m n (Atom n)
+ptrOffset :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 ptrOffset x (IdxRepVal 0) = return x
 ptrOffset x i = emitOp $ PtrOffset x i
 {-# INLINE ptrOffset #-}
 
-unsafePtrLoad :: (Builder m, Emits n) => Atom n -> m n (Atom n)
+unsafePtrLoad :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 unsafePtrLoad x = do
   lam <- liftEmitBuilder $ buildLam noHint PlainArrow UnitTy (OneEffect IOEffect) \_ ->
     emitOp . PtrLoad =<< sinkM x
@@ -1358,7 +1362,7 @@ unsafePtrLoad x = do
 -- XXX: it's important that we do the reduction here, because we need the
 -- property that if we call this with a simplified dict, we only produce
 -- simplified decls.
-applyIxMethod :: (Builder m, Emits n) => Atom n -> IxMethod -> [Atom n] -> m n (Atom n)
+applyIxMethod :: (Builder r m, Emits n) => Atom r n -> IxMethod -> [Atom r n] -> m n (Atom r n)
 applyIxMethod dict method args = case dict of
   DictCon (IxFin n) -> case method of
     Size -> do
@@ -1372,7 +1376,7 @@ applyIxMethod dict method args = case dict of
       return $ Con $ Newtype (TC $ Fin n) ix  -- result : Fin n
   DictCon (ExplicitMethods d params) -> do
     SpecializedDictBinding (SpecializedDict _ (Just fs)) <- lookupEnv d
-    NaryLamExpr bs _ body <- return $ fs !! fromEnum method
+    NaryLamExpr bs _ body <- return $ unsafeCoerceIRE $ fs !! fromEnum method
     let args' = case method of
           Size -> params ++ [UnitVal]
           _    -> params ++ args
@@ -1383,7 +1387,7 @@ applyIxMethod dict method args = case dict of
 
 -- This works with `Nat` instead of `IndexRepTy` because it's used alongside
 -- user-defined instances.
-projectIxFinMethod :: EnvReader m => IxMethod -> Atom n -> m n (Atom n)
+projectIxFinMethod :: EnvReader m => IxMethod -> Atom r n -> m n (Atom r n)
 projectIxFinMethod method n = liftBuilder do
   case method of
     Size -> return n  -- result : Nat
@@ -1395,19 +1399,19 @@ projectIxFinMethod method n = liftBuilder do
 -- XXX: these internal versions of `ordinal`, `unsafeFromOrdinal` and
 -- `indexSetSize`. work with `IdxRepTy` (whereas the user-facing versions work
 -- with `Nat`)
-unsafeFromOrdinal :: forall m n. (Builder m, Emits n) => IxType n -> Atom n -> m n (Atom n)
+unsafeFromOrdinal :: forall r m n. (Builder r m, Emits n) => IxType r n -> Atom r n -> m n (Atom r n)
 unsafeFromOrdinal (IxType _ dict) i = applyIxMethod dict UnsafeFromOrdinal [repToNat i]
 
-ordinal :: forall m n. (Builder m, Emits n) => IxType n -> Atom n -> m n (Atom n)
+ordinal :: forall r m n. (Builder r m, Emits n) => IxType r n -> Atom r n -> m n (Atom r n)
 ordinal (IxType _ dict) idx = do
   unwrapBaseNewtype <$> applyIxMethod dict Ordinal [idx]
 
-indexSetSize :: (Builder m, Emits n) => IxType n -> m n (Atom n)
+indexSetSize :: (Builder r m, Emits n) => IxType r n -> m n (Atom r n)
 indexSetSize (IxType _ dict) = do
   sizeNat <- applyIxMethod dict Size []
   return $ unwrapBaseNewtype sizeNat
 
-repToNat :: Atom n -> Atom n
+repToNat :: Atom r n -> Atom r n
 repToNat x = Con $ Newtype NatTy x
 {-# INLINE repToNat #-}
 
@@ -1418,12 +1422,12 @@ repToNat x = Con $ Newtype NatTy x
 -- surface-level `if ... then ... else ...`, but the order
 -- is flipped in the actual `Case`, because False acts like 0.
 -- TODO: consider a version that figures out the result type itself.
-emitIf :: (Emits n, ScopableBuilder m)
-       => Atom n
-       -> Type n
-       -> (forall l. (Emits l, DExt n l) => m l (Atom l))
-       -> (forall l. (Emits l, DExt n l) => m l (Atom l))
-       -> m n (Atom n)
+emitIf :: (Emits n, ScopableBuilder r m)
+       => Atom r n
+       -> Type r n
+       -> (forall l. (Emits l, DExt n l) => m l (Atom r l))
+       -> (forall l. (Emits l, DExt n l) => m l (Atom r l))
+       -> m n (Atom r n)
 emitIf predicate resultTy trueCase falseCase = do
   predicate' <- emitOp $ ToEnum (SumTy [UnitTy, UnitTy]) predicate
   buildCase predicate' resultTy \i _ ->
@@ -1432,11 +1436,11 @@ emitIf predicate resultTy trueCase falseCase = do
       1 -> trueCase
       _ -> error "should only have two cases"
 
-emitMaybeCase :: (Emits n, ScopableBuilder m)
-              => Atom n -> Type n
-              -> (forall l. (Emits l, DExt n l) =>           m l (Atom l))
-              -> (forall l. (Emits l, DExt n l) => Atom l -> m l (Atom l))
-              -> m n (Atom n)
+emitMaybeCase :: (Emits n, ScopableBuilder r m)
+              => Atom r n -> Type r n
+              -> (forall l. (Emits l, DExt n l) =>             m l (Atom r l))
+              -> (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
+              -> m n (Atom r n)
 emitMaybeCase scrut resultTy nothingCase justCase = do
   buildCase scrut resultTy \i v ->
     case i of
@@ -1445,7 +1449,7 @@ emitMaybeCase scrut resultTy nothingCase justCase = do
       _ -> error "should be a binary scrutinee"
 
 -- Maybe a -> a
-fromJustE :: (Emits n, Builder m) => Atom n -> m n (Atom n)
+fromJustE :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n)
 fromJustE x = liftEmitBuilder do
   MaybeTy a <- getType x
   emitMaybeCase x a
@@ -1453,12 +1457,12 @@ fromJustE x = liftEmitBuilder do
     (return)
 
 -- Maybe a -> Bool
-isJustE :: (Emits n, Builder m) => Atom n -> m n (Atom n)
+isJustE :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n)
 isJustE x = liftEmitBuilder $
   emitMaybeCase x BoolTy (return FalseAtom) (\_ -> return TrueAtom)
 
 -- Monoid a -> (n=>a) -> a
-reduceE :: (Emits n, Builder m) => BaseMonoid n -> Atom n -> m n (Atom n)
+reduceE :: (Emits n, Builder r m) => BaseMonoid r n -> Atom r n -> m n (Atom r n)
 reduceE monoid xs = liftEmitBuilder do
   TabTy (n:>ty) a <- getType xs
   a' <- return $ ignoreHoistFailure $ hoist n a
@@ -1467,7 +1471,7 @@ reduceE monoid xs = liftEmitBuilder do
       x <- tabApp (sink xs) (Var i)
       emitOp $ PrimEffect (sink $ Var ref) $ MExtend (fmap sink monoid) x
 
-andMonoid :: EnvReader m => m n (BaseMonoid n)
+andMonoid :: EnvReader m => m n (BaseMonoid r n)
 andMonoid =  liftM (BaseMonoid TrueAtom) do
   liftBuilder $
     buildLam noHint PlainArrow BoolTy Pure \x ->
@@ -1475,9 +1479,9 @@ andMonoid =  liftM (BaseMonoid TrueAtom) do
         emitOp $ BinOp BAnd (sink $ Var x) (Var y)
 
 -- (a-> {|eff} b) -> n=>a -> {|eff} (n=>b)
-mapE :: (Emits n, ScopableBuilder m)
-     => (forall l. (Emits l, DExt n l) => Atom l -> m l (Atom l))
-     -> Atom n -> m n (Atom n)
+mapE :: (Emits n, ScopableBuilder r m)
+     => (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
+     -> Atom r n -> m n (Atom r n)
 mapE f xs = do
   TabTy (n:>ty) _ <- getType xs
   buildFor (getNameHint n) Fwd ty \i -> do
@@ -1485,7 +1489,7 @@ mapE f xs = do
     f x
 
 -- (n:Type) ?-> (a:Type) ?-> (xs : n=>Maybe a) : Maybe (n => a) =
-catMaybesE :: (Emits n, Builder m) => Atom n -> m n (Atom n)
+catMaybesE :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n)
 catMaybesE maybes = do
   TabTy n (MaybeTy a) <- getType maybes
   justs <- liftEmitBuilder $ mapE isJustE maybes
@@ -1495,8 +1499,8 @@ catMaybesE maybes = do
     (JustAtom (sink $ TabTy n a) <$> mapE fromJustE (sink maybes))
     (return (NothingAtom $ sink $ TabTy n a))
 
-emitWhile :: (Emits n, ScopableBuilder m)
-          => (forall l. (Emits l, DExt n l) => m l (Atom l))
+emitWhile :: (Emits n, ScopableBuilder r m)
+          => (forall l. (Emits l, DExt n l) => m l (Atom r l))
           -> m n ()
 emitWhile body = do
   eff <- getAllowedEffects
@@ -1517,9 +1521,9 @@ emitWhile body = do
 --     then Nothing
 --     else Just ()
 
-runMaybeWhile :: (Emits n, ScopableBuilder m)
-              => (forall l. (Emits l, DExt n l) => m l (Atom l))
-              -> m n (Atom n)
+runMaybeWhile :: (Emits n, ScopableBuilder r m)
+              => (forall l. (Emits l, DExt n l) => m l (Atom r l))
+              -> m n (Atom r n)
 runMaybeWhile body = do
   hadError <- getSnd =<< emitRunState noHint FalseAtom \_ ref -> do
     emitWhile do
@@ -1535,25 +1539,25 @@ runMaybeWhile body = do
 -- === capturing closures with telescopes ===
 
 type ReconAbs e n = NaryAbs AtomNameC e n
-data ReconstructAtom (n::S) =
+data ReconstructAtom (r::IR) (n::S) =
    IdentityRecon
- | LamRecon (ReconAbs Atom n)
+ | LamRecon (ReconAbs (Atom r) n)
 
 applyRecon :: (EnvReader m, Fallible1 m)
-           => ReconstructAtom n -> Atom n -> m n (Atom n)
+           => ReconstructAtom r n -> Atom r n -> m n (Atom r n)
 applyRecon IdentityRecon x = return x
 applyRecon (LamRecon ab) x = applyReconAbs ab x
 
 applyReconAbs
-  :: (EnvReader m, Fallible1 m, SinkableE e, SubstE AtomSubstVal e)
-  => ReconAbs e n -> Atom n -> m n (e n)
+  :: (EnvReader m, Fallible1 m, SinkableE e, SubstE (AtomSubstVal r) e)
+  => ReconAbs e n -> Atom r n -> m n (e n)
 applyReconAbs ab x = do
   xs <- unpackTelescope x
   applyNaryAbs ab $ map SubstVal xs
 
 telescopicCapture
   :: (EnvReader m, HoistableE e, HoistableB b)
-  => b n l -> e l -> m l (Atom l, Type n, ReconAbs e n)
+  => b n l -> e l -> m l (Atom r l, Type r n, ReconAbs e n)
 telescopicCapture bs e = do
   vs <- localVarsAndTypeVars bs e
   vTys <- mapM (getType . Var) vs
@@ -1566,7 +1570,7 @@ telescopicCapture bs e = do
 
 -- XXX: assumes arguments are toposorted
 buildTelescopeTy :: (EnvReader m, EnvExtender m)
-                 => [AtomName n] -> [Type n] -> m n (Type n)
+                 => [AtomName r n] -> [Type r n] -> m n (Type r n)
 buildTelescopeTy [] [] = return UnitTy
 buildTelescopeTy (v:vs) (ty:tys) = do
   withFreshBinder (getNameHint v) (MiscBound ty) \b -> do
@@ -1578,10 +1582,10 @@ buildTelescopeTy (v:vs) (ty:tys) = do
       HoistFailure _ -> DepPairTy $ DepPairType (b:>ty) innerTelescope
 buildTelescopeTy _ _ = error "zip mismatch"
 
-buildTelescopeVal :: EnvReader m => [Atom n] -> Type n -> m n (Atom n)
+buildTelescopeVal :: EnvReader m => [Atom r n] -> Type r n -> m n (Atom r n)
 buildTelescopeVal elts telescopeTy = go elts telescopeTy
   where
-    go :: (EnvReader m) => [Atom n] -> Type n -> m n (Atom n)
+    go :: (EnvReader m) => [Atom r n] -> Type r n -> m n (Atom r n)
     go [] UnitTy = return UnitVal
     go (x:xs) (PairTy _ xsTy) = do
       rest <- go xs xsTy
@@ -1606,18 +1610,18 @@ toposortAnnVars annVars =
     nodeToAnnVar :: (e n, Name c n, [Name c n]) -> (Name c n, e n)
     nodeToAnnVar (ann, v, _) = (v, ann)
 
-unpackTelescope :: (Fallible1 m, EnvReader m) => Atom n -> m n [Atom n]
+unpackTelescope :: (Fallible1 m, EnvReader m) => Atom r n -> m n [Atom r n]
 unpackTelescope atom = do
   n <- telescopeLength <$> getType atom
   return $ go n atom
   where
-    go :: Int -> Atom n -> [Atom n]
+    go :: Int -> Atom r n -> [Atom r n]
     go 0 _ = []
     go n pair = left : go (n-1) right
       where left  = getProjection [ProjectProduct 0] pair
             right = getProjection [ProjectProduct 1] pair
 
-    telescopeLength :: Type n -> Int
+    telescopeLength :: Type r n -> Int
     telescopeLength ty = case ty of
       UnitTy -> 0
       PairTy _ rest -> 1 + telescopeLength rest
@@ -1629,11 +1633,11 @@ unpackTelescope atom = do
 localVarsAndTypeVars
   :: forall m b e n l.
      (EnvReader m, BindsNames b, HoistableE e)
-  => b n l -> e l -> m l [AtomName l]
+  => b n l -> e l -> m l [Name AtomNameC l]
 localVarsAndTypeVars b e =
   transitiveClosureM varsViaType (localVars b e)
   where
-    varsViaType :: AtomName l -> m l [AtomName l]
+    varsViaType :: Name AtomNameC l -> m l [Name AtomNameC l]
     varsViaType v = do
       ty <- getType $ Var v
       return $ localVars b ty
@@ -1643,24 +1647,24 @@ localVars :: (Color c, BindsNames b, HoistableE e)
 localVars b e = nameSetToList $
   R.intersection (toNameSet (toScopeFrag b)) (freeVarsE e)
 
-instance GenericE ReconstructAtom where
-  type RepE ReconstructAtom = EitherE UnitE (NaryAbs AtomNameC Atom)
+instance GenericE (ReconstructAtom r) where
+  type RepE (ReconstructAtom r) = EitherE UnitE (NaryAbs AtomNameC (Atom r))
   fromE IdentityRecon = LeftE UnitE
   fromE (LamRecon recon) = RightE recon
   toE (LeftE _) = IdentityRecon
   toE (RightE recon) = LamRecon recon
 
-instance SinkableE   ReconstructAtom
-instance HoistableE  ReconstructAtom
-instance AlphaEqE    ReconstructAtom
-instance SubstE Name ReconstructAtom
-instance SubstE AtomSubstVal ReconstructAtom
+instance SinkableE   (ReconstructAtom r)
+instance HoistableE  (ReconstructAtom r)
+instance AlphaEqE    (ReconstructAtom r)
+instance SubstE Name (ReconstructAtom r)
+instance SubstE (AtomSubstVal r) (ReconstructAtom r)
 
-instance Pretty (ReconstructAtom n) where
+instance Pretty (ReconstructAtom r n) where
   pretty IdentityRecon = "Identity reconstruction"
   pretty (LamRecon ab) = "Reconstruction abs: " <> pretty ab
 
 -- See Note [Confuse GHC] from Simplify.hs
-confuseGHC :: BuilderM n (DistinctEvidence n)
+confuseGHC :: BuilderM r n (DistinctEvidence n)
 confuseGHC = getDistinct
 {-# INLINE confuseGHC #-}

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -39,11 +39,11 @@ import Util (for, onSndM)
 
 -- === api ===
 
-type NiceE e = (HoistableE e, SinkableE e, SubstE AtomSubstVal e, SubstE Name e)
+type NiceE r e = (HoistableE e, SinkableE e, SubstE (AtomSubstVal r) e, SubstE Name e)
 
-cheapReduce :: forall e' e m n
-             . (EnvReader m, CheaplyReducibleE e e', NiceE e, NiceE e')
-            => e n -> m n (Maybe (e' n), DictTypeHoistStatus, [Type n])
+cheapReduce :: forall r e' e m n
+             . (EnvReader m, CheaplyReducibleE r e e', NiceE r e, NiceE r e')
+            => e n -> m n (Maybe (e' n), DictTypeHoistStatus, [Type r n])
 cheapReduce e = liftCheapReducerM idSubst $ cheapReduceE e
 {-# INLINE cheapReduce #-}
 {-# SCC cheapReduce #-}
@@ -51,9 +51,9 @@ cheapReduce e = liftCheapReducerM idSubst $ cheapReduceE e
 -- Third result contains the set of dictionary types that failed to synthesize
 -- during traversal of the supplied decls.
 cheapReduceWithDecls
-  :: forall e' e m n l
-   . ( CheaplyReducibleE e e', NiceE e', NiceE e, EnvReader m )
-  => Nest Decl n l -> e l -> m n (Maybe (e' n), DictTypeHoistStatus, [Type n])
+  :: forall r e' e m n l
+   . ( CheaplyReducibleE r e e', NiceE r e', NiceE r e, EnvReader m )
+  => Nest (Decl r) n l -> e l -> m n (Maybe (e' n), DictTypeHoistStatus, [Type r n])
 cheapReduceWithDecls decls result = do
   Abs decls' result' <- sinkM $ Abs decls result
   liftCheapReducerM idSubst $
@@ -62,7 +62,7 @@ cheapReduceWithDecls decls result = do
 {-# INLINE cheapReduceWithDecls #-}
 {-# SCC cheapReduceWithDecls #-}
 
-cheapNormalize :: (EnvReader m, CheaplyReducibleE e e, NiceE e) => e n -> m n (e n)
+cheapNormalize :: (EnvReader m, CheaplyReducibleE r e e, NiceE r e) => e n -> m n (e n)
 cheapNormalize a = cheapReduce a >>= \case
   (Just ans, _, _) -> return ans
   _ -> error "couldn't normalize expression"
@@ -70,36 +70,36 @@ cheapNormalize a = cheapReduce a >>= \case
 
 -- === internal ===
 
-newtype CheapReducerM (i :: S) (o :: S) (a :: *) =
+newtype CheapReducerM (r::IR) (i :: S) (o :: S) (a :: *) =
   CheapReducerM
-    (SubstReaderT AtomSubstVal
+    (SubstReaderT (AtomSubstVal r)
       (MaybeT1
-        (WriterT1 FailedDictTypes
-          (ScopedT1 (MapE AtomName (MaybeE Atom))
+        (WriterT1 (FailedDictTypes r)
+          (ScopedT1 (MapE (AtomName r) (MaybeE (Atom r)))
             (EnvReaderT Identity)))) i o a)
   deriving ( Functor, Applicative, Monad, Alternative
            , EnvReader, ScopeReader, EnvExtender
-           , SubstReader AtomSubstVal)
+           , SubstReader (AtomSubstVal r))
 
 -- The `NothingE` case indicates dictionaries couldn't be hoisted
-newtype FailedDictTypes (n::S) = FailedDictTypes (ESet (MaybeE Type) n)
+newtype FailedDictTypes (r::IR) (n::S) = FailedDictTypes (ESet (MaybeE (Type r)) n)
         deriving (SinkableE, HoistableE, Semigroup, Monoid)
 data DictTypeHoistStatus = DictTypeHoistFailure | DictTypeHoistSuccess
 
-instance HoistableState FailedDictTypes where
+instance HoistableState (FailedDictTypes r) where
   hoistState _ b (FailedDictTypes ds) =
     FailedDictTypes $ eSetFromList $
       for (eSetToList ds) \d -> case hoist b d of
         HoistSuccess d' -> d'
         HoistFailure _  -> NothingE
 
-class ( Alternative2 m, SubstReader AtomSubstVal m
-      , EnvReader2 m, EnvExtender2 m) => CheapReducer m where
-  reportSynthesisFail :: Type o -> m i o ()
-  updateCache :: AtomName o -> Maybe (Atom o) -> m i o ()
-  lookupCache :: AtomName o -> m i o (Maybe (Maybe (Atom o)))
+class ( Alternative2 m, SubstReader (AtomSubstVal r) m
+      , EnvReader2 m, EnvExtender2 m) => CheapReducer m r | m -> r where
+  reportSynthesisFail :: Type r o -> m i o ()
+  updateCache :: AtomName r o -> Maybe (Atom r o) -> m i o ()
+  lookupCache :: AtomName r o -> m i o (Maybe (Maybe (Atom r o)))
 
-instance CheapReducer CheapReducerM where
+instance CheapReducer (CheapReducerM r) r where
   reportSynthesisFail ty = CheapReducerM $ SubstReaderT $ lift $ lift11 $
     tell $ FailedDictTypes $ eSetSingleton (JustE ty)
   updateCache v u = CheapReducerM $ SubstReaderT $ lift $ lift11 $ lift11 $
@@ -108,8 +108,8 @@ instance CheapReducer CheapReducerM where
     fmap fromMaybeE <$> gets (M.lookup v . fromMapE)
 
 liftCheapReducerM :: EnvReader m
-                  => Subst AtomSubstVal i o -> CheapReducerM i o a
-                  -> m o (Maybe a, DictTypeHoistStatus, [Type o])
+                  => Subst (AtomSubstVal r) i o -> CheapReducerM r i o a
+                  -> m o (Maybe a, DictTypeHoistStatus, [Type r o])
 liftCheapReducerM subst (CheapReducerM m) = do
   (result, FailedDictTypes tySet) <-
     liftM runIdentity $ liftEnvReaderT $ runScopedT1
@@ -123,22 +123,21 @@ liftCheapReducerM subst (CheapReducerM m) = do
 {-# INLINE liftCheapReducerM #-}
 
 cheapReduceFromSubst
-  :: forall e i o .
-     ( SinkableE e, SubstE AtomSubstVal e, HoistableE e)
-  => e i -> CheapReducerM i o (e o)
+  :: forall r e i o . NiceE r e
+  => e i -> CheapReducerM r i o (e o)
 cheapReduceFromSubst e = traverseNames cheapSubstName =<< substM e
   where
-    cheapSubstName :: Color c => Name c o -> CheapReducerM i o (AtomSubstVal c o)
+    cheapSubstName :: Color c => Name c o -> CheapReducerM r i o (AtomSubstVal r c o)
     cheapSubstName v = lookupEnv v >>= \case
       AtomNameBinding (LetBound (DeclBinding _ _ (Atom x))) ->
-        liftM SubstVal $ dropSubst $ cheapReduceFromSubst x
+        liftM SubstVal $ dropSubst $ cheapReduceFromSubst $ unsafeCoerceIRE x
       _ -> return $ Rename v
 
 cheapReduceWithDeclsB
-  :: ( HoistableE e, SinkableE e, SubstE AtomSubstVal e, SubstE Name e)
-  => Nest Decl i i'
-  -> (forall o'. Ext o o' => CheapReducerM i' o' (e o'))
-  -> CheapReducerM i o (e o)
+  :: NiceE r e
+  => Nest (Decl r) i i'
+  -> (forall o'. Ext o o' => CheapReducerM r i' o' (e o'))
+  -> CheapReducerM r i o (e o)
 cheapReduceWithDeclsB decls cont = do
   Abs irreducibleDecls result <- cheapReduceWithDeclsRec decls cont
   case hoist irreducibleDecls result of
@@ -146,10 +145,10 @@ cheapReduceWithDeclsB decls cont = do
     HoistFailure _       -> empty
 
 cheapReduceWithDeclsRec
-  :: ( HoistableE e, SinkableE e, SubstE AtomSubstVal e, SubstE Name e)
-  => Nest Decl i i'
-  -> (forall o'. Ext o o' => CheapReducerM i' o' (e o'))
-  -> CheapReducerM i o (Abs (Nest Decl) e o)
+  :: NiceE r e
+  => Nest (Decl r) i i'
+  -> (forall o'. Ext o o' => CheapReducerM r i' o' (e o'))
+  -> CheapReducerM r i o (Abs (Nest (Decl r)) e o)
 cheapReduceWithDeclsRec decls cont = case decls of
   Empty -> Abs Empty <$> cont
   Nest (Let b binding@(DeclBinding _ _ expr)) rest -> do
@@ -165,7 +164,7 @@ cheapReduceWithDeclsRec decls cont = case decls of
         extendSubst (b@>SubstVal x) $
           cheapReduceWithDeclsRec rest cont
 
-cheapReduceName :: Color c => Name c o -> CheapReducerM i o (AtomSubstVal c o)
+cheapReduceName :: Color c => Name c o -> CheapReducerM r i o (AtomSubstVal r c o)
 cheapReduceName v =
   lookupEnv v >>= \case
     AtomNameBinding (LetBound (DeclBinding _ _ e)) -> case e of
@@ -174,7 +173,7 @@ cheapReduceName v =
       _ -> do
         cachedVal <- lookupCache v >>= \case
           Nothing -> do
-            result <- optional (dropSubst $ cheapReduceE e)
+            result <- optional (dropSubst $ cheapReduceE $ unsafeCoerceIRE e)
             updateCache v result
             return result
           Just result -> return result
@@ -184,11 +183,11 @@ cheapReduceName v =
     _ -> stuck
   where stuck = return $ Rename v
 
-class CheaplyReducibleE (e::E) (e'::E) where
-  cheapReduceE :: e i -> CheapReducerM i o (e' o)
+class CheaplyReducibleE (r::IR) (e::E) (e'::E) | e -> e', e -> r where
+  cheapReduceE :: e i -> CheapReducerM r i o (e' o)
 
-instance CheaplyReducibleE Atom Atom where
-  cheapReduceE :: forall i o. Atom i -> CheapReducerM i o (Atom o)
+instance CheaplyReducibleE r (Atom r) (Atom r) where
+  cheapReduceE :: forall i o. Atom r i -> CheapReducerM r i o (Atom r o)
   cheapReduceE a = confuseGHC >>=  \_ -> case a of
     -- Don't try to eagerly reduce lambda bodies. We might get stuck long before
     -- we have a chance to apply tham. Also, recursive traversal of those bodies
@@ -198,8 +197,8 @@ instance CheaplyReducibleE Atom Atom where
     Lam _   -> substM a
     Con (DictHole ctx ty') -> do
       ty <- cheapReduceE ty'
-      runFallibleT1 (trySynthTerm ty) >>= \case
-        Success d -> return d
+      runFallibleT1 (trySynthTerm $ unsafeCoerceIRE ty) >>= \case
+        Success d -> return $ unsafeCoerceIRE d
         Failure _ -> do
           reportSynthesisFail ty
           return $ Con $ DictHole ctx ty
@@ -220,15 +219,15 @@ instance CheaplyReducibleE Atom Atom where
       a' <- substM a
       dropSubst $ traverseNames cheapReduceName a'
 
-instance CheaplyReducibleE DictExpr Atom where
+instance CheaplyReducibleE r (DictExpr r) (Atom r) where
   cheapReduceE d = case d of
     SuperclassProj child superclassIx -> do
       cheapReduceE child >>= \case
         DictCon (InstanceDict instanceName args) -> dropSubst do
-          args' <- mapM (cheapReduceE @Atom @Atom) args
+          args' <- mapM cheapReduceE args
           InstanceDef _ bs _ body <- lookupInstanceDef instanceName
           let InstanceBody superclasses _ = body
-          applySubst (bs@@>(SubstVal <$> args')) (superclasses !! superclassIx)
+          applySubst (bs@@>(SubstVal <$> args')) (unsafeCoerceIRE $ superclasses !! superclassIx)
         child' -> return $ DictCon $ SuperclassProj child' superclassIx
     InstantiatedGiven f xs -> do
       cheapReduceE (App f xs) <|> justSubst
@@ -237,17 +236,17 @@ instance CheaplyReducibleE DictExpr Atom where
     ExplicitMethods _ _ -> justSubst
     where justSubst = DictCon <$> substM d
 
-instance CheaplyReducibleE DataDefParams DataDefParams where
+instance CheaplyReducibleE r (DataDefParams r) (DataDefParams r) where
   cheapReduceE (DataDefParams ps) =
     DataDefParams <$> mapM (onSndM cheapReduceE) ps
 
-instance (CheaplyReducibleE e e', NiceE e') => CheaplyReducibleE (Abs (Nest Decl) e) e' where
+instance (CheaplyReducibleE r e e', NiceE r e') => CheaplyReducibleE r (Abs (Nest (Decl r)) e) e' where
   cheapReduceE (Abs decls result) = cheapReduceWithDeclsB decls $ cheapReduceE result
 
-instance (CheaplyReducibleE Atom e', NiceE e') => CheaplyReducibleE Block e' where
+instance (CheaplyReducibleE r (Atom r) e', NiceE r e') => CheaplyReducibleE r (Block r) e' where
   cheapReduceE (Block _ decls result) = cheapReduceE $ Abs decls result
 
-instance CheaplyReducibleE Expr Atom where
+instance CheaplyReducibleE r (Expr r) (Atom r) where
   cheapReduceE expr = confuseGHC >>= \_ -> case expr of
     Atom atom -> cheapReduceE atom
     App f' xs' -> do
@@ -276,26 +275,23 @@ instance CheaplyReducibleE Expr Atom where
           InstanceDef _ bs _ (InstanceBody _ methods) <- lookupInstanceDef instanceName
           let method = methods !! i
           extendSubst (bs@@>(SubstVal <$> args')) $
-            cheapReduceE method
+            cheapReduceE $ unsafeCoerceIRE method
         _ -> empty
     _ -> empty
 
-instance (CheaplyReducibleE e1 e1', CheaplyReducibleE e2 e2')
-  => CheaplyReducibleE (PairE e1 e2) (PairE e1' e2') where
+instance (CheaplyReducibleE r e1 e1', CheaplyReducibleE r e2 e2')
+  => CheaplyReducibleE r (PairE e1 e2) (PairE e1' e2') where
     cheapReduceE (PairE e1 e2) = PairE <$> cheapReduceE e1 <*> cheapReduceE e2
 
-instance (CheaplyReducibleE e1 e1', CheaplyReducibleE e2 e2')
-  => CheaplyReducibleE (EitherE e1 e2) (EitherE e1' e2') where
+instance (CheaplyReducibleE r e1 e1', CheaplyReducibleE r e2 e2')
+  => CheaplyReducibleE r (EitherE e1 e2) (EitherE e1' e2') where
     cheapReduceE (LeftE e) = LeftE <$> cheapReduceE e
     cheapReduceE (RightE e) = RightE <$> cheapReduceE e
 
-instance CheaplyReducibleE EffectRow EffectRow where
-  cheapReduceE row = cheapReduceFromSubst row
-
-instance CheaplyReducibleE FieldRowElems FieldRowElems where
+instance CheaplyReducibleE r (FieldRowElems r) (FieldRowElems r) where
   cheapReduceE elems = cheapReduceFromSubst elems
 
 -- See Note [Confuse GHC] from Simplify.hs
-confuseGHC :: CheapReducerM i n (DistinctEvidence n)
+confuseGHC :: CheapReducerM r i n (DistinctEvidence n)
 confuseGHC = getDistinct
 {-# INLINE confuseGHC #-}

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -184,8 +184,8 @@ refreshAbsI ab cont = do
     extendI b $ cont b e
 
 refreshLamI :: EnvReaderI m
-            => LamExpr i
-            -> (forall i'. DExt i i' => LamBinder i i' -> Block i' -> m i' o a)
+            => LamExpr r i
+            -> (forall i'. DExt i i' => LamBinder r i i' -> Block r i' -> m i' o a)
             -> m i o a
 refreshLamI _ _ = undefined
 
@@ -299,7 +299,7 @@ instance (Color c, SinkableE ann, ToBinding ann c) => BindsEnv (BinderP c ann) w
   toEnvFrag (b:>ann) = EnvFrag (RecSubstFrag (b @> toBinding ann')) Nothing
     where ann' = withExtEvidence b $ sink ann
 
-instance (SinkableE ann, ToBinding ann AtomNameC) => BindsEnv (NonDepNest ann) where
+instance (SinkableE ann, ToBinding ann AtomNameC) => BindsEnv (NonDepNest r ann) where
   toEnvFrag (NonDepNest topBs topAnns) = toEnvFrag $ zipNest topBs topAnns
     where
       zipNest :: Distinct l => Nest AtomNameBinder n l -> [ann n] -> Nest (BinderP AtomNameC ann) n l
@@ -311,21 +311,21 @@ instance (SinkableE ann, ToBinding ann AtomNameC) => BindsEnv (NonDepNest ann) w
 instance BindsEnv EffectBinder where
   toEnvFrag (EffectBinder effs) = EnvFrag emptyOutFrag $ Just effs
 
-instance BindsEnv LamBinder where
+instance BindsEnv (LamBinder r) where
   toEnvFrag (LamBinder b ty arrow effects) =
     withExtEvidence b do
       let binding = toBinding $ sink $ LamBinding arrow ty
       EnvFrag (RecSubstFrag $ b @> binding)
                    (Just $ sink effects)
 
-instance BindsEnv PiBinder where
-  toEnvFrag :: Distinct l => PiBinder n l -> EnvFrag n l
+instance BindsEnv (PiBinder r) where
+  toEnvFrag :: Distinct l => PiBinder r n l -> EnvFrag n l
   toEnvFrag (PiBinder b ty arr) =
     withExtEvidence b do
       let binding = toBinding $ sink $ PiBinding arr ty
       EnvFrag (RecSubstFrag $ b @> binding) (Just Pure)
 
-instance BindsEnv Decl where
+instance BindsEnv (Decl r) where
   toEnvFrag (Let b binding) = toEnvFrag $ b :> binding
   {-# INLINE toEnvFrag #-}
 
@@ -336,7 +336,7 @@ instance BindsEnv EnvFrag where
   toEnvFrag frag = frag
   {-# INLINE toEnvFrag #-}
 
-instance BindsEnv RolePiBinder where
+instance BindsEnv (RolePiBinder r) where
   toEnvFrag (RolePiBinder b ty arr _) = toEnvFrag (PiBinder b ty arr)
   {-# INLINE toEnvFrag #-}
 
@@ -394,12 +394,12 @@ instance (BindsEnv b1, BindsEnv b2)
 instance BindsEnv UnitB where
   toEnvFrag UnitB = emptyOutFrag
 
-instance ExtOutMap Env (Nest Decl) where
+instance ExtOutMap Env (Nest (Decl r)) where
   extendOutMap bindings emissions =
     bindings `extendOutMap` toEnvFrag emissions
   {-# INLINE extendOutMap #-}
 
-instance ExtOutMap Env (RNest Decl) where
+instance ExtOutMap Env (RNest (Decl r)) where
   extendOutMap bindings emissions =
     bindings `extendOutMap` toEnvFrag emissions
   {-# INLINE extendOutMap #-}
@@ -414,11 +414,11 @@ lookupEnv :: (Color c, EnvReader m) => Name c o -> m o (Binding c o)
 lookupEnv v = withEnv $ flip lookupEnvPure v
 {-# INLINE lookupEnv #-}
 
-lookupAtomName :: EnvReader m => AtomName n -> m n (AtomBinding n)
-lookupAtomName name = lookupEnv name >>= \case AtomNameBinding x -> return x
+lookupAtomName :: EnvReader m => AtomName r n -> m n (AtomBinding r n)
+lookupAtomName name = bindingToAtomBinding <$> lookupEnv name
 {-# INLINE lookupAtomName #-}
 
-lookupCustomRules :: EnvReader m => AtomName n -> m n (Maybe (AtomRules n))
+lookupCustomRules :: EnvReader m => AtomName CoreIR n -> m n (Maybe (AtomRules n))
 lookupCustomRules name = liftM fromMaybeE $ withEnv $
   toMaybeE . M.lookup name . customRulesMap . envCustomRules . topEnv
 {-# INLINE lookupCustomRules #-}
@@ -517,10 +517,10 @@ withFreshBinders (binding:rest) cont = do
            (sink (binderName b) : vs)
 
 withFreshLamBinder
-  :: (EnvExtender m)
-  => NameHint -> LamBinding n
-  -> Abs Binder EffectRow n
-  -> (forall l. DExt n l => LamBinder n l -> m l a)
+  :: EnvExtender m
+  => NameHint -> LamBinding r n
+  -> Abs (Binder r) EffectRow n
+  -> (forall l. DExt n l => LamBinder r n l -> m l a)
   -> m n a
 withFreshLamBinder hint binding@(LamBinding arr ty) effAbs cont = do
   withFreshBinder hint binding \b -> do
@@ -529,9 +529,9 @@ withFreshLamBinder hint binding@(LamBinding arr ty) effAbs cont = do
       cont $ LamBinder b ty arr effs
 
 withFreshPureLamBinder
-  :: (EnvExtender m)
-  => NameHint -> LamBinding n
-  -> (forall l. DExt n l => LamBinder n l -> m l a)
+  :: EnvExtender m
+  => NameHint -> LamBinding r n
+  -> (forall l. DExt n l => LamBinder r n l -> m l a)
   -> m n a
 withFreshPureLamBinder hint binding@(LamBinding arr ty) cont = do
   withFreshBinder hint binding \b -> do
@@ -540,21 +540,21 @@ withFreshPureLamBinder hint binding@(LamBinding arr ty) cont = do
 
 withFreshPiBinder
   :: EnvExtender m
-  => NameHint -> PiBinding n
-  -> (forall l. DExt n l => PiBinder n l -> m l a)
+  => NameHint -> PiBinding r n
+  -> (forall l. DExt n l => PiBinder r n l -> m l a)
   -> m n a
 withFreshPiBinder hint binding@(PiBinding arr ty) cont = do
   withFreshBinder hint binding \b ->
     withAllowedEffects Pure $
       cont $ PiBinder b ty arr
 
-piBinderAsBinder :: PiBinder n l -> Binder n l
+piBinderAsBinder :: PiBinder r n l -> Binder r n l
 piBinderAsBinder (PiBinder b ty _) = b:>ty
 
-plainPiBinder :: Binder n l -> PiBinder n l
+plainPiBinder :: Binder r n l -> PiBinder r n l
 plainPiBinder (b:>ty) = PiBinder b ty PlainArrow
 
-classPiBinder :: Binder n l -> PiBinder n l
+classPiBinder :: Binder r n l -> PiBinder r n l
 classPiBinder (b:>ty) = PiBinder b ty ClassArrow
 
 withAllowedEffects :: EnvExtender m => EffectRow n -> m n a -> m n a
@@ -562,7 +562,7 @@ withAllowedEffects effs cont =
   refreshAbs (Abs (EffectBinder effs) UnitE) \(EffectBinder _) UnitE ->
     cont
 
-getLambdaDicts :: EnvReader m => m n [AtomName n]
+getLambdaDicts :: EnvReader m => m n [AtomName CoreIR n]
 getLambdaDicts = do
   env <- withEnv moduleEnv
   return $ lambdaDicts $ envSynthCandidates env
@@ -579,31 +579,31 @@ getAllowedEffects = withEnv $ allowedEffects . moduleEnv
 {-# INLINE getAllowedEffects #-}
 
 nonDepPiType :: ScopeReader m
-             => Arrow -> Type n -> EffectRow n -> Type n -> m n (PiType n)
+             => Arrow -> Type r n -> EffectRow n -> Type r n -> m n (PiType r n)
 nonDepPiType arr argTy eff resultTy =
   toConstAbs (PairE eff resultTy) >>= \case
     Abs b (PairE eff' resultTy') ->
       return $ PiType (PiBinder b argTy arr) eff' resultTy'
 
-nonDepTabPiType :: ScopeReader m => IxType n -> Type n -> m n (TabPiType n)
+nonDepTabPiType :: ScopeReader m => IxType r n -> Type r n -> m n (TabPiType r n)
 nonDepTabPiType argTy resultTy =
   toConstAbs resultTy >>= \case
     Abs b resultTy' -> return $ TabPiType (b:>argTy) resultTy'
 
-considerNonDepPiType :: PiType n -> Maybe (Arrow, Type n, EffectRow n, Type n)
+considerNonDepPiType :: PiType r n -> Maybe (Arrow, Type r n, EffectRow n, Type r n)
 considerNonDepPiType (PiType (PiBinder b argTy arr) eff resultTy) = do
   HoistSuccess (PairE eff' resultTy') <- return $ hoist b (PairE eff resultTy)
   return (arr, argTy, eff', resultTy')
 
 fromNonDepPiType :: (ScopeReader m, MonadFail1 m)
-                 => Arrow -> Type n -> m n (Type n, EffectRow n, Type n)
+                 => Arrow -> Type r n -> m n (Type r n, EffectRow n, Type r n)
 fromNonDepPiType arr ty = do
   Pi (PiType (PiBinder b argTy arr') eff resultTy) <- return ty
   unless (arr == arr') $ fail "arrow type mismatch"
   HoistSuccess (PairE eff' resultTy') <- return $ hoist b (PairE eff resultTy)
   return $ (argTy, eff', resultTy')
 
-naryNonDepPiType :: ScopeReader m =>  Arrow -> EffectRow n -> [Type n] -> Type n -> m n (Type n)
+naryNonDepPiType :: ScopeReader m =>  Arrow -> EffectRow n -> [Type r n] -> Type r n -> m n (Type r n)
 naryNonDepPiType _ Pure [] resultTy = return resultTy
 naryNonDepPiType _ _    [] _        = error "nullary function can't have effects"
 naryNonDepPiType arr eff [ty] resultTy = Pi <$> nonDepPiType arr ty eff resultTy
@@ -611,14 +611,14 @@ naryNonDepPiType arr eff (ty:tys) resultTy = do
   innerFunctionTy <- naryNonDepPiType arr eff tys resultTy
   Pi <$> nonDepPiType arr ty Pure innerFunctionTy
 
-naryNonDepTabPiType :: ScopeReader m =>  [IxType n] -> Type n -> m n (Type n)
+naryNonDepTabPiType :: ScopeReader m =>  [IxType r n] -> Type r n -> m n (Type r n)
 naryNonDepTabPiType [] resultTy = return resultTy
 naryNonDepTabPiType (ty:tys) resultTy = do
   innerFunctionTy <- naryNonDepTabPiType tys resultTy
   ty ==> innerFunctionTy
 
 fromNaryNonDepPiType :: (ScopeReader m, MonadFail1 m)
-                     => [Arrow] -> Type n -> m n ([Type n], EffectRow n, Type n)
+                     => [Arrow] -> Type r n -> m n ([Type r n], EffectRow n, Type r n)
 fromNaryNonDepPiType [] ty = return ([], Pure, ty)
 fromNaryNonDepPiType [arr] ty = do
   (argTy, eff, resultTy) <- fromNonDepPiType arr ty
@@ -629,20 +629,20 @@ fromNaryNonDepPiType (arr:arrs) ty = do
   return (argTy:argTys, eff, resultTy)
 
 fromNaryNonDepTabType :: (ScopeReader m, MonadFail1 m)
-                      => [()] -> Type n -> m n ([IxType n], Type n)
+                      => [()] -> Type r n -> m n ([IxType r n], Type r n)
 fromNaryNonDepTabType [] ty = return ([], ty)
 fromNaryNonDepTabType (():rest) ty = do
   (argTy, innerTy) <- fromNonDepTabType ty
   (argTys, resultTy) <- fromNaryNonDepTabType rest innerTy
   return (argTy:argTys, resultTy)
 
-fromNonDepTabType :: (ScopeReader m, MonadFail1 m) => Type n -> m n (IxType n, Type n)
+fromNonDepTabType :: (ScopeReader m, MonadFail1 m) => Type r n -> m n (IxType r n, Type r n)
 fromNonDepTabType ty = do
   TabPi (TabPiType (b :> ixTy) resultTy) <- return ty
   HoistSuccess resultTy' <- return $ hoist b resultTy
   return (ixTy, resultTy')
 
-nonDepDataConTys :: DataConDef n -> Maybe [Type n]
+nonDepDataConTys :: DataConDef n -> Maybe [CType n]
 nonDepDataConTys (DataConDef _ repTy idxs) =
   case repTy of
     ProdTy tys | length idxs == length tys -> Just tys
@@ -652,27 +652,27 @@ infixr 1 ?-->
 infixr 1 -->
 infixr 1 --@
 
-(?-->) :: ScopeReader m => Type n -> Type n -> m n (Type n)
+(?-->) :: ScopeReader m => Type r n -> Type r n -> m n (Type r n)
 a ?--> b = Pi <$> nonDepPiType ImplicitArrow a Pure b
 
-(-->) :: ScopeReader m => Type n -> Type n -> m n (Type n)
+(-->) :: ScopeReader m => Type r n -> Type r n -> m n (Type r n)
 a --> b = Pi <$> nonDepPiType PlainArrow a Pure b
 
-(--@) :: ScopeReader m => Type n -> Type n -> m n (Type n)
+(--@) :: ScopeReader m => Type r n -> Type r n -> m n (Type r n)
 a --@ b = Pi <$> nonDepPiType LinArrow a Pure b
 
-(==>) :: ScopeReader m => IxType n -> Type n -> m n (Type n)
+(==>) :: ScopeReader m => IxType r n -> Type r n -> m n (Type r n)
 a ==> b = TabPi <$> nonDepTabPiType a b
 
 -- first argument is the number of args expected
-fromNaryLamExact :: Int -> Atom n -> Maybe (NaryLamExpr n)
+fromNaryLamExact :: Int -> Atom r n -> Maybe (NaryLamExpr r n)
 fromNaryLamExact exactDepth _ | exactDepth <= 0 = error "expected positive number of args"
 fromNaryLamExact exactDepth lam = do
   (realDepth, naryLam) <- fromNaryLam exactDepth lam
   guard $ realDepth == exactDepth
   return naryLam
 
-fromNaryLam :: Int -> Atom n -> Maybe (Int, NaryLamExpr n)
+fromNaryLam :: Int -> Atom r n-> Maybe (Int, NaryLamExpr r n)
 fromNaryLam maxDepth | maxDepth <= 0 = error "expected positive number of args"
 fromNaryLam maxDepth = \case
   (Lam (LamExpr (LamBinder b ty _ effs) body)) ->
@@ -685,7 +685,7 @@ fromNaryLam maxDepth = \case
         _ -> Nothing
   _ -> Nothing
 
-fromNaryTabLam :: Int -> Atom n -> Maybe (Int, NaryLamExpr n)
+fromNaryTabLam :: Int -> Atom r n -> Maybe (Int, NaryLamExpr r n)
 fromNaryTabLam maxDepth | maxDepth <= 0 = error "expected positive number of args"
 fromNaryTabLam maxDepth = \case
   (TabLam (TabLamExpr (b:>IxType ty _) body)) ->
@@ -699,7 +699,7 @@ fromNaryTabLam maxDepth = \case
   _ -> Nothing
 
 -- first argument is the number of args expected
-fromNaryTabLamExact :: Int -> Atom n -> Maybe (NaryLamExpr n)
+fromNaryTabLamExact :: Int -> Atom r n -> Maybe (NaryLamExpr r n)
 fromNaryTabLamExact exactDepth _ | exactDepth <= 0 = error "expected positive number of args"
 fromNaryTabLamExact exactDepth lam = do
   (realDepth, naryLam) <- fromNaryTabLam exactDepth lam
@@ -707,7 +707,7 @@ fromNaryTabLamExact exactDepth lam = do
   return naryLam
 
 -- first argument is the number of args expected
-fromNaryPiType :: Int -> Type n -> Maybe (NaryPiType n)
+fromNaryPiType :: Int -> Type r n -> Maybe (NaryPiType r n)
 fromNaryPiType n _ | n <= 0 = error "expected positive number of args"
 fromNaryPiType 1 ty = case ty of
   Pi (PiType b effs resultTy) -> Just $ NaryPiType (NonEmptyNest b Empty) effs resultTy
@@ -717,20 +717,20 @@ fromNaryPiType n (Pi (PiType b1 Pure piTy)) = do
   Just $ NaryPiType (NonEmptyNest b1 (Nest b2 bs)) effs resultTy
 fromNaryPiType _ _ = Nothing
 
-mkConsListTy :: [Type n] -> Type n
+mkConsListTy :: [Type r n] -> Type r n
 mkConsListTy = foldr PairTy UnitTy
 
-mkConsList :: [Atom n] -> Atom n
+mkConsList :: [Atom r n] -> Atom r n
 mkConsList = foldr PairVal UnitVal
 
-fromConsListTy :: Fallible m => Type n -> m [Type n]
+fromConsListTy :: Fallible m => Type r n -> m [Type r n]
 fromConsListTy ty = case ty of
   UnitTy         -> return []
   PairTy t rest -> (t:) <$> fromConsListTy rest
   _              -> throw CompilerErr $ "Not a pair or unit: " ++ show ty
 
 -- ((...((ans & x{n}) & x{n-1})... & x2) & x1) -> (ans, [x1, ..., x{n}])
-fromLeftLeaningConsListTy :: Fallible m => Int -> Type n -> m (Type n, [Type n])
+fromLeftLeaningConsListTy :: Fallible m => Int -> Type r n -> m (Type r n, [Type r n])
 fromLeftLeaningConsListTy depth initTy = go depth initTy []
   where
     go 0        ty xs = return (ty, reverse xs)
@@ -738,7 +738,7 @@ fromLeftLeaningConsListTy depth initTy = go depth initTy []
       PairTy lt rt -> go (remDepth - 1) lt (rt : xs)
       _ -> throw CompilerErr $ "Not a pair: " ++ show xs
 
-fromConsList :: Fallible m => Atom n -> m [Atom n]
+fromConsList :: Fallible m => Atom r n -> m [Atom r n]
 fromConsList xs = case xs of
   UnitVal        -> return []
   PairVal x rest -> (x:) <$> fromConsList rest
@@ -753,13 +753,13 @@ bundleFold emptyVal pair els = case els of
   h:t -> (pair h tb, td + 1)
     where (tb, td) = bundleFold emptyVal pair t
 
-mkBundleTy :: [Type n] -> (Type n, BundleDesc)
+mkBundleTy :: [Type r n] -> (Type r n, BundleDesc)
 mkBundleTy = bundleFold UnitTy PairTy
 
-mkBundle :: [Atom n] -> (Atom n, BundleDesc)
+mkBundle :: [Atom r n] -> (Atom r n, BundleDesc)
 mkBundle = bundleFold UnitVal PairVal
 
-trySelectBranch :: Atom n -> Maybe (Int, Atom n)
+trySelectBranch :: Atom r n -> Maybe (Int, Atom r n)
 trySelectBranch e = case e of
   SumVal _ i value -> Just (i, value)
   Con (SumAsProd _ (TagRepVal tag) vals) -> Just (i, vals !! i)
@@ -767,7 +767,7 @@ trySelectBranch e = case e of
   Con (Newtype _ e') -> trySelectBranch e'
   _ -> Nothing
 
-freeAtomVarsList :: HoistableE e => e n -> [AtomName n]
+freeAtomVarsList :: HoistableE e => e n -> [Name AtomNameC n]
 freeAtomVarsList = freeVarsList
 
 freshNameM :: (Color c, EnvReader m)

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -672,7 +672,7 @@ fromNaryLamExact exactDepth lam = do
   guard $ realDepth == exactDepth
   return naryLam
 
-fromNaryLam :: Int -> Atom r n-> Maybe (Int, NaryLamExpr r n)
+fromNaryLam :: Int -> Atom r n -> Maybe (Int, NaryLamExpr r n)
 fromNaryLam maxDepth | maxDepth <= 0 = error "expected positive number of args"
 fromNaryLam maxDepth = \case
   (Lam (LamExpr (LamBinder b ty _ effs) body)) ->

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -37,7 +37,7 @@ import Types.Imp
 import Algebra
 import RawName qualified as R
 
-type AtomRecon = Abs (Nest (NameBinder AtomNameC)) Atom
+type AtomRecon = Abs (Nest (NameBinder AtomNameC)) SAtom
 
 type PtrBinder = IBinder
 
@@ -50,11 +50,11 @@ blockToImpFunction _ cc absBlock = liftImpM $
   translateTopLevel cc absBlock
 {-# SCC blockToImpFunction #-}
 
-toImpStandaloneFunction :: EnvReader m => NaryLamExpr n -> m n (ImpFunction n)
+toImpStandaloneFunction :: EnvReader m => NaryLamExpr SimpIR n -> m n (ImpFunction n)
 toImpStandaloneFunction lam = liftImpM $ toImpStandaloneFunction' lam
 {-# SCC toImpStandaloneFunction #-}
 
-toImpStandaloneFunction' :: NaryLamExpr o -> SubstImpM i o (ImpFunction o)
+toImpStandaloneFunction' :: NaryLamExpr SimpIR o -> SubstImpM i o (ImpFunction o)
 toImpStandaloneFunction' lam@(NaryLamExpr bs effs body) = do
   case effs of
     Pure -> return ()
@@ -78,7 +78,7 @@ data UnpackCC = FlatUnpackCC Int
               | XLAUnpackCC [FormalArg] [FormalArg]
 
 type FormalArg = (NameHint, IType)
-type ActualArg = AtomName
+type ActualArg = SAtomName
 
 ccPrepareFormals :: ExportCC -> Nest IBinder n l -> [FormalArg] -> ([FormalArg], UnpackCC)
 ccPrepareFormals cc args destFormals = case cc of
@@ -120,8 +120,8 @@ ccUnpackActuals cc actual = case cc of
 
 toImpExportedFunction :: EnvReader m
                       => ExportCC
-                      -> Abs (Nest Binder) DestBlock n
-                      -> (Abs (Nest IBinder) (ListE Block) n)
+                      -> Abs (Nest (Binder SimpIR)) DestBlock n
+                      -> (Abs (Nest IBinder) (ListE SBlock) n)
                       -> m n (ImpFunction n)
 toImpExportedFunction cc def@(Abs bs (Abs d body)) (Abs baseArgBs argRecons) = liftImpM do
   -- XXX: We assume that makeDest is deterministic in here! We first run it outside of
@@ -148,7 +148,7 @@ toImpExportedFunction cc def@(Abs bs (Abs d body)) (Abs baseArgBs argRecons) = l
 
 {-# SCC toImpExportedFunction #-}
 
-loadArgDests :: Emits n => NaryLamDest n -> SubstImpM i n ([Atom n], Dest n)
+loadArgDests :: Emits n => NaryLamDest n -> SubstImpM i n ([SAtom n], Dest n)
 loadArgDests (Abs Empty resultDest) = return ([], resultDest)
 loadArgDests (Abs (Nest (b:>argDest) bs) resultDest) = do
   arg <- destToAtom argDest
@@ -156,7 +156,7 @@ loadArgDests (Abs (Nest (b:>argDest) bs) resultDest) = do
   (args, resultDest') <- loadArgDests restDest
   return (arg:args, resultDest')
 
-storeArgDests :: Emits n => NaryLamDest n -> [Atom n] -> SubstImpM i n (Dest n)
+storeArgDests :: Emits n => NaryLamDest n -> [SAtom n] -> SubstImpM i n (Dest n)
 storeArgDests (Abs Empty resultDest) [] = return resultDest
 storeArgDests (Abs (Nest (b:>argDest) bs) resultDest) (x:xs) = do
   copyAtom argDest x
@@ -201,13 +201,13 @@ newtype ImpM (n::S) (a:: *) =
                        (InplaceT Env ImpBuilderEmissions HardFailM) n a }
   deriving ( Functor, Applicative, Monad, ScopeReader, Fallible, MonadFail)
 
-type SubstImpM = SubstReaderT AtomSubstVal ImpM :: S -> S -> * -> *
+type SubstImpM = SubstReaderT (AtomSubstVal SimpIR) ImpM :: S -> S -> * -> *
 
 instance ExtOutMap Env ImpBuilderEmissions where
   extendOutMap bindings emissions =
     bindings `extendOutMap` toEnvFrag emissions
 
-class (ImpBuilder2 m, SubstReader AtomSubstVal m, EnvReader2 m, EnvExtender2 m)
+class (ImpBuilder2 m, SubstReader (AtomSubstVal SimpIR) m, EnvReader2 m, EnvExtender2 m)
       => Imper (m::MonadKind2) where
 
 instance EnvReader ImpM where
@@ -262,7 +262,7 @@ instance ImpBuilder ImpM where
   extendAllocsToFree ptr = ImpM $ tell $ ListE [ptr]
   {-# INLINE extendAllocsToFree #-}
 
-instance ImpBuilder m => ImpBuilder (SubstReaderT AtomSubstVal m i) where
+instance ImpBuilder m => ImpBuilder (SubstReaderT (AtomSubstVal SimpIR) m i) where
   emitMultiReturnInstr instr = SubstReaderT $ lift $ emitMultiReturnInstr instr
   {-# INLINE emitMultiReturnInstr #-}
   buildScopedImp cont = SubstReaderT $ ReaderT \env ->
@@ -271,7 +271,7 @@ instance ImpBuilder m => ImpBuilder (SubstReaderT AtomSubstVal m i) where
   extendAllocsToFree ptr = SubstReaderT $ lift $ extendAllocsToFree ptr
   {-# INLINE extendAllocsToFree #-}
 
-instance ImpBuilder m => Imper (SubstReaderT AtomSubstVal m)
+instance ImpBuilder m => Imper (SubstReaderT (AtomSubstVal SimpIR) m)
 
 liftImpM :: EnvReader m => SubstImpM n n a -> m n a
 liftImpM cont = do
@@ -304,7 +304,7 @@ translateTopLevel cc (Abs (destb:>destTy) body) = do
 
 buildRecon :: (HoistableB b, EnvReader m)
            => b n l
-           -> Atom l
+           -> SAtom l
            -> m l ([IExpr l], AtomRecon n)
 buildRecon b x = do
   let (vs, recon) = captureClosure b x
@@ -314,24 +314,26 @@ buildRecon b x = do
   return (xs, recon)
 
 translateBlock :: forall i o. Emits o
-               => MaybeDest o -> Block i -> SubstImpM i o (Atom o)
+               => MaybeDest o -> SBlock i -> SubstImpM i o (SAtom o)
 translateBlock dest (Block _ decls result) = translateDeclNest decls $ translateExpr dest $ Atom result
 
-translateDeclNestSubst :: Emits o => Subst AtomSubstVal l o -> Nest Decl l i' -> SubstImpM i o (Subst AtomSubstVal i' o)
+translateDeclNestSubst
+  :: Emits o => Subst (AtomSubstVal SimpIR) l o
+  -> Nest SDecl l i' -> SubstImpM i o (Subst (AtomSubstVal SimpIR) i' o)
 translateDeclNestSubst !s = \case
   Empty -> return s
   Nest (Let b (DeclBinding _ _ expr)) rest -> do
     x <- withSubst s $ translateExpr Nothing expr
     translateDeclNestSubst (s <>> (b@>SubstVal x)) rest
 
-translateDeclNest :: Emits o => Nest Decl i i' -> SubstImpM i' o a -> SubstImpM i o a
+translateDeclNest :: Emits o => Nest SDecl i i' -> SubstImpM i' o a -> SubstImpM i o a
 translateDeclNest decls cont = do
   s  <- getSubst
   s' <- translateDeclNestSubst s decls
   withSubst s' cont
 {-# INLINE translateDeclNest #-}
 
-translateExpr :: Emits o => MaybeDest o -> Expr i -> SubstImpM i o (Atom o)
+translateExpr :: Emits o => MaybeDest o -> SExpr i -> SubstImpM i o (SAtom o)
 translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
   Hof hof -> toImpHof maybeDest hof
   App f' xs' -> do
@@ -394,7 +396,7 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
       Just dest -> copyAtom dest atom >> return atom
 
 toImpOp :: forall i o .
-           Emits o => MaybeDest o -> PrimOp (Atom o) -> SubstImpM i o (Atom o)
+           Emits o => MaybeDest o -> PrimOp (SAtom o) -> SubstImpM i o (SAtom o)
 toImpOp maybeDest op = case op of
   TabCon ty rows -> do
     TabPi (TabPiType b _) <- return ty
@@ -424,7 +426,7 @@ toImpOp maybeDest op = case op of
         copyAtom dest =<< destToAtom refDest
         destToAtom dest
     where
-      liftMonoidCombine :: Emits n => Type n -> Atom n -> Atom n -> Atom n -> BuilderM n (Atom n)
+      liftMonoidCombine :: Emits n => SType n -> SAtom n -> SAtom n -> SAtom n -> SBuilderM n (SAtom n)
       liftMonoidCombine accTy bc x y = do
         Pi baseCombineTy <- getType bc
         let baseTy = argType baseCombineTy
@@ -547,13 +549,13 @@ toImpOp maybeDest op = case op of
     emitInstr instr >>= toScalarAtom >>= returnVal
   where
     unsupported = error $ "Unsupported PrimOp encountered in Imp" ++ pprint op
-    resultTyM :: SubstImpM i o (Type o)
+    resultTyM :: SubstImpM i o (SType o)
     resultTyM = getType $ Op op
     returnVal atom = case maybeDest of
       Nothing   -> return atom
       Just dest -> copyAtom dest atom >> return atom
 
-toImpHof :: Emits o => Maybe (Dest o) -> PrimHof (Atom i) -> SubstImpM i o (Atom o)
+toImpHof :: Emits o => Maybe (Dest o) -> PrimHof (SAtom i) -> SubstImpM i o (SAtom o)
 toImpHof maybeDest hof = do
   resultTy <- getTypeSubst (Hof hof)
   case hof of
@@ -624,7 +626,7 @@ toImpHof maybeDest hof = do
       return d'
     _ -> error $ "not implemented: " ++ pprint hof
     where
-      liftMonoidEmpty :: Type n -> Atom n -> BuilderM n (Atom n)
+      liftMonoidEmpty :: SType n -> SAtom n -> SBuilderM n (SAtom n)
       liftMonoidEmpty accTy x = do
         xTy <- getType x
         alphaEq xTy accTy >>= \case
@@ -651,21 +653,21 @@ toImpHof maybeDest hof = do
 -- parameters, where you can separately emit into either. The types would then
 -- look like this:
 
---   makeDestRec :: Idxs n -> Abs IdxNest Type n -> DestM n l (Dest l)
+--   makeDestRec :: Idxs n -> Abs IdxNest SType n -> DestM n l (Dest l)
 --   emitDecl    :: Expr  l -> DestM n l (AtomName l)
 --   emitPointer :: Block n -> DestM n l (AtomName n)
 
-data DestPtrInfo n = DestPtrInfo PtrType (Block n)
+data DestPtrInfo n = DestPtrInfo PtrType (SBlock n)
 type PtrBinders  = Nest  AtomNameBinder
 type RPtrBinders = RNest AtomNameBinder
 data DestEmissions n l where
   DestEmissions
     :: {-# UNPACK #-} !(DestPtrEmissions n h)  -- pointers to allocate
-    ->                !(RNest Decl h l)        -- decls to compute indexing offsets
+    ->                !(RNest SDecl h l)       -- decls to compute indexing offsets
     -> DestEmissions n l
 
 instance GenericB DestEmissions where
-  type RepB DestEmissions = DestPtrEmissions `PairB` RNest Decl
+  type RepB DestEmissions = DestPtrEmissions `PairB` RNest SDecl
   fromB (DestEmissions bs ds) = bs `PairB` ds
   {-# INLINE fromB #-}
   toB   (bs `PairB` ds) = DestEmissions bs ds
@@ -706,7 +708,7 @@ catDestEmissions (DestEmissions ptrs1 d1) (DestEmissions ptrs2 d2) =
   #-}
 
 newtype DestDeclEmissions (n::S) (l::S)
-  = DestDeclEmissions (Decl n l)
+  = DestDeclEmissions (SDecl n l)
   deriving (ProvesExt, BindsNames, SinkableB, SubstB Name)
 instance ExtOutMap Env DestDeclEmissions where
   extendOutMap env (DestDeclEmissions decl) = env `extendOutMap` toEnvFrag decl
@@ -788,7 +790,7 @@ getAllocInfo :: DestM n AllocInfo
 getAllocInfo = DestM $ lift1 ask
 {-# INLINE getAllocInfo #-}
 
-introduceNewPtr :: Mut n => NameHint -> PtrType -> Block n -> DestM n (AtomName n)
+introduceNewPtr :: Mut n => NameHint -> PtrType -> SBlock n -> DestM n (SAtomName n)
 introduceNewPtr hint ptrTy numel =
   DestM $ freshExtendSubInplaceT hint \b ->
     (DestPtrEmissions (ReversedList [DestPtrInfo ptrTy numel]) $ RNest REmpty b, binderName b)
@@ -810,7 +812,7 @@ buildLocalDest cont = do
 buildDeclsDest
   :: (Mut n, SubstE Name e, SinkableE e)
   => (forall l. (Emits l, DExt n l) => DestM l (e l))
-  -> DestM n (Abs (Nest Decl) e n)
+  -> DestM n (Abs (Nest SDecl) e n)
 buildDeclsDest cont = do
   DestM do
     Abs (DestEmissions ptrs decls) result <- locallyMutableInplaceT do
@@ -822,8 +824,8 @@ buildDeclsDest cont = do
 
 buildBlockDest
   :: Mut n
-  => (forall l. (Emits l, DExt n l) => DestM l (Atom l))
-  -> DestM n (Block n)
+  => (forall l. (Emits l, DExt n l) => DestM l (SAtom l))
+  -> DestM n (SBlock n)
 buildBlockDest cont = buildDeclsDest (cont >>= withType) >>= computeAbsEffects >>= absToBlock
 {-# INLINE buildBlockDest #-}
 
@@ -862,15 +864,15 @@ buildAbsHoistingDeclsDest hint binding cont =
 
 buildTabLamDest
   :: Mut n
-  => NameHint -> IxType n
-  -> (forall l. (Emits l, DExt n l) => AtomName l -> DestM l (Atom l))
-  -> DestM n (Atom n)
+  => NameHint -> IxType SimpIR n
+  -> (forall l. (Emits l, DExt n l) => SAtomName l -> DestM l (SAtom l))
+  -> DestM n (SAtom n)
 buildTabLamDest hint ty cont = do
   Abs (b:>_) body <- buildAbsDest hint ty \v ->
     buildBlockDest $ sinkM v >>= cont
   return $ TabLam $ TabLamExpr (b:>ty) body
 
-instance Builder DestM where
+instance Builder SimpIR DestM where
   emitDecl hint ann expr = do
     ty <- getType expr
     DestM $ freshExtendSubInplaceT hint \b ->
@@ -878,18 +880,18 @@ instance Builder DestM where
   {-# INLINE emitDecl #-}
 
 instance GenericE DestPtrInfo where
-  type RepE DestPtrInfo = PairE (LiftE PtrType) Block
+  type RepE DestPtrInfo = PairE (LiftE PtrType) SBlock
   fromE (DestPtrInfo ty n) = PairE (LiftE ty) n
   toE   (PairE (LiftE ty) n) = DestPtrInfo ty n
 
 instance SinkableE DestPtrInfo
 instance HoistableE  DestPtrInfo
 instance SubstE Name DestPtrInfo
-instance SubstE AtomSubstVal DestPtrInfo
+instance SubstE (AtomSubstVal SimpIR) DestPtrInfo
 
 -- === Destination builder ===
 
-type Dest = Atom  -- has type `Ref a` for some a
+type Dest = SAtom  -- has type `Ref a` for some a
 type MaybeDest n = Maybe (Dest n)
 
 data AbsPtrs e n = AbsPtrs (Abs PtrBinders e n) [DestPtrInfo n]
@@ -902,15 +904,15 @@ instance GenericE (AbsPtrs e) where
 instance SinkableE e => SinkableE (AbsPtrs e)
 instance HoistableE e => HoistableE (AbsPtrs e)
 instance SubstE Name e => SubstE Name (AbsPtrs e)
-instance SubstE AtomSubstVal e => SubstE AtomSubstVal (AbsPtrs e)
+instance SubstE (AtomSubstVal SimpIR) e => SubstE (AtomSubstVal SimpIR) (AbsPtrs e)
 
 -- builds a dest and a list of pointer binders along with their required allocation sizes
-makeDest :: AllocInfo -> Type n -> SubstImpM i n (AbsPtrs Dest n)
+makeDest :: AllocInfo -> SType n -> SubstImpM i n (AbsPtrs Dest n)
 makeDest allocInfo ty =
   liftDestM allocInfo $ buildLocalDest $ makeSingleDest [] $ sink ty
 {-# SCC makeDest #-}
 
-makeSingleDest :: Mut n => [AtomName n] -> Type n -> DestM n (Dest n)
+makeSingleDest :: Mut n => [SAtomName n] -> SType n -> DestM n (Dest n)
 makeSingleDest depVars ty = do
   Abs decls dest <- buildDeclsDest $
     makeDestRec (Abs Empty UnitE, []) (map sink depVars) (sink ty)
@@ -922,7 +924,7 @@ makeSingleDest depVars ty = do
 
 extendIdxsTy
   :: EnvReader m
-  => DestIdxs n -> IxType n -> m n (EmptyAbs IdxNest n)
+  => DestIdxs n -> IxType SimpIR n -> m n (EmptyAbs IdxNest n)
 extendIdxsTy (idxsTy, idxs) new = do
   let newAbs = abstractFreeVarsNoAnn idxs new
   Abs bs (Abs b UnitE) <- liftBuilder $ buildNaryAbs idxsTy \idxs' -> do
@@ -930,10 +932,10 @@ extendIdxsTy (idxsTy, idxs) new = do
     singletonBinderNest noHint ty'
   return $ Abs (bs >>> b) UnitE
 
-type Idxs n = [AtomName n]
-type IdxNest = Nest IxBinder
+type Idxs n = [SAtomName n]
+type IdxNest = Nest (IxBinder SimpIR)
 type DestIdxs n = (EmptyAbs IdxNest n, Idxs n)
-type DepVars n = [AtomName n]
+type DepVars n = [SAtomName n]
 
 -- TODO: make `DestIdxs` a proper E-kinded thing
 sinkDestIdxs :: DExt n l => DestIdxs n -> DestIdxs l
@@ -943,7 +945,7 @@ sinkDestIdxs (idxsTy, idxs) = (sink idxsTy, map sink idxs)
 -- TODO: de-dup some of the plumbing stuff here with the ordinary makeDest path
 type NaryLamDest = Abs (Nest (BinderP AtomNameC Dest)) Dest
 
-makeNaryLamDest :: NaryPiType n -> AllocType -> SubstImpM i n (AbsPtrs NaryLamDest n)
+makeNaryLamDest :: NaryPiType SimpIR n -> AllocType -> SubstImpM i n (AbsPtrs NaryLamDest n)
 makeNaryLamDest piTy mgmt = do
   let allocInfo = (LLVM, CPU, mgmt) -- TODO! This is just a placeholder
   liftDestM allocInfo $ buildLocalDest do
@@ -954,7 +956,7 @@ makeNaryLamDest piTy mgmt = do
       _ -> error "shouldn't have decls if we have empty indices"
 
 makeNaryLamDestRec :: forall n. Emits n => DestIdxs n -> DepVars n
-                   -> NaryPiType n -> DestM n (NaryLamDest n)
+                   -> NaryPiType SimpIR n -> DestM n (NaryLamDest n)
 makeNaryLamDestRec idxs depVars (NaryPiType (NonEmptyNest b bs) effs resultTy) = do
   case effs of
     Pure -> return ()
@@ -977,9 +979,9 @@ makeNaryLamDestRec idxs depVars (NaryPiType (NonEmptyNest b bs) effs resultTy) =
 -- be a substituting one.
 buildDepDest
   :: (SinkableE e, SubstE Name e, HoistableE e, Emits n)
-  => DestIdxs n -> DepVars n -> NameHint -> Type n
-  -> (forall l. (Emits l, DExt n l) => DestIdxs l -> DepVars l -> AtomName l -> DestM l (e l))
-  -> DestM n (Abs Binder e n)
+  => DestIdxs n -> DepVars n -> NameHint -> SType n
+  -> (forall l. (Emits l, DExt n l) => DestIdxs l -> DepVars l -> SAtomName l -> DestM l (e l))
+  -> DestM n (Abs (Binder SimpIR) e n)
 buildDepDest idxs depVars hint ty cont =
   buildAbsHoistingDeclsDest hint ty \v -> do
     let depVars' = map sink depVars ++ [v]
@@ -991,7 +993,7 @@ buildDepDest idxs depVars hint ty cont =
 -- variables whose values we won't know until we actually store something. The
 -- resulting `Dest n` may mention these variables, but the pointer allocation
 -- sizes can't.
-makeDestRec :: forall n. Emits n => DestIdxs n -> DepVars n -> Type n -> DestM n (Dest n)
+makeDestRec :: forall n. Emits n => DestIdxs n -> DepVars n -> SType n -> DestM n (Dest n)
 makeDestRec idxs depVars ty = confuseGHC >>= \_ -> case ty of
   TabTy (b:>iTy) bodyTy -> do
     if depVars `anyFreeIn` iTy
@@ -1042,7 +1044,7 @@ makeDestRec idxs depVars ty = confuseGHC >>= \_ -> case ty of
       contents <- forM cases rec
       return $ Con $ ConRef $ SumAsProd cases tag $ contents
 
-makeBaseTypePtr :: Emits n => DestIdxs n -> BaseType -> DestM n (Atom n)
+makeBaseTypePtr :: Emits n => DestIdxs n -> BaseType -> DestM n (SAtom n)
 makeBaseTypePtr (idxsTy, idxs) ty = do
   offset <- liftEmitBuilder $ computeOffset idxsTy idxs
   numel <- liftBuilder $ buildBlock $ computeElemCount (sink idxsTy)
@@ -1053,10 +1055,10 @@ makeBaseTypePtr (idxsTy, idxs) ty = do
   ptrOffset ptr offset
 {-# SCC makeBaseTypePtr #-}
 
-copyAtom :: Emits n => Dest n -> Atom n -> SubstImpM i n ()
+copyAtom :: Emits n => Dest n -> SAtom n -> SubstImpM i n ()
 copyAtom topDest topSrc = copyRec topDest topSrc
   where
-    copyRec :: Emits n => Dest n -> Atom n -> SubstImpM i n ()
+    copyRec :: Emits n => Dest n -> SAtom n -> SubstImpM i n ()
     copyRec dest src = confuseGHC >>= \_ -> case (dest, src) of
       (BoxedRef (Abs (NonDepNest bs ptrsSizes) boxedDest), _) -> do
         -- TODO: load old ptr and free (recursively)
@@ -1098,8 +1100,8 @@ copyAtom topDest topSrc = copyRec topDest topSrc
       _ -> error "unexpected src/dest pair"
 
     zipTabDestAtom :: Emits n
-                   => (forall l. (Emits l, DExt n l) => Dest l -> Atom l -> SubstImpM i l ())
-                   -> Dest n -> Atom n -> SubstImpM i n ()
+                   => (forall l. (Emits l, DExt n l) => Dest l -> SAtom l -> SubstImpM i l ())
+                   -> Dest n -> SAtom n -> SubstImpM i n ()
     zipTabDestAtom f dest src = do
       Con (TabRef (TabLam (TabLamExpr b _))) <- return dest
       TabLam (TabLamExpr b' _)               <- return src
@@ -1122,16 +1124,16 @@ storeAnywhere ptr val = store ptr val
 store :: Emits n => IExpr n -> IExpr n -> SubstImpM i n ()
 store dest src = emitStatement $ Store dest src
 
-alloc :: Emits n => Type n -> SubstImpM i n (Dest n)
+alloc :: Emits n => SType n -> SubstImpM i n (Dest n)
 alloc ty = makeAllocDest Managed ty
 
-indexDest :: Emits n => Dest n -> Atom n -> BuilderM n (Dest n)
+indexDest :: Emits n => Dest n -> SAtom n -> SBuilderM n (Dest n)
 indexDest (Con (TabRef (TabVal b body))) i = do
   body' <- applyAbs (Abs b body) $ SubstVal i
   emitBlock body'
 indexDest dest _ = error $ pprint dest
 
-loadDest :: Emits n => Dest n -> BuilderM n (Atom n)
+loadDest :: Emits n => Dest n -> SBuilderM n (SAtom n)
 loadDest (DepPairRef lr rra a) = do
   l <- loadDest lr
   r <- loadDest =<< applyAbs rra (SubstVal l)
@@ -1193,7 +1195,7 @@ emitLoop hint d n cont = do
       return $ Abs b body
   emitStatement $ IFor d n loopBody
 
-restructureScalarOrPairType :: Type n -> [IExpr n] -> SubstImpM i n (Atom n)
+restructureScalarOrPairType :: SType n -> [IExpr n] -> SubstImpM i n (SAtom n)
 restructureScalarOrPairType topTy topXs =
   go topTy topXs >>= \case
     (atom, []) -> return atom
@@ -1215,10 +1217,10 @@ buildBlockImp cont = do
   Abs decls (ListE results) <- buildScopedImp $ ListE <$> cont
   return $ ImpBlock decls results
 
-destToAtom :: Emits n => Dest n -> SubstImpM i n (Atom n)
+destToAtom :: Emits n => Dest n -> SubstImpM i n (SAtom n)
 destToAtom dest = liftBuilderImp $ loadDest =<< sinkM dest
 
-destGet :: Emits n => Dest n -> Atom n -> SubstImpM i n (Dest n)
+destGet :: Emits n => Dest n -> SAtom n -> SubstImpM i n (Dest n)
 destGet dest i = liftBuilderImp $ do
   Distinct <- getDistinct
   indexDest (sink dest) (sink i)
@@ -1233,7 +1235,7 @@ _fromDestConsList dest = case dest of
   Con (ConRef (ProdCon []))     -> []
   _ -> error $ "Not a dest cons list: " ++ pprint dest
 
-makeAllocDest :: Emits n => AllocType -> Type n -> SubstImpM i n (Dest n)
+makeAllocDest :: Emits n => AllocType -> SType n -> SubstImpM i n (Dest n)
 makeAllocDest allocTy ty = fst <$> makeAllocDestWithPtrs allocTy ty
 
 backend_TODO_DONT_HARDCODE :: Backend
@@ -1243,7 +1245,7 @@ curDev_TODO_DONT_HARDCODE :: Device
 curDev_TODO_DONT_HARDCODE = CPU
 
 makeAllocDestWithPtrs :: Emits n
-                      => AllocType -> Type n -> SubstImpM i n (Dest n, [IExpr n])
+                      => AllocType -> SType n -> SubstImpM i n (Dest n, [IExpr n])
 makeAllocDestWithPtrs allocTy ty = do
   let backend = backend_TODO_DONT_HARDCODE
   let curDev  = curDev_TODO_DONT_HARDCODE
@@ -1260,12 +1262,12 @@ makeAllocDestWithPtrs allocTy ty = do
   dest' <- applyNaryAbs absDest $ map SubstVal ptrAtoms
   return (dest', ptrs)
 
-_copyDest :: Emits n => Maybe (Dest n) -> Atom n -> SubstImpM i n (Atom n)
+_copyDest :: Emits n => Maybe (Dest n) -> SAtom n -> SubstImpM i n (SAtom n)
 _copyDest maybeDest atom = case maybeDest of
   Nothing   -> return atom
   Just dest -> copyAtom dest atom >> return atom
 
-allocDest :: Emits n => Maybe (Dest n) -> Type n -> SubstImpM i n (Dest n)
+allocDest :: Emits n => Maybe (Dest n) -> SType n -> SubstImpM i n (Dest n)
 allocDest maybeDest t = case maybeDest of
   Nothing   -> alloc t
   Just dest -> return dest
@@ -1274,7 +1276,7 @@ type AllocInfo = (Backend, Device, AllocType)
 
 data AllocType = Managed | Unmanaged  deriving (Show, Eq)
 
-chooseAddrSpace :: AllocInfo -> Block n -> AddressSpace
+chooseAddrSpace :: AllocInfo -> SBlock n -> AddressSpace
 chooseAddrSpace (backend, curDev, allocTy) numel = case allocTy of
   Unmanaged -> Heap mainDev
   Managed | curDev == mainDev -> if isSmall then Stack else Heap mainDev
@@ -1295,14 +1297,10 @@ chooseAddrSpace (backend, curDev, allocTy) numel = case allocTy of
 
 -- === Determining buffer sizes and offsets using polynomials ===
 
--- These document that we're only building terms that are valid in the
--- post-simplification IR (one day we should enforce this properly)
-type SimpleBuilderM = BuilderM
-type SimpleBlock = Block
-
+type SBuilderM = BuilderM SimpIR
 type IndexStructure = EmptyAbs IdxNest :: E
 
-computeElemCount :: Emits n => IndexStructure n -> SimpleBuilderM n (Atom n)
+computeElemCount :: Emits n => IndexStructure n -> SBuilderM n (SAtom n)
 computeElemCount (EmptyAbs Empty) =
   -- XXX: this optimization is important because we don't want to emit any decls
   -- in the case that we don't have any indices. The more general path will
@@ -1315,7 +1313,7 @@ computeElemCount idxNest' = do
   nestSize <- elemCountPoly idxNest
   imul listSize nestSize
 
-elemCountPoly :: Emits n => IndexStructure n -> SimpleBuilderM n (Atom n)
+elemCountPoly :: Emits n => IndexStructure n -> SBuilderM n (SAtom n)
 elemCountPoly (Abs bs UnitE) = case bs of
   Empty -> return $ IdxRepVal 1
   Nest b@(_:>ixTy) rest -> do
@@ -1325,7 +1323,7 @@ elemCountPoly (Abs bs UnitE) = case bs of
 
 computeSizeGivenOrdinal
   :: EnvReader m
-  => IxBinder n l -> IndexStructure l -> m n (Abs Binder SimpleBlock n)
+  => IxBinder SimpIR n l -> IndexStructure l -> m n (Abs (Binder SimpIR) SBlock n)
 computeSizeGivenOrdinal (b:>idxTy) idxStruct = liftBuilder do
   withFreshBinder noHint IdxRepTy \bOrdinal ->
     Abs (bOrdinal:>IdxRepTy) <$> buildBlock do
@@ -1335,7 +1333,7 @@ computeSizeGivenOrdinal (b:>idxTy) idxStruct = liftBuilder do
 
 -- Split the index structure into a prefix of non-dependent index types
 -- and a trailing nest of indices that can contain inter-dependencies.
-indexStructureSplit :: IndexStructure n -> ([IxType n], IndexStructure n)
+indexStructureSplit :: IndexStructure n -> ([IxType SimpIR n], IndexStructure n)
 indexStructureSplit (Abs Empty UnitE) = ([], EmptyAbs Empty)
 indexStructureSplit s@(Abs (Nest b rest) UnitE) =
   case hoist b (EmptyAbs rest) of
@@ -1343,14 +1341,14 @@ indexStructureSplit s@(Abs (Nest b rest) UnitE) =
     HoistSuccess rest' -> (binderAnn b:ans1, ans2)
       where (ans1, ans2) = indexStructureSplit rest'
 
-getIxType :: EnvReader m => AtomName n -> m n (IxType n)
+getIxType :: EnvReader m => SAtomName n -> m n (IxType SimpIR n)
 getIxType name = do
   lookupAtomName name >>= \case
     IxBound ixTy -> return ixTy
     _ -> error $ "not an ix-bound name" ++ pprint name
 
 computeOffset :: forall n. Emits n
-              => IndexStructure n -> [AtomName n] -> SimpleBuilderM n (Atom n)
+              => IndexStructure n -> [SAtomName n] -> SBuilderM n (SAtom n)
 computeOffset idxNest' idxs = do
   let (idxList , idxNest ) = indexStructureSplit idxNest'
   let (listIdxs, nestIdxs) = splitAt (length idxList) idxs
@@ -1369,7 +1367,7 @@ computeOffset idxNest' idxs = do
   where
    accumStrided (total, stride) (size, i) = (,) <$> (iadd total =<< imul i stride) <*> imul stride size
    -- Recursively process the dependent part of the nest
-   rec :: IndexStructure n -> [AtomName n] -> SimpleBuilderM n (Atom n)
+   rec :: IndexStructure n -> [SAtomName n] -> SBuilderM n (SAtom n)
    rec (Abs Empty UnitE) [] = return $ IdxRepVal 0
    rec (Abs (Nest b@(_:>ixTy) bs) UnitE) (i:is) = do
      let rest = EmptyAbs bs
@@ -1381,15 +1379,15 @@ computeOffset idxNest' idxs = do
      iadd significantOffset otherOffsets
    rec _ _ = error "zip error"
 
-sumUsingPolysImp :: Emits n => Atom n -> Abs Binder SimpleBlock n -> SimpleBuilderM n (Atom n)
+sumUsingPolysImp :: Emits n => SAtom n -> Abs (Binder SimpIR) SBlock n -> SBuilderM n (SAtom n)
 sumUsingPolysImp lim (Abs i body) = do
   ab <- hoistDecls i body
   sumUsingPolys lim ab
 
 hoistDecls
-  :: ( Builder m, EnvReader m, Emits n
+  :: ( Builder SimpIR m, EnvReader m, Emits n
      , BindsNames b, BindsEnv b, SubstB Name b, SinkableB b)
-  => b n l -> Block l -> m n (Abs b Block n)
+  => b n l -> SBlock l -> m n (Abs b SBlock n)
 hoistDecls b block = do
   Abs hoistedDecls rest <- liftEnvReaderM $
     refreshAbs (Abs b block) \b' (Block _ decls result) ->
@@ -1400,8 +1398,8 @@ hoistDecls b block = do
 
 hoistDeclsRec
   :: (BindsNames b, SinkableB b)
-  => b n1 n2 -> Decls n2 n3 -> Decls n3 n4 -> Atom n4
-  -> EnvReaderM n3 (Abs Decls (Abs b (Abs Decls Atom)) n1)
+  => b n1 n2 -> SDecls n2 n3 -> SDecls n3 n4 -> SAtom n4
+  -> EnvReaderM n3 (Abs SDecls (Abs b (Abs SDecls SAtom)) n1)
 hoistDeclsRec b declsAbove Empty result =
   return $ Abs Empty $ Abs b $ Abs declsAbove result
 hoistDeclsRec b declsAbove (Nest decl declsBelow) result  = do
@@ -1440,7 +1438,7 @@ withFreshIBinder hint ty cont = do
 {-# INLINE withFreshIBinder #-}
 
 emitCall :: Emits n
-         => NaryPiType n -> ImpFunName n -> [Atom n] -> SubstImpM i n (Atom n)
+         => NaryPiType SimpIR n -> ImpFunName n -> [SAtom n] -> SubstImpM i n (SAtom n)
 emitCall piTy f xs = do
   AbsPtrs absDest ptrDefs <- makeNaryLamDest piTy Managed
   ptrs <- forM ptrDefs \(DestPtrInfo ptrTy sizeBlock) -> do
@@ -1456,7 +1454,7 @@ emitCall piTy f xs = do
 buildImpFunction
   :: CallingConvention
   -> [(NameHint, IType)]
-  -> (forall l. (Emits l, DExt n l) => [AtomName l] -> SubstImpM i l [IExpr l])
+  -> (forall l. (Emits l, DExt n l) => [SAtomName l] -> SubstImpM i l [IExpr l])
   -> SubstImpM i n (ImpFunction n)
 buildImpFunction cc argHintsTys body = do
   Abs bs (Abs decls (ListE results)) <-
@@ -1468,7 +1466,7 @@ buildImpFunction cc argHintsTys body = do
 buildImpNaryAbs
   :: (SinkableE e, HasNamesE e, SubstE Name e, HoistableE e)
   => [(NameHint, IType)]
-  -> (forall l. (Emits l, DExt n l) => [AtomName l] -> SubstImpM i l (e l))
+  -> (forall l. (Emits l, DExt n l) => [SAtomName l] -> SubstImpM i l (e l))
   -> SubstImpM i n (Abs (Nest IBinder) (Abs (Nest ImpDecl) e) n)
 buildImpNaryAbs [] cont = do
   Distinct <- getDistinct
@@ -1518,7 +1516,7 @@ load x = emitInstr $ IPrimOp $ PtrLoad x
 
 -- === Atom <-> IExpr conversions ===
 
-fromScalarAtom :: Atom n -> SubstImpM i n (IExpr n)
+fromScalarAtom :: SAtom n -> SubstImpM i n (IExpr n)
 fromScalarAtom atom = confuseGHC >>= \_ -> case atom of
   Var v -> do
     BaseTy b <- getType v
@@ -1526,15 +1524,15 @@ fromScalarAtom atom = confuseGHC >>= \_ -> case atom of
   Con (Lit x) -> return $ ILit x
   _ -> error $ "Expected scalar, got: " ++ pprint atom
 
-toScalarAtom :: Monad m => IExpr n -> m (Atom n)
+toScalarAtom :: Monad m => IExpr n -> m (SAtom n)
 toScalarAtom ie = case ie of
   ILit l   -> return $ Con $ Lit l
   IVar v _ -> return $ Var v
 
 -- TODO: we shouldn't need the rank-2 type here because ImpBuilder and Builder
 -- are part of the same conspiracy.
-liftBuilderImp :: (Emits n, SubstE AtomSubstVal e, SinkableE e)
-               => (forall l. (Emits l, DExt n l) => BuilderM l (e l))
+liftBuilderImp :: (Emits n, SubstE (AtomSubstVal CoreIR) e, SinkableE e)
+               => (forall l. (Emits l, DExt n l) => BuilderM SimpIR l (e l))
                -> SubstImpM i n (e n)
 liftBuilderImp cont = do
   Abs decls result <- liftBuilder $ buildScoped cont
@@ -1543,7 +1541,7 @@ liftBuilderImp cont = do
 
 -- === Type classes ===
 
-unsafeFromOrdinalImp :: Emits n => IxType n -> IExpr n -> SubstImpM i n (Atom n)
+unsafeFromOrdinalImp :: Emits n => IxType SimpIR n -> IExpr n -> SubstImpM i n (SAtom n)
 unsafeFromOrdinalImp (IxType _ dict) i = do
   i' <- (Con . Newtype NatTy) <$> toScalarAtom i
   case dict of
@@ -1553,7 +1551,7 @@ unsafeFromOrdinalImp (IxType _ dict) i = do
       appSpecializedIxMethod (fs !! fromEnum UnsafeFromOrdinal) (params ++ [i'])
     _ -> error $ "Not a simplified dict: " ++ pprint dict
 
-indexSetSizeImp :: Emits n => IxType n -> SubstImpM i n (IExpr n)
+indexSetSizeImp :: Emits n => IxType SimpIR n -> SubstImpM i n (IExpr n)
 indexSetSizeImp (IxType _ dict) = do
   ans <- case dict of
     DictCon (IxFin n) -> return n
@@ -1563,7 +1561,7 @@ indexSetSizeImp (IxType _ dict) = do
     _ -> error $ "Not a simplified dict: " ++ pprint dict
   fromScalarAtom $ unwrapBaseNewtype ans
 
-appSpecializedIxMethod :: Emits n => NaryLamExpr n -> [Atom n] -> SubstImpM i n (Atom n)
+appSpecializedIxMethod :: Emits n => NaryLamExpr SimpIR n -> [SAtom n] -> SubstImpM i n (SAtom n)
 appSpecializedIxMethod (NaryLamExpr bs _ body) args = do
   dropSubst $ extendSubst (bs @@> map SubstVal args) $ translateBlock Nothing body
 
@@ -1592,7 +1590,7 @@ abstractLinktimeObjects f = do
 
 -- === type checking imp programs ===
 
-toIVectorType :: Type n -> IVectorType
+toIVectorType :: SType n -> IVectorType
 toIVectorType = \case
   BaseTy vty@(Vector _ _) -> vty
   _ -> error "Not a vector type"
@@ -1650,7 +1648,7 @@ instance BindsEnv ImpDecl where
 instance BindsEnv IBinder where
   toEnvFrag (IBinder b ty) = toEnvFrag $ b :> BaseTy ty
 
-instance SubstB AtomSubstVal IBinder
+instance SubstB (AtomSubstVal SimpIR) IBinder
 
 captureClosure
   :: (HoistableB b, HoistableE e, Color c)

--- a/src/lib/ImpToLLVM.hs
+++ b/src/lib/ImpToLLVM.hs
@@ -1148,7 +1148,7 @@ liftCompile dev subst m =
 opSubstVal :: Operand -> OperandSubstVal AtomNameC n
 opSubstVal x = OperandSubstVal x
 
-lookupImpVar :: Compiler m => AtomName i -> m i o Operand
+lookupImpVar :: Compiler m => SAtomName i -> m i o Operand
 lookupImpVar v = lookupSubstM v <&> \case
   OperandSubstVal x -> x
   RenameOperandSubstVal _ -> error "Shouldn't have any imp vars left"

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -52,18 +52,18 @@ import Util
 
 -- === Top-level interface ===
 
-checkTopUType :: (Fallible1 m, EnvReader m) => UType n -> m n (Type n)
+checkTopUType :: (Fallible1 m, EnvReader m) => UType n -> m n (CType n)
 checkTopUType ty = liftInfererM $ solveLocal $ withApplyDefaults $ checkUType ty
 {-# SCC checkTopUType #-}
 
-inferTopUExpr :: (Fallible1 m, EnvReader m) => UExpr n -> m n (Block n)
+inferTopUExpr :: (Fallible1 m, EnvReader m) => UExpr n -> m n (CBlock n)
 inferTopUExpr e = liftInfererM do
   solveLocal $ buildBlockInf $ withApplyDefaults $ inferSigma noHint e
 {-# SCC inferTopUExpr #-}
 
 data UDeclInferenceResult e n =
    UDeclResultDone (e n)  -- used for UDataDefDecl, UInterface and UInstance
- | UDeclResultWorkRemaining (Block n) (Abs UDecl e n) -- used for ULet
+ | UDeclResultWorkRemaining (CBlock n) (Abs UDecl e n) -- used for ULet
 
 inferTopUDecl :: (Mut n, Fallible1 m, TopBuilder m, SinkableE e, SubstE Name e)
               => UDecl n l -> e l -> m n (UDeclInferenceResult e n)
@@ -157,10 +157,10 @@ inferTopUDecl (UHandlerDecl effName bodyTyArg tyArgs _retEff retTy opDefs handle
 
 checkHandlerBody :: EmitsInf o
                  => EffectName o
-                 -> AtomName o
-                 -> Type o
+                 -> CAtomName o
+                 -> CType o
                  -> [UEffectOpDef i]
-                 -> InfererM i o (Block o, [Block o])
+                 -> InfererM i o (CBlock o, [CBlock o])
 checkHandlerBody effName r retTy opDefs = do
   EffectDef _ effBody <- lookupEffectDef effName
   let (rets, ops) = partition isReturnOpDef opDefs
@@ -183,9 +183,9 @@ checkHandlerBody effName r retTy opDefs = do
 
 checkHandlerOp :: EmitsInf o
                => EffectName o
-               -> Type o
+               -> CType o
                -> UEffectOpDef i
-               -> InfererM i o (Int, Block o)
+               -> InfererM i o (Int, CBlock o)
 checkHandlerOp effName retTy ~(UEffectOpDef pol (InternalName _ opName) opBody) = do
   EffectOpDef effName' (OpIdx opIdx) <- substM opName >>= lookupEffectOpDef
   EffectDef _ ops <- lookupEffectDef effName'
@@ -204,7 +204,7 @@ checkHandlerOp effName retTy ~(UEffectOpDef pol (InternalName _ opName) opBody) 
   opBody' <- buildBlockInf $ checkSigma noHint opBody (sink internalOpTy)
   return (opIdx, opBody')
 
-mkRetOpTy :: (EnvReader m, Fallible1 m) => AtomName n -> Type n -> m n (Type n)
+mkRetOpTy :: (EnvReader m, Fallible1 m) => CAtomName n -> CType n -> m n (CType n)
 mkRetOpTy r retTy =
   Pi <$> (liftBuilder $ buildPi noHint PlainArrow (Var r) \_ -> do
     retTy' <- sinkM retTy
@@ -224,7 +224,7 @@ inferEffOpType (UEffectOpType policy ty) = do
 -- We use this to finish the processing the decl after we've completely
 -- evaluated the right-hand side
 applyUDeclAbs :: (Mut n, TopBuilder m, SinkableE e, SubstE Name e, MonadIO1 m)
-              => Abs UDecl e n -> Atom n -> m n (e n)
+              => Abs UDecl e n -> CAtom n -> m n (e n)
 applyUDeclAbs (Abs decl result) x = case decl of
   ULet letAnn (UPatAnn pat _) _ -> do
     v <- emitTopLet (getNameHint pat) letAnn (Atom x)
@@ -240,11 +240,11 @@ applyUDeclAbs (Abs decl result) x = case decl of
 
 
 emitAtomSubstFrag :: (Mut o, TopBuilder m)
-                  => SubstFrag AtomSubstVal i i' o -> m o (SubstFrag Name i i' o)
+                  => SubstFrag (AtomSubstVal CoreIR) i i' o -> m o (SubstFrag Name i i' o)
 emitAtomSubstFrag frag = go $ toSubstPairs frag
   where
     go :: (Mut o, TopBuilder m)
-       => Nest (SubstPair AtomSubstVal o) i i' -> m o (SubstFrag Name i i' o)
+       => Nest (SubstPair (AtomSubstVal CoreIR) o) i i' -> m o (SubstFrag Name i i' o)
     go Empty = return emptyInFrag
     go (Nest (SubstPair b val) rest) = do
       v <- case val of
@@ -254,7 +254,7 @@ emitAtomSubstFrag frag = go $ toSubstPairs frag
 
 -- === Inferer interface ===
 
-class ( MonadFail1 m, Fallible1 m, Catchable1 m, CtxReader1 m, Builder m )
+class ( MonadFail1 m, Fallible1 m, Catchable1 m, CtxReader1 m, Builder CoreIR m )
       => InfBuilder (m::MonadKind1) where
 
   -- XXX: we should almost always used the zonking `buildDeclsInf` and variant,
@@ -264,7 +264,7 @@ class ( MonadFail1 m, Fallible1 m, Catchable1 m, CtxReader1 m, Builder m )
     :: (SinkableE e, HoistableE e, SubstE Name e)
     => EmitsInf n
     => (forall l. (EmitsBoth l, DExt n l) => m l (e l))
-    -> m n (Abs (Nest Decl) e n)
+    -> m n (Abs (Nest CDecl) e n)
 
   buildAbsInf
     :: (SinkableE e, HoistableE e, SubstE Name e, Color c, ToBinding binding c)
@@ -274,23 +274,23 @@ class ( MonadFail1 m, Fallible1 m, Catchable1 m, CtxReader1 m, Builder m )
     -> m n (Abs (BinderP c binding) e n)
 
 buildDeclsInf
-  :: (SubstE AtomSubstVal e, SubstE Name e, Solver m, InfBuilder m)
+  :: (SubstE (AtomSubstVal CoreIR) e, SubstE Name e, Solver m, InfBuilder m)
   => (SinkableE e, HoistableE e)
   => EmitsInf n
   => (forall l. (EmitsBoth l, DExt n l) => m l (e l))
-  -> m n (Abs (Nest Decl) e n)
+  -> m n (Abs (Nest CDecl) e n)
 buildDeclsInf cont = buildDeclsInfUnzonked $ cont >>= zonk
 
 type InfBuilder2 (m::MonadKind2) = forall i. InfBuilder (m i)
 
-type IfaceTypeSet = ESet Type
+type IfaceTypeSet = ESet CType
 
 class (SubstReader Name m, InfBuilder2 m, Solver2 m)
       => Inferer (m::MonadKind2) where
   liftSolverMInf :: EmitsInf o => SolverM o a -> m i o a
   gatherUnsolvedInterfaces :: m i o a -> m i o (a, IfaceTypeSet o)
-  reportUnsolvedInterface  :: Type o  -> m i o ()
-  addDefault :: AtomName o -> DefaultType -> m i o ()
+  reportUnsolvedInterface  :: CType o  -> m i o ()
+  addDefault :: CAtomName o -> DefaultType -> m i o ()
   getDefaults :: m i o (Defaults o)
 
 applyDefaults :: EmitsInf o => InfererM i o ()
@@ -351,7 +351,7 @@ zonkDefaults s (Defaults d1 d2) =
 
 data InfOutFrag (n::S) (l::S) = InfOutFrag (InfEmissions n l) (Defaults l) (SolverSubst l)
 
-type InfEmission  = EitherE DeclBinding SolverBinding
+type InfEmission  = EitherE (DeclBinding CoreIR) (SolverBinding CoreIR)
 type InfEmissions = RNest (BinderP AtomNameC InfEmission)
 
 instance GenericB InfOutFrag where
@@ -389,13 +389,13 @@ instance ExtOutMap InfOutMap EnvFrag where
       InfOutMap zonkedEnv (sink ss) (sink dd) (sink oldUn <> zonkedUn)
 
 newtype UnsolvedEnv (n::S) =
-  UnsolvedEnv { fromUnsolvedEnv :: S.Set (AtomName n) }
+  UnsolvedEnv { fromUnsolvedEnv :: S.Set (CAtomName n) }
   deriving (Semigroup, Monoid)
 
 instance SinkableE UnsolvedEnv where
   sinkingProofE = todoSinkableProof
 
-getAtomNames :: Distinct l => EnvFrag n l -> S.Set (AtomName l)
+getAtomNames :: Distinct l => EnvFrag n l -> S.Set (CAtomName l)
 getAtomNames frag = S.fromList $ nameSetToList $ toNameSet $ toScopeFrag frag
 
 -- TODO: zonk the allowed effects and synth candidates in the bindings too
@@ -426,14 +426,14 @@ hasInferenceVars :: (EnvReader m, HoistableE e) => e n -> m n Bool
 hasInferenceVars e = liftEnvReaderM $ anyInferenceVars $ freeAtomVarsList e
 {-# INLINE hasInferenceVars #-}
 
-anyInferenceVars :: [AtomName n] -> EnvReaderM n Bool
+anyInferenceVars :: [CAtomName n] -> EnvReaderM n Bool
 anyInferenceVars = \case
   [] -> return False
   (v:vs) -> isInferenceVar v >>= \case
     True  -> return True
     False -> anyInferenceVars vs
 
-isInferenceVar :: EnvReader m => AtomName n -> m n Bool
+isInferenceVar :: EnvReader m => CAtomName n -> m n Bool
 isInferenceVar v = lookupEnv v >>= \case
   AtomNameBinding (SolverBound _) -> return True
   _                               -> return False
@@ -518,7 +518,7 @@ instance ExtOutFrag InfOutFrag InfDeclEmission where
     withSubscopeDistinct em $ InfOutFrag (RNest ems em) (sink ds) (sink ss)
   {-# INLINE extendOutFrag #-}
 
-emitInfererM :: Mut o => NameHint -> InfEmission o -> InfererM i o (AtomName o)
+emitInfererM :: Mut o => NameHint -> InfEmission o -> InfererM i o (CAtomName o)
 emitInfererM hint emission = do
   InfererM $ SubstReaderT $ lift $ lift11 $ freshExtendSubInplaceT hint \b ->
     (InfDeclEmission (b :> emission), binderName b)
@@ -618,7 +618,7 @@ instance Inferer InfererM where
           ++ pprintCanonicalized iface ++ givensStr
       GatherRequired ds -> put $ GatherRequired $ eSetSingleton iface <> ds
 
-instance Builder (InfererM i) where
+instance Builder CoreIR (InfererM i) where
   emitDecl hint ann expr = do
     -- This zonking, and the zonking of the bindings elsewhere, is only to
     -- prevent `getType` from failing. But maybe we should just catch the
@@ -629,7 +629,7 @@ instance Builder (InfererM i) where
     emitInfererM hint $ LeftE $ DeclBinding ann ty expr'
   {-# INLINE emitDecl #-}
 
-type InferenceNameBinders = Nest (BinderP AtomNameC SolverBinding)
+type InferenceNameBinders = Nest (BinderP AtomNameC (SolverBinding CoreIR))
 
 -- When we finish building a block of decls we need to hoist the local solver
 -- information into the outer scope. If the local solver state mentions local
@@ -640,7 +640,7 @@ hoistThroughDecls
   :: ( SubstE Name e, HoistableE e, Fallible1 m, ScopeReader m, EnvExtender m)
   => InfOutFrag n l
   ->   e l
-  -> m n (Abs InfOutFrag (Abs (Nest Decl) e) n)
+  -> m n (Abs InfOutFrag (Abs (Nest CDecl) e) n)
 hoistThroughDecls outFrag result = do
   scope <- unsafeGetScope
   refreshAbs (Abs outFrag result) \outFrag' result' -> do
@@ -652,7 +652,7 @@ hoistThroughDecls'
   => Scope n
   -> InfOutFrag n l
   ->   e l
-  -> Except (Abs InfOutFrag (Abs (Nest Decl) e) n)
+  -> Except (Abs InfOutFrag (Abs (Nest CDecl) e) n)
 hoistThroughDecls' scope (InfOutFrag emissions defaults subst) result = do
   withSubscopeDistinct emissions do
     HoistedSolverState infVars defaults' subst' decls result' <-
@@ -666,7 +666,7 @@ data HoistedSolverState e n where
     :: InferenceNameBinders n l1
     ->   Defaults l1
     ->   SolverSubst l1
-    ->   Nest Decl l1 l2
+    ->   Nest CDecl l1 l2
     ->     e l2
     -> HoistedSolverState e n
 
@@ -677,7 +677,7 @@ data HoistedSolverState e n where
 -- which is how we use them in `hoistInfStateRec`.
 type DelayedSolveNest (b::B) (n::S) (l::S) = Nest (EitherB b (LiftB SolverSubst)) n l
 
-resolveDelayedSolve :: Distinct l => Scope n -> SolverSubst n -> DelayedSolveNest Decl n l -> Nest Decl n l
+resolveDelayedSolve :: Distinct l => Scope n -> SolverSubst n -> DelayedSolveNest CDecl n l -> Nest CDecl n l
 resolveDelayedSolve scope subst = \case
   Empty -> Empty
   Nest (RightB (LiftB sfrag)) rest -> resolveDelayedSolve scope (subst `unsafeCatSolverSubst` sfrag) rest
@@ -703,7 +703,9 @@ emptyInferenceNameBindersFV = InferenceNameBindersFV mempty Empty
 dropInferenceNameBindersFV :: InferenceNameBindersFV n l -> InferenceNameBinders n l
 dropInferenceNameBindersFV (InferenceNameBindersFV _ bs) = bs
 
-prependNameBinder :: BinderP AtomNameC SolverBinding n q -> InferenceNameBindersFV q l -> InferenceNameBindersFV n l
+prependNameBinder
+  :: BinderP AtomNameC (SolverBinding CoreIR) n q
+  -> InferenceNameBindersFV q l -> InferenceNameBindersFV n l
 prependNameBinder b (InferenceNameBindersFV fvs bs) =
   InferenceNameBindersFV (freeVarsB b <> hoistFilterNameSet b fvs) (Nest b bs)
 
@@ -721,10 +723,12 @@ hoistSolverSubst (UnhoistedSolverSubst frag s) = hoist frag s
 -- TODO: Instead of delaying the solve, compute the most-nested scope once
 -- and then use it for all _eager_ substitutions while hoisting! Using a super-scope
 -- for substitution shouldn't be a problem!
-hoistInfStateRec :: forall n l l1 l2 e. (Distinct n, Distinct l2, HoistableE e)
-                 => Scope n -> InfEmissions n l
-                 -> InferenceNameBindersFV l l1 -> Defaults l1 -> UnhoistedSolverSubst l1 -> DelayedSolveNest Decl l1 l2 -> e l2
-                 -> Except (HoistedSolverState e n)
+hoistInfStateRec
+  :: forall n l l1 l2 e. (Distinct n, Distinct l2, HoistableE e)
+  => Scope n -> InfEmissions n l
+  -> InferenceNameBindersFV l l1 -> Defaults l1 -> UnhoistedSolverSubst l1
+  -> DelayedSolveNest CDecl l1 l2 -> e l2
+  -> Except (HoistedSolverState e n)
 hoistInfStateRec scope emissions !infVars defaults !subst decls e = case emissions of
  REmpty -> do
   subst' <- liftHoistExcept $ hoistSolverSubst subst
@@ -736,7 +740,7 @@ hoistInfStateRec scope emissions !infVars defaults !subst decls e = case emissio
     case infEmission of
       RightE binding@(InfVarBound _ _) -> do
         UnhoistedSolverSubst frag (SolverSubst substMap) <- return subst
-        let vHoist :: AtomName l1 = withSubscopeDistinct infVars $ sink $ binderName b  -- binder name at l1
+        let vHoist :: CAtomName l1 = withSubscopeDistinct infVars $ sink $ binderName b  -- binder name at l1
         let vUnhoist = withExtEvidence frag $ sink vHoist                               -- binder name below frag
         case M.lookup vUnhoist substMap of
           -- Unsolved inference variables are just gathered as they are.
@@ -854,14 +858,14 @@ instance EnvExtender (InfererM i) where
 
 -- === actual inference pass ===
 
-type SigmaType = Type  -- may     start with an implicit lambda
-type RhoType   = Type  -- doesn't start with an implicit lambda
+type SigmaType = CType  -- may     start with an implicit lambda
+type RhoType   = CType  -- doesn't start with an implicit lambda
 data RequiredTy (e::E) (n::S) = Check (e n)
                               | Infer
                                 deriving Show
 
 checkSigma :: EmitsBoth o
-           => NameHint -> UExpr i -> SigmaType o -> InfererM i o (Atom o)
+           => NameHint -> UExpr i -> SigmaType o -> InfererM i o (CAtom o)
 checkSigma hint expr sTy = confuseGHC >>= \_ -> case sTy of
   Pi piTy@(PiType (PiBinder b _ arrow) _ _)
     | arrow `elem` [ImplicitArrow, ClassArrow] -> case expr of
@@ -876,7 +880,7 @@ checkSigma hint expr sTy = confuseGHC >>= \_ -> case sTy of
               checkSigma hint expr bodyTy
   _ -> checkOrInferRho hint expr (Check sTy)
 
-inferSigma :: EmitsBoth o => NameHint -> UExpr i -> InfererM i o (Atom o)
+inferSigma :: EmitsBoth o => NameHint -> UExpr i -> InfererM i o (CAtom o)
 inferSigma hint (WithSrcE pos expr) = case expr of
   ULam lam@(ULamExpr ImplicitArrow _ _) ->
     addSrcContext pos $ inferULam Pure lam
@@ -884,25 +888,25 @@ inferSigma hint (WithSrcE pos expr) = case expr of
   _ -> inferRho hint (WithSrcE pos expr)
 
 checkRho :: EmitsBoth o =>
-  NameHint -> UExpr i -> RhoType o -> InfererM i o (Atom o)
+  NameHint -> UExpr i -> RhoType o -> InfererM i o (CAtom o)
 checkRho hint expr ty = checkOrInferRho hint expr (Check ty)
 {-# INLINE checkRho #-}
 
 inferRho :: EmitsBoth o =>
-  NameHint -> UExpr i -> InfererM i o (Atom o)
+  NameHint -> UExpr i -> InfererM i o (CAtom o)
 inferRho hint expr = checkOrInferRho hint expr Infer
 {-# INLINE inferRho #-}
 
-instantiateSigma :: EmitsBoth o => Atom o -> InfererM i o (Atom o)
+instantiateSigma :: EmitsBoth o => CAtom o -> InfererM i o (CAtom o)
 instantiateSigma f = fst <$> instantiateSigmaWithArgs f
 
-instantiateSigmaWithArgs :: EmitsBoth o => Atom o -> InfererM i o (Atom o, [Atom o])
+instantiateSigmaWithArgs :: EmitsBoth o => CAtom o -> InfererM i o (CAtom o, [CAtom o])
 instantiateSigmaWithArgs f = do
   ty <- tryGetType f
   args <- getImplicitArgs ty
   (,args) <$> naryApp f args
 
-getImplicitArgs :: EmitsInf o => Type o -> InfererM i o [Atom o]
+getImplicitArgs :: EmitsInf o => CType o -> InfererM i o [CAtom o]
 getImplicitArgs ty = case ty of
   Pi (PiType b _ _) ->
     getImplicitArg b >>= \case
@@ -912,7 +916,7 @@ getImplicitArgs ty = case ty of
         (arg:) <$> getImplicitArgs appTy
   _ -> return []
 
-getImplicitArg :: EmitsInf o => PiBinder o o' -> InfererM i o (Maybe (Atom o))
+getImplicitArg :: EmitsInf o => PiBinder CoreIR o o' -> InfererM i o (Maybe (CAtom o))
 getImplicitArg (PiBinder _ argTy arr) = case arr of
   ImplicitArrow -> Just <$> freshType argTy
   ClassArrow -> do
@@ -923,7 +927,7 @@ getImplicitArg (PiBinder _ argTy arr) = case arr of
 -- The name hint names the object being computed
 checkOrInferRho :: forall i o. EmitsBoth o
                 => NameHint -> UExpr i
-                -> RequiredTy RhoType o -> InfererM i o (Atom o)
+                -> RequiredTy RhoType o -> InfererM i o (CAtom o)
 checkOrInferRho hint (WithSrcE pos expr) reqTy = do
  addSrcContext pos $ confuseGHC >>= \_ -> case expr of
   UVar ~(InternalName _ v) -> do
@@ -995,9 +999,9 @@ checkOrInferRho hint (WithSrcE pos expr) reqTy = do
               bindLamPat (WithSrcB pos' pat) v' do
                 effs' <- checkUEffRow effs
                 ty'   <- checkUType   ty
-                return $ PairE effs' ty'
+                return $ PairE (Eff effs') ty'
             cheapReduceWithDecls decls result >>= \case
-              (Just (PairE effs' ty'), DictTypeHoistSuccess, []) -> return $ (effs', ty')
+              (Just (PairE (Eff effs') ty'), DictTypeHoistSuccess, []) -> return $ (effs', ty')
               _ -> throw TypeErr $ "Can't reduce type expression: " ++
                      docAsStr (prettyBlock decls $ snd $ fromPairE result)
     matchRequirement $ Pi piTy
@@ -1088,8 +1092,8 @@ checkOrInferRho hint (WithSrcE pos expr) reqTy = do
     matchRequirement =<< resolveDelay =<< foldM go (Nothing, mempty) (reverse elems)
     where
       go :: EmitsInf o
-         => (Maybe (Atom o), LabeledItems (Atom o)) -> UFieldRowElem i
-         -> InfererM i o (Maybe (Atom o), LabeledItems (Atom o))
+         => (Maybe (CAtom o), LabeledItems (CAtom o)) -> UFieldRowElem i
+         -> InfererM i o (Maybe (CAtom o), LabeledItems (CAtom o))
       go delayedRec = \case
         UStaticField l e -> do
           e' <- inferRho noHint e
@@ -1110,7 +1114,7 @@ checkOrInferRho hint (WithSrcE pos expr) reqTy = do
               return (Just rec', mempty)
 
       resolveDelay :: EmitsInf o
-                   => (Maybe (Atom o), LabeledItems (Atom o)) -> InfererM i o (Atom o)
+                   => (Maybe (CAtom o), LabeledItems (CAtom o)) -> InfererM i o (CAtom o)
       resolveDelay = \case
         (Nothing , delayedItems) -> getRecord delayedItems
         (Just rec, delayedItems) -> case null delayedItems of
@@ -1170,7 +1174,7 @@ checkOrInferRho hint (WithSrcE pos expr) reqTy = do
   UFloatLit x -> matchRequirement $ Con $ Lit  $ Float32Lit $ realToFrac x
   -- TODO: Make sure that this conversion is not lossy!
   where
-    matchRequirement :: Atom o -> InfererM i o (Atom o)
+    matchRequirement :: CAtom o -> InfererM i o (CAtom o)
     matchRequirement x = return x <*
       case reqTy of
         Infer -> return ()
@@ -1179,7 +1183,7 @@ checkOrInferRho hint (WithSrcE pos expr) reqTy = do
           constrainEq req ty
     {-# INLINE matchRequirement #-}
 
-inferFieldRowElem :: EmitsBoth o => UFieldRowElem i -> InfererM i o [FieldRowElem o]
+inferFieldRowElem :: EmitsBoth o => UFieldRowElem i -> InfererM i o [FieldRowElem CoreIR o]
 inferFieldRowElem = \case
   UStaticField l ty -> do
     ty' <- checkUType ty
@@ -1207,7 +1211,7 @@ inferFieldRowElem = \case
 
 -- This allows us to make the instantiated params/dicts part of an n-ary
 -- application along with the ordinary explicit args
-inferFunNoInstantiation :: EmitsBoth o => UExpr i -> InfererM i o (Atom o)
+inferFunNoInstantiation :: EmitsBoth o => UExpr i -> InfererM i o (CAtom o)
 inferFunNoInstantiation expr@(WithSrcE pos expr') = do
  addSrcContext pos $ case expr' of
   UVar ~(InternalName _ v) -> do
@@ -1228,7 +1232,7 @@ asNaryTabApp (WithSrcE appCtx (UTabApp f x)) =
   where (f', xs) = asNaryTabApp f
 asNaryTabApp e = (e, [])
 
-inferNaryTabApp :: EmitsBoth o => SrcPosCtx -> Atom o -> NonEmpty (UExprArg i) -> InfererM i o (Atom o)
+inferNaryTabApp :: EmitsBoth o => SrcPosCtx -> CAtom o -> NonEmpty (UExprArg i) -> InfererM i o (CAtom o)
 inferNaryTabApp tabCtx tab args = addSrcContext tabCtx do
   tabTy <- getType tab
   (arg':args') <- inferNaryTabAppArgs tabTy $ toList args
@@ -1236,7 +1240,7 @@ inferNaryTabApp tabCtx tab args = addSrcContext tabCtx do
 
 inferNaryTabAppArgs
   :: EmitsBoth o
-  => Type o -> [UExprArg i] -> InfererM i o [Atom o]
+  => CType o -> [UExprArg i] -> InfererM i o [CAtom o]
 inferNaryTabAppArgs _ [] = return []
 inferNaryTabAppArgs tabTy ((appCtx, arg):rest) = do
   TabPiType b resultTy <- fromTabPiType True tabTy
@@ -1251,7 +1255,7 @@ inferNaryTabAppArgs tabTy ((appCtx, arg):rest) = do
   rest' <- inferNaryTabAppArgs resultTy' rest
   return $ arg'':rest'
 
-inferNaryApp :: EmitsBoth o => SrcPosCtx -> Atom o -> NonEmpty (UExprArg i) -> InfererM i o (Atom o)
+inferNaryApp :: EmitsBoth o => SrcPosCtx -> CAtom o -> NonEmpty (UExprArg i) -> InfererM i o (CAtom o)
 inferNaryApp fCtx f args = addSrcContext fCtx do
   fTy <- getType f
   Just naryPi <- asNaryPiType <$> Pi <$> fromPiType True PlainArrow fTy
@@ -1272,7 +1276,7 @@ inferNaryApp fCtx f args = addSrcContext fCtx do
 -- includes instantiated params and dicts.
 inferNaryAppArgs
   :: EmitsBoth o
-  => NaryPiType o -> NonEmpty (UExprArg i) -> InfererM i o (NonEmpty (Atom o), [UExprArg i])
+  => NaryPiType CoreIR o -> NonEmpty (UExprArg i) -> InfererM i o (NonEmpty (CAtom o), [UExprArg i])
 inferNaryAppArgs (NaryPiType (NonEmptyNest b Empty) effs resultTy) uArgs = do
   let isDependent = binderName b `isFreeIn` PairE effs resultTy
   (x, remaining) <- inferAppArg isDependent b uArgs
@@ -1291,7 +1295,7 @@ inferNaryAppArgs (NaryPiType (NonEmptyNest b1 (Nest b2 rest)) effs resultTy) uAr
 
 inferAppArg
   :: EmitsBoth o
-  => Bool -> PiBinder o o' -> NonEmpty (UExprArg i) -> InfererM i o (Atom o, [UExprArg i])
+  => Bool -> PiBinder CoreIR o o' -> NonEmpty (UExprArg i) -> InfererM i o (CAtom o, [UExprArg i])
 inferAppArg isDependent b@(PiBinder _ argTy _) uArgs = getImplicitArg b >>= \case
   Just x -> return $ (x, toList uArgs)
   Nothing -> do
@@ -1302,7 +1306,7 @@ inferAppArg isDependent b@(PiBinder _ argTy _) uArgs = getImplicitArg b >>= \cas
         else checkSigma (getNameHint b) arg argTy
 
 checkSigmaDependent :: EmitsBoth o
-                    => NameHint -> UExpr i -> SigmaType o -> InfererM i o (Atom o)
+                    => NameHint -> UExpr i -> SigmaType o -> InfererM i o (CAtom o)
 checkSigmaDependent hint e@(WithSrcE ctx _) ty = do
   Abs decls result <- buildDeclsInf $ checkSigma hint e (sink ty)
   cheapReduceWithDecls decls result >>= \case
@@ -1316,14 +1320,14 @@ checkSigmaDependent hint e@(WithSrcE ctx _) ty = do
 
 -- === sorting case alternatives ===
 
-data IndexedAlt n = IndexedAlt CaseAltIndex (Alt n)
+data IndexedAlt n = IndexedAlt CaseAltIndex (Alt CoreIR n)
 
 instance SinkableE IndexedAlt where
   sinkingProofE = todoSinkableProof
 
-buildNthOrderedAlt :: (Emits n, Builder m)
-                   => [IndexedAlt n] -> Type n -> Type n -> Int -> Atom n
-                   -> m n (Atom n)
+buildNthOrderedAlt :: (Emits n, Builder CoreIR m)
+                   => [IndexedAlt n] -> CType n -> CType n -> Int -> CAtom n
+                   -> m n (CAtom n)
 buildNthOrderedAlt alts scrutTy resultTy i v = do
   case lookup (nthCaseAltIdx scrutTy i) [(idx, alt) | IndexedAlt idx alt <- alts] of
     Nothing -> do
@@ -1333,7 +1337,7 @@ buildNthOrderedAlt alts scrutTy resultTy i v = do
 
 -- converts from the ordinal index used in the core IR to the more complicated
 -- `CaseAltIndex` used in the surface IR.
-nthCaseAltIdx :: Type n -> Int -> CaseAltIndex
+nthCaseAltIdx :: CType n -> Int -> CaseAltIndex
 nthCaseAltIdx ty i = case ty of
   TypeCon _ _ _ -> ConAlt i
   VariantTy (NoExt types) -> case lookup i pairedIndices of
@@ -1345,8 +1349,8 @@ nthCaseAltIdx ty i = case ty of
   _ -> error $ "can't pattern-match on: " <> pprint ty
 
 buildMonomorphicCase
-  :: (Emits n, ScopableBuilder m)
-  => [IndexedAlt n] -> Atom n -> Type n -> m n (Atom n)
+  :: (Emits n, ScopableBuilder CoreIR m)
+  => [IndexedAlt n] -> CAtom n -> CType n -> m n (CAtom n)
 buildMonomorphicCase alts scrut resultTy = do
   scrutTy <- getType scrut
   buildCase scrut resultTy \i v -> do
@@ -1355,9 +1359,9 @@ buildMonomorphicCase alts scrut resultTy = do
     resultTy'   <- sinkM resultTy
     buildNthOrderedAlt alts' scrutTy' resultTy' i v
 
-buildSortedCase :: (Fallible1 m, Builder m, Emits n)
-                 => Atom n -> [IndexedAlt n] -> Type n
-                 -> m n (Atom n)
+buildSortedCase :: (Fallible1 m, Builder CoreIR m, Emits n)
+                 => CAtom n -> [IndexedAlt n] -> CType n
+                 -> m n (CAtom n)
 buildSortedCase scrut alts resultTy = do
   scrutTy <- getType scrut
   case scrutTy of
@@ -1403,7 +1407,7 @@ buildSortedCase scrut alts resultTy = do
 -- Make sure all of the alternatives are exclusive with the tail pattern (could
 -- technically allow overlap but this is simpler). Split based on the tail
 -- pattern's skipped types.
-checkNoTailOverlaps :: Fallible1 m => [IndexedAlt n] -> LabeledItems (Type n) ->  m n ()
+checkNoTailOverlaps :: Fallible1 m => [IndexedAlt n] -> LabeledItems (CType n) ->  m n ()
 checkNoTailOverlaps alts (LabeledItems tys) = do
   forM_ alts \case
     (IndexedAlt (VariantAlt label i) _) ->
@@ -1418,7 +1422,7 @@ isVariantTailAlt _ = False
 
 -- ===
 
-inferUVar :: EmitsBoth o => UVar o -> InfererM i o (Atom o)
+inferUVar :: EmitsBoth o => UVar o -> InfererM i o (CAtom o)
 inferUVar = \case
   UAtomVar v ->
     return $ Var v
@@ -1439,7 +1443,7 @@ inferUVar = \case
     Var <$> (emit $ Op (Perform (Eff (OneEffect (UserEffect effName))) i))
   UHandlerVar v -> liftBuilder $ buildHandlerLam v
 
-buildHandlerLam :: EmitsBoth n => HandlerName n -> BuilderM n (Atom n)
+buildHandlerLam :: EmitsBoth n => HandlerName n -> BuilderM CoreIR n (CAtom n)
 buildHandlerLam v = do
   HandlerBinding (HandlerDef effName _r _ns _hndEff _retTy _ _) <- lookupEnv v
   buildLam "r" ImplicitArrow TyKind Pure $ \r ->
@@ -1452,7 +1456,7 @@ buildHandlerLam v = do
         block <- buildBlock $ app (Var (sink body)) UnitVal
         Var <$> (emit $ Handle (sink v) [] block)
 
-buildForTypeFromTabType :: EffectRow n -> TabPiType n -> InfererM i n (PiType n)
+buildForTypeFromTabType :: EffectRow n -> TabPiType CoreIR n -> InfererM i n (PiType CoreIR n)
 buildForTypeFromTabType effs tabPiTy@(TabPiType (b:>ixTy) _) = do
   let IxType ty _ = ixTy
   buildPi (getNameHint b) PlainArrow ty \i -> do
@@ -1461,12 +1465,12 @@ buildForTypeFromTabType effs tabPiTy@(TabPiType (b:>ixTy) _) = do
     return (sink effs, resultTy)
 
 checkMaybeAnnExpr :: EmitsBoth o
-  => NameHint -> Maybe (UType i) -> UExpr i -> InfererM i o (Atom o)
+  => NameHint -> Maybe (UType i) -> UExpr i -> InfererM i o (CAtom o)
 checkMaybeAnnExpr hint ty expr = confuseGHC >>= \_ -> case ty of
   Nothing -> inferSigma hint expr
   Just ty' -> checkSigma hint expr =<< zonk =<< checkUType ty'
 
-dictTypeFun :: EnvReader m => ClassName n -> m n (Atom n)
+dictTypeFun :: EnvReader m => ClassName n -> m n (CAtom n)
 dictTypeFun v = do
   -- TODO: we should cache this in the ClassDef
   ClassDef classSourceName _ paramBinders _ _ <- lookupClassDef v
@@ -1474,7 +1478,7 @@ dictTypeFun v = do
     v' <- sinkM v
     return $ go classSourceName bs' v' $ nestToNames bs'
   where
-    go :: SourceName -> Nest RolePiBinder n l -> ClassName l -> [AtomName l] -> Atom n
+    go :: SourceName -> Nest (RolePiBinder CoreIR) n l -> ClassName l -> [CAtomName l] -> CAtom n
     go classSourceName bs className params = case bs of
       Empty -> DictTy $ DictType classSourceName className $ map Var params
       Nest (RolePiBinder b ty _ _) rest ->
@@ -1482,7 +1486,7 @@ dictTypeFun v = do
           AtomicBlock $ go classSourceName rest className params
 
 -- TODO: cache this with the instance def (requires a recursive binding)
-instanceFun :: EnvReader m => InstanceName n -> m n (Atom n)
+instanceFun :: EnvReader m => InstanceName n -> m n (CAtom n)
 instanceFun instanceName = do
   InstanceDef _ bs _ _ <- lookupInstanceDef instanceName
   liftEnvReaderM $ refreshAbs (Abs bs UnitE) \bs' UnitE -> do
@@ -1490,7 +1494,7 @@ instanceFun instanceName = do
     instanceName' <- sinkM instanceName
     return $ go bs' instanceName' args
   where
-    go :: Nest RolePiBinder n l -> InstanceName l -> [Atom l] -> Atom n
+    go :: Nest (RolePiBinder CoreIR) n l -> InstanceName l -> [CAtom l] -> CAtom n
     go bs name args = case bs of
       Empty -> DictCon $ InstanceDict name args
       Nest (RolePiBinder b ty arr _) rest -> do
@@ -1498,37 +1502,37 @@ instanceFun instanceName = do
         Lam $ LamExpr (LamBinder b ty arr Pure) (AtomicBlock restAtom)
 
 buildTyConLam
-  :: ScopableBuilder m
+  :: ScopableBuilder CoreIR m
   => DataDefName n
   -> Arrow
-  -> (forall l. DExt n l => SourceName -> DataDefParams l -> m l (Atom l))
-  -> m n (Atom n)
+  -> (forall l. DExt n l => SourceName -> DataDefParams CoreIR l -> m l (CAtom l))
+  -> m n (CAtom n)
 buildTyConLam defName arr cont = do
   DataDef sourceName paramBs _ <- lookupDataDef =<< sinkM defName
   buildPureNaryLam (EmptyAbs $ fmapNest replacePlain paramBs) \params -> do
     cont sourceName $ DataDefParams (attachArrows paramBs params)
   where
-    replacePlain :: RolePiBinder n l -> PiBinder n l
+    replacePlain :: RolePiBinder CoreIR n l -> PiBinder CoreIR n l
     replacePlain (RolePiBinder b ty binderArr _) = PiBinder b ty arr'
       where arr' = case binderArr of
                      PlainArrow -> arr
                      _          -> binderArr
 
-    attachArrows :: Nest RolePiBinder n l
-                  -> [AtomName l2] -> [(Arrow, Atom l2)]
+    attachArrows :: Nest (RolePiBinder CoreIR) n l
+                  -> [CAtomName l2] -> [(Arrow, CAtom l2)]
     attachArrows Empty []     = []
     attachArrows (Nest (RolePiBinder _ _ arr' _) bs) (x:xs)
       = (arr', Var x):attachArrows bs xs
     attachArrows _ _ = error "zip error"
 
-tyConDefAsAtom :: EnvReader m => DataDefName n -> m n (Atom n)
+tyConDefAsAtom :: EnvReader m => DataDefName n -> m n (CAtom n)
 tyConDefAsAtom defName = liftBuilder do
   buildTyConLam defName PlainArrow \sourceName params ->
     return $ TypeCon sourceName (sink defName) params
 
 dataConDefAsAtom :: EnvReader m
-                 => Abs (Nest RolePiBinder) (EmptyAbs (Nest Binder)) n
-                 -> DataDefName n -> Int -> m n (Atom n)
+                 => Abs (Nest (RolePiBinder CoreIR)) (EmptyAbs (Nest (Binder CoreIR))) n
+                 -> DataDefName n -> Int -> m n (CAtom n)
 dataConDefAsAtom bsAbs defName conIx = liftBuilder do
   buildTyConLam defName ImplicitArrow \_ params -> do
     defName' <- sinkM defName
@@ -1545,10 +1549,10 @@ dataConDefAsAtom bsAbs defName conIx = liftBuilder do
           _   -> SumVal conTys conIx conProd
             where conTys = sinkList $ conDefs <&> \(DataConDef _ rty _) -> rty
 
-buildDataCon :: EnvReader m => Type n -> [Atom n] -> m n (Atom n)
+buildDataCon :: EnvReader m => CType n -> [CAtom n] -> m n (CAtom n)
 buildDataCon repTy topArgs = wrap repTy topArgs
   where
-    wrap :: EnvReader m => Type n -> [Atom n] -> m n (Atom n)
+    wrap :: EnvReader m => CType n -> [CAtom n] -> m n (CAtom n)
     wrap _ [arg] = return $ arg
     wrap rty args = case rty of
       ProdTy tys  ->
@@ -1565,12 +1569,12 @@ buildDataCon repTy topArgs = wrap repTy topArgs
         where h:t = args
       _ -> error $ "Unexpected data con representation type: " ++ pprint repTy
 
-binderNestAsPiNest :: Arrow -> Nest Binder n l -> Nest PiBinder n l
+binderNestAsPiNest :: Arrow -> Nest (Binder CoreIR) n l -> Nest (PiBinder CoreIR) n l
 binderNestAsPiNest arr = \case
   Empty             -> Empty
   Nest (b:>ty) rest -> Nest (PiBinder b ty arr) $ binderNestAsPiNest arr rest
 
-inferRole :: Type o -> Arrow -> InfererM i o ParamRole
+inferRole :: CType o -> Arrow -> InfererM i o ParamRole
 inferRole ty arr = case arr of
   ClassArrow -> return DictParam
   _ -> do
@@ -1585,8 +1589,10 @@ inferRole ty arr = case arr of
         False -> return DataParam
 {-# INLINE inferRole #-}
 
-inferDataDef :: EmitsInf o => UDataDef i
-             -> InfererM i o (PairE DataDef (Abs (Nest RolePiBinder) (ListE (EmptyAbs (Nest Binder)))) o)
+inferDataDef
+  :: EmitsInf o => UDataDef i
+  -> InfererM i o (PairE DataDef
+                         (Abs (Nest (RolePiBinder CoreIR)) (ListE (EmptyAbs (Nest (Binder CoreIR))))) o)
 inferDataDef (UDataDef tyConName paramBs dataCons) = do
   Abs paramBs' (ListE dataConsWithBs') <-
     withNestedUBindersTyCon paramBs \_ -> do
@@ -1596,10 +1602,10 @@ inferDataDef (UDataDef tyConName paramBs dataCons) = do
                  (Abs paramBs' $ ListE bs')
 
 withNestedUBindersTyCon
-  :: forall i i' o e. (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e)
+  :: forall i i' o e. (EmitsInf o, HasNamesE e, SubstE (AtomSubstVal CoreIR) e, SinkableE e)
   => Nest (UAnnBinderArrow AtomNameC) i i'
-  -> (forall o'. (EmitsInf o', Ext o o') => [AtomName o'] -> InfererM i' o' (e o'))
-  -> InfererM i o (Abs (Nest RolePiBinder) e o)
+  -> (forall o'. (EmitsInf o', Ext o o') => [CAtomName o'] -> InfererM i' o' (e o'))
+  -> InfererM i o (Abs (Nest (RolePiBinder CoreIR)) e o)
 withNestedUBindersTyCon bs cont = case bs of
   Empty -> Abs Empty <$> cont []
   Nest (UAnnBinderArrow b ty arr) rest -> do
@@ -1612,18 +1618,18 @@ withNestedUBindersTyCon bs cont = case bs of
 
 inferDataCon :: EmitsInf o
              => (SourceName, UDataDefTrail i)
-             -> InfererM i o (PairE DataConDef (EmptyAbs (Nest Binder)) o)
+             -> InfererM i o (PairE DataConDef (EmptyAbs (Nest (Binder CoreIR))) o)
 inferDataCon (sourceName, UDataDefTrail argBs) = do
   argBs' <- checkUBinders (EmptyAbs argBs)
   let (repTy, projIdxs) = dataConRepTy argBs'
   return $ PairE (DataConDef sourceName repTy projIdxs) argBs'
 
-dataConRepTy :: EmptyAbs (Nest Binder) n -> (Type n, [[Projection]])
+dataConRepTy :: EmptyAbs (Nest (Binder CoreIR)) n -> (CType n, [[Projection]])
 dataConRepTy (Abs topBs UnitE) = case topBs of
   Empty -> (UnitTy, [])
   _ -> go [] [UnwrapCompoundNewtype] topBs
   where
-    go :: [Type l] -> [Projection] -> Nest Binder l p -> (Type l, [[Projection]])
+    go :: [CType l] -> [Projection] -> Nest (Binder CoreIR) l p -> (CType l, [[Projection]])
     go revAcc projIdxs = \case
       Empty -> case revAcc of
         []   -> error "should never happen"
@@ -1658,10 +1664,10 @@ inferClassDef className methodNames paramBs superclassTys methods = solveLocal d
   return $ ClassDef className methodNames bs scs mtys
 
 withClassDefBinders
-  :: (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e)
+  :: (EmitsInf o, HasNamesE e, SubstE (AtomSubstVal CoreIR) e, SinkableE e)
   => Nest (UAnnBinder AtomNameC) i i'
-  -> (forall o'. (EmitsInf o', Ext o o') => [AtomName o'] -> InfererM i' o' (e o'))
-  -> InfererM i o (Abs (Nest RolePiBinder) e o)
+  -> (forall o'. (EmitsInf o', Ext o o') => [CAtomName o'] -> InfererM i' o' (e o'))
+  -> InfererM i o (Abs (Nest (RolePiBinder CoreIR)) e o)
 withClassDefBinders bs cont = case bs of
   Empty -> Abs Empty <$> cont []
   Nest b rest -> do
@@ -1673,7 +1679,7 @@ withClassDefBinders bs cont = case bs of
 
 withSuperclassBinders
   :: (SinkableE e, SubstE Name e, HoistableE e, EmitsInf o)
-  => [Type o]
+  => [CType o]
   -> (forall o'. (EmitsInf o', DExt o o') => InfererM i o' (e o'))
   -> InfererM i o (Abs SuperclassBinders e o)
 withSuperclassBinders tys cont = do
@@ -1682,7 +1688,7 @@ withSuperclassBinders tys cont = do
 
 withSuperclassBindersRec
   :: (SinkableE e, SubstE Name e, HoistableE e, EmitsInf o)
-  => [Type o]
+  => [CType o]
   -> (forall o'. (EmitsInf o', DExt o o') => InfererM i o' (e o'))
   -> InfererM i o (Abs (Nest AtomNameBinder) e o)
 withSuperclassBindersRec [] cont = do
@@ -1697,11 +1703,11 @@ withSuperclassBindersRec (ty:rest) cont = do
   return $ Abs (Nest b bs) e
 
 withNestedUBinders
-  :: (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e, ToBinding binding AtomNameC)
+  :: (EmitsInf o, HasNamesE e, SubstE (AtomSubstVal CoreIR) e, SinkableE e, ToBinding binding AtomNameC)
   => Nest (UAnnBinder AtomNameC) i i'
-  -> (forall l. Type l -> binding l)
-  -> (forall o'. (EmitsInf o', Ext o o') => [AtomName o'] -> InfererM i' o' (e o'))
-  -> InfererM i o (Abs (Nest Binder) e o)
+  -> (forall l. CType l -> binding l)
+  -> (forall o'. (EmitsInf o', Ext o o') => [CAtomName o'] -> InfererM i' o' (e o'))
+  -> InfererM i o (Abs (Nest (Binder CoreIR)) e o)
 withNestedUBinders bs asBinding cont = case bs of
   Empty -> Abs Empty <$> cont []
   Nest b rest -> do
@@ -1712,10 +1718,10 @@ withNestedUBinders bs asBinding cont = case bs of
     return $ Abs (Nest b' rest') body
 
 withRoleUBinder
-  :: (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e)
+  :: (EmitsInf o, HasNamesE e, SubstE (AtomSubstVal CoreIR) e, SinkableE e)
   => UAnnBinder AtomNameC i i' -> Arrow
-  -> (forall o'. (EmitsInf o', Ext o o') => AtomName o' -> InfererM i' o' (e o'))
-  -> InfererM i o (Abs RolePiBinder e o)
+  -> (forall o'. (EmitsInf o', Ext o o') => CAtomName o' -> InfererM i' o' (e o'))
+  -> InfererM i o (Abs (RolePiBinder CoreIR) e o)
 withRoleUBinder (UAnnBinder b ann) arr cont = do
   ty <- checkUType ann
   role <- inferRole ty arr
@@ -1724,11 +1730,11 @@ withRoleUBinder (UAnnBinder b ann) arr cont = do
     extendSubst (b @> name) $ cont name
   return $ Abs (RolePiBinder b' ty arr role) ans
 
-withUBinder :: (EmitsInf o, HasNamesE e, SubstE AtomSubstVal e, SinkableE e, ToBinding binding AtomNameC)
+withUBinder :: (EmitsInf o, HasNamesE e, SubstE (AtomSubstVal CoreIR) e, SinkableE e, ToBinding binding AtomNameC)
             => UAnnBinder AtomNameC i i'
-            -> (Type o -> binding o)
-            -> (forall o'. (EmitsInf o', Ext o o') => AtomName o' -> InfererM i' o' (e o'))
-            -> InfererM i o (Abs Binder e o)
+            -> (CType o -> binding o)
+            -> (forall o'. (EmitsInf o', Ext o o') => CAtomName o' -> InfererM i' o' (e o'))
+            -> InfererM i o (Abs (Binder CoreIR) e o)
 withUBinder (UAnnBinder b ann) asBinding cont = do
   ann' <- checkUType ann
   Abs (n :> _) ans <- buildAbsInf (getNameHint b) (asBinding ann') \name ->
@@ -1737,17 +1743,17 @@ withUBinder (UAnnBinder b ann) asBinding cont = do
 
 checkUBinders :: EmitsInf o
               => EmptyAbs (Nest (UAnnBinder AtomNameC)) i
-              -> InfererM i o (EmptyAbs (Nest Binder) o)
+              -> InfererM i o (EmptyAbs (Nest (Binder CoreIR)) o)
 checkUBinders (EmptyAbs bs) = withNestedUBinders bs id \_ -> return UnitE
 checkUBinders _ = error "impossible"
 
-inferULam :: EmitsBoth o => EffectRow o -> ULamExpr i -> InfererM i o (Atom o)
+inferULam :: EmitsBoth o => EffectRow o -> ULamExpr i -> InfererM i o (CAtom o)
 inferULam effs (ULamExpr arrow (UPatAnn p ann) body) = do
   argTy <- checkAnn ann
   buildLamInf (getNameHint p) arrow argTy (\_ -> sinkM effs) \v ->
     bindLamPat p v $ inferSigma noHint body
 
-checkULam :: EmitsBoth o => ULamExpr i -> PiType o -> InfererM i o (Atom o)
+checkULam :: EmitsBoth o => ULamExpr i -> PiType CoreIR o -> InfererM i o (CAtom o)
 checkULam (ULamExpr _ (UPatAnn p ann) body) piTy@(PiType (PiBinder _ argTy arr) _ _) = do
   case ann of
     Nothing    -> return ()
@@ -1767,7 +1773,7 @@ checkInstanceArgs
   :: (EmitsInf o, SinkableE e, SubstE Name e, HoistableE e)
   => Nest UPatAnnArrow i i'
   -> (forall o'. (EmitsInf o', DExt o o') => InfererM i' o' (e o'))
-  -> InfererM i o (Abs (Nest RolePiBinder) e o)
+  -> InfererM i o (Abs (Nest (RolePiBinder CoreIR)) e o)
 checkInstanceArgs Empty cont = do
   Distinct <- getDistinct
   Abs Empty <$> cont
@@ -1799,7 +1805,7 @@ checkHandlerArgs
   :: (EmitsInf o, SinkableE e, SubstE Name e, HoistableE e)
   => Nest UPatAnnArrow i i'
   -> (forall o'. (EmitsInf o', DExt o o') => InfererM i' o' (e o'))
-  -> InfererM i o (Abs (Nest PiBinder) e o)
+  -> InfererM i o (Abs (Nest (PiBinder CoreIR)) e o)
 checkHandlerArgs bs cont = do
   Abs bs' result <- checkInstanceArgs bs cont
   let bs'' = fmapNest (\(RolePiBinder b ty arr _) -> PiBinder b ty arr) bs'
@@ -1808,8 +1814,8 @@ checkHandlerArgs bs cont = do
 checkHandlerBodyTyArg
   :: (EmitsInf o, SinkableE e, SubstE Name e, HoistableE e)
   => UBinder AtomNameC i i'
-  -> (forall o'. (EmitsInf o', Ext o o') => AtomName o' -> InfererM i' o' (e o'))
-  -> InfererM i o (Abs PiBinder e o)
+  -> (forall o'. (EmitsInf o', Ext o o') => CAtomName o' -> InfererM i' o' (e o'))
+  -> InfererM i o (Abs (PiBinder CoreIR) e o)
 checkHandlerBodyTyArg b cont = do
   argTy <- freshType TyKind
   buildPiAbsInf (getNameHint b) ImplicitArrow argTy \v -> do
@@ -1820,12 +1826,12 @@ checkInstanceParams
   :: forall i o e.
      (EmitsInf o, SinkableE e, HoistableE e, SubstE Name e)
   => [UType i]
-  -> (forall o'. (EmitsInf o', Ext o o') => [Type o'] -> InfererM i o' (e o'))
-  -> InfererM i o (Abs (Nest RolePiBinder) e o)
+  -> (forall o'. (EmitsInf o', Ext o o') => [CType o'] -> InfererM i o' (e o'))
+  -> InfererM i o (Abs (Nest (RolePiBinder CoreIR)) e o)
 checkInstanceParams params cont = go params []
   where
-    go :: forall o'. (EmitsInf o', Ext o o') => [UType i] -> [Type o']
-       -> InfererM i o' (Abs (Nest RolePiBinder) e o')
+    go :: forall o'. (EmitsInf o', Ext o o') => [UType i] -> [CType o']
+       -> InfererM i o' (Abs (Nest (RolePiBinder CoreIR)) e o')
     go []    ptys = Abs Empty <$> cont (reverse ptys)
     go (p:t) ptys = checkUTypeWithMissingDicts p \ds getParamType -> do
       mergeAbs <$> introDicts (eSetToList ds) do
@@ -1838,7 +1844,7 @@ mergeAbs (Abs bs (Abs bs' e)) = Abs (bs >>> bs') e
 
 checkInstanceBody :: EmitsInf o
                   => ClassName o
-                  -> [Type o]
+                  -> [CType o]
                   -> [UMethodDef i]
                   -> InfererM i o (InstanceBody o)
 checkInstanceBody className params methods = do
@@ -1858,9 +1864,9 @@ checkInstanceBody className params methods = do
 introDicts
   :: forall i o e.
      (EmitsInf o, SinkableE e, HoistableE e, SubstE Name e)
-  => [Type o]
+  => [CType o]
   -> (forall l. (EmitsInf l, Ext o l) => InfererM i l (e l))
-  -> InfererM i o (Abs (Nest RolePiBinder) e o)
+  -> InfererM i o (Abs (Nest (RolePiBinder CoreIR)) e o)
 introDicts []    m = Abs Empty <$> m
 introDicts (h:t) m = do
   ab <- buildPiAbsInf (getNameHint @String "_autoq") ClassArrow h \_ -> do
@@ -1870,16 +1876,16 @@ introDicts (h:t) m = do
   return $ Abs (Nest (RolePiBinder b ty arr DictParam) bs) e
 
 introDictTys :: forall i o. EmitsInf o
-             => [Type o]
-             -> (forall l. (EmitsInf l, Ext o l) => InfererM i l (PiType l))
-             -> InfererM i o (PiType o)
+             => [CType o]
+             -> (forall l. (EmitsInf l, Ext o l) => InfererM i l (PiType CoreIR l))
+             -> InfererM i o (PiType CoreIR o)
 introDictTys []    m = m
 introDictTys (h:t) m = buildPiInf (getNameHint @String "_autoq") ClassArrow h \_ -> do
   ListE t' <- sinkM $ ListE t
   (Pure,) . Pi <$> (introDictTys t' m)
 
 checkMethodDef :: EmitsInf o
-               => ClassName o -> [MethodType o] -> UMethodDef i -> InfererM i o (Int, Block o)
+               => ClassName o -> [MethodType o] -> UMethodDef i -> InfererM i o (Int, CBlock o)
 checkMethodDef className methodTys (UMethodDef ~(InternalName sourceName v) rhs) = do
   MethodBinding className' i _ <- substM v >>= lookupEnv
   when (className /= className') do
@@ -1913,7 +1919,7 @@ checkUEff eff = case eff of
   UserEffect ~(SIInternalName _ name) -> UserEffect <$> substM name
   InitEffect -> return InitEffect
 
-constrainVarTy :: EmitsInf o => AtomName o -> Type o -> InfererM i o ()
+constrainVarTy :: EmitsInf o => CAtomName o -> CType o -> InfererM i o ()
 constrainVarTy v tyReq = do
   varTy <- getType $ Var v
   constrainEq tyReq varTy
@@ -1924,7 +1930,7 @@ data CaseAltIndex = ConAlt Int
   deriving (Eq, Show)
 
 checkCaseAlt :: EmitsBoth o
-             => RhoType o -> Type o -> UAlt i -> InfererM i o (IndexedAlt o)
+             => RhoType o -> CType o -> UAlt i -> InfererM i o (IndexedAlt o)
 checkCaseAlt reqTy scrutineeTy (UAlt pat body) = do
   alt <- checkCasePat pat scrutineeTy do
     reqTy' <- sinkM reqTy
@@ -1948,9 +1954,9 @@ getCaseAltIndex (WithSrcB _ pat) = case pat of
 
 checkCasePat :: EmitsBoth o
              => UPat i i'
-             -> Type o
-             -> (forall o'. (EmitsBoth o', Ext o o') => InfererM i' o' (Atom o'))
-             -> InfererM i o (Alt o)
+             -> CType o
+             -> (forall o'. (EmitsBoth o', Ext o o') => InfererM i' o' (CAtom o'))
+             -> InfererM i o (Alt CoreIR o)
 checkCasePat (WithSrcB pos pat) scrutineeTy cont = addSrcContext pos $ case pat of
   UPatCon ~(InternalName _ conName) ps -> do
     (dataDefName, con) <- substM conName >>= getDataCon
@@ -1986,8 +1992,8 @@ checkCasePat (WithSrcB pos pat) scrutineeTy cont = addSrcContext pos $ case pat 
       bindLamPat p x cont
   _ -> throw TypeErr $ "Case patterns must start with a data constructor or variant pattern"
 
-inferParams :: (EmitsBoth o, HasNamesE e, SinkableE e, SubstE AtomSubstVal e)
-            => Abs (Nest RolePiBinder) e o -> InfererM i o (DataDefParams o, e o)
+inferParams :: (EmitsBoth o, HasNamesE e, SinkableE e, SubstE (AtomSubstVal CoreIR) e)
+            => Abs (Nest (RolePiBinder CoreIR)) e o -> InfererM i o (DataDefParams CoreIR o, e o)
 inferParams (Abs paramBs body) = case paramBs of
   Empty -> return (DataDefParams [], body)
   Nest (RolePiBinder b ty PlainArrow _) bs -> do
@@ -2005,12 +2011,12 @@ inferParams (Abs paramBs body) = case paramBs of
     error "TODO Handle implicit or linear parameters for data constructors"
 
 bindLamPats :: EmitsBoth o
-            => Nest UPat i i' -> [AtomName o] -> InfererM i' o a -> InfererM i o a
+            => Nest UPat i i' -> [CAtomName o] -> InfererM i' o a -> InfererM i o a
 bindLamPats Empty [] cont = cont
 bindLamPats (Nest p ps) (x:xs) cont = bindLamPat p x $ bindLamPats ps xs cont
 bindLamPats _ _ _ = error "mismatched number of args"
 
-bindLamPat :: EmitsBoth o => UPat i i' -> AtomName o -> InfererM i' o a -> InfererM i o a
+bindLamPat :: EmitsBoth o => UPat i i' -> CAtomName o -> InfererM i' o a -> InfererM i o a
 bindLamPat (WithSrcB pos pat) v cont = addSrcContext pos $ case pat of
   UPatBinder b -> extendSubst (b @> v) cont
   UPatUnit UnitB -> do
@@ -2043,7 +2049,7 @@ bindLamPat (WithSrcB pos pat) v cont = addSrcContext pos $ case pat of
     bindPats cont ([], Empty, v) rowPat
     where
       bindPats :: EmitsBoth o
-               => InfererM i' o a -> ([Label], Nest UPat i l, AtomName o) -> UFieldRowPat l i' -> InfererM i o a
+               => InfererM i' o a -> ([Label], Nest UPat i l, CAtomName o) -> UFieldRowPat l i' -> InfererM i o a
       bindPats c rv = \case
         UEmptyRowPat -> case rv of
           (_ , Empty, _) -> c
@@ -2083,14 +2089,14 @@ bindLamPat (WithSrcB pos pat) v cont = addSrcContext pos $ case pat of
       -- were looked up by consecutive labels. Note that the number of labels
       -- should match the total number of record fields, and the record should
       -- have no dynamic extensions!
-      unpackInLabelOrder :: EmitsBoth o => Atom o -> [Label] -> InfererM i o [AtomName o]
+      unpackInLabelOrder :: EmitsBoth o => CAtom o -> [Label] -> InfererM i o [CAtomName o]
       unpackInLabelOrder r ls = do
         itemsNatural <- emitUnpacked =<< zonk r
         let labelOrder = toList $ foldMap (\(i, l) -> labeledSingleton l i) $ enumerate ls
         let itemsMap = M.fromList $ zip labelOrder itemsNatural
         return $ (itemsMap M.!) <$> [0..M.size itemsMap - 1]
 
-      resolveDelay :: EmitsBoth o => ([Label], Nest UPat i l, AtomName o) -> (AtomName o -> InfererM l o a) -> InfererM i o a
+      resolveDelay :: EmitsBoth o => ([Label], Nest UPat i l, CAtomName o) -> (CAtomName o -> InfererM l o a) -> InfererM i o a
       resolveDelay (ls, ps, r) f = case ps of
         Empty -> f r
         _     -> do
@@ -2122,24 +2128,26 @@ bindLamPat (WithSrcB pos pat) v cont = addSrcContext pos $ case pat of
                         <> pprint trueSize <> " elements but there are "
                         <> pprint (nestLength ps) <> " patterns."
 
-checkAnn :: EmitsInf o => Maybe (UType i) -> InfererM i o (Type o)
+checkAnn :: EmitsInf o => Maybe (UType i) -> InfererM i o (CType o)
 checkAnn ann = case ann of
   Just ty -> checkUType ty
   Nothing -> freshType TyKind
 
-checkAnnWithMissingDicts :: EmitsInf o
-                         => Maybe (UType i)
-                         -> (IfaceTypeSet o -> (forall o'. (EmitsInf o', Ext o o') => InfererM i o' (Type o')) -> InfererM i o a)
-                         -> InfererM i o a
+checkAnnWithMissingDicts
+  :: EmitsInf o
+  => Maybe (UType i)
+  -> (IfaceTypeSet o -> (forall o'. (EmitsInf o', Ext o o') => InfererM i o' (CType o')) -> InfererM i o a)
+  -> InfererM i o a
 checkAnnWithMissingDicts ann cont = case ann of
   Just ty -> checkUTypeWithMissingDicts ty cont
   Nothing ->
     cont mempty (freshType TyKind)  -- Unannotated binders are never auto-quantified
 
-checkUTypeWithMissingDicts :: EmitsInf o
-                           => UType i
-                           -> (IfaceTypeSet o -> (forall o'. (EmitsInf o', Ext o o') => InfererM i o' (Type o')) -> InfererM i o a)
-                           -> InfererM i o a
+checkUTypeWithMissingDicts
+  :: EmitsInf o
+  => UType i
+  -> (IfaceTypeSet o -> (forall o'. (EmitsInf o', Ext o o') => InfererM i o' (CType o')) -> InfererM i o a)
+  -> InfererM i o a
 checkUTypeWithMissingDicts uty@(WithSrcE _ _) cont = do
   unsolvedSubset <- do
     -- We have to be careful not to emit inference vars out of the initial solve.
@@ -2156,14 +2164,14 @@ checkUTypeWithMissingDicts uty@(WithSrcE _ _) cont = do
       -- Note that we ignore the hoist success/failure bit because we're just
       -- collecting required dictionaries on a best-effort basis here. Failure
       -- to hoist only becomes an error later.
-      (_, _, unsolved) <- cheapReduceWithDecls @Atom decls result
+      (_, _, unsolved) <- cheapReduceWithDecls @CoreIR @CAtom decls result
       return $ unsolvedSubset <> eSetFromList unsolved
     return $ case hoistRequiredIfaces frag (GatherRequired unsolvedSubset') of
       GatherRequired unsolvedSubset -> unsolvedSubset
       FailIfRequired                -> error "Unreachable"
   cont unsolvedSubset $ checkUType uty
 
-checkUType :: EmitsInf o => UType i -> InfererM i o (Type o)
+checkUType :: EmitsInf o => UType i -> InfererM i o (CType o)
 checkUType uty@(WithSrcE pos _) = do
   Abs decls result <- buildDeclsInf $ withAllowedEffects Pure $ checkRho noHint uty TyKind
   (ans, hoistStatus, ds) <- cheapReduceWithDecls decls result
@@ -2182,7 +2190,7 @@ checkUType uty@(WithSrcE pos _) = do
 
 checkExtLabeledRow :: EmitsBoth o
                    => ExtLabeledItems (UExpr i) (UExpr i)
-                   -> InfererM i o (ExtLabeledItems (Type o) (AtomName o))
+                   -> InfererM i o (ExtLabeledItems (CType o) (CAtomName o))
 checkExtLabeledRow (Ext types Nothing) = do
   types' <- mapM checkUType types
   return $ Ext types' Nothing
@@ -2193,7 +2201,7 @@ checkExtLabeledRow (Ext types (Just ext)) = do
   return $ Ext types' $ Just ext'
 
 inferTabCon :: EmitsBoth o
-  => NameHint -> [UExpr i] -> RequiredTy RhoType o -> InfererM i o (Atom o)
+  => NameHint -> [UExpr i] -> RequiredTy RhoType o -> InfererM i o (CAtom o)
 inferTabCon hint xs reqTy = do
   (tabTy, xs') <- case reqTy of
     Check tabTy@(TabPi piTy) -> do
@@ -2241,7 +2249,7 @@ inferTabCon hint xs reqTy = do
         xs' <- mapM (\x -> checkRho noHint x elemTy) xs
         return (tabTy, xs')
 
-      staticallyKnownIdx :: (EnvReader m) => Abs (Nest Decl) Atom n -> m n (Maybe Word32)
+      staticallyKnownIdx :: (EnvReader m) => Abs (Nest CDecl) CAtom n -> m n (Maybe Word32)
       staticallyKnownIdx (Abs decls res) = unsafeLiftInterpMCatch (evalDecls decls $ evalExpr $ Atom res) >>= \case
         (Success (IdxRepVal ix)) -> return $ Just ix
         _ -> return Nothing
@@ -2254,7 +2262,7 @@ inferTabCon hint xs reqTy = do
                 "annotation."
 
 -- Bool flag is just to tweak the reported error message
-fromTabPiType :: EmitsBoth o => Bool -> Type o -> InfererM i o (TabPiType o)
+fromTabPiType :: EmitsBoth o => Bool -> CType o -> InfererM i o (TabPiType CoreIR o)
 fromTabPiType _ (TabPi piTy) = return piTy
 fromTabPiType expectPi ty = do
   a <- freshType TyKind
@@ -2266,7 +2274,7 @@ fromTabPiType expectPi ty = do
   return piTy
 
 -- Bool flag is just to tweak the reported error message
-fromPiType :: EmitsBoth o => Bool -> Arrow -> Type o -> InfererM i o (PiType o)
+fromPiType :: EmitsBoth o => Bool -> Arrow -> CType o -> InfererM i o (PiType CoreIR o)
 fromPiType _ _ (Pi piTy) = return piTy -- TODO: check arrow
 fromPiType expectPi arr ty = do
   a <- freshType TyKind
@@ -2276,7 +2284,7 @@ fromPiType expectPi arr ty = do
               else  constrainEq ty (Pi piTy)
   return piTy
 
-fromPairType :: EmitsBoth o => Type o -> InfererM i o (Type o, Type o)
+fromPairType :: EmitsBoth o => CType o -> InfererM i o (CType o, CType o)
 fromPairType (PairTy t1 t2) = return (t1, t2)
 fromPairType ty = do
   a <- freshType TyKind
@@ -2305,7 +2313,7 @@ openEffectRow :: EmitsBoth o => EffectRow o -> InfererM i o (EffectRow o)
 openEffectRow (EffectRow effs Nothing) = extendEffRow effs <$> freshEff
 openEffectRow effRow = return effRow
 
-asIxType :: Type o -> InfererM i o (IxType o)
+asIxType :: CType o -> InfererM i o (IxType CoreIR o)
 asIxType ty = do
   dictTy <- DictTy <$> ixDictType ty
   ctx <- srcPosCtx <$> getErrCtx
@@ -2314,15 +2322,15 @@ asIxType ty = do
 
 -- === Solver ===
 
-newtype SolverSubst n = SolverSubst (M.Map (AtomName n) (Type n))
+newtype SolverSubst n = SolverSubst (M.Map (CAtomName n) (CType n))
 
 instance Pretty (SolverSubst n) where
   pretty (SolverSubst m) = pretty $ M.toList m
 
 class (CtxReader1 m, EnvReader m) => Solver (m::MonadKind1) where
-  zonk :: (SubstE AtomSubstVal e, SinkableE e) => e n -> m n (e n)
-  extendSolverSubst :: AtomName n -> Type n -> m n ()
-  emitSolver :: EmitsInf n => SolverBinding n -> m n (AtomName n)
+  zonk :: (SubstE (AtomSubstVal CoreIR) e, SinkableE e) => e n -> m n (e n)
+  extendSolverSubst :: CAtomName n -> CType n -> m n ()
+  emitSolver :: EmitsInf n => SolverBinding CoreIR n -> m n (CAtomName n)
   solveLocal :: (SinkableE e, HoistableE e)
              => (forall l. (EmitsInf l, Ext n l, Distinct l) => m l (e l))
              -> m n (e n)
@@ -2332,7 +2340,7 @@ type SolverOutMap = InfOutMap
 data SolverOutFrag (n::S) (l::S) =
   SolverOutFrag (SolverEmissions n l) (SolverSubst l)
 
-type SolverEmissions = RNest (BinderP AtomNameC SolverBinding)
+type SolverEmissions = RNest (BinderP AtomNameC (SolverBinding CoreIR))
 
 instance GenericB SolverOutFrag where
   type RepB SolverOutFrag = PairB SolverEmissions (LiftB SolverSubst)
@@ -2377,7 +2385,7 @@ instance EnvReader SolverM where
     return env
   {-# INLINE unsafeGetEnv #-}
 
-newtype SolverEmission (n::S) (l::S) = SolverEmission (BinderP AtomNameC SolverBinding n l)
+newtype SolverEmission (n::S) (l::S) = SolverEmission (BinderP AtomNameC (SolverBinding CoreIR) n l)
 instance ExtOutMap SolverOutMap SolverEmission where
   extendOutMap env (SolverEmission e) = env `extendOutMap` toEnvFrag e
 instance ExtOutFrag SolverOutFrag SolverEmission where
@@ -2416,13 +2424,13 @@ instance Solver SolverM where
 
 instance Unifier SolverM
 
-freshInferenceName :: (EmitsInf n, Solver m) => Kind n -> m n (AtomName n)
+freshInferenceName :: (EmitsInf n, Solver m) => Kind CoreIR n -> m n (CAtomName n)
 freshInferenceName k = do
   ctx <- srcPosCtx <$> getErrCtx
   emitSolver $ InfVarBound k ctx
 {-# INLINE freshInferenceName #-}
 
-freshSkolemName :: (EmitsInf n, Solver m) => Kind n -> m n (AtomName n)
+freshSkolemName :: (EmitsInf n, Solver m) => Kind CoreIR n -> m n (CAtomName n)
 freshSkolemName k = emitSolver $ SkolemBound k
 {-# INLINE freshSkolemName #-}
 
@@ -2431,7 +2439,7 @@ type Solver2 (m::MonadKind2) = forall i. Solver (m i)
 emptySolverSubst :: SolverSubst n
 emptySolverSubst = SolverSubst mempty
 
-singletonSolverSubst :: AtomName n -> Type n -> SolverSubst n
+singletonSolverSubst :: CAtomName n -> CType n -> SolverSubst n
 singletonSolverSubst v ty = SolverSubst $ M.singleton v ty
 
 -- We apply the rhs subst over the full lhs subst. We could try tracking
@@ -2444,7 +2452,7 @@ catSolverSubsts scope (SolverSubst s1) (SolverSubst s2) =
 
 -- TODO: put this pattern and friends in the Name library? Don't really want to
 -- have to think about `eqNameColorRep` just to implement a partial map.
-lookupSolverSubst :: forall c n. Color c => SolverSubst n -> Name c n -> AtomSubstVal c n
+lookupSolverSubst :: forall c n. Color c => SolverSubst n -> Name c n -> AtomSubstVal CoreIR c n
 lookupSolverSubst (SolverSubst m) name =
   case eqColorRep of
     Nothing -> Rename name
@@ -2452,12 +2460,12 @@ lookupSolverSubst (SolverSubst m) name =
       Nothing -> Rename name
       Just ty -> SubstVal ty
 
-applySolverSubstE :: (SubstE (SubstVal AtomNameC Atom) e, Distinct n)
+applySolverSubstE :: (SubstE (SubstVal AtomNameC CAtom) e, Distinct n)
                   => Scope n -> SolverSubst n -> e n -> e n
 applySolverSubstE scope solverSubst@(SolverSubst m) e =
   if M.null m then e else fmapNames scope (lookupSolverSubst solverSubst) e
 
-zonkWithOutMap :: (SubstE AtomSubstVal e, Distinct n)
+zonkWithOutMap :: (SubstE (AtomSubstVal CoreIR) e, Distinct n)
                => InfOutMap n -> e n -> e n
 zonkWithOutMap (InfOutMap bindings solverSubst _ _) e =
   applySolverSubstE (toScope bindings) solverSubst e
@@ -2478,7 +2486,7 @@ fmapRNest f (RNest rest b) = RNest (fmapRNest f rest) (f b)
 
 instance GenericE SolverSubst where
   -- XXX: this is a bit sketchy because it's not actually bijective...
-  type RepE SolverSubst = ListE (PairE AtomName Type)
+  type RepE SolverSubst = ListE (PairE CAtomName CType)
   fromE (SolverSubst m) = ListE $ map (uncurry PairE) $ M.toList m
   {-# INLINE fromE #-}
   toE (ListE pairs) = SolverSubst $ M.fromList $ map fromPairE pairs
@@ -2488,7 +2496,7 @@ instance SinkableE SolverSubst where
 instance SubstE Name SolverSubst where
 instance HoistableE SolverSubst
 
-constrainEq :: EmitsInf o => Type o -> Type o -> InfererM i o ()
+constrainEq :: EmitsInf o => CType o -> CType o -> InfererM i o ()
 constrainEq t1 t2 = do
   t1' <- zonk t1
   t2' <- zonk t2
@@ -2504,10 +2512,10 @@ constrainEq t1 t2 = do
 
 class (Alternative1 m, Searcher1 m, Fallible1 m, Solver m) => Unifier m
 
-class (AlphaEqE e, SinkableE e, SubstE AtomSubstVal e) => Unifiable (e::E) where
+class (AlphaEqE e, SinkableE e, SubstE (AtomSubstVal CoreIR) e) => Unifiable (e::E) where
   unifyZonked :: EmitsInf n => e n -> e n -> SolverM n ()
 
-tryConstrainEq :: EmitsInf o => Type o -> Type o -> InfererM i o ()
+tryConstrainEq :: EmitsInf o => CType o -> CType o -> InfererM i o ()
 tryConstrainEq t1 t2 = do
   constrainEq t1 t2 `catchErr` \errs -> case errs of
     Errs [Err TypeErr _ _] -> return ()
@@ -2521,7 +2529,7 @@ unify e1 e2 = do
 {-# INLINE unify #-}
 {-# SCC unify #-}
 
-instance Unifiable Atom where
+instance Unifiable (Atom CoreIR) where
   unifyZonked e1 e2 = confuseGHC >>= \_ -> case sameConstructor e1 e2 of
     False -> case (e1, e2) of
       (t, Var v) -> extendSolution v t
@@ -2543,16 +2551,16 @@ instance Unifiable Atom where
       (DictTy d, DictTy d') -> unify d d'
       _ -> unifyEq e1 e2
 
-instance Unifiable DictType where
+instance Unifiable (DictType CoreIR) where
   unifyZonked (DictType _ c params) (DictType _ c' params') =
     guard (c == c') >> zipWithM_ unify params params'
   {-# INLINE unifyZonked #-}
 
-instance Unifiable IxType where
+instance Unifiable (IxType CoreIR) where
   -- We ignore the dictionaries because we assume coherence
   unifyZonked (IxType t _) (IxType t' _) = unifyZonked t t'
 
-instance Unifiable DataDefParams where
+instance Unifiable (DataDefParams CoreIR) where
   -- We ignore the dictionaries because we assume coherence
   unifyZonked (DataDefParams xs) (DataDefParams xs')
     = zipWithM_ unify (plainArrows xs) (plainArrows xs')
@@ -2585,7 +2593,7 @@ instance Unifiable (EffectRowP Name) where
 -- TODO: This unification procedure is incomplete! There are types that we might
 -- want to treat as equivalent, but for now they would be rejected conservatively!
 -- One example would is the unification of {a: ty} and {@infVar: ty}.
-instance Unifiable FieldRowElems where
+instance Unifiable (FieldRowElems CoreIR) where
   unifyZonked e1 e2 = go (fromFieldRowElems e1) (fromFieldRowElems e2)
     where
       go = curry \case
@@ -2596,10 +2604,10 @@ instance Unifiable FieldRowElems where
         (l@(h:t)      , r@(h':t')    ) -> (unifyElem h h' >> go t t') <|> unifyAsExtLabledItems l r
         (l            , r            ) -> unifyAsExtLabledItems l r
 
-      unifyElem :: EmitsInf n => FieldRowElem n -> FieldRowElem n -> SolverM n ()
+      unifyElem :: forall n. EmitsInf n => FieldRowElem CoreIR n -> FieldRowElem CoreIR n -> SolverM n ()
       unifyElem f1 f2 = case (f1, f2) of
-        (DynField v ty     , DynField v' ty'    ) -> unify (Var v) (Var v') >> unify ty ty'
-        (DynFields r       , DynFields r'       ) -> unify (Var r) (Var r')
+        (DynField v ty     , DynField v' ty'    ) -> unify (Var v :: CAtom n) (Var v') >> unify ty ty'
+        (DynFields r       , DynFields r'       ) -> unify (Var r :: CAtom n) (Var r')
         (StaticFields items, StaticFields items') -> do
           guard $ reflectLabels items == reflectLabels items'
           zipWithM_ unify (toList items) (toList items')
@@ -2609,7 +2617,7 @@ instance Unifiable FieldRowElems where
 
       asExtLabeledItems x = ExtLabeledItemsE <$> fieldRowElemsAsExtRow (fieldRowElemsFromList x)
 
-instance Unifiable (ExtLabeledItemsE Type AtomName) where
+instance Unifiable (ExtLabeledItemsE CType CAtomName) where
   unifyZonked x1 x2 =
         unifyDirect x1 x2
     <|> unifyDirect x2 x1
@@ -2617,8 +2625,8 @@ instance Unifiable (ExtLabeledItemsE Type AtomName) where
 
    where
      unifyDirect :: EmitsInf n
-                 => ExtLabeledItemsE Type AtomName n
-                 -> ExtLabeledItemsE Type AtomName n -> SolverM n ()
+                 => ExtLabeledItemsE CType CAtomName n
+                 -> ExtLabeledItemsE CType CAtomName n -> SolverM n ()
      unifyDirect (ExtLabeledItemsE (Ext NoLabeledItems (Just v))) (ExtLabeledItemsE r@(Ext items mv)) =
        case mv of
          Just v' | v == v' -> guard $ null items
@@ -2627,8 +2635,8 @@ instance Unifiable (ExtLabeledItemsE Type AtomName) where
      {-# INLINE unifyDirect #-}
 
      unifyZip :: EmitsInf n
-              => ExtLabeledItemsE Type AtomName n
-              -> ExtLabeledItemsE Type AtomName n -> SolverM n ()
+              => ExtLabeledItemsE CType CAtomName n
+              -> ExtLabeledItemsE CType CAtomName n -> SolverM n ()
      unifyZip (ExtLabeledItemsE r1) (ExtLabeledItemsE r2) = case (r1, r2) of
        (Ext NoLabeledItems Nothing, Ext NoLabeledItems Nothing) -> return ()
        (_, Ext NoLabeledItems _) -> empty
@@ -2659,7 +2667,7 @@ unifyEq :: AlphaEqE e => e n -> e n -> SolverM n ()
 unifyEq e1 e2 = guard =<< alphaEq e1 e2
 {-# INLINE unifyEq #-}
 
-unifyPiType :: EmitsInf n => PiType n -> PiType n -> SolverM n ()
+unifyPiType :: EmitsInf n => PiType CoreIR n -> PiType CoreIR n -> SolverM n ()
 unifyPiType (PiType (PiBinder b1 ann1 arr1) eff1 ty1)
             (PiType (PiBinder b2 ann2 arr2) eff2 ty2) = do
   unless (arr1 == arr2) empty
@@ -2670,7 +2678,7 @@ unifyPiType (PiType (PiBinder b1 ann1 arr1) eff1 ty1)
   unify ty1'  ty2'
   unify eff1' eff2'
 
-unifyTabPiType :: EmitsInf n => TabPiType n -> TabPiType n -> SolverM n ()
+unifyTabPiType :: EmitsInf n => TabPiType CoreIR n -> TabPiType CoreIR n -> SolverM n ()
 unifyTabPiType (TabPiType b1 ty1) (TabPiType b2 ty2) = do
   let ann1 = binderType b1
   let ann2 = binderType b2
@@ -2680,7 +2688,7 @@ unifyTabPiType (TabPiType b1 ty1) (TabPiType b2 ty2) = do
   ty2' <- applyAbs (Abs b2 ty2) v
   unify ty1'  ty2'
 
-extendSolution :: AtomName n -> Type n -> SolverM n ()
+extendSolution :: CAtomName n -> CType n -> SolverM n ()
 extendSolution v t =
   isInferenceName v >>= \case
     True -> do
@@ -2694,19 +2702,19 @@ extendSolution v t =
       extendSolverSubst v t
     False -> empty
 
-isInferenceName :: EnvReader m => AtomName n -> m n Bool
+isInferenceName :: EnvReader m => CAtomName n -> m n Bool
 isInferenceName v = lookupEnv v >>= \case
   AtomNameBinding (SolverBound (InfVarBound _ _)) -> return True
   _ -> return False
 {-# INLINE isInferenceName #-}
 
-isSkolemName :: EnvReader m => AtomName n -> m n Bool
+isSkolemName :: EnvReader m => CAtomName n -> m n Bool
 isSkolemName v = lookupEnv v >>= \case
   AtomNameBinding (SolverBound (SkolemBound _)) -> return True
   _ -> return False
 {-# INLINE isSkolemName #-}
 
-freshType :: (EmitsInf n, Solver m) => Kind n -> m n (Type n)
+freshType :: (EmitsInf n, Solver m) => Kind CoreIR n -> m n (CType n)
 freshType k = Var <$> freshInferenceName k
 {-# INLINE freshType #-}
 
@@ -2731,7 +2739,7 @@ renameForPrinting e = do
 
 -- === dictionary synthesis ===
 
-synthTopBlock :: (EnvReader m, Fallible1 m) => Block n -> m n (Block n)
+synthTopBlock :: (EnvReader m, Fallible1 m) => CBlock n -> m n (CBlock n)
 synthTopBlock block = do
   (liftExcept =<<) $ liftDictSynthTraverserM $ traverseGenericE block
 {-# SCC synthTopBlock #-}
@@ -2743,21 +2751,21 @@ synthTopBlock block = do
 -- valid to implement `generalizeDict` by re-synthesizing the whole dictionary,
 -- but we know that the derivation tree has to be the same, so we take the
 -- shortcut of just generalizing the data parameters.
-generalizeDict :: (EnvReader m) => Type n -> Dict n-> m n (Dict n)
+generalizeDict :: (EnvReader m) => CType n -> Dict CoreIR n-> m n (Dict CoreIR n)
 generalizeDict ty dict = do
   result <- liftSolverM $ solveLocal $ generalizeDictAndUnify (sink ty) (sink dict)
   case result of
     Failure e -> error $ pprint e
     Success ans -> return ans
 
-generalizeDictAndUnify :: EmitsInf n => Type n -> Dict n -> SolverM n (Dict n)
+generalizeDictAndUnify :: EmitsInf n => CType n -> Dict CoreIR n -> SolverM n (Dict CoreIR n)
 generalizeDictAndUnify ty dict = do
   dict' <- generalizeDictRec dict
   dictTy <- getType dict'
   unify ty dictTy
   zonk dict'
 
-generalizeDictRec :: EmitsInf n => Dict n -> SolverM n (Dict n)
+generalizeDictRec :: EmitsInf n => Dict CoreIR n -> SolverM n (Dict CoreIR n)
 generalizeDictRec dict = do
   -- TODO: we should be able to avoid the normalization here . We only need it
   -- because we sometimes end up with superclass projections. But they shouldn't
@@ -2778,7 +2786,7 @@ generalizeDictRec dict = do
     SuperclassProj _ _    -> notSimplifiedDict
     where notSimplifiedDict = error $ "Not a simplified dict: " ++ pprint dict
 
-generalizeInstanceArgs :: EmitsInf n => Nest RolePiBinder n l -> [Atom n] -> SolverM n [Atom n]
+generalizeInstanceArgs :: EmitsInf n => Nest (RolePiBinder CoreIR) n l -> [CAtom n] -> SolverM n [CAtom n]
 generalizeInstanceArgs Empty [] = return []
 generalizeInstanceArgs (Nest (RolePiBinder b ty _ role) bs) (arg:args) = do
   arg' <- case role of
@@ -2804,7 +2812,7 @@ synthInstanceDef (InstanceDef className bs params body) = do
       return $ InstanceDef className bs' params' $ InstanceBody superclasses methods'
 
 -- main entrypoint to dictionary synthesizer
-trySynthTerm :: (Fallible1 m, EnvReader m) => Type n -> m n (SynthAtom n)
+trySynthTerm :: (Fallible1 m, EnvReader m) => CType n -> m n (SynthAtom n)
 trySynthTerm ty = do
   hasInferenceVars ty >>= \case
     True -> throw TypeErr "Can't synthesize a dictionary for a type with inference vars"
@@ -2820,11 +2828,11 @@ trySynthTerm ty = do
 -- The type of a `SynthAtom` atom must be `DictTy _` or `Pi _`. If it's `Pi _`,
 -- then the atom itself is either a variable or a trivial lambda whose body
 -- is also a `SynthAtom`.
-type SynthAtom = Atom
+type SynthAtom = CAtom
 
 data SynthType n =
-   SynthDictType (DictType n)
- | SynthPiType (Abs PiBinder SynthType n)
+   SynthDictType (DictType CoreIR n)
+ | SynthPiType (Abs (PiBinder CoreIR) SynthType n)
    deriving (Show, Generic)
 
 data Givens n = Givens { fromGivens :: HM.HashMap (EKey SynthType n) (SynthAtom n) }
@@ -2875,7 +2883,7 @@ getSynthType x = do
     Success ty'  -> ty'
 {-# INLINE getSynthType #-}
 
-typeAsSynthType :: Type n -> Except (SynthType n)
+typeAsSynthType :: CType n -> Except (SynthType n)
 typeAsSynthType (DictTy dictTy) = return $ SynthDictType dictTy
 typeAsSynthType (Pi (PiType b@(PiBinder _ _ arrow) Pure resultTy))
   | arrow == ImplicitArrow || arrow == ClassArrow = do
@@ -2942,7 +2950,7 @@ synthTerm ty = confuseGHC >>= \_ -> case ty of
     _ -> synthDictFromInstance dictTy <!> synthDictFromGiven dictTy
 {-# SCC synthTerm #-}
 
-synthDictFromGiven :: DictType n -> SyntherM n (SynthAtom n)
+synthDictFromGiven :: DictType CoreIR n -> SyntherM n (SynthAtom n)
 synthDictFromGiven dictTy = do
   givens <- ((HM.elems . fromGivens) <$> getGivens)
   asum $ givens <&> \given -> do
@@ -2952,7 +2960,7 @@ synthDictFromGiven dictTy = do
       Nothing -> return given
       Just args' -> return $ DictCon $ InstantiatedGiven given args'
 
-synthDictFromInstance :: DictType n -> SyntherM n (SynthAtom n)
+synthDictFromInstance :: DictType CoreIR n -> SyntherM n (SynthAtom n)
 synthDictFromInstance dictTy@(DictType _ targetClass _) = do
   instances <- getInstanceDicts targetClass
   asum $ instances <&> \candidate -> do
@@ -2969,7 +2977,7 @@ getInstanceType instanceName = do
     className' <- sinkM className
     return $ go bs' classSourceName className' params'
   where
-    go :: Nest RolePiBinder n l -> SourceName -> ClassName l -> [Atom l] -> SynthType n
+    go :: Nest (RolePiBinder CoreIR) n l -> SourceName -> ClassName l -> [CAtom l] -> SynthType n
     go bs classSourceName className params = case bs of
       Empty -> SynthDictType $ DictType classSourceName className params
       Nest (RolePiBinder b ty arr _) rest ->
@@ -2977,7 +2985,7 @@ getInstanceType instanceName = do
         in SynthPiType $ Abs (PiBinder b ty arr) restTy
 {-# SCC getInstanceType #-}
 
-instantiateSynthArgs :: DictType n -> SynthType n -> SyntherM n [Atom n]
+instantiateSynthArgs :: DictType CoreIR n -> SynthType n -> SyntherM n [CAtom n]
 instantiateSynthArgs target synthTy = do
   ListE args <- {-# SCC argSolving #-} (liftExceptAlt =<<) $ liftSolverM $ solveLocal do
     target' <- sinkM target
@@ -2990,7 +2998,8 @@ instantiateSynthArgs target synthTy = do
 
 instantiateSynthArgsRec
   :: EmitsInf n
-  => [Atom n] -> DictType n -> SubstFrag AtomSubstVal n l n -> SynthType l -> SolverM n [Atom n]
+  => [Atom CoreIR n] -> DictType CoreIR n -> SubstFrag (AtomSubstVal CoreIR) n l n
+  -> SynthType l -> SolverM n [CAtom n]
 instantiateSynthArgsRec prevArgsRec dictTy subst synthTy = case synthTy of
   SynthPiType (Abs (PiBinder b argTy arrow) resultTy) -> do
     argTy' <- applySubst subst argTy
@@ -3024,7 +3033,7 @@ liftDictSynthTraverserM m = do
     Errs [] -> Success ans
     _       -> Failure $ coerce errs
 
-type DictSynthTraverserM = GenericTraverserM UnitB DictSynthTraverserS
+type DictSynthTraverserM = GenericTraverserM CoreIR UnitB DictSynthTraverserS
 
 newtype DictSynthTraverserS (n::S) = DictSynthTraverserS Errs
 instance GenericE DictSynthTraverserS where
@@ -3035,7 +3044,7 @@ instance SinkableE DictSynthTraverserS
 instance HoistableState DictSynthTraverserS where
   hoistState _ _ (DictSynthTraverserS errs) = DictSynthTraverserS errs
 
-instance GenericTraverser UnitB DictSynthTraverserS where
+instance GenericTraverser CoreIR UnitB DictSynthTraverserS where
   traverseAtom a@(Con (DictHole (AlwaysEqual ctx) ty)) = do
     ty' <- cheapNormalize =<< substM ty
     ans <- liftEnvReaderT $ addSrcContext ctx $ trySynthTerm ty'
@@ -3056,17 +3065,17 @@ instance GenericTraverser UnitB DictSynthTraverserS where
 
 buildBlockInf
   :: EmitsInf n
-  => (forall l. (EmitsBoth l, DExt n l) => InfererM i l (Atom l))
-  -> InfererM i n (Block n)
+  => (forall l. (EmitsBoth l, DExt n l) => InfererM i l (CAtom l))
+  -> InfererM i n (CBlock n)
 buildBlockInf cont = buildDeclsInf (cont >>= withType) >>= computeAbsEffects >>= absToBlock
 {-# INLINE buildBlockInf #-}
 
 buildLamInf
   :: EmitsInf n
-  => NameHint -> Arrow -> Type n
-  -> (forall l. (EmitsInf  l, Ext n l) => AtomName l -> InfererM i l (EffectRow l))
-  -> (forall l. (EmitsBoth l, Ext n l) => AtomName l -> InfererM i l (Atom l))
-  -> InfererM i n (Atom n)
+  => NameHint -> Arrow -> CType n
+  -> (forall l. (EmitsInf  l, Ext n l) => CAtomName l -> InfererM i l (EffectRow l))
+  -> (forall l. (EmitsBoth l, Ext n l) => CAtomName l -> InfererM i l (CAtom l))
+  -> InfererM i n (CAtom n)
 buildLamInf hint arr ty fEff fBody = do
   Abs (b:>_) (PairE effs body) <-
     buildAbsInf hint (LamBinding arr ty) \v -> do
@@ -3077,9 +3086,9 @@ buildLamInf hint arr ty fEff fBody = do
 
 buildPiAbsInf
   :: (EmitsInf n, SinkableE e, SubstE Name e, HoistableE e)
-  => NameHint -> Arrow -> Type n
-  -> (forall l. (EmitsInf l, Ext n l) => AtomName l -> InfererM i l (e l))
-  -> InfererM i n (Abs PiBinder e n)
+  => NameHint -> Arrow -> CType n
+  -> (forall l. (EmitsInf l, Ext n l) => CAtomName l -> InfererM i l (e l))
+  -> InfererM i n (Abs (PiBinder CoreIR) e n)
 buildPiAbsInf hint arr ty body = do
   Abs (b:>_) resultTy <-
     buildAbsInf hint (PiBinding arr ty) \v ->
@@ -3088,9 +3097,9 @@ buildPiAbsInf hint arr ty body = do
 
 buildPiInf
   :: EmitsInf n
-  => NameHint -> Arrow -> Type n
-  -> (forall l. (EmitsInf l, Ext n l) => AtomName l -> InfererM i l (EffectRow l, Type l))
-  -> InfererM i n (PiType n)
+  => NameHint -> Arrow -> CType n
+  -> (forall l. (EmitsInf l, Ext n l) => CAtomName l -> InfererM i l (EffectRow l, CType l))
+  -> InfererM i n (PiType CoreIR n)
 buildPiInf hint arr ty body = do
   Abs (b:>_) (PairE effs resultTy) <-
     buildAbsInf hint (PiBinding arr ty) \v ->
@@ -3101,9 +3110,9 @@ buildPiInf hint arr ty body = do
 
 buildTabPiInf
   :: EmitsInf n
-  => NameHint -> IxType n
-  -> (forall l. (EmitsInf l, Ext n l) => AtomName l -> InfererM i l (Type l))
-  -> InfererM i n (TabPiType n)
+  => NameHint -> IxType CoreIR n
+  -> (forall l. (EmitsInf l, Ext n l) => CAtomName l -> InfererM i l (CType l))
+  -> InfererM i n (TabPiType CoreIR n)
 buildTabPiInf hint ty body = do
   Abs (b:>_) resultTy <-
     buildAbsInf hint ty \v ->
@@ -3112,18 +3121,18 @@ buildTabPiInf hint ty body = do
 
 buildDepPairTyInf
   :: EmitsInf n
-  => NameHint -> Type n
-  -> (forall l. (EmitsInf l, Ext n l) => AtomName l -> InfererM i l (Type l))
-  -> InfererM i n (DepPairType n)
+  => NameHint -> CType n
+  -> (forall l. (EmitsInf l, Ext n l) => CAtomName l -> InfererM i l (CType l))
+  -> InfererM i n (DepPairType CoreIR n)
 buildDepPairTyInf hint ty body = do
   Abs (b:>_) resultTy <- buildAbsInf hint ty body
   return $ DepPairType (b :> ty) resultTy
 
 buildAltInf
   :: EmitsInf n
-  => Type n
-  -> (forall l. (EmitsBoth l, Ext n l) => AtomName l -> InfererM i l (Atom l))
-  -> InfererM i n (Alt n)
+  => CType n
+  -> (forall l. (EmitsBoth l, Ext n l) => CAtomName l -> InfererM i l (CAtom l))
+  -> InfererM i n (Alt CoreIR n)
 buildAltInf ty body = do
   buildAbsInf noHint ty \v ->
     buildBlockInf do
@@ -3190,7 +3199,7 @@ instance BindsEnv InfOutFrag where
   toEnvFrag (InfOutFrag frag _ _) = toEnvFrag frag
 
 instance GenericE SynthType where
-  type RepE SynthType = EitherE2 DictType (Abs PiBinder SynthType)
+  type RepE SynthType = EitherE2 (DictType CoreIR) (Abs (PiBinder CoreIR) SynthType)
   fromE (SynthDictType d) = Case0 d
   fromE (SynthPiType   t) = Case1 t
   toE (Case0 d) = SynthDictType d
@@ -3202,7 +3211,7 @@ instance AlphaHashableE SynthType
 instance SinkableE      SynthType
 instance HoistableE     SynthType
 instance SubstE Name         SynthType
-instance SubstE AtomSubstVal SynthType
+instance SubstE (AtomSubstVal CoreIR) SynthType
 
 -- See Note [Confuse GHC] from Simplify.hs
 confuseGHC :: EnvReader m => m n (DistinctEvidence n)

--- a/src/lib/Inference.hs-boot
+++ b/src/lib/Inference.hs-boot
@@ -9,4 +9,4 @@ module Inference (trySynthTerm) where
 import Name
 import Syntax
 
-trySynthTerm :: (Fallible1 m, EnvReader m) => Type n -> m n (Atom n)
+trySynthTerm :: (Fallible1 m, EnvReader m) => CType n -> m n (CAtom n)

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -37,19 +37,19 @@ import Util ((...), iota, onSndM, restructure)
 import Builder
 import CheapReduction (cheapNormalize)
 
-newtype InterpM (i::S) (o::S) (a:: *) =
-  InterpM { runInterpM' :: SubstReaderT AtomSubstVal (EnvReaderT IO) i o a }
+newtype InterpM (r::IR) (i::S) (o::S) (a:: *) =
+  InterpM { runInterpM' :: SubstReaderT (AtomSubstVal r) (EnvReaderT IO) i o a }
   deriving ( Functor, Applicative, Monad
            , MonadIO, ScopeReader, EnvReader, MonadFail, Fallible
-           , SubstReader AtomSubstVal)
+           , SubstReader (AtomSubstVal r))
 
-class ( SubstReader AtomSubstVal m, EnvReader2 m
+class ( SubstReader (AtomSubstVal r) m, EnvReader2 m
       , Monad2 m, MonadIO2 m)
-      => Interp m
+      => Interp r m | m -> r
 
-instance Interp InterpM
+instance Interp r (InterpM r)
 
-liftInterpM :: (EnvReader m, MonadIO1 m) => InterpM n n a -> m n a
+liftInterpM :: (EnvReader m, MonadIO1 m) => InterpM r n n a -> m n a
 liftInterpM cont = do
   resultIO <- liftEnvReaderT $ runSubstReaderT idSubst $ runInterpM' cont
   liftIO resultIO
@@ -60,17 +60,17 @@ liftInterpM cont = do
 -- TODO Can we implement a FakeIOT monad transformer that provides
 -- MonadIO but with liftIO = fail ?  Then we could call the interpreter
 -- while guaranteeing that no real IO actually happens.
-unsafeLiftInterpMCatch :: (EnvReader m) => InterpM n n a -> m n (Except a)
+unsafeLiftInterpMCatch :: (EnvReader m) => InterpM r n n a -> m n (Except a)
 unsafeLiftInterpMCatch cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
   return $ unsafePerformIO $ catchIOExcept $ runInterpM env cont
 {-# INLINE unsafeLiftInterpMCatch #-}
 
-evalBlock :: Interp m => Block i -> m i o (Atom o)
+evalBlock :: Interp r m => Block r i -> m i o (Atom r o)
 evalBlock (Block _ decls result) = evalDecls decls $ evalAtom result
 
-evalDecls :: Interp m => Nest Decl i i' -> m i' o a -> m i o a
+evalDecls :: Interp r m => Nest (Decl r) i i' -> m i' o a -> m i o a
 evalDecls Empty cont = cont
 evalDecls (Nest (Let b (DeclBinding _ _ rhs)) rest) cont = do
   result <- evalExpr rhs
@@ -79,10 +79,10 @@ evalDecls (Nest (Let b (DeclBinding _ _ rhs)) rest) cont = do
 
 -- XXX: this doesn't go under lambda or pi binders
 traverseSurfaceAtomNames
-  :: (SubstReader AtomSubstVal m, EnvReader2 m)
-  => Atom i
-  -> (AtomName i -> m i o (Atom o))
-  -> m i o (Atom o)
+  :: (SubstReader (AtomSubstVal r) m, EnvReader2 m)
+  => Atom r i
+  -> (AtomName r i -> m i o (Atom r o))
+  -> m i o (Atom r o)
 traverseSurfaceAtomNames atom doWithName = case atom of
   Var v -> doWithName v
   Lam _    -> substM atom
@@ -110,23 +110,22 @@ traverseSurfaceAtomNames atom doWithName = case atom of
   where
     rec x = traverseSurfaceAtomNames x doWithName
 
-evalAtom :: Interp m => Atom i -> m i o (Atom o)
+evalAtom :: forall i o r m. Interp r m => Atom r i -> m i o (Atom r o)
 evalAtom atom = traverseSurfaceAtomNames atom \v -> do
   env <- getSubst
   case env ! v of
     SubstVal x -> return x
     Rename v' -> do
-      ~(AtomNameBinding bindingInfo) <- lookupEnv v'
-      case bindingInfo of
-        LetBound (DeclBinding _ _ (Atom x)) -> dropSubst $ evalAtom x
+      lookupAtomName v' >>= \case
+        LetBound (DeclBinding _ _ (Atom x)) -> dropSubst $ evalAtom $ unsafeCoerceIRE @r x
         TopFunBound _ _ -> return $ Var v'
         PtrLitBound _ ptrName -> do
           ~(PtrBinding ptr) <- lookupEnv ptrName
           return $ Con $ Lit $ PtrLit ptr
-        _ -> error $ "shouldn't have irreducible atom names left. Got " ++ pprint bindingInfo
+        bindingInfo -> error $ "shouldn't have irreducible atom names left. Got " ++ pprint bindingInfo
 {-# SCC evalAtom #-}
 
-evalExpr :: Interp m => Expr i -> m i o (Atom o)
+evalExpr :: Interp r m => Expr r i -> m i o (Atom r o)
 evalExpr expr = case expr of
   App f xs -> do
     f' <- evalAtom f
@@ -169,7 +168,7 @@ evalExpr expr = case expr of
   Handle _ _ _ -> error $ "Not implemented: " ++ pprint expr
 {-# SCC evalExpr #-}
 
-evalOp :: Interp m => Op i -> m i o (Atom o)
+evalOp :: Interp r m => Op r i -> m i o (Atom r o)
 evalOp expr = mapM evalAtom expr >>= \case
   BinOp op x y -> return $ case op of
     IAdd -> applyIntBinOp   (+) x y
@@ -229,7 +228,7 @@ evalOp expr = mapM evalAtom expr >>= \case
     return $ Con $ Newtype ty $ SumVal (toList tys) ix v
   _ -> error $ "Not implemented: " ++ pprint expr
 
-evalProjectDictMethod :: Interp m => Atom o -> Int -> m i o (Atom o)
+evalProjectDictMethod :: Interp r m => Atom r o -> Int -> m i o (Atom r o)
 evalProjectDictMethod d i = cheapNormalize d >>= \case
   DictCon (InstanceDict instanceName args) -> dropSubst do
     args' <- mapM evalAtom args
@@ -237,7 +236,7 @@ evalProjectDictMethod d i = cheapNormalize d >>= \case
     let InstanceBody _ methods = body
     let method = methods !! i
     extendSubst (bs@@>(SubstVal <$> args')) $
-      evalBlock method
+      evalBlock $ unsafeCoerceIRE method
   Con (ExplicitDict _ method) -> do
     case i of
       0 -> return method
@@ -251,7 +250,7 @@ evalProjectDictMethod d i = cheapNormalize d >>= \case
       _    -> dropSubst $ evalExpr $ App (head mts) (UnitVal NE.:| [])
   _ -> error $ "Not a simplified dict: " ++ pprint d
 
-matchUPat :: Interp m => UPat i i' -> Atom o -> m i o (SubstFrag AtomSubstVal i i' o)
+matchUPat :: Interp r m => UPat i i' -> Atom r o -> m i o (SubstFrag (AtomSubstVal r) i i' o)
 matchUPat (WithSrcB _ pat) x = do
   x' <- dropSubst $ evalAtom x
   case (pat, x') of
@@ -266,9 +265,9 @@ matchUPat (WithSrcB _ pat) x = do
     (UPatUnit UnitB, UnitVal) -> return emptyInFrag
     (UPatRecord pats, Record initTys initXs) -> go initTys (restructure initXs initTys) pats
       where
-        go :: Interp m
-           => LabeledItems (Type o) -> LabeledItems (Atom o)
-           -> UFieldRowPat i i' -> m i o (SubstFrag AtomSubstVal i i' o)
+        go :: Interp r m
+           => LabeledItems (Type r o) -> LabeledItems (Atom r o)
+           -> UFieldRowPat i i' -> m i o (SubstFrag (AtomSubstVal r) i i' o)
         go tys xs = \case
           UEmptyRowPat    -> return emptyInFrag
           URemFieldsPat b -> return $ b @> SubstVal (Record tys $ toList xs)
@@ -303,7 +302,7 @@ matchUPat (WithSrcB _ pat) x = do
     _ -> error "bad pattern match"
   where followedByFrag f m = extendSubst f $ fmap (f <.>) m
 
-matchUPats :: Interp m => Nest UPat i i' -> [Atom o] -> m i o (SubstFrag AtomSubstVal i i' o)
+matchUPats :: Interp r m => Nest UPat i i' -> [Atom r o] -> m i o (SubstFrag (AtomSubstVal r) i i' o)
 matchUPats Empty [] = return emptyInFrag
 matchUPats (Nest b bs) (x:xs) = do
   s <- matchUPat b x
@@ -315,41 +314,41 @@ matchUPats _ _ = error "mismatched lengths"
 -- XXX: It is a bit shady to unsafePerformIO here since this runs during typechecking.
 -- We could have a partial version of the interpreter that fails when any IO is to happen.
 liftBuilderInterp ::
-  (forall l. (Emits l, DExt n l) => BuilderM l (Atom l))
-  -> InterpM n n (Atom n)
+  (forall l. (Emits l, DExt n l) => BuilderM r l (Atom r l))
+  -> InterpM r n n (Atom r n)
 liftBuilderInterp cont = do
   Abs decls result <- liftBuilder $ buildScoped cont
   evalDecls decls $ evalAtom result
 {-# SCC liftBuilderInterp #-}
 
-runInterpM :: Distinct n => Env n -> InterpM n n a -> IO a
+runInterpM :: Distinct n => Env n -> InterpM r n n a -> IO a
 runInterpM bindings cont =
   runEnvReaderT bindings $ runSubstReaderT idSubst $ runInterpM' cont
 {-# SCC runInterpM #-}
 
-unsafeLiftInterpM :: (EnvReader m) => InterpM n n a -> m n a
+unsafeLiftInterpM :: (EnvReader m) => InterpM r n n a -> m n a
 unsafeLiftInterpM cont = do
   env <- unsafeGetEnv
   Distinct <- getDistinct
   return $ unsafePerformIO $ runInterpM env cont
 {-# INLINE unsafeLiftInterpM #-}
 
-indices :: EnvReader m => IxType n -> m n [Atom n]
+indices :: EnvReader m => IxType r n -> m n [Atom r n]
 indices ixTy = unsafeLiftInterpM $ do
   ~(IdxRepVal size) <- interpIndexSetSize ixTy
   forM (iota size) \i -> interpUnsafeFromOrdinal ixTy $ IdxRepVal i
 {-# SCC indices #-}
 
-interpIndexSetSize :: IxType n -> InterpM n n (Atom n)
+interpIndexSetSize :: IxType r n -> InterpM r n n (Atom r n)
 interpIndexSetSize ixTy = liftBuilderInterp $ indexSetSize $ sink ixTy
 
-interpUnsafeFromOrdinal :: IxType n -> Atom n -> InterpM n n (Atom n)
+interpUnsafeFromOrdinal :: IxType r n -> Atom r n -> InterpM r n n (Atom r n)
 interpUnsafeFromOrdinal ixTy i = liftBuilderInterp $ unsafeFromOrdinal (sink ixTy) (sink i)
 
 -- A variant of `indices` that accepts an expected number of them and
 -- only tries to construct the set if the expected number matches the
 -- given index set's size.
-indicesLimit :: EnvReader m => Int -> IxType n -> m n (Either Word32 [Atom n])
+indicesLimit :: EnvReader m => Int -> IxType r n -> m n (Either Word32 [Atom r n])
 indicesLimit sizeReq ixTy = unsafeLiftInterpM $ do
   ~(IdxRepVal size) <- interpIndexSetSize ixTy
   if size == fromIntegral sizeReq then
@@ -361,7 +360,7 @@ indicesLimit sizeReq ixTy = unsafeLiftInterpM $ do
 -- === Helpers for function evaluation over fixed-width types ===
 
 applyIntBinOp' :: (forall a. (Eq a, Ord a, Num a, Integral a)
-               => (a -> Atom n) -> a -> a -> Atom n) -> Atom n -> Atom n -> Atom n
+               => (a -> Atom r n) -> a -> a -> Atom r n) -> Atom r n -> Atom r n -> Atom r n
 applyIntBinOp' f x y = case (x, y) of
   (Con (Lit (Int64Lit xv)), Con (Lit (Int64Lit yv))) -> f (Con . Lit . Int64Lit) xv yv
   (Con (Lit (Int32Lit xv)), Con (Lit (Int32Lit yv))) -> f (Con . Lit . Int32Lit) xv yv
@@ -370,17 +369,17 @@ applyIntBinOp' f x y = case (x, y) of
   (Con (Lit (Word64Lit xv)), Con (Lit (Word64Lit yv))) -> f (Con . Lit . Word64Lit) xv yv
   _ -> error "Expected integer atoms"
 
-applyIntBinOp :: (forall a. (Num a, Integral a) => a -> a -> a) -> Atom n -> Atom n -> Atom n
+applyIntBinOp :: (forall a. (Num a, Integral a) => a -> a -> a) -> Atom r n -> Atom r n -> Atom r n
 applyIntBinOp f x y = applyIntBinOp' (\w -> w ... f) x y
 
-applyIntCmpOp :: (forall a. (Eq a, Ord a) => a -> a -> Bool) -> Atom n -> Atom n -> Atom n
+applyIntCmpOp :: (forall a. (Eq a, Ord a) => a -> a -> Bool) -> Atom r n -> Atom r n -> Atom r n
 applyIntCmpOp f x y = applyIntBinOp' (\_ -> (Con . Lit . Word8Lit . fromIntegral . fromEnum) ... f) x y
 
-applyFloatBinOp :: (forall a. (Num a, Fractional a) => a -> a -> a) -> Atom n -> Atom n -> Atom n
+applyFloatBinOp :: (forall a. (Num a, Fractional a) => a -> a -> a) -> Atom r n -> Atom r n -> Atom r n
 applyFloatBinOp f x y = case (x, y) of
   (Con (Lit (Float64Lit xv)), Con (Lit (Float64Lit yv))) -> Con $ Lit $ Float64Lit $ f xv yv
   (Con (Lit (Float32Lit xv)), Con (Lit (Float32Lit yv))) -> Con $ Lit $ Float32Lit $ f xv yv
   _ -> error "Expected float atoms"
 
-applyFloatUnOp :: (forall a. (Num a, Fractional a) => a -> a) -> Atom n -> Atom n
+applyFloatUnOp :: (forall a. (Num a, Fractional a) => a -> a) -> Atom r n -> Atom r n
 applyFloatUnOp f x = applyFloatBinOp (\_ -> f) undefined x

--- a/src/lib/Interpreter.hs-boot
+++ b/src/lib/Interpreter.hs-boot
@@ -9,10 +9,10 @@ module Interpreter (indices, indicesLimit, applyIntBinOp, applyIntCmpOp, applyFl
 import Data.Word
 import Syntax
 
-indices :: EnvReader m => IxType n -> m n [Atom n]
-indicesLimit :: EnvReader m => Int -> IxType n -> m n (Either Word32 [Atom n])
+indices :: EnvReader m => IxType r n -> m n [Atom r n]
+indicesLimit :: EnvReader m => Int -> IxType r n -> m n (Either Word32 [Atom r n])
 
-applyIntBinOp :: (forall a. (Num a, Integral a) => a -> a -> a) -> Atom n -> Atom n -> Atom n
-applyIntCmpOp :: (forall a. (Eq a, Ord a) => a -> a -> Bool) -> Atom n -> Atom n -> Atom n
-applyFloatBinOp :: (forall a. (Num a, Fractional a) => a -> a -> a) -> Atom n -> Atom n -> Atom n
-applyFloatUnOp :: (forall a. (Num a, Fractional a) => a -> a) -> Atom n -> Atom n
+applyIntBinOp :: (forall a. (Num a, Integral a) => a -> a -> a) -> Atom r n -> Atom r n -> Atom r n
+applyIntCmpOp :: (forall a. (Eq a, Ord a) => a -> a -> Bool) -> Atom r n -> Atom r n -> Atom r n
+applyFloatBinOp :: (forall a. (Num a, Fractional a) => a -> a -> a) -> Atom r n -> Atom r n -> Atom r n
+applyFloatUnOp :: (forall a. (Num a, Fractional a) => a -> a) -> Atom r n -> Atom r n

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -28,10 +28,10 @@ import Builder
 import QueryType
 import Util (iota)
 
-earlyOptimize :: EnvReader m => Block n -> m n (Block n)
+earlyOptimize :: EnvReader m => SBlock n -> m n (SBlock n)
 earlyOptimize = unrollTrivialLoops
 
-optimize :: EnvReader m => Block n -> m n (Block n)
+optimize :: EnvReader m => SBlock n -> m n (SBlock n)
 optimize = dceBlock     -- Clean up user code
        >=> unrollLoops
        >=> dceBlock     -- Clean up peephole-optimized code after unrolling
@@ -41,7 +41,7 @@ optimize = dceBlock     -- Clean up user code
 -- This pass unrolls loops that use Fin 0 or Fin 1 as an index set.
 
 data UTLS n = UTLS
-type UTLM = GenericTraverserM UnitB UTLS
+type UTLM = GenericTraverserM SimpIR UnitB UTLS
 instance SinkableE UTLS where
   sinkingProofE _ UTLS = UTLS
 instance HoistableState UTLS where
@@ -50,17 +50,17 @@ instance HoistableState UTLS where
 
 data IndexSetKind n
   = EmptyIxSet
-  | SingletonIxSet (Atom n)
+  | SingletonIxSet (SAtom n)
   | UnknownIxSet
 
-isTrivialIndex :: Type i -> UTLM i o (IndexSetKind o)
+isTrivialIndex :: Type SimpIR i -> UTLM i o (IndexSetKind o)
 isTrivialIndex = \case
   TC (Fin (NatVal n)) | n <= 0 -> return EmptyIxSet
   TC (Fin (NatVal n)) | n == 1 ->
     return $ SingletonIxSet $ Con $ Newtype (FinConst n) (NatVal 0)
   _ -> return UnknownIxSet
 
-instance GenericTraverser UnitB UTLS where
+instance GenericTraverser SimpIR UnitB UTLS where
   traverseExpr expr = case expr of
     Hof (For _ ixDict (Lam (LamExpr b body@(Block _ decls a)))) -> do
       isTrivialIndex (binderType b) >>= \case
@@ -76,12 +76,12 @@ instance GenericTraverser UnitB UTLS where
             emitOp $ ThrowError (sink resTy')
     _ -> traverseExprDefault expr
 
-unrollTrivialLoops :: EnvReader m => Block n -> m n (Block n)
+unrollTrivialLoops :: EnvReader m => SBlock n -> m n (SBlock n)
 unrollTrivialLoops b = liftM fst $ liftGenericTraverserM UTLS $ traverseGenericE b
 
 -- === Peephole optimizations ===
 
-peepholeOp :: Op o -> EnvReaderM o (Either (Atom o) (Op o))
+peepholeOp :: Op SimpIR o -> EnvReaderM o (Either (SAtom o) (Op SimpIR o))
 peepholeOp op = case op of
   CastOp (BaseTy (Scalar sTy)) (Con (Lit l)) -> return $ case sTy of
     -- TODO: Support all casts.
@@ -176,7 +176,7 @@ peepholeOp op = case op of
       LessEqual    -> (<=)
       GreaterEqual -> (>=)
 
-peepholeExpr :: Expr o -> EnvReaderM o (Either (Atom o) (Expr o))
+peepholeExpr :: SExpr o -> EnvReaderM o (Either (SAtom o) (SExpr o))
 peepholeExpr expr = case expr of
   Op op -> fmap Op <$> peepholeOp op
   TabApp (Var t) ((Con (Newtype (TC (Fin _)) (NatVal ord))) NE.:| []) ->
@@ -195,11 +195,11 @@ peepholeExpr expr = case expr of
 
 -- === Loop unrolling ===
 
-unrollLoops :: EnvReader m => Block n -> m n (Block n)
+unrollLoops :: EnvReader m => SBlock n -> m n (SBlock n)
 unrollLoops b = liftM fst $ liftGenericTraverserM (ULS 0) $ traverseGenericE b
 
 newtype ULS n = ULS Int deriving Show
-type ULM = GenericTraverserM UnitB ULS
+type ULM = GenericTraverserM SimpIR UnitB ULS
 instance SinkableE ULS where
   sinkingProofE _ (ULS c) = ULS c
 instance HoistableState ULS where
@@ -208,7 +208,7 @@ instance HoistableState ULS where
 
 -- TODO: Refine the cost accounting so that operations that will become
 -- constant-foldable after inlining don't count towards it.
-instance GenericTraverser UnitB ULS where
+instance GenericTraverser SimpIR UnitB ULS where
   traverseInlineExpr expr = case expr of
     Hof (For Fwd ixDict body@(Lam (LamExpr b _))) -> do
       case binderType b of
@@ -247,13 +247,13 @@ instance GenericTraverser UnitB ULS where
         put oldCost $> (ans, newCost)
       {-# INLINE withLocalAccounting #-}
 
-emitSubstBlock :: Emits o => Block i -> ULM i o (Atom o)
+emitSubstBlock :: Emits o => SBlock i -> ULM i o (SAtom o)
 emitSubstBlock (Block _ decls ans) = traverseDeclNest decls $ traverseAtom ans
 
 -- === Loop invariant code motion ===
 
 -- TODO: Resolve import cycle with Lower
-type DestBlock = Abs Binder Block
+type DestBlock = Abs (Binder SimpIR) SBlock
 
 hoistLoopInvariantDest :: EnvReader m => DestBlock n -> m n (DestBlock n)
 hoistLoopInvariantDest (Abs (db:>dTy) body) =
@@ -261,7 +261,7 @@ hoistLoopInvariantDest (Abs (db:>dTy) body) =
     dTy' <- traverseGenericE dTy
     buildAbs (getNameHint db) dTy' \v -> extendRenamer (db@>v) $ traverseGenericE body
 
-hoistLoopInvariant :: EnvReader m => Block n -> m n (Block n)
+hoistLoopInvariant :: EnvReader m => SBlock n -> m n (SBlock n)
 hoistLoopInvariant body = liftM fst $ liftGenericTraverserM LICMS $ traverseGenericE body
 
 data LICMS (n::S) = LICMS
@@ -270,7 +270,7 @@ instance SinkableE LICMS where
 instance HoistableState LICMS where
   hoistState _ _ LICMS = LICMS
 
-instance GenericTraverser UnitB LICMS where
+instance GenericTraverser SimpIR UnitB LICMS where
   traverseExpr = \case
     Hof (Seq dir ix (ProdVal dests) (Lam (LamExpr b body))) -> do
       ix' <- traverseAtom ix
@@ -303,9 +303,9 @@ instance GenericTraverser UnitB LICMS where
       return $ Hof $ For dir ix' body'
     expr -> traverseExprDefault expr
     where
-      rebuildBody :: LamBinder i i' -> Block i'
-                  -> AtomNameBinder n l -> Type n -> Abs (Nest Decl) Atom l
-                  -> GenericTraverserM UnitB LICMS i n (Atom n)
+      rebuildBody :: LamBinder SimpIR i i' -> SBlock i'
+                  -> AtomNameBinder n l -> SType n -> Abs (Nest SDecl) SAtom l
+                  -> GenericTraverserM SimpIR UnitB LICMS i n (SAtom n)
       rebuildBody b body@(Block ann _ _) lnb lbTy bodyAbs = do
         Distinct <- getDistinct
         refreshAbs (Abs (lnb:>lbTy) bodyAbs) \lb (Abs decls ans) -> do
@@ -317,16 +317,16 @@ instance GenericTraverser UnitB LICMS where
             return $ Lam $ LamExpr b'' $ Block ann' decls ans
 
 seqLICM :: Int
-        -> RNest Decl n1 n2      -- hoisted decls
-        -> [AtomName n2]         -- hoisted dests
-        -> AtomNameBinder n2 n3  -- loop binder
-        -> RNest Decl n3 n4      -- loop-dependent decls
-        -> Nest Decl m1 m2       -- decls remaining to process
-        -> Atom m2               -- loop result
-        -> SubstReaderT AtomSubstVal EnvReaderM m1 n4
-             (Abs (Nest Decl)
-                (PairE (ListE AtomName)
-                       (Abs AtomNameBinder (Abs (Nest Decl) Atom))) n1)
+        -> RNest SDecl n1 n2      -- hoisted decls
+        -> [SAtomName n2]         -- hoisted dests
+        -> AtomNameBinder n2 n3   -- loop binder
+        -> RNest SDecl n3 n4      -- loop-dependent decls
+        -> Nest SDecl m1 m2       -- decls remaining to process
+        -> SAtom m2               -- loop result
+        -> SubstReaderT (AtomSubstVal SimpIR) EnvReaderM m1 n4
+             (Abs (Nest SDecl)
+                (PairE (ListE SAtomName)
+                       (Abs AtomNameBinder (Abs (Nest SDecl) SAtom))) n1)
 seqLICM !nextProj !top !topDestNames !lb !reg decls ans = case decls of
   Empty -> do
     ans' <- substM ans
@@ -370,7 +370,7 @@ dceDestBlock :: EnvReader m => DestBlock n -> m n (DestBlock n)
 dceDestBlock idb = liftEnvReaderM $
   refreshAbs idb \d b -> Abs d <$> dceBlock b
 
-dceBlock :: EnvReader m => Block n -> m n (Block n)
+dceBlock :: EnvReader m => SBlock n -> m n (SBlock n)
 dceBlock b = liftEnvReaderM $ evalStateT1 (dce b) mempty
 
 class HasDCE (e::E) where
@@ -383,7 +383,7 @@ class HasDCE (e::E) where
 instance Color c => HasDCE (Name c) where
   dce n = modify (<> FV (freeVarsE n)) $> n
 
-instance HasDCE Block where
+instance HasDCE SBlock where
   dce (Block ann decls ans) = case (ann, decls) of
     (NoBlockAnn      , Empty) -> Block NoBlockAnn Empty <$> dce ans
     (NoBlockAnn      , _    ) -> error "should be unreachable"
@@ -430,10 +430,10 @@ hoistUsingCachedFVs b e = do
     HoistFailure err -> HoistFailure err
 
 data ElimResult n where
-  ElimSuccess :: Abs (Nest Decl) Atom n -> ElimResult n
-  ElimFailure :: Decl n l -> Abs (Nest Decl) Atom l -> ElimResult n
+  ElimSuccess :: Abs (Nest SDecl) SAtom n -> ElimResult n
+  ElimFailure :: SDecl n l -> Abs (Nest SDecl) SAtom l -> ElimResult n
 
-dceNest :: Nest Decl n l -> Atom l -> DCEM n (Abs (Nest Decl) Atom n)
+dceNest :: Nest SDecl n l -> SAtom l -> DCEM n (Abs (Nest SDecl) SAtom n)
 dceNest decls ans = case decls of
   Empty -> Abs Empty <$> dce ans
   Nest b@(Let _ decl) bs -> do
@@ -460,22 +460,22 @@ dceNest decls ans = case decls of
 -- The generic instances
 
 instance (HasDCE e1, HasDCE e2) => HasDCE (ExtLabeledItemsE e1 e2)
-instance HasDCE Expr
-instance HasDCE Atom
-instance HasDCE LamExpr
-instance HasDCE TabLamExpr
-instance HasDCE PiType
-instance HasDCE TabPiType
-instance HasDCE DepPairType
+instance HasDCE SExpr
+instance HasDCE SAtom
+instance HasDCE (LamExpr     SimpIR)
+instance HasDCE (TabLamExpr  SimpIR)
+instance HasDCE (PiType      SimpIR)
+instance HasDCE (TabPiType   SimpIR)
+instance HasDCE (DepPairType SimpIR)
 instance HasDCE EffectRow
 instance HasDCE Effect
 instance HasDCE EffectOpType
-instance HasDCE DictExpr
-instance HasDCE DictType
-instance HasDCE FieldRowElems
-instance HasDCE FieldRowElem
-instance HasDCE DataDefParams
-instance HasDCE DeclBinding
+instance HasDCE (DictExpr      SimpIR)
+instance HasDCE (DictType      SimpIR)
+instance HasDCE (FieldRowElems SimpIR)
+instance HasDCE (FieldRowElem  SimpIR)
+instance HasDCE (DataDefParams SimpIR)
+instance HasDCE (DeclBinding   SimpIR)
 
 -- The instances for RepE types
 

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -128,12 +128,12 @@ pApp a = prettyPrec a AppPrec
 pArg :: PrettyPrec a => a -> Doc ann
 pArg a = prettyPrec a ArgPrec
 
-instance Pretty (Block n) where
+instance Pretty (Block r n) where
   pretty (Block _ decls expr) = prettyBlock decls expr
-instance PrettyPrec (Block n) where
+instance PrettyPrec (Block r n) where
   prettyPrec (Block _ decls expr) = atPrec LowestPrec $ prettyBlock decls expr
 
-prettyBlock :: (PrettyPrec (e l)) => Nest Decl n l -> e l -> Doc ann
+prettyBlock :: (PrettyPrec (e l)) => Nest (Decl r) n l -> e l -> Doc ann
 prettyBlock Empty expr = group $ line <> pLowest expr
 prettyBlock decls expr = prettyLines decls' <> hardline <> pLowest expr
     where decls' = fromNest decls
@@ -151,8 +151,8 @@ instance PrettyPrec a => PrettyPrec [a] where
 instance PrettyE ann => Pretty (BinderP c ann n l)
   where pretty (b:>ty) = p b <> ":" <> p ty
 
-instance Pretty (Expr n) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (Expr n) where
+instance Pretty (Expr r n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (Expr r n) where
   prettyPrec (Atom x ) = prettyPrec x
   prettyPrec (App f xs) = atPrec AppPrec $ pApp f <+> spaced (toList xs)
   prettyPrec (TabApp f xs) = atPrec AppPrec $ pApp f <> "." <> dotted (toList xs)
@@ -168,7 +168,7 @@ instance PrettyPrec (Expr n) where
   prettyPrec (Handle v args body) =
       atPrec LowestPrec $ p v <+> p args <+> prettyLam "\\_." Pure body
 
-prettyPrecCase :: PrettyE e => Doc ann -> Atom n -> [AltP e n] -> EffectRow n -> DocPrec ann
+prettyPrecCase :: PrettyE e => Doc ann -> Atom r n -> [AltP r e n] -> EffectRow n -> DocPrec ann
 prettyPrecCase name e alts effs = atPrec LowestPrec $
   name <+> pApp e <+> "of" <>
   nest 2 (foldMap (\alt -> hardline <> prettyAlt alt) alts
@@ -178,54 +178,55 @@ prettyPrecCase name e alts effs = atPrec LowestPrec $
     effectLine Pure = ""
     effectLine row = hardline <> "case annotated with effects" <+> p row
 
-prettyAlt :: PrettyE e => AltP e n -> Doc ann
+prettyAlt :: PrettyE e => AltP r e n -> Doc ann
 prettyAlt (Abs b body) = prettyBinderNoAnn b <+> "->" <> nest 2 (p body)
 
-prettyBinderNoAnn :: Binder n l -> Doc ann
+prettyBinderNoAnn :: Binder r n l -> Doc ann
 prettyBinderNoAnn (b:>_) = p b
 
-instance PrettyPrecE e => Pretty     (Abs Binder e n) where pretty = prettyFromPrettyPrec
-instance PrettyPrecE e => PrettyPrec (Abs Binder e n) where
+instance PrettyPrecE e => Pretty     (Abs (Binder r) e n) where pretty = prettyFromPrettyPrec
+instance PrettyPrecE e => PrettyPrec (Abs (Binder r) e n) where
   prettyPrec (Abs binder body) = atPrec LowestPrec $ "\\" <> p binder <> "." <> pLowest body
 
-instance Pretty (DeclBinding n) where
+instance Pretty (DeclBinding r n) where
   pretty (DeclBinding ann ty expr) =
     "Decl" <> p ann <> indented (               "type: " <+> p ty
                                  <> hardline <> "value:" <+> p expr)
 
-instance Pretty (Decl n l) where
+instance Pretty (Decl r n l) where
   pretty (Let b (DeclBinding ann ty rhs)) =
     align $ annDoc <> p (b:>ty) <+> "=" <> (nest 2 $ group $ line <> pLowest rhs)
     where annDoc = case ann of PlainLet -> mempty; _ -> pretty ann <> " "
 
-instance Pretty (NaryLamExpr n) where
+instance Pretty (NaryLamExpr r n) where
   pretty (NaryLamExpr (NonEmptyNest b bs) _ body) =
     "\\" <> (spaced $ fromNest $ Nest b bs) <+> "." <> nest 2 (p body)
 
-instance Pretty (NaryPiType n) where
+instance Pretty (NaryPiType r n) where
   pretty (NaryPiType (NonEmptyNest b bs) effs resultTy) =
     (spaced $ fromNest $ Nest b bs) <+> "->" <+> "{" <> p effs <> "}" <+> p resultTy
 
-instance Pretty (PiBinder n l) where
-  pretty (PiBinder b ty PlainArrow) = p (b:>ty)
-  pretty (PiBinder b ty ClassArrow) = "[" <> p (b:>ty) <> "]"
-  pretty (PiBinder b ty ImplicitArrow) = "{" <> p (b:>ty) <> "}"
-  pretty (PiBinder b ty LinArrow) = p (b:>ty)
+instance Pretty (PiBinder r n l) where
+  pretty (PiBinder b ty arrow) = case arrow of
+    PlainArrow    -> p (b:>ty)
+    ClassArrow    -> "[" <> p (b:>ty) <> "]"
+    ImplicitArrow -> "{" <> p (b:>ty) <> "}"
+    LinArrow      -> p (b:>ty)
 
-instance Pretty (LamExpr n) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (LamExpr n) where
+instance Pretty (LamExpr r n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (LamExpr r n) where
   prettyPrec lamExpr =
     atPrec LowestPrec $ "\\" <> prettyLamHelper lamExpr PrettyLam
 
-instance Pretty (IxType n) where
+instance Pretty (IxType r n) where
   pretty (IxType ty _) = parens $ "IxType" <+> pretty ty
 
-instance Pretty (TabLamExpr n) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (TabLamExpr n) where
+instance Pretty (TabLamExpr r n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (TabLamExpr r n) where
   prettyPrec (TabLamExpr b body) =
     atPrec LowestPrec $ "view" <+> p b <+> "." <+> p body
 
-instance Pretty (DictExpr n) where
+instance Pretty (DictExpr r n) where
   pretty d = case d of
     InstanceDict name args -> "Instance" <+> p name <+> p args
     InstantiatedGiven v args -> "Given" <+> p v <+> p (toList args)
@@ -233,20 +234,20 @@ instance Pretty (DictExpr n) where
     IxFin n -> "Ix (Fin" <+> p n <> ")"
     ExplicitMethods v args -> "ExplicitMethods" <+> p v <+> p args
 
-instance Pretty (DictType n) where
+instance Pretty (DictType r n) where
   pretty (DictType classSourceName _ params) =
     p classSourceName <+> spaced params
 
-instance Pretty (DepPairType n) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (DepPairType n) where
+instance Pretty (DepPairType r n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (DepPairType r n) where
   prettyPrec (DepPairType b rhs) =
     atPrec ArgPrec $ align $ group $ parens $ p b <+> "&>" <+> p rhs
 
 instance Pretty (EffectOpType n) where
   pretty (EffectOpType pol ty) = "[" <+> p pol <+> ":" <+> p ty <+> "]"
 
-instance Pretty (Atom n) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (Atom n) where
+instance Pretty (Atom r n) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (Atom r n) where
   prettyPrec atom = case atom of
     Var v -> atPrec ArgPrec $ p v
     Lam lamExpr -> prettyPrec lamExpr
@@ -288,7 +289,7 @@ instance PrettyPrec (Atom n) where
     DepPairRef l (Abs b r) _ -> atPrec LowestPrec $
       "DepPairRef" <+> p l <+> "as" <+> p b <+> "in" <+> p r
 
-instance Pretty (BoxPtr n) where
+instance Pretty (BoxPtr r n) where
   pretty (BoxPtr ptrptr sb) = pretty (ptrptr, sb)
 
 instance Pretty Projection where
@@ -297,7 +298,7 @@ instance Pretty Projection where
     UnwrapBaseNewtype -> "ub"
     ProjectProduct i -> p i
 
-prettyRecordTyRow :: FieldRowElems n -> Doc ann -> DocPrec ann
+prettyRecordTyRow :: FieldRowElems r n -> Doc ann -> DocPrec ann
 prettyRecordTyRow elems separator = do
   atPrec ArgPrec $ align $ group $ braces $ (prefix <>) $
     concatWith (surround $ line <> separator <> " ") $ p <$> fromFieldRowElems elems
@@ -306,7 +307,7 @@ prettyRecordTyRow elems separator = do
                       [DynFields _] -> separator
                       _ -> mempty
 
-instance Pretty (FieldRowElem n) where
+instance Pretty (FieldRowElem r n) where
   pretty = \case
     StaticFields items -> concatWith (surround $ line <> "& ") $
       withLabels items <&> \(l, _, ty) -> p l <> ":" <+> pLowest ty
@@ -345,7 +346,7 @@ forStr :: ForAnn -> Doc ann
 forStr Fwd = "for"
 forStr Rev = "rof"
 
-instance Pretty (PiType n) where
+instance Pretty (PiType r n) where
   pretty (PiType (PiBinder b ty arr) eff body) = let
     prettyBinder = prettyBinderHelper (b:>ty) (PairE eff body)
     prettyBody = case body of
@@ -356,7 +357,7 @@ instance Pretty (PiType n) where
       _    -> space <> pretty eff <> space
     in prettyBinder <> (group $ line <> p arr <> prettyEff <> prettyBody)
 
-instance Pretty (TabPiType n) where
+instance Pretty (TabPiType r n) where
   pretty (TabPiType (b :> IxType ty _) body) = let
     prettyBinder = prettyBinderHelper (b:>ty) body
     prettyBody = case body of
@@ -364,7 +365,7 @@ instance Pretty (TabPiType n) where
       _ -> pLowest body
     in prettyBinder <> (group $ line <> "=>" <+> prettyBody)
 
-prettyBinderHelper :: HoistableE e => Binder n l -> e l -> Doc ann
+prettyBinderHelper :: HoistableE e => Binder r n l -> e l -> Doc ann
 prettyBinderHelper (b:>ty) body =
   if binderName b `isFreeIn` body
     then parens $ p (b:>ty)
@@ -372,7 +373,7 @@ prettyBinderHelper (b:>ty) body =
 
 data PrettyLamType = PrettyLam | PrettyFor ForAnn deriving (Eq)
 
-prettyLamHelper :: LamExpr n -> PrettyLamType -> Doc ann
+prettyLamHelper :: LamExpr r n -> PrettyLamType -> Doc ann
 prettyLamHelper lamExpr lamType = let
   wrap :: Arrow -> Doc ann -> Doc ann
   wrap arr arg = case lamType of
@@ -382,7 +383,7 @@ prettyLamHelper lamExpr lamType = let
       ImplicitArrow -> "{" <> arg <> "}"
       ClassArrow    -> "[" <> arg <> "]"
     PrettyFor _ -> arg
-  rec :: LamExpr n -> Bool -> (Doc ann, EffectRow n, Block n)
+  rec :: LamExpr r n -> Bool -> (Doc ann, EffectRow n, Block r n)
   rec (LamExpr (LamBinder b ty arr effs') body') first =
     let thisOne = (if first then "" else line) <> wrap arr (p (b:>ty))
     in case inlineLastDeclBlock body' of
@@ -397,7 +398,7 @@ prettyLamHelper lamExpr lamType = let
   (binders, effs, body) = rec lamExpr True
   in prettyLam binders effs body
 
-prettyLam :: Doc ann -> EffectRow n -> Block n -> Doc ann
+prettyLam :: Doc ann -> EffectRow n -> Block r n -> Doc ann
 prettyLam binders effs body =
   group $ group (nest 4 $ binders) <> group (nest 2 $ p body) <> lamAnnot
   where
@@ -405,10 +406,10 @@ prettyLam binders effs body =
       Pure -> ""
       _ -> line <> "lam annotated with effects" <+> p effs
 
-inlineLastDeclBlock :: Block n -> Abs (Nest Decl) Expr n
+inlineLastDeclBlock :: Block r n -> Abs (Nest (Decl r)) (Expr r) n
 inlineLastDeclBlock (Block _ decls expr) = inlineLastDecl decls expr
 
-inlineLastDecl :: Nest Decl n l -> Atom l -> Abs (Nest Decl) Expr n
+inlineLastDecl :: Nest (Decl r) n l -> Atom r l -> Abs (Nest (Decl r)) (Expr r) n
 inlineLastDecl Empty result = Abs Empty $ Atom result
 inlineLastDecl (Nest (Let b (DeclBinding _ _ expr)) Empty) (Var v)
   | v == binderName b = Abs Empty expr
@@ -443,7 +444,7 @@ instance Pretty (UEffect n) where
 
 instance PrettyPrec (Name s n) where prettyPrec = atPrec ArgPrec . pretty
 
-instance Pretty (AtomBinding n) where
+instance Pretty (AtomBinding r n) where
   pretty binding = case binding of
     LetBound    b -> p b
     LamBound    b -> p b
@@ -468,15 +469,15 @@ instance Pretty (SpecializationSpec n) where
 instance Pretty IxMethod where
   pretty method = p $ show method
 
-instance Pretty (LamBinding n) where
+instance Pretty (LamBinding r n) where
   pretty (LamBinding arr ty) =
     "Lambda binding. Type:" <+> p ty <+> "  Arrow" <+> p arr
 
-instance Pretty (PiBinding n) where
+instance Pretty (PiBinding r n) where
   pretty (PiBinding arr ty) =
     "Pi binding. Type:" <+> p ty <+> "  Arrow" <+> p arr
 
-instance Pretty (SolverBinding n) where
+instance Pretty (SolverBinding r n) where
   pretty (InfVarBound  ty _) = "Inference variable of type:" <+> p ty
   pretty (SkolemBound  ty  ) = "Skolem variable of type:"    <+> p ty
 
@@ -507,7 +508,7 @@ instance Pretty (Module n) where
     , ("moduleExports"        , p $ moduleExports m)
     , ("moduleSynthCandidates", p $ moduleSynthCandidates m) ]
 
-instance Pretty (DataDefParams n) where
+instance Pretty (DataDefParams r n) where
   pretty (DataDefParams bs) = hsep $ map bracketize bs where
     bracketize (PlainArrow, x) = p x
     bracketize (ClassArrow, x) = "[" <> p x <> "]"
@@ -533,7 +534,7 @@ instance Pretty (ClassDef n) where
 instance Pretty ParamRole where
   pretty r = p (show r)
 
-instance Pretty (RolePiBinder n l) where
+instance Pretty (RolePiBinder r n l) where
   pretty (RolePiBinder b ty _ _) = p (b:>ty)
 
 instance Pretty (InstanceDef n) where
@@ -966,8 +967,8 @@ instance PrettyPrec e => Pretty (PrimCon e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimCon e) where
   prettyPrec = prettyPrecPrimCon
 -- TODO: Define Show instances in user-space and avoid those overlapping instances!
-instance Pretty (PrimCon (Atom n)) where pretty = prettyFromPrettyPrec
-instance PrettyPrec (PrimCon (Atom n)) where
+instance Pretty (PrimCon (Atom r n)) where pretty = prettyFromPrettyPrec
+instance PrettyPrec (PrimCon (Atom r n)) where
   prettyPrec = \case
     Newtype (StaticRecordTy ty) (ProdVal itemList) ->
       prettyLabeledItems (restructure itemList ty) (line' <> ",") " ="
@@ -1131,16 +1132,16 @@ instance Pretty CTopDecl where
   pretty (WithSrc _ d) = p d
 
 instance Pretty CTopDecl' where
-  pretty (CDecl ann decl) = annDoc <> p decl
+  pretty (C.CDecl ann decl) = annDoc <> p decl
     where annDoc = case ann of
             PlainLet -> mempty
             _ -> p ann <> " "
   pretty d = fromString $ show d
 
-instance Pretty CDecl where
+instance Pretty C.CDecl where
   pretty (WithSrc _ d) = p d
 
-instance Pretty CDecl' where
+instance Pretty C.CDecl' where
   pretty (CLet pat blk) = pArg pat <+> "=" <+> p blk
   pretty (CDef name args (Just ty) blk) =
     "def " <> fromString name <> " " <> pArg args <> " : " <> pArg ty <> " ="
@@ -1158,7 +1159,7 @@ instance Pretty CDecl' where
       _ -> " given" <+> p givens <> " "
   pretty (CExpr e) = p e
 
-instance Pretty CBlock where
+instance Pretty C.CBlock where
   pretty (ExprBlock g) = pArg g
   pretty (CBlock decls) = nest 2 $ prettyLines decls
 

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -43,30 +43,30 @@ import PPrint ()
 
 -- === Main API for querying types ===
 
-getTypeSubst :: (SubstReader AtomSubstVal m
-                , EnvReader2 m, HasType e)
-             => e i -> m i o (Type o)
+getTypeSubst :: (SubstReader (AtomSubstVal r) m
+                , EnvReader2 m, HasType r e)
+             => e i -> m i o (Type r o)
 getTypeSubst e = do
   subst <- getSubst
   liftTypeQueryM subst $ getTypeE e
 {-# INLINE getTypeSubst #-}
 
-getType :: (EnvReader m, HasType e) => e n -> m n (Type n)
+getType :: (EnvReader m, HasType r e) => e n -> m n (Type r n)
 getType e = liftTypeQueryM idSubst $ getTypeE e
 {-# INLINE getType #-}
 
 -- === Querying effects ===
 
-isPure :: (EnvReader m, HasEffectsE e) => e n -> m n Bool
+isPure :: (EnvReader m, HasEffectsE e r) => e n -> m n Bool
 isPure e = getEffects e <&> \case
   Pure -> True
   _    -> False
 
-getEffects :: (EnvReader m, HasEffectsE e) => e n -> m n (EffectRow n)
+getEffects :: (EnvReader m, HasEffectsE e r) => e n -> m n (EffectRow n)
 getEffects e = liftTypeQueryM idSubst $ getEffectsImpl e
 {-# INLINE getEffects #-}
 
-getEffectsSubst :: (EnvReader2 m, SubstReader AtomSubstVal m, HasEffectsE e)
+getEffectsSubst :: (EnvReader2 m, SubstReader (AtomSubstVal r) m, HasEffectsE e r)
               => e i -> m i o (EffectRow o)
 getEffectsSubst e = do
   subst <- getSubst
@@ -76,41 +76,41 @@ getEffectsSubst e = do
 -- === Exposed helpers for querying types and effects ===
 
 caseAltsBinderTys :: (Fallible1 m, EnvReader m)
-                  => Type n -> m n [Type n]
+                  => Type r n -> m n [Type r n]
 caseAltsBinderTys ty = case ty of
   TypeCon _ defName params -> do
     def <- lookupDataDef defName
     cons <- instantiateDataDef def params
-    return [repTy | DataConDef _ repTy _ <- cons]
+    return [unsafeCoerceIRE repTy | DataConDef _ repTy _ <- cons]
   SumTy types -> return types
   VariantTy (NoExt types) -> return $ toList types
   VariantTy _ -> fail "Can't pattern-match partially-known variants"
   _ -> fail $ "Case analysis only supported on ADTs and variants, not on " ++ pprint ty
 
-depPairLeftTy :: DepPairType n -> Type n
+depPairLeftTy :: DepPairType r n -> Type r n
 depPairLeftTy (DepPairType (_:>ty) _) = ty
 {-# INLINE depPairLeftTy #-}
 
 extendEffect :: Effect n -> EffectRow n -> EffectRow n
 extendEffect eff (EffectRow effs t) = EffectRow (S.insert eff effs) t
 
-getAppType :: EnvReader m => Type n -> [Atom n] -> m n (Type n)
+getAppType :: EnvReader m => Type r n -> [Atom r n] -> m n (Type r n)
 getAppType f xs = liftTypeQueryM idSubst $ typeApp f xs
 {-# INLINE getAppType #-}
 
-getTabAppType :: EnvReader m => Type n -> [Atom n] -> m n (Type n)
+getTabAppType :: EnvReader m => Type r n -> [Atom r n] -> m n (Type r n)
 getTabAppType f xs = case NE.nonEmpty xs of
   Nothing -> getType f
   Just xs' -> liftTypeQueryM idSubst $ typeTabApp f xs'
 {-# INLINE getTabAppType #-}
 
-getBaseMonoidType :: Fallible1 m => ScopeReader m => Type n -> m n (Type n)
+getBaseMonoidType :: Fallible1 m => ScopeReader m => Type r n -> m n (Type r n)
 getBaseMonoidType ty = case ty of
   Pi (PiType b _ resultTy) -> liftHoistExcept $ hoist b resultTy
   _     -> return ty
 {-# INLINE getBaseMonoidType #-}
 
-getReferentTy :: MonadFail m => EmptyAbs (PairB LamBinder LamBinder) n -> m (Type n)
+getReferentTy :: MonadFail m => EmptyAbs (PairB (LamBinder r) (LamBinder r)) n -> m (Type r n)
 getReferentTy (Abs (PairB hB refB) UnitE) = do
   RefTy _ ty <- return $ binderType refB
   HoistSuccess ty' <- return $ hoist hB ty
@@ -125,26 +125,27 @@ getMethodIndex className methodSourceName = do
     Just i -> return i
 {-# INLINE getMethodIndex #-}
 
-instantiateDataDef :: ScopeReader m => DataDef n -> DataDefParams n -> m n [DataConDef n]
-instantiateDataDef (DataDef _ bs cons) params = do
-  fromListE <$> applyDataConAbs (Abs bs $ ListE cons) params
+instantiateDataDef :: ScopeReader m => DataDef n -> DataDefParams r n -> m n [DataConDef n]
+instantiateDataDef (DataDef _ bs cons) (DataDefParams params) = do
+  let dataDefParams' = DataDefParams [(arr, unsafeCoerceIRE x) | (arr, x) <- params]
+  fromListE <$> applyDataConAbs (Abs bs $ ListE cons) dataDefParams'
 {-# INLINE instantiateDataDef #-}
 
-applyDataConAbs :: (SubstE AtomSubstVal e, SinkableE e, ScopeReader m)
-                => Abs (Nest RolePiBinder) e n -> DataDefParams n -> m n (e n)
+applyDataConAbs :: (SubstE (AtomSubstVal r) e, SinkableE e, ScopeReader m)
+                => Abs (Nest (RolePiBinder r)) e n -> DataDefParams r n -> m n (e n)
 applyDataConAbs (Abs bs e) (DataDefParams xs) =
   applySubst (bs @@> (SubstVal <$> map snd xs)) e
 {-# INLINE applyDataConAbs #-}
 
 -- Returns a representation type (type of an TypeCon-typed Newtype payload)
 -- given a list of instantiated DataConDefs.
-dataDefRep :: [DataConDef n] -> Type n
+dataDefRep :: [DataConDef n] -> Type r n
 dataDefRep = \case
   [] -> error "unreachable"  -- There's no representation for a void type
-  [DataConDef _ ty _] -> ty
-  tys -> SumTy $ tys <&> \(DataConDef _ ty _) -> ty
+  [DataConDef _ ty _] -> unsafeCoerceIRE ty
+  tys -> SumTy $ tys <&> \(DataConDef _ ty _) -> unsafeCoerceIRE ty
 
-instantiateNaryPi :: EnvReader m => NaryPiType n -> [Atom n] -> m n (NaryPiType n)
+instantiateNaryPi :: EnvReader m => NaryPiType r n  -> [Atom r n] -> m n (NaryPiType r n)
 instantiateNaryPi (NaryPiType bs eff resultTy) args = do
   PairB bs1 bs2 <- return $ splitNestAt (length args) $ nonEmptyToNest bs
   let bs2' = case bs2 of
@@ -153,17 +154,17 @@ instantiateNaryPi (NaryPiType bs eff resultTy) args = do
   applySubst (bs1 @@> map SubstVal args) (NaryPiType bs2' eff resultTy)
 {-# INLINE instantiateNaryPi #-}
 
-instantiateDepPairTy :: ScopeReader m => DepPairType n -> Atom n -> m n (Type n)
+instantiateDepPairTy :: ScopeReader m => DepPairType r n -> Atom r n -> m n (Type r n)
 instantiateDepPairTy (DepPairType b rhsTy) x = applyAbs (Abs b rhsTy) (SubstVal x)
 {-# INLINE instantiateDepPairTy #-}
 
-instantiatePi :: ScopeReader m => PiType n -> Atom n -> m n (EffectRow n, Type n)
+instantiatePi :: ScopeReader m => PiType r n -> Atom r n -> m n (EffectRow n, Type r n)
 instantiatePi (PiType b eff body) x = do
   PairE eff' body' <- applyAbs (Abs b (PairE eff body)) (SubstVal x)
   return (eff', body')
 {-# INLINE instantiatePi #-}
 
-instantiateTabPi :: ScopeReader m => TabPiType n -> Atom n -> m n (Type n)
+instantiateTabPi :: ScopeReader m => TabPiType r n -> Atom r n -> m n (Type r n)
 instantiateTabPi (TabPiType b body) x = applyAbs (Abs b body) (SubstVal x)
 {-# INLINE instantiateTabPi #-}
 
@@ -179,14 +180,14 @@ litType v = case v of
   PtrLit (PtrSnapshot t _) -> PtrType t
   PtrLit (PtrLitVal   t _) -> PtrType t
 
-lamExprTy :: LamBinder n l -> Type l -> Type n
+lamExprTy :: LamBinder r n l -> Type r l -> Type r n
 lamExprTy (LamBinder b ty arr eff) bodyTy =
   Pi $ PiType (PiBinder b ty arr) eff bodyTy
 
-numNaryPiArgs :: NaryPiType n -> Int
+numNaryPiArgs :: NaryPiType r n -> Int
 numNaryPiArgs (NaryPiType (NonEmptyNest _ bs) _ _) = 1 + nestLength bs
 
-naryLamExprType :: EnvReader m => NaryLamExpr n -> m n (NaryPiType n)
+naryLamExprType :: EnvReader m => NaryLamExpr r n -> m n (NaryPiType r n)
 naryLamExprType (NaryLamExpr (NonEmptyNest b bs) eff body) = liftTypeQueryM idSubst do
   substBinders b \b' -> do
     substBinders bs \bs' -> do
@@ -196,10 +197,10 @@ naryLamExprType (NaryLamExpr (NonEmptyNest b bs) eff body) = liftTypeQueryM idSu
       bodyTy <- getTypeE body
       return $ NaryPiType (NonEmptyNest b'' bs'') eff' bodyTy
   where
-    binderToPiBinder :: Binder n l -> PiBinder n l
+    binderToPiBinder :: Binder r n l -> PiBinder r n l
     binderToPiBinder (nameBinder:>ty) = PiBinder nameBinder ty PlainArrow
 
-specializedFunType :: EnvReader m => SpecializationSpec n -> m n (NaryPiType n)
+specializedFunType :: EnvReader m => SpecializationSpec n -> m n (NaryPiType r n)
 specializedFunType (AppSpecialization f ab) = liftEnvReaderM $
   refreshAbs ab \extraArgBs (ListE staticArgs) -> do
     let extraArgBs' = fmapNest plainPiBinder extraArgBs
@@ -207,13 +208,13 @@ specializedFunType (AppSpecialization f ab) = liftEnvReaderM $
       TopFunBound fTy _ -> do
         NaryPiType dynArgBs effs resultTy <- instantiateNaryPi fTy staticArgs
         let allBs = fromJust $ nestToNonEmpty $ extraArgBs' >>> nonEmptyToNest dynArgBs
-        return $ NaryPiType allBs effs resultTy
+        return $ unsafeCoerceIRE $ NaryPiType allBs effs resultTy
       _ -> error "should only be specializing top-level functions"
 
-userEffect :: EffectName n -> Atom n
+userEffect :: EffectName n -> Atom r n
 userEffect v = Eff (OneEffect (UserEffect v))
 
-projectionIndices :: (Fallible1 m, EnvReader m) => Type n -> m n [[Projection]]
+projectionIndices :: (Fallible1 m, EnvReader m) => Type r n -> m n [[Projection]]
 projectionIndices ty = case ty of
   TypeCon _ defName _ -> do
     DataDef _ _ cons <- lookupDataDef defName
@@ -227,16 +228,16 @@ projectionIndices ty = case ty of
   where unsupported = error $ "Projecting a type that doesn't support projecting: " ++ pprint ty
 
 sourceNameType :: (EnvReader m, Fallible1 m)
-               => SourceName -> m n (Type n)
+               => SourceName -> m n (Type r n)
 sourceNameType v = do
   lookupSourceMap v >>= \case
     Nothing -> throw UnboundVarErr $ pprint v
     Just uvar -> case uvar of
       UAtomVar    v' -> getType $ Var v'
-      UTyConVar   v' -> lookupEnv v' >>= \case TyConBinding _     e -> getType e
-      UDataConVar v' -> lookupEnv v' >>= \case DataConBinding _ _ e -> getType e
-      UClassVar   v' -> lookupEnv v' >>= \case ClassBinding  def -> return $ getClassTy def
-      UMethodVar  v' -> lookupEnv v' >>= \case MethodBinding _ _ e  -> getType e
+      UTyConVar   v' -> lookupEnv v' >>= \case TyConBinding _     e -> unsafeCoerceIRE <$> getType e
+      UDataConVar v' -> lookupEnv v' >>= \case DataConBinding _ _ e -> unsafeCoerceIRE <$> getType e
+      UClassVar   v' -> lookupEnv v' >>= \case ClassBinding  def    -> return $ unsafeCoerceIRE $ getClassTy def
+      UMethodVar  v' -> lookupEnv v' >>= \case MethodBinding _ _ e  -> unsafeCoerceIRE <$> getType e
       UEffectVar  v' -> getType $ userEffect v'
       UEffectOpVar _ -> error "not implemented: sourceNameType::UEffectOpVar"  -- TODO(alex): implement
       UHandlerVar  _ -> error "not implemented: sourceNameType::UHandlerVar"   -- TODO(alex): implement
@@ -261,17 +262,17 @@ typeUnOp = const id  -- All unary ops preserve the type of the input
 -- === computing effects ===
 
 computeAbsEffects :: (EnvExtender m, SubstE Name e)
-  => Abs (Nest Decl) e n -> m n (Abs (Nest Decl) (EffectRow `PairE` e) n)
+  => Abs (Nest (Decl r)) e n -> m n (Abs (Nest (Decl r)) (EffectRow `PairE` e) n)
 computeAbsEffects it = refreshAbs it \decls result -> do
   effs <- declNestEffects decls
   return $ Abs decls (effs `PairE` result)
 {-# INLINE computeAbsEffects #-}
 
-declNestEffects :: (EnvReader m) => Nest Decl n l -> m l (EffectRow l)
+declNestEffects :: (EnvReader m) => Nest (Decl r) n l -> m l (EffectRow l)
 declNestEffects decls = liftEnvReaderM $ declNestEffectsRec decls mempty
 {-# INLINE declNestEffects #-}
 
-declNestEffectsRec :: Nest Decl n l -> EffectRow l -> EnvReaderM l (EffectRow l)
+declNestEffectsRec :: Nest (Decl r) n l -> EffectRow l -> EnvReaderM l (EffectRow l)
 declNestEffectsRec Empty !acc = return acc
 declNestEffectsRec n@(Nest decl rest) !acc = withExtEvidence n do
   expr <- sinkM $ declExpr decl
@@ -279,46 +280,47 @@ declNestEffectsRec n@(Nest decl rest) !acc = withExtEvidence n do
   acc' <- sinkM $ acc <> deff
   declNestEffectsRec rest acc'
   where
-    declExpr :: Decl n l -> Expr n
+    declExpr :: Decl r n l -> Expr r n
     declExpr (Let _ (DeclBinding _ _ expr)) = expr
 
 -- === implementation of querying types ===
 
-newtype TypeQueryM (i::S) (o::S) (a :: *) = TypeQueryM {
-  runTypeQueryM :: SubstReaderT AtomSubstVal EnvReaderM i o a }
+newtype TypeQueryM (r::IR) (i::S) (o::S) (a :: *) = TypeQueryM {
+  runTypeQueryM :: SubstReaderT (AtomSubstVal r) EnvReaderM i o a }
   deriving ( Functor, Applicative, Monad
            , EnvReader, EnvExtender, ScopeReader
-           , SubstReader AtomSubstVal)
+           , SubstReader (AtomSubstVal r))
 
-liftTypeQueryM :: (EnvReader m) => Subst AtomSubstVal i o
-               -> TypeQueryM i o a -> m o a
+liftTypeQueryM :: (EnvReader m) => Subst (AtomSubstVal r) i o
+               -> TypeQueryM r i o a -> m o a
 liftTypeQueryM subst act =
   liftEnvReaderM $
     runSubstReaderT subst $
       runTypeQueryM act
 {-# INLINE liftTypeQueryM #-}
 
-instance MonadFail (TypeQueryM i o) where
+instance MonadFail (TypeQueryM r i o) where
   fail = error
   {-# INLINE fail #-}
 
-instance Fallible (TypeQueryM i o) where
+instance Fallible (TypeQueryM r i o) where
   throwErrs err = error $ pprint err
   {-# INLINE throwErrs #-}
   addErrCtx = const id
   {-# INLINE addErrCtx #-}
 
-class HasType (e::E) where
-  getTypeE :: e i -> TypeQueryM i o (Type o)
+class HasType (r::IR) (e::E) | e -> r where
+  getTypeE :: e i -> TypeQueryM r i o (Type r o)
 
-instance HasType AtomName where
+instance HasType r (AtomName r) where
   getTypeE name = do
     substM (Var name) >>= \case
-      Var name' -> atomBindingType <$> lookupEnv name'
+      Var name' -> atomBindingType <$> lookupAtomName name'
       atom -> getType atom
   {-# INLINE getTypeE #-}
 
-instance HasType Atom where
+instance HasType r (Atom r) where
+  getTypeE :: forall i o. Atom r i -> TypeQueryM r i o (Type r o)
   getTypeE atom = case atom of
     Var name -> getTypeE name
     Lam lamExpr -> getTypeE lamExpr
@@ -356,7 +358,7 @@ instance HasType Atom where
         ProdTy xs -> return $ xs !! iProj
         DepPairTy t | iProj == 0 -> return $ depPairLeftTy t
         DepPairTy t | iProj == 1 -> do
-          v' <- substM (Var v) >>= \case
+          v' <- substM (Var v :: Atom r i) >>= \case
             (Var v') -> return v'
             _ -> error "!?"
           instantiateDepPairTy t (ProjectElt (ProjectProduct 0 NE.:| is) v')
@@ -371,7 +373,7 @@ instance HasType Atom where
 
 -- === newtype conversion ===
 
-isNewtype :: Type n -> Bool
+isNewtype :: Type r n -> Bool
 isNewtype ty = case ty of
   TC Nat        -> True
   TC (Fin _)    -> True
@@ -380,7 +382,7 @@ isNewtype ty = case ty of
   VariantTy _   -> True
   _ -> False
 
-projectNewtype :: Type o -> TypeQueryM i o (Type o)
+projectNewtype :: Type r o -> TypeQueryM r i o (Type r o)
 projectNewtype ty = case ty of
   TC Nat     -> return IdxRepTy
   TC (Fin _) -> return NatTy
@@ -391,12 +393,12 @@ projectNewtype ty = case ty of
   RecordTy _ -> throw CompilerErr "Can't project partially-known records"
   _ -> error $ "not a newtype: " ++ pprint ty
 
-getTypeRef :: HasType e => e i -> TypeQueryM i o (Type o)
+getTypeRef :: HasType r e => e i -> TypeQueryM r i o (Type r o)
 getTypeRef x = do
   TC (RefType _ a) <- getTypeE x
   return a
 
-instance HasType LamExpr where
+instance HasType r (LamExpr r) where
   getTypeE (LamExpr (LamBinder b ty arr effs) body) = do
     ty' <- substM ty
     let binding = toBinding $ LamBinding arr ty'
@@ -406,7 +408,7 @@ instance HasType LamExpr where
         bodyTy <- getTypeE body
         return $ lamExprTy (LamBinder b' ty' arr effs') bodyTy
 
-instance HasType TabLamExpr where
+instance HasType r (TabLamExpr r) where
   getTypeE (TabLamExpr (b:>ann) body) = do
     ann' <- substM ann
     withFreshBinder (getNameHint b) (toBinding ann') \b' ->
@@ -414,7 +416,7 @@ instance HasType TabLamExpr where
         bodyTy <- getTypeE body
         return $ TabTy (b':>ann') bodyTy
 
-getTypePrimCon :: PrimCon (Atom i) -> TypeQueryM i o (Type o)
+getTypePrimCon :: PrimCon (Atom r i) -> TypeQueryM r i o (Type r o)
 getTypePrimCon con = case con of
   Lit l -> return $ BaseTy $ litType l
   ProdCon xs -> ProdTy <$> mapM getTypeE xs
@@ -437,14 +439,15 @@ getTypePrimCon con = case con of
   ExplicitDict dictTy _ -> substM dictTy
   DictHole _ ty -> substM ty
 
-dictExprType :: DictExpr i -> TypeQueryM i o (Type o)
+dictExprType :: DictExpr r i -> TypeQueryM r i o (Type r o)
 dictExprType e = case e of
   InstanceDict instanceName args -> do
     instanceName' <- substM instanceName
     InstanceDef className bs params _ <- lookupInstanceDef instanceName'
     ClassDef sourceName _ _ _ _ <- lookupClassDef className
     args' <- mapM substM args
-    ListE params' <- applyNaryAbs (Abs bs (ListE params)) (map SubstVal args')
+    let bs' = fmapNest (\(RolePiBinder b _ _ _) -> b) bs
+    ListE params' <- applyNaryAbs (Abs bs' (ListE (map unsafeCoerceIRE params))) (map SubstVal args')
     return $ DictTy $ DictType sourceName className params'
   InstantiatedGiven given args -> do
     givenTy <- getTypeE given
@@ -452,14 +455,14 @@ dictExprType e = case e of
   SuperclassProj d i -> do
     DictTy (DictType _ className params) <- getTypeE d
     ClassDef _ _ bs superclasses _ <- lookupClassDef className
-    applySubst (bs @@> map SubstVal params) $ superclassTypes superclasses !! i
+    applySubst (bs @@> map SubstVal params) $ unsafeCoerceIRE (superclassTypes superclasses !! i)
   IxFin n -> do
     n' <- substM n
     liftM DictTy $ ixDictType $ TC $ Fin n'
   ExplicitMethods v params -> do
     params' <- mapM substM params
     SpecializedDictBinding (SpecializedDict (Abs bs dict) _) <- lookupEnv =<< substM v
-    dropSubst $ extendSubst (bs @@> map SubstVal params') $ getTypeE dict
+    dropSubst $ extendSubst (bs @@> map SubstVal params') $ getTypeE (unsafeCoerceIRE dict)
 
 getIxClassName :: (Fallible1 m, EnvReader m) => m n (ClassName n)
 getIxClassName = lookupSourceMap "Ix" >>= \case
@@ -467,12 +470,12 @@ getIxClassName = lookupSourceMap "Ix" >>= \case
   Just (UClassVar v) -> return v
   Just _ -> error "not a class var"
 
-ixDictType :: (Fallible1 m, EnvReader m) => Type n -> m n (DictType n)
+ixDictType :: (Fallible1 m, EnvReader m) => Type r n -> m n (DictType r n)
 ixDictType ty = do
   ixClassName <- getIxClassName
   return $ DictType "Ix" ixClassName [ty]
 
-typeApp  :: Type o -> [Atom i] -> TypeQueryM i o (Type o)
+typeApp  :: Type r o -> [Atom r i] -> TypeQueryM r i o (Type r o)
 typeApp fTy [] = return fTy
 typeApp fTy xs = case fromNaryPiType (length xs) fTy of
   Just (NaryPiType bs _ resultTy) -> do
@@ -483,10 +486,10 @@ typeApp fTy xs = case fromNaryPiType (length xs) fTy of
     "Not a " ++ show (length xs) ++ "-argument pi type: " ++ pprint fTy
       ++ " (tried to apply it to: " ++ pprint xs ++ ")"
 
-typeTabApp :: Type o -> NE.NonEmpty (Atom i) -> TypeQueryM i o (Type o)
+typeTabApp :: Type r o -> NE.NonEmpty (Atom r i) -> TypeQueryM r i o (Type r o)
 typeTabApp tabTy xs = go tabTy $ toList xs
   where
-    go :: Type o -> [Atom i] -> TypeQueryM i o (Type o)
+    go :: Type r o -> [Atom r i] -> TypeQueryM r i o (Type r o)
     go ty [] = return ty
     go ty (i:rest) = do
       TabTy (b:>_) resultTy <- return ty
@@ -494,10 +497,10 @@ typeTabApp tabTy xs = go tabTy $ toList xs
       resultTy' <- applySubst (b@>SubstVal i') resultTy
       go resultTy' rest
 
-instance HasType DictExpr where
+instance HasType r (DictExpr r) where
   getTypeE e = dictExprType e
 
-instance HasType Expr where
+instance HasType r (Expr r) where
   getTypeE expr = case expr of
     App f xs -> do
       fTy <- getTypeE f
@@ -516,12 +519,12 @@ instance HasType Expr where
     -- TODO(alex): implement
     Handle _ _ _  -> error "not implemented"
 
-instantiateHandlerType :: EnvReader m => HandlerName n -> Atom n -> [Atom n] -> m n (Type n)
+instantiateHandlerType :: EnvReader m => HandlerName n -> Atom r n -> [Atom r n] -> m n (Type r n)
 instantiateHandlerType hndName r args = do
   HandlerDef _ rb bs _effs retTy _ _ <- lookupHandlerDef hndName
-  applySubst (rb @> (SubstVal r) <.> bs @@> (map SubstVal args)) retTy
+  applySubst (rb @> (SubstVal r) <.> bs @@> (map SubstVal args)) (unsafeCoerceIRE retTy)
 
-getTypePrimOp :: PrimOp (Atom i) -> TypeQueryM i o (Type o)
+getTypePrimOp :: PrimOp (Atom r i) -> TypeQueryM r i o (Type r o)
 getTypePrimOp op = case op of
   TabCon ty _ -> substM ty
   BinOp binop x _ -> do
@@ -648,7 +651,7 @@ getTypePrimOp op = case op of
     Eff (OneEffect (UserEffect effName)) <- return eff
     EffectDef _ ops <- substM effName >>= lookupEffectDef
     let (_, EffectOpType _pol lamTy) = ops !! i
-    return lamTy
+    return $ unsafeCoerceIRE lamTy
   ProjMethod dict i -> do
     DictTy (DictType _ className params) <- getTypeE dict
     def@(ClassDef _ _ paramBs classBs methodTys) <- lookupClassDef className
@@ -656,7 +659,7 @@ getTypePrimOp op = case op of
     superclassDicts <- getSuperclassDicts def <$> substM dict
     let subst = (    paramBs @@> map SubstVal params
                  <.> classBs @@> map SubstVal superclassDicts)
-    applySubst subst methodTy
+    applySubst subst (unsafeCoerceIRE methodTy)
   ExplicitApply _ _ -> error "shouldn't appear after inference"
   MonoLiteral _ -> error "shouldn't appear after inference"
   AllocDest ty -> RawRefTy <$> substM ty
@@ -671,19 +674,19 @@ getTypePrimOp op = case op of
     ty -> error $ "Not a reference type: " ++ pprint ty
   Resume retTy _ -> substM retTy
 
-getSuperclassDicts :: ClassDef n -> Atom n -> [Atom n]
+getSuperclassDicts :: ClassDef n -> Atom r n -> [Atom r n]
 getSuperclassDicts (ClassDef _ _ _ (SuperclassBinders classBs _) _) dict =
   for [0 .. nestLength classBs - 1] \i -> DictCon $ SuperclassProj dict i
 
-getTypeBaseType :: HasType e => e i -> TypeQueryM i o BaseType
+getTypeBaseType :: HasType r e => e i -> TypeQueryM r i o BaseType
 getTypeBaseType e =
   getTypeE e >>= \case
     TC (BaseType b) -> return b
     ty -> throw TypeErr $ "Expected a base type. Got: " ++ pprint ty
 
-labeledRowDifference' :: ExtLabeledItems (Type o) (AtomName o)
-                      -> ExtLabeledItems (Type o) (AtomName o)
-                      -> TypeQueryM i o (ExtLabeledItems (Type o) (AtomName o))
+labeledRowDifference' :: ExtLabeledItems (Type r o) (AtomName r o)
+                      -> ExtLabeledItems (Type r o) (AtomName r o)
+                      -> TypeQueryM r i o (ExtLabeledItems (Type r o) (AtomName r o))
 labeledRowDifference' (Ext (LabeledItems items) rest)
                       (Ext (LabeledItems subitems) subrest) = do
   -- Extract remaining types from the left.
@@ -698,7 +701,7 @@ labeledRowDifference' (Ext (LabeledItems items) rest)
       ++ " is not known to be a subset of " ++ pprint rest
   return $ Ext (LabeledItems diffitems) diffrest
 
-getTypePrimHof :: PrimHof (Atom i) -> TypeQueryM i o (Type o)
+getTypePrimHof :: PrimHof (Atom r i) -> TypeQueryM r i o (Type r o)
 getTypePrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
   For _ dict f -> do
     Pi (PiType (PiBinder b _ _) _ eltTy) <- getTypeE f
@@ -734,7 +737,7 @@ getTypePrimHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
   Seq _ _ cinit _ -> getTypeE cinit
   RememberDest d _ -> getTypeE d
 
-getTypeRWSAction :: Atom i -> TypeQueryM i o (Type o, Type o)
+getTypeRWSAction :: Atom r i -> TypeQueryM r i o (Type r o, Type r o)
 getTypeRWSAction f = do
   BinaryFunTy regionBinder refBinder _ resultTy <- getTypeE f
   PiBinder _ (RefTy _ referentTy) _ <- return refBinder
@@ -742,19 +745,19 @@ getTypeRWSAction f = do
   let resultTy' = ignoreHoistFailure $ hoist (PairB regionBinder refBinder) resultTy
   return (resultTy', referentTy')
 
-instance HasType Block where
+instance HasType r (Block r) where
   getTypeE (Block NoBlockAnn Empty result) = getTypeE result
   getTypeE (Block (BlockAnn ty _) _ _) = substM ty
   getTypeE _ = error "impossible"
 
-getClassTy :: ClassDef n -> Type n
+getClassTy :: ClassDef n -> Type CoreIR n
 getClassTy (ClassDef _ _ bs _ _) = go bs
   where
-    go :: Nest RolePiBinder n l -> Type n
+    go :: Nest (RolePiBinder r) n l -> Type r n
     go Empty = TyKind
     go (Nest (RolePiBinder b ty arr _) rest) = Pi $ PiType (PiBinder b ty arr) Pure $ go rest
 
-ixTyFromDict :: EnvReader m => Atom n -> m n (IxType n)
+ixTyFromDict :: (EnvReader m) => Atom r n -> m n (IxType r n)
 ixTyFromDict dict = do
   getType dict >>= \case
     DictTy (DictType "Ix" _ [iTy]) -> return $ IxType iTy dict
@@ -762,18 +765,18 @@ ixTyFromDict dict = do
 
 -- === querying effects implementation ===
 
-class HasEffectsE (e::E) where
-  getEffectsImpl :: e i -> TypeQueryM i o (EffectRow o)
+class HasEffectsE (e::E) (r::IR) | e -> r where
+  getEffectsImpl :: e i -> TypeQueryM r i o (EffectRow o)
 
-instance HasEffectsE Expr where
+instance HasEffectsE (Expr r) r where
   getEffectsImpl = exprEffects
   {-# INLINE getEffectsImpl #-}
 
-instance HasEffectsE DeclBinding where
+instance HasEffectsE (DeclBinding r) r where
   getEffectsImpl (DeclBinding _ _ expr) = getEffectsImpl expr
   {-# INLINE getEffectsImpl #-}
 
-exprEffects :: Expr i -> TypeQueryM i o (EffectRow o)
+exprEffects :: Expr r i -> TypeQueryM r i o (EffectRow o)
 exprEffects expr = case expr of
   Atom _  -> return Pure
   App f xs -> do
@@ -823,30 +826,30 @@ exprEffects expr = case expr of
       return $ deleteEff ExceptionEffect effs
     Seq _ _ _ f   -> functionEffs f
     RememberDest _ f -> functionEffs f
-    where maybeInit :: Maybe (Atom i) -> (EffectRow o -> EffectRow o)
+    where maybeInit :: Maybe (Atom r i) -> (EffectRow o -> EffectRow o)
           maybeInit d = case d of Just _ -> (<>OneEffect InitEffect); Nothing -> id
   Case _ _ _ effs -> substM effs
   Handle v _ body -> do
     HandlerDef eff _ _ _ _ _ _ <- substM v >>= lookupHandlerDef
     deleteEff (UserEffect eff) <$> getEffectsImpl body
 
-instance HasEffectsE Block where
+instance HasEffectsE (Block r) r where
   getEffectsImpl (Block (BlockAnn _ effs) _ _) = substM effs
   getEffectsImpl (Block NoBlockAnn _ _) = return Pure
   {-# INLINE getEffectsImpl #-}
 
-instance HasEffectsE Alt where
+instance HasEffectsE (Alt r) r where
   getEffectsImpl (Abs bs body) =
     substBinders bs \bs' ->
       ignoreHoistFailure . hoist bs' <$> getEffectsImpl body
   {-# INLINE getEffectsImpl #-}
 
-functionEffs :: Atom i -> TypeQueryM i o (EffectRow o)
+functionEffs :: Atom r i -> TypeQueryM r i o (EffectRow o)
 functionEffs f = getTypeSubst f >>= \case
   Pi (PiType b effs _) -> return $ ignoreHoistFailure $ hoist b effs
   _ -> error "Expected a function type"
 
-rwsFunEffects :: RWS -> Atom i -> TypeQueryM i o (EffectRow o)
+rwsFunEffects :: RWS -> Atom r i -> TypeQueryM r i o (EffectRow o)
 rwsFunEffects rws f = getTypeSubst f >>= \case
    BinaryFunTy h ref effs _ -> do
      let effs' = ignoreHoistFailure $ hoist ref effs
@@ -869,10 +872,10 @@ deleteEff eff (EffectRow effs t) = EffectRow (S.delete eff effs) t
 -- because it doesn't have to reconstruct the singleton value (which
 -- may be type annotated and whose type may refer to names).
 
-isSingletonType :: Type n -> Bool
+isSingletonType :: Type r n -> Bool
 isSingletonType topTy = isJust $ checkIsSingleton topTy
   where
-    checkIsSingleton :: Type n -> Maybe ()
+    checkIsSingleton :: Type r n -> Maybe ()
     checkIsSingleton ty = case ty of
       Pi (PiType _ Pure body) -> checkIsSingleton body
       TabPi (TabPiType _ body) -> checkIsSingleton body
@@ -882,14 +885,14 @@ isSingletonType topTy = isJust $ checkIsSingleton topTy
         _ -> Nothing
       _ -> Nothing
 
-singletonTypeVal :: EnvReader m => Type n -> m n (Maybe (Atom n))
+singletonTypeVal :: EnvReader m => Type r n -> m n (Maybe (Atom r n))
 singletonTypeVal ty = liftEnvReaderT $
   runSubstReaderT idSubst $ singletonTypeValRec ty
 {-# INLINE singletonTypeVal #-}
 
 -- TODO: TypeCon with a single case?
-singletonTypeValRec :: Type i
-  -> SubstReaderT Name (EnvReaderT Maybe) i o (Atom o)
+singletonTypeValRec :: Type r i
+  -> SubstReaderT Name (EnvReaderT Maybe) i o (Atom r o)
 singletonTypeValRec ty = case ty of
   Pi (PiType b Pure body) ->
     substBinders b \(PiBinder b' ty' arr) -> do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -833,7 +833,7 @@ simplifyHof hint hof = case hof of
   Seq _ _ _ _ -> error "Shouldn't ever see a Seq in Simplify"
   RememberDest _ _ -> error "Shouldn't ever see a RememberDest in Simplify"
 
-simplifyBlock :: Emits o => SBlock i -> SimplifyM i o (SAtom o)
+simplifyBlock :: Emits o => CBlock i -> SimplifyM i o (SAtom o)
 simplifyBlock (Block _ decls result) = simplifyDecls decls $ simplifyAtom result
 
 exceptToMaybeBlock :: Emits o => CBlock i -> SimplifyM i o (SAtom o)
@@ -920,10 +920,10 @@ hasExceptions expr = do
 
 {-# SPECIALIZE
   buildNaryAbs
-    :: (SinkableE e, SubstE Name e, SubstE AtomSubstVal e, HoistableE e)
-    => EmptyAbs (Nest Binder) n
-    -> (forall l. DExt n l => [AtomName l] -> SimplifyM i l (e l))
-    -> SimplifyM i n (Abs (Nest Binder) e n) #-}
+    :: (SinkableE e, SubstE Name e, SubstE (AtomSubstVal SimpIR) e, HoistableE e)
+    => EmptyAbs (Nest (Binder SimpIR)) n
+    -> (forall l. DExt n l => [AtomName SimpIR l] -> SimplifyM i l (e l))
+    -> SimplifyM i n (Abs (Nest (Binder SimpIR)) e n) #-}
 
 -- Note [Confuse GHC]
 -- I can't explain this, but for some reason using this function in strategic

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -93,7 +93,7 @@ import Types.Core
 
 -- === Simplification monad ===
 
-class (ScopableBuilder2 m, SubstReader AtomSubstVal m) => Simplifier m
+class (ScopableBuilder2 SimpIR m, SubstReader (AtomSubstVal CoreIR) m) => Simplifier m
 
 data WillLinearize = WillLinearize | NoLinearize
 
@@ -104,10 +104,10 @@ data WillLinearize = WillLinearize | NoLinearize
 -- elimination form for function is application, we do some extra handling in simplifyApp.
 newtype SimplifyM (i::S) (o::S) (a:: *) = SimplifyM
   { runSimplifyM'
-    :: SubstReaderT AtomSubstVal (DoubleBuilderT TopEnvFrag (ReaderT WillLinearize HardFailM)) i o a }
+    :: SubstReaderT (AtomSubstVal CoreIR) (DoubleBuilderT SimpIR TopEnvFrag (ReaderT WillLinearize HardFailM)) i o a }
   deriving ( Functor, Applicative, Monad, ScopeReader, EnvExtender, Fallible
-           , EnvReader, SubstReader AtomSubstVal, MonadFail
-           , Builder, HoistingTopBuilder TopEnvFrag)
+           , EnvReader, SubstReader (AtomSubstVal CoreIR), MonadFail
+           , Builder SimpIR, HoistingTopBuilder TopEnvFrag)
 
 liftSimplifyM
   :: (SinkableE e, SubstE Name e, TopBuilder m, Mut n)
@@ -126,18 +126,18 @@ instance MonadReader WillLinearize (SimplifyM i o) where
   local f m = SimplifyM $ SubstReaderT $ ReaderT \s -> local f $ runSubstReaderT s $ runSimplifyM' m
 
 -- TODO: figure out why we can't derive this one (here and elsewhere)
-instance ScopableBuilder (SimplifyM i) where
+instance ScopableBuilder SimpIR (SimplifyM i) where
   buildScoped cont = SimplifyM $ SubstReaderT $ ReaderT \env ->
     buildScoped $ runSubstReaderT (sink env) (runSimplifyM' cont)
   {-# INLINE buildScoped #-}
 
 -- === Top-level API ===
 
-data SimplifiedBlock n = SimplifiedBlock (Block n) (ReconstructAtom n)
+data SimplifiedBlock n = SimplifiedBlock (SBlock n) (ReconstructAtom CoreIR n)
 
 -- TODO: extend this to work on functions instead of blocks (with blocks still
 -- accessible as nullary functions)
-simplifyTopBlock :: (TopBuilder m, Mut n) => Block n -> m n (SimplifiedBlock n)
+simplifyTopBlock :: (TopBuilder m, Mut n) => CBlock n -> m n (SimplifiedBlock n)
 simplifyTopBlock block = liftSimplifyM do
   (Abs UnitB block', Abs UnitB recon) <- simplifyAbs $ Abs UnitB block
   return $ SimplifiedBlock block' recon
@@ -145,13 +145,13 @@ simplifyTopBlock block = liftSimplifyM do
 
 simplifyTopFunction
   :: (TopBuilder m, Mut n)
-  => NaryLamExpr n -> m n (NaryLamExpr n)
+  => NaryLamExpr CoreIR n -> m n (NaryLamExpr SimpIR n)
 simplifyTopFunction f = do
   liftSimplifyM $ dropSubst $ simplifyNaryLam $ sink f
 {-# SCC simplifyTopFunction #-}
 
 instance GenericE SimplifiedBlock where
-  type RepE SimplifiedBlock = PairE Block ReconstructAtom
+  type RepE SimplifiedBlock = PairE SBlock (ReconstructAtom CoreIR)
   fromE (SimplifiedBlock block recon) = PairE block recon
   {-# INLINE fromE #-}
   toE   (PairE block recon) = SimplifiedBlock block recon
@@ -171,14 +171,16 @@ instance Pretty (SimplifiedBlock n) where
 
 -- === All the bits of IR  ===
 
-simplifyDecls :: Emits o => Nest Decl i i' -> SimplifyM i' o a -> SimplifyM i o a
+simplifyDecls :: Emits o => Nest CDecl i i' -> SimplifyM i' o a -> SimplifyM i o a
 simplifyDecls topDecls cont = do
   s  <- getSubst
   s' <- simpDeclsSubst s topDecls
   withSubst s' cont
 {-# INLINE simplifyDecls #-}
 
-simpDeclsSubst :: Emits o => Subst AtomSubstVal l o -> Nest Decl l i' -> SimplifyM i o (Subst AtomSubstVal i' o)
+simpDeclsSubst
+  :: Emits o => Subst (AtomSubstVal CoreIR) l o -> Nest CDecl l i'
+  -> SimplifyM i o (Subst (AtomSubstVal CoreIR) i' o)
 simpDeclsSubst !s = \case
   Empty -> return s
   Nest (Let b (DeclBinding ann _ expr)) rest -> do
@@ -189,7 +191,7 @@ simpDeclsSubst !s = \case
       _ -> simplifyExpr hint expr
     simpDeclsSubst (s <>> (b@>SubstVal x)) rest
 
-simplifyExpr :: Emits o => NameHint -> Expr i -> SimplifyM i o (Atom o)
+simplifyExpr :: Emits o => NameHint -> CExpr i -> SimplifyM i o (SAtom o)
 simplifyExpr hint expr = confuseGHC >>= \_ -> case expr of
   App f xs -> do
     xs' <- mapM simplifyAtom xs
@@ -230,12 +232,12 @@ simplifyExpr hint expr = confuseGHC >>= \_ -> case expr of
 
 caseComputingEffs
   :: forall m n. (MonadFail1 m, EnvReader m)
-  => Atom n -> [Alt n] -> Type n -> m n (Expr n)
+  => Atom SimpIR n -> [Alt SimpIR n] -> Type SimpIR n -> m n (SExpr n)
 caseComputingEffs scrut alts resultTy = do
   Case scrut alts resultTy <$> foldMapM getEffects alts
 {-# INLINE caseComputingEffs #-}
 
-defuncCase :: Emits o => Atom o -> [Alt i] -> Type o -> SimplifyM i o (Atom o)
+defuncCase :: Emits o => SAtom o -> [Alt CoreIR i] -> SType o -> SimplifyM i o (SAtom o)
 defuncCase scrut alts resultTy = do
   split <- splitDataComponents resultTy
   (alts', recons) <- unzip <$> mapM (simplifyAlt split) alts
@@ -253,14 +255,14 @@ defuncCase scrut alts resultTy = do
   Distinct <- getDistinct
   fromSplit split dataVal nonDataVal
   where
-    getAltNonDataTy :: EnvReader m => Alt n -> m n (Type n)
+    getAltNonDataTy :: EnvReader m => Alt SimpIR n -> m n (Type SimpIR n)
     getAltNonDataTy (Abs bs body) = liftSubstEnvReaderM do
       substBinders bs \bs' -> do
         ~(PairTy _ ty) <- getTypeSubst body
         -- Result types of simplified abs should be hoistable past binder
         return $ ignoreHoistFailure $ hoist bs' ty
 
-    injectAltResult :: EnvReader m => [Type n] -> Int -> Alt n -> m n (Alt n)
+    injectAltResult :: EnvReader m => [SType n] -> Int -> Alt SimpIR n -> m n (Alt SimpIR n)
     injectAltResult sumTys con (Abs b body) = liftBuilder do
       buildAlt (binderType b) \v -> do
         originalResult <- emitBlock =<< applySubst (b@>v) body
@@ -271,9 +273,9 @@ defuncCase scrut alts resultTy = do
     -- whose first component is data. The reconstruction returned only
     -- applies to the second component.
     simplifyAlt
-      :: (BindsEnv b, SubstB Name b, SubstB AtomSubstVal b)
-      => SplitDataNonData n -> Abs b Block i
-      -> SimplifyM i o (Abs b Block o, ReconstructAtom o)
+      :: (BindsEnv b, SubstB Name b, SubstB (AtomSubstVal CoreIR) b)
+      => SplitDataNonData n -> Abs b CBlock i
+      -> SimplifyM i o (Abs b SBlock o, ReconstructAtom CoreIR o)
     simplifyAlt split (Abs bs body) = fromPairE <$> do
       substBinders bs \bs' -> do
         ab <- buildScoped $ simplifyBlock body
@@ -292,13 +294,13 @@ defuncCase scrut alts resultTy = do
           return $ PairE (Abs bs' block) (LamRecon reconAbs)
 
 simplifyApp :: forall i o. Emits o
-  => NameHint -> Atom i -> NonEmpty (Atom o) -> SimplifyM i o (Atom o)
+  => NameHint -> CAtom i -> NonEmpty (SAtom o) -> SimplifyM i o (SAtom o)
 simplifyApp hint f xs =
   simplifyFuncAtom f >>= \case
     Left  lam  -> fast lam
     Right atom -> slow atom
   where
-    fast :: LamExpr i' -> SimplifyM i' o (Atom o)
+    fast :: LamExpr CoreIR i' -> SimplifyM i' o (SAtom o)
     fast lam = case fromNaryLam (NE.length xs) (Lam lam) of
       Just (bsCount, NaryLamExpr bs _ (Block _ decls atom)) -> do
           let (xsPref, xsRest) = NE.splitAt bsCount xs
@@ -308,7 +310,7 @@ simplifyApp hint f xs =
               Just rest' -> simplifyApp hint atom rest'
       Nothing -> error "should never happen"
 
-    slow :: Atom o -> SimplifyM i o (Atom o)
+    slow :: CAtom o -> SimplifyM i o (SAtom o)
     slow atom = case atom of
       Lam lam -> dropSubst $ fast lam
       ACase e alts ty -> do
@@ -336,7 +338,7 @@ simplifyApp hint f xs =
           _ -> naryAppHinted hint atom $ toList xs
       _ -> error $ "Unexpected function: " ++ pprint atom
 
-    simplifyFuncAtom :: Atom i -> SimplifyM i o (Either (LamExpr i) (Atom o))
+    simplifyFuncAtom :: CAtom i -> SimplifyM i o (Either (LamExpr CoreIR i) (SAtom o))
     simplifyFuncAtom func = case func of
       Lam lam -> return $ Left lam
       _ -> Right <$> simplifyAtomAndInline func
@@ -344,7 +346,7 @@ simplifyApp hint f xs =
 -- | Like `simplifyAtom`, but will try to inline function definitions found
 -- in the environment. The only exception is when we're going to differentiate
 -- and the function has a custom derivative rule defined.
-simplifyAtomAndInline :: Atom i -> SimplifyM i o (Atom o)
+simplifyAtomAndInline :: CAtom i -> SimplifyM i o (SAtom o)
 simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
   Var v -> do
     env <- getSubst
@@ -356,7 +358,7 @@ simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
     Var v -> inlineVar v
     ans -> return ans
   where
-    inlineVar :: AtomName o -> SimplifyM i o (Atom o)
+    inlineVar :: SAtomName o -> SimplifyM i o (SAtom o)
     inlineVar v = do
       -- We simplify all applications, except those that have custom linearizations
       -- and are inside a linearization operation.
@@ -373,7 +375,7 @@ simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
             _ -> return $ Var v
 
 determineSpecializationSpec
-  :: EnvReader m => AtomName n -> [Atom n] -> m n (SpecializationSpec n, [Atom n])
+  :: EnvReader m => SAtomName n -> [SAtom n] -> m n (SpecializationSpec n, [SAtom n])
 determineSpecializationSpec fname staticArgs = do
   lookupAtomName fname >>= \case
     TopFunBound (NaryPiType bs _ _) _ -> do
@@ -383,13 +385,13 @@ determineSpecializationSpec fname staticArgs = do
       return (AppSpecialization fname ab, extraArgs)
     _ -> error "should only be specializing top functions"
 
-getSpecializedFunction :: EnvReader m => SpecializationSpec n -> m n (Abs TopEnvFrag AtomName n)
+getSpecializedFunction :: EnvReader m => SpecializationSpec n -> m n (Abs TopEnvFrag SAtomName n)
 getSpecializedFunction s = do
   querySpecializationCache s >>= \case
     Just name -> return $ Abs emptyOutFrag name
     _ -> liftTopBuilderHoisted $ emitSpecialization (sink s)
 
-emitIxDictSpecialization :: DictExpr n -> SimplifyM i n (DictExpr n)
+emitIxDictSpecialization :: DictExpr SimpIR n -> SimplifyM i n (DictExpr SimpIR n)
 emitIxDictSpecialization d@(ExplicitMethods _ _) = return d
 emitIxDictSpecialization d@(IxFin _)             = return d -- `Ix (Fin n))` is built-in
 emitIxDictSpecialization ixDict = do
@@ -409,13 +411,13 @@ emitIxDictSpecialization ixDict = do
 
 -- TODO: de-dup this and simplifyApp?
 simplifyTabApp :: forall i o. Emits o
-  => NameHint -> Atom i -> NonEmpty (Atom o) -> SimplifyM i o (Atom o)
+  => NameHint -> CAtom i -> NonEmpty (SAtom o) -> SimplifyM i o (SAtom o)
 simplifyTabApp hint f xs =
   simplifyFuncAtom f >>= \case
     Left  lam  -> fast lam
     Right atom -> slow atom
   where
-    fast :: TabLamExpr i' -> SimplifyM i' o (Atom o)
+    fast :: TabLamExpr SimpIR i' -> SimplifyM i' o (Atom SimpIR o)
     fast lam = case fromNaryTabLam (NE.length xs) (TabLam lam) of
       Just (bsCount, NaryLamExpr bs _ (Block _ decls atom)) -> do
           let (xsPref, xsRest) = NE.splitAt bsCount xs
@@ -425,7 +427,7 @@ simplifyTabApp hint f xs =
               Just rest' -> simplifyTabApp hint atom rest'
       Nothing -> error "should never happen"
 
-    slow :: Atom o -> SimplifyM i o (Atom o)
+    slow :: SAtom o -> SimplifyM i o (SAtom o)
     slow atom = case atom of
       TabLam   lam       -> dropSubst $ fast lam
       ACase e alts ty -> do
@@ -440,12 +442,12 @@ simplifyTabApp hint f xs =
         dropSubst $ simplifyExpr hint $ caseExpr
       _ -> naryTabAppHinted hint atom $ toList xs
 
-    simplifyFuncAtom :: Atom i -> SimplifyM i o (Either (TabLamExpr i) (Atom o))
+    simplifyFuncAtom :: CAtom i -> SimplifyM i o (Either (TabLamExpr SimpIR i) (SAtom o))
     simplifyFuncAtom func = case func of
       TabLam lam -> return $ Left lam
       _ -> Right <$> simplifyAtom func
 
-simplifyAtom :: Atom i -> SimplifyM i o (Atom o)
+simplifyAtom :: CAtom i -> SimplifyM i o (SAtom o)
 simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   Var v -> simplifyVar v
   -- Tables that only contain data aren't necessarily getting inlined,
@@ -517,7 +519,7 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> simplifyVar v
 
-simplifyVar :: AtomName i -> SimplifyM i o (Atom o)
+simplifyVar :: CAtomName i -> SimplifyM i o (CAtom o)
 simplifyVar v = do
   env <- getSubst
   case env ! v of
@@ -531,37 +533,37 @@ simplifyVar v = do
         _ -> return $ Var v'
 
 -- Assumes first order, monormophic
-simplifyNaryLam :: NaryLamExpr i -> SimplifyM i o (NaryLamExpr o)
+simplifyNaryLam :: NaryLamExpr CoreIR i -> SimplifyM i o (NaryLamExpr SimpIR o)
 simplifyNaryLam (NaryLamExpr bs effs body) = do
   (Abs (PairB bs' (LiftB effs')) block, IdentityReconAbs) <-
      simplifyAbs $ Abs (PairB bs (LiftB effs)) body
   return $ NaryLamExpr bs' effs' block
 
-simplifyLam :: Atom i -> SimplifyM i o (Atom o, Abs LamBinder ReconstructAtom o)
+simplifyLam :: CAtom i -> SimplifyM i o (SAtom o, Abs (LamBinder CoreIR) (ReconstructAtom CoreIR) o)
 simplifyLam atom = case atom of
   Lam (LamExpr b body) -> doSimpLam b body
   _ -> simplifyAtom atom >>= \case
     Lam (LamExpr b body) -> dropSubst $ doSimpLam b body
     _ -> error "Not a lambda expression"
   where
-    doSimpLam :: LamBinder i i' -> Block i'
-      -> SimplifyM i o (Atom o, Abs LamBinder ReconstructAtom o)
+    doSimpLam :: LamBinder CoreIR i i' -> CBlock i'
+      -> SimplifyM i o (SAtom o, Abs (LamBinder SimpIR) (ReconstructAtom SimpIR) o)
     doSimpLam b body = do
       (Abs b' body', recon) <- simplifyAbs $ Abs b body
       return $! (Lam $ LamExpr b' body', recon)
 
-type BinaryLamBinder = (PairB LamBinder LamBinder)
+type BinaryLamBinder = (PairB (LamBinder SimpIR) (LamBinder SimpIR))
 
-simplifyBinaryLam :: Emits o => Atom i
-  -> SimplifyM i o (Atom o, Abs BinaryLamBinder ReconstructAtom o)
+simplifyBinaryLam :: Emits o => CAtom i
+  -> SimplifyM i o (SAtom o, Abs BinaryLamBinder (ReconstructAtom CoreIR) o)
 simplifyBinaryLam atom = case atom of
   Lam (LamExpr b1 (Block _ body1 (Lam (LamExpr b2 body2)))) -> doSimpBinaryLam b1 body1 b2 body2
   _ -> simplifyAtom atom >>= \case
     Lam (LamExpr b1 (Block _ body1 (Lam (LamExpr b2 body2)))) -> dropSubst $ doSimpBinaryLam b1 body1 b2 body2
     _ -> error "Not a binary lambda expression"
   where
-    doSimpBinaryLam :: LamBinder i i' -> Nest Decl i' i'' -> LamBinder i'' i''' -> Block i'''
-      -> SimplifyM i o (Atom o, Abs BinaryLamBinder ReconstructAtom o)
+    doSimpBinaryLam :: LamBinder CoreIR i i' -> Nest CDecl i' i'' -> LamBinder CoreIR i'' i''' -> CBlock i'''
+      -> SimplifyM i o (CAtom o, Abs BinaryLamBinder (ReconstructAtom CoreIR) o)
     doSimpBinaryLam b1 body1 b2 body2 =
       substBinders b1 \b1' -> do
         Abs decls (effs `PairE` (lam2 `PairE` lam2Ty `PairE` (Abs b2' recon'))) <-
@@ -579,13 +581,13 @@ simplifyBinaryLam atom = case atom of
           HoistFailure _ -> error "Binary lambda simplification failed: binder/recon depends on intermediate decls"
 
 data SplitDataNonData n = SplitDataNonData
-  { dataTy    :: Type n
-  , nonDataTy :: Type n
-  , toSplit   :: forall m l . (Fallible1 m, EnvReader m) => Atom l -> m l (Atom l, Atom l)
-  , fromSplit :: forall m l . (Fallible1 m, EnvReader m) => Atom l -> Atom l -> m l (Atom l) }
+  { dataTy    :: SType n
+  , nonDataTy :: CType n
+  , toSplit   :: forall m l . (Fallible1 m, EnvReader m) => SAtom l -> m l (SAtom l, CAtom l)
+  , fromSplit :: forall m l . (Fallible1 m, EnvReader m) => SAtom l -> CAtom l -> m l (SAtom l) }
 
 -- bijection between that type and a (data, non-data) pair type.
-splitDataComponents :: EnvReader m => Type n -> m n (SplitDataNonData n)
+splitDataComponents :: EnvReader m => CType n -> m n (SplitDataNonData n)
 splitDataComponents = \case
   ProdTy tys -> do
     splits <- mapM splitDataComponents tys
@@ -612,11 +614,11 @@ splitDataComponents = \case
       , nonDataTy = ty
       , toSplit = \x -> return (UnitVal, x)
       , fromSplit = \_ x -> return x }
-{-# SPECIALIZE splitDataComponents :: Type o -> SimplifyM i o (SplitDataNonData o) #-}
+{-# SPECIALIZE splitDataComponents :: CType o -> SimplifyM i o (SplitDataNonData o) #-}
 
 simplifyAbs
-  :: (BindsEnv b, SubstB Name b, SubstB AtomSubstVal b)
-  => Abs b Block i -> SimplifyM i o (Abs b Block o, Abs b ReconstructAtom o)
+  :: (BindsEnv b, SubstB Name b, SubstB (AtomSubstVal CoreIR) b)
+  => Abs b CBlock i -> SimplifyM i o (Abs b SBlock o, Abs b (ReconstructAtom CoreIR) o)
 simplifyAbs (Abs bs body@(Block ann _ _)) = fromPairE <$> do
   substBinders bs \bs' -> do
     Abs decls (PairE result ansTy) <- buildScoped $ simplifyBlock body >>= withType
@@ -636,7 +638,7 @@ simplifyAbs (Abs bs body@(Block ann _ _)) = fromPairE <$> do
         return $ PairE (Abs bs' block) (Abs bs' (LamRecon reconAbs))
 
 -- TODO: come up with a coherent strategy for ordering these various reductions
-simplifyOp :: Emits o => Op o -> SimplifyM i o (Atom o)
+simplifyOp :: Emits o => Op CoreIR o -> SimplifyM i o (SAtom o)
 simplifyOp op = case op of
   RecordCons left right -> getType left >>= \case
     StaticRecordTy leftTys -> getType right >>= \case
@@ -737,10 +739,10 @@ simplifyOp op = case op of
     Left  a   -> return a
     Right op' -> emitOp op'
 
-pattern IdentityReconAbs :: Abs binder ReconstructAtom n
+pattern IdentityReconAbs :: Abs binder (ReconstructAtom SimpIR) n
 pattern IdentityReconAbs <- Abs _ IdentityRecon
 
-projectDictMethod :: Emits o => Atom o -> Int -> SimplifyM i o (Atom o)
+projectDictMethod :: Emits o => SAtom o -> Int -> SimplifyM i o (SAtom o)
 projectDictMethod d i = do
   cheapNormalize d >>= \case
     DictCon (InstanceDict instanceName args) -> dropSubst do
@@ -765,7 +767,7 @@ projectDictMethod d i = do
     DictCon (IxFin n) -> projectIxFinMethod (toEnum i) n
     d' -> error $ "Not a simplified dict: " ++ pprint d'
 
-simplifyHof :: Emits o => NameHint -> Hof i -> SimplifyM i o (Atom o)
+simplifyHof :: Emits o => NameHint -> Hof CoreIR i -> SimplifyM i o (SAtom o)
 simplifyHof hint hof = case hof of
   For d ixDict lam -> do
     ixTy@(IxType _ ixDict') <- ixTyFromDict =<< simplifyAtom ixDict
@@ -831,17 +833,17 @@ simplifyHof hint hof = case hof of
   Seq _ _ _ _ -> error "Shouldn't ever see a Seq in Simplify"
   RememberDest _ _ -> error "Shouldn't ever see a RememberDest in Simplify"
 
-simplifyBlock :: Emits o => Block i -> SimplifyM i o (Atom o)
+simplifyBlock :: Emits o => SBlock i -> SimplifyM i o (SAtom o)
 simplifyBlock (Block _ decls result) = simplifyDecls decls $ simplifyAtom result
 
-exceptToMaybeBlock :: Emits o => Block i -> SimplifyM i o (Atom o)
+exceptToMaybeBlock :: Emits o => CBlock i -> SimplifyM i o (SAtom o)
 exceptToMaybeBlock (Block (BlockAnn ty _) decls result) = do
   ty' <- substM ty
   exceptToMaybeDecls ty' decls $ Atom result
 exceptToMaybeBlock (Block NoBlockAnn Empty result) = exceptToMaybeExpr $ Atom result
 exceptToMaybeBlock _ = error "impossible"
 
-exceptToMaybeDecls :: Emits o => Type o -> Nest Decl i i' -> Expr i' -> SimplifyM i o (Atom o)
+exceptToMaybeDecls :: Emits o => CType o -> Nest CDecl i i' -> CExpr i' -> SimplifyM i o (SAtom o)
 exceptToMaybeDecls _ Empty result = exceptToMaybeExpr result
 exceptToMaybeDecls resultTy (Nest (Let b (DeclBinding _ _ rhs)) decls) finalResult = do
   maybeResult <- exceptToMaybeExpr rhs
@@ -854,7 +856,7 @@ exceptToMaybeDecls resultTy (Nest (Let b (DeclBinding _ _ rhs)) decls) finalResu
           (\v -> extendSubst (b@> SubstVal v) $
                    exceptToMaybeDecls (sink resultTy) decls finalResult)
 
-exceptToMaybeExpr :: Emits o => Expr i -> SimplifyM i o (Atom o)
+exceptToMaybeExpr :: Emits o => CExpr i -> SimplifyM i o (SAtom o)
 exceptToMaybeExpr expr = case expr of
   Case e alts resultTy _ -> do
     e' <- substM e
@@ -907,7 +909,7 @@ exceptToMaybeExpr expr = case expr of
         ty <- getType v
         return $ JustAtom ty (Var v)
 
-hasExceptions :: (EnvReader m, MonadFail1 m) => Expr n -> m n Bool
+hasExceptions :: (EnvReader m, MonadFail1 m) => SExpr n -> m n Bool
 hasExceptions expr = do
   (EffectRow effs t) <- getEffects expr
   case t of

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -125,7 +125,12 @@ module Syntax (
     pattern BoolTy, pattern FalseAtom, pattern TrueAtom,
     pattern SISourceName, pattern SIInternalName,
     pattern OneEffect,
-    (-->), (?-->), (--@), (==>)) where
+    (-->), (?-->), (--@), (==>),
+    IR (..), SimpIR,
+    CAtom, CType, CExpr, CBlock, CDecl, CDecls, CAtomSubstVal, CAtomName,
+    SAtom, SType, SExpr, SBlock, SDecl, SDecls, SAtomSubstVal, SAtomName,
+    unsafeCoerceIRE, unsafeCoerceIRB
+    ) where
 
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
 import Foreign.Ptr

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -307,9 +307,9 @@ evalSourceBlock' mname block = case sbContents block of
       Just _ -> throw TypeErr
         $ "Custom linearization can only be defined for functions"
     where
-      getLinearizationType :: Type n -> RNest PiBinder n l
-                           -> [Type l] -> Type l
-                           -> EnvReaderT FallibleM l (Int, Type n)
+      getLinearizationType :: CType n -> RNest (PiBinder CoreIR) n l
+                           -> [CType l] -> CType l
+                           -> EnvReaderT FallibleM l (Int, CType n)
       getLinearizationType fullTy implicitArgs revArgTys = \case
         Pi (PiType pbinder@(PiBinder binder a arr) eff b') -> do
           unless (eff == Pure) $ throw TypeErr $
@@ -375,7 +375,7 @@ evalSourceBlock' mname block = case sbContents block of
             <$> foldM (flip (-->)) (PairTy resultTy tanFunTy) revArgTys
         where
           but = ", but " ++ pprint fname ++ " has type " ++ pprint fullTy
-          prependImplicit :: RNest PiBinder n l -> Type l -> Type n
+          prependImplicit :: RNest (PiBinder CoreIR) n l -> CType l -> CType n
           prependImplicit is ty = case is of
             REmpty -> ty
             RNest is' i -> prependImplicit is' $ Pi $ PiType i Pure ty
@@ -570,13 +570,13 @@ isLogInfo out = case out of
   TotalTime _  -> True
   _ -> False
 
-evalUType :: (Topper m, Mut n) => UType VoidS -> m n (Type n)
+evalUType :: (Topper m, Mut n) => UType VoidS -> m n (CType n)
 evalUType ty = do
   logTop $ PassInfo Parse $ pprint ty
   renamed <- logPass RenamePass $ renameSourceNamesUExpr ty
   checkPass TypePass $ checkTopUType renamed
 
-evalUExpr :: (Topper m, Mut n) => UExpr VoidS -> m n (Atom n)
+evalUExpr :: (Topper m, Mut n) => UExpr VoidS -> m n (CAtom n)
 evalUExpr expr = do
   logTop $ PassInfo Parse $ pprint expr
   renamed <- logPass RenamePass $ renameSourceNamesUExpr expr
@@ -589,7 +589,7 @@ whenOpt x act = getConfig <&> optLevel >>= \case
   NoOptimize -> return x
   Optimize   -> act x
 
-evalBlock :: (Topper m, Mut n) => Block n -> m n (Atom n)
+evalBlock :: (Topper m, Mut n) => CBlock n -> m n (CAtom n)
 evalBlock typed = do
   eopt <- checkPass EarlyOptPass $ earlyOptimize typed
   synthed <- checkPass SynthPass $ synthTopBlock eopt
@@ -606,7 +606,7 @@ evalBlock typed = do
   applyRecon recon result
 {-# SCC evalBlock #-}
 
-evalSpecializations :: (Topper m, Mut n) => [AtomName n] -> [SpecDictName n] -> m n ()
+evalSpecializations :: (Topper m, Mut n) => [CAtomName n] -> [SpecDictName n] -> m n ()
 evalSpecializations vs sdVs = do
   forM_ vs \v -> do
     lookupAtomName v >>= \case
@@ -628,7 +628,7 @@ evalSpecializations vs sdVs = do
       simplifyTopFunction lamExpr
     finishSpecializedDict d methods
 
-ixMethodType :: IxMethod -> AbsDict n -> EnvReaderM n (NaryPiType n)
+ixMethodType :: IxMethod -> AbsDict CoreIR n -> EnvReaderM n (NaryPiType CoreIR n)
 ixMethodType method absDict = do
   refreshAbs absDict \extraArgBs dict -> do
     let extraArgBs' = fmapNest plainPiBinder extraArgBs
@@ -675,7 +675,7 @@ execUDecl mname decl = do
     UDeclResultDone sourceMap' -> emitSourceMap sourceMap'
 {-# SCC execUDecl #-}
 
-compileTopLevelFun :: (Topper m, Mut n) => AtomName n -> m n ()
+compileTopLevelFun :: (Topper m, Mut n) => CAtomName n -> m n ()
 compileTopLevelFun fname = do
   fPreSimp <- specializedFunPreSimpDefinition fname
   fSimp <- simplifyTopFunction fPreSimp
@@ -720,7 +720,7 @@ linkFunObjCode objCode dyvarStores (LinktimeVals funVals ptrVals) = do
 
 -- Get the definition of a specialized function in the pre-simplification IR.
 specializedFunPreSimpDefinition
-  :: (MonadFail1 m, EnvReader m) => AtomName n -> m n (NaryLamExpr n)
+  :: (MonadFail1 m, EnvReader m) => CAtomName n -> m n (NaryLamExpr SimpIR n)
 specializedFunPreSimpDefinition fname = do
   TopFunBound ty (SpecializedTopFun s) <- lookupAtomName fname
   case s of
@@ -734,7 +734,7 @@ specializedFunPreSimpDefinition fname = do
 -- This is needed to avoid an infinite loop. Otherwise, in simplifyTopFunction,
 -- where we eta-expand and try to simplify `App f args`, we would see `f` as a
 -- "noinline" function and defer its simplification.
-forceDeferredInlining :: EnvReader m => AtomName n -> m n (Atom n)
+forceDeferredInlining :: EnvReader m => CAtomName n -> m n (CAtom n)
 forceDeferredInlining v =
   lookupAtomName v >>= \case
     TopFunBound _ (AwaitingSpecializationArgsTopFun _ f) -> return f
@@ -754,7 +754,7 @@ getLLVMOptLevel cfg = case optLevel cfg of
   NoOptimize -> OptALittle
   Optimize   -> OptAggressively
 
-evalLLVM :: (Topper m, Mut n) => DestBlock n -> m n (Atom n)
+evalLLVM :: forall n m. (Topper m, Mut n) => DestBlock n -> m n (CAtom n)
 evalLLVM block = do
   backend <- backendName <$> getConfig
   logger  <- getFilteredLogger
@@ -775,7 +775,7 @@ evalLLVM block = do
   resultVals <-
     liftIO $ callNativeFun nativeFun benchRequired logger [] resultTypes
   resultValsNoPtrs <- mapM litValToPointerlessAtom resultVals
-  applyNaryAbs reconAtom $ map SubstVal resultValsNoPtrs
+  applyNaryAbs reconAtom $ (map SubstVal resultValsNoPtrs :: [CAtomSubstVal AtomNameC n])
 {-# SCC evalLLVM #-}
 
 compileToObjCode
@@ -796,7 +796,7 @@ impNameToObj v = do
     Nothing -> throw CompilerErr
       $ "Expected to find an object cache entry for: " ++ pprint v
 
-evalBackend :: (Topper m, Mut n) => DestBlock n -> m n (Atom n)
+evalBackend :: (Topper m, Mut n) => DestBlock n -> m n (CAtom n)
 evalBackend block = do
   backend <- backendName <$> getConfig
   let eval = case backend of

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -720,7 +720,7 @@ linkFunObjCode objCode dyvarStores (LinktimeVals funVals ptrVals) = do
 
 -- Get the definition of a specialized function in the pre-simplification IR.
 specializedFunPreSimpDefinition
-  :: (MonadFail1 m, EnvReader m) => CAtomName n -> m n (NaryLamExpr SimpIR n)
+  :: (MonadFail1 m, EnvReader m) => CAtomName n -> m n (NaryLamExpr CoreIR n)
 specializedFunPreSimpDefinition fname = do
   TopFunBound ty (SpecializedTopFun s) <- lookupAtomName fname
   case s of

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -31,6 +31,7 @@ import Data.List.NonEmpty (NonEmpty (..))
 import qualified Data.List.NonEmpty    as NE
 import qualified Data.Map.Strict       as M
 import qualified Data.Set              as S
+import qualified Unsafe.Coerce as TrulyUnsafe
 
 import GHC.Stack
 import GHC.Generics (Generic (..))
@@ -46,55 +47,88 @@ import Types.Primitives
 import Types.Source
 import Types.Imp
 
+-- === IR variants ===
+
+data IR = CoreIR
+type SimpIR = CoreIR  -- TODO: actually distinguish these two
+
+type CAtom  = Atom CoreIR
+type CType  = Type CoreIR
+type CExpr  = Expr CoreIR
+type CBlock = Block CoreIR
+type CDecl  = Decl  CoreIR
+type CDecls = Decls CoreIR
+type CAtomSubstVal = AtomSubstVal CoreIR
+type CAtomName  = AtomName CoreIR
+
+type SAtom  = Atom SimpIR
+type SType  = Type SimpIR
+type SExpr  = Expr SimpIR
+type SBlock = Block SimpIR
+type SDecl  = Decl  SimpIR
+type SDecls = Decls SimpIR
+type SAtomSubstVal = AtomSubstVal SimpIR
+type SAtomName  = AtomName SimpIR
+
+-- XXX: the intention is that we won't have to use these much
+unsafeCoerceIRE :: forall (r'::IR) (r::IR) (e::IR->E) (n::S). e r n -> e r' n
+unsafeCoerceIRE = TrulyUnsafe.unsafeCoerce
+
+unsafeCoerceIRB :: forall (r'::IR) (r::IR) (b::IR->B) (n::S) (l::S) . b r n l -> b r' n l
+unsafeCoerceIRB = TrulyUnsafe.unsafeCoerce
+
 -- === core IR ===
 
-data Atom (n::S) =
-   Var (AtomName n)
- | Lam (LamExpr n)
- | Pi  (PiType  n)
- | TabLam (TabLamExpr n)
- | TabPi  (TabPiType n)
- | DepPairTy (DepPairType n)
- | DepPair   (Atom n) (Atom n) (DepPairType n)
- | TypeCon SourceName (DataDefName n) (DataDefParams n)
- | DictCon (DictExpr n)
- | DictTy  (DictType n)
- | LabeledRow (FieldRowElems n)
- | RecordTy  (FieldRowElems n)
- | VariantTy (ExtLabeledItems (Type n) (AtomName n))
- | Con (Con n)
- | TC  (TC  n)
+data Atom (r::IR) (n::S) =
+   Var (AtomName r n)
+ | Lam (LamExpr r n)
+ | Pi  (PiType  r n)
+ | TabLam (TabLamExpr r n)
+ | TabPi  (TabPiType r n)
+ | DepPairTy (DepPairType r n)
+ | DepPair   (Atom r n) (Atom r n) (DepPairType r n)
+ | TypeCon SourceName (DataDefName n) (DataDefParams r n)
+ | DictCon (DictExpr r n)
+ | DictTy  (DictType r n)
+ | LabeledRow (FieldRowElems r n)
+ | RecordTy  (FieldRowElems r n)
+ | VariantTy (ExtLabeledItems (Type r n) (AtomName r n))
+ | Con (Con r n)
+ | TC  (TC  r n)
  | Eff (EffectRow n)
    -- only used within Simplify
- | ACase (Atom n) [AltP Atom n] (Type n)
+ | ACase (Atom r n) [AltP r (Atom r) n] (Type r n)
  -- lhs ref, rhs ref abstracted over the eventual value of lhs ref, type
- | DepPairRef (Atom n) (Abs Binder Atom n) (DepPairType n)
- | BoxedRef (Abs (NonDepNest BoxPtr) Atom n)
+ | DepPairRef (Atom r n) (Abs (Binder r) (Atom r) n) (DepPairType r n)
+ | BoxedRef (Abs (NonDepNest r (BoxPtr r)) (Atom r) n)
  -- access a nested member of a binder
  -- XXX: Variable name must not be an alias for another name or for
  -- a statically-known atom. This is because the variable name used
  -- here may also appear in the type of the atom. (We maintain this
  -- invariant during substitution and in Builder.hs.)
- | ProjectElt (NE.NonEmpty Projection) (AtomName n)
+ | ProjectElt (NE.NonEmpty Projection) (AtomName r n)
    deriving (Show, Generic)
 
-data Expr n =
-   App (Atom n) (NonEmpty (Atom n))
- | TabApp (Atom n) (NonEmpty (Atom n)) -- TODO: put this in PrimOp?
- | Case (Atom n) [Alt n] (Type n) (EffectRow n)
- | Atom (Atom n)
- | Op  (Op  n)
- | Hof (Hof n)
- | Handle (HandlerName n) [Atom n] (Block n)
+data Expr r n =
+   App (Atom r n) (NonEmpty (Atom r n))
+ | TabApp (Atom r n) (NonEmpty (Atom r n)) -- TODO: put this in PrimOp?
+ | Case (Atom r n) [Alt r n] (Type r n) (EffectRow n)
+ | Atom (Atom r n)
+ | Op  (Op  r n)
+ | Hof (Hof r n)
+ | Handle (HandlerName n) [Atom r n] (Block r n)
    deriving (Show, Generic)
 
-data DeclBinding n = DeclBinding LetAnn (Type n) (Expr n)
+data DeclBinding r n = DeclBinding LetAnn (Type r n) (Expr r n)
      deriving (Show, Generic)
-data Decl n l = Let (NameBinder AtomNameC n l) (DeclBinding n)
+data Decl (r::IR) (n::S) (l::S) = Let (AtomNameBinder n l) (DeclBinding r n)
      deriving (Show, Generic)
-type Decls = Nest Decl
+type Decls r = Nest (Decl r)
 
-type AtomName     = Name AtomNameC
+-- TODO: make this a newtype with an unsafe constructor
+type AtomName (r::IR) = Name AtomNameC
+type AtomNameBinder   = NameBinder AtomNameC
+
 type ClassName    = Name ClassNameC
 type DataDefName  = Name DataDefNameC
 type EffectName   = Name EffectNameC
@@ -107,43 +141,41 @@ type PtrName      = Name PtrNameC
 type SpecDictName = Name SpecializedDictNameC
 type FunObjCodeName = Name FunObjCodeNameC
 
-type AtomNameBinder = NameBinder AtomNameC
-
 type Effect    = EffectP    Name
 type EffectRow = EffectRowP Name
-type BaseMonoid n = BaseMonoidP (Atom n)
+type BaseMonoid r n = BaseMonoidP (Atom r n)
 
 type AtomBinderP = BinderP AtomNameC
-type Binder = AtomBinderP Type
-type AltP (e::E) = Abs Binder e :: E
-type Alt = AltP Block           :: E
+type Binder r = AtomBinderP (Type r) :: B
+type AltP (r::IR) (e::E) = Abs (Binder r) e :: E
+type Alt r = AltP r (Block r) :: E
 
 -- The additional invariant enforced by this newtype is that the list should
 -- never contain empty StaticFields members, nor StaticFields in two consecutive
 -- positions.
-newtype FieldRowElems (n::S) = UnsafeFieldRowElems { fromFieldRowElems :: [FieldRowElem n] }
-                               deriving (Show, Generic)
+newtype FieldRowElems (r::IR) (n::S) = UnsafeFieldRowElems { fromFieldRowElems :: [FieldRowElem r n] }
+                                       deriving (Show, Generic)
 
-data FieldRowElem (n::S)
-  = StaticFields (LabeledItems (Type n))
-  | DynField     (AtomName n) (Type n)
-  | DynFields    (AtomName n)
+data FieldRowElem (r::IR) (n::S)
+  = StaticFields (LabeledItems (Type r n))
+  | DynField     (AtomName r n) (Type r n)
+  | DynFields    (AtomName r n)
   deriving (Show, Generic)
 
 data DataDef n where
   -- The `SourceName` is just for pretty-printing. The actual alpha-renamable
   -- binder name is in UExpr and Env
-  DataDef :: SourceName -> Nest RolePiBinder n l -> [DataConDef l] -> DataDef n
+  DataDef :: SourceName -> Nest (RolePiBinder CoreIR) n l -> [DataConDef l] -> DataDef n
 
 data DataConDef n =
   -- Name for pretty printing, constructor elements, representation type,
   -- list of projection indices that recovers elements from the representation.
-  DataConDef SourceName (Type n) [[Projection]]
+  DataConDef SourceName (CType n) [[Projection]]
   deriving (Show, Generic)
 
 data ParamRole = TypeParam | DictParam | DataParam deriving (Show, Generic, Eq)
 
-newtype DataDefParams n = DataDefParams [(Arrow, Atom n)]
+newtype DataDefParams r n = DataDefParams [(Arrow, Atom r n)]
   deriving (Show, Generic)
 
 -- The Type is the type of the result expression (and thus the type of the
@@ -153,66 +185,66 @@ newtype DataDefParams n = DataDefParams [(Arrow, Atom n)]
 -- If the decls are empty we can skip the type annotation, because then we can
 -- cheaply query the result, and, more importantly, there's no risk of having a
 -- type that mentions local variables.
-data Block n where
-  Block :: BlockAnn n l -> Nest Decl n l -> Atom l -> Block n
+data Block (r::IR) (n::S) where
+  Block :: BlockAnn r n l -> Nest (Decl r) n l -> Atom r l -> Block r n
 
-data BlockAnn n l where
-  BlockAnn :: Type n -> EffectRow n -> BlockAnn n l
-  NoBlockAnn :: BlockAnn n n
+data BlockAnn r n l where
+  BlockAnn :: Type r n -> EffectRow n -> BlockAnn r n l
+  NoBlockAnn :: BlockAnn r n n
 
-data LamBinding (n::S) = LamBinding Arrow (Type n)
+data LamBinding (r::IR) (n::S) = LamBinding Arrow (Type r n)
   deriving (Show, Generic)
 
-data LamBinder (n::S) (l::S) =
-  LamBinder (NameBinder AtomNameC n l) (Type n) Arrow (EffectRow l)
+data LamBinder (r::IR) (n::S) (l::S) =
+  LamBinder (AtomNameBinder n l) (Type r n) Arrow (EffectRow l)
   deriving (Show, Generic)
 
-data LamExpr (n::S) where
-  LamExpr :: LamBinder n l -> Block l -> LamExpr n
+data LamExpr (r::IR) (n::S) where
+  LamExpr :: LamBinder r n l -> Block r l -> LamExpr r n
 
 type IxDict = Atom
 
 data IxMethod = Size | Ordinal | UnsafeFromOrdinal
      deriving (Show, Generic, Enum, Bounded, Eq)
 
-data IxType (n::S) =
-  IxType { ixTypeType :: Type n
-         , ixTypeDict :: IxDict n }
+data IxType (r::IR) (n::S) =
+  IxType { ixTypeType :: Type r n
+         , ixTypeDict :: IxDict r n }
   deriving (Show, Generic)
 
-type IxBinder = BinderP AtomNameC IxType
+type IxBinder r = BinderP AtomNameC (IxType r)
 
-data TabLamExpr (n::S) where
-  TabLamExpr :: IxBinder n l -> Block l -> TabLamExpr n
+data TabLamExpr (r::IR) (n::S) where
+  TabLamExpr :: IxBinder r n l -> Block r l -> TabLamExpr r n
 
-data TabPiType (n::S) where
-  TabPiType :: IxBinder n l -> Type l -> TabPiType n
+data TabPiType (r::IR) (n::S) where
+  TabPiType :: IxBinder r n l -> Type r l -> TabPiType r n
 
 -- TODO: sometimes I wish we'd written these this way instead:
 --   data NaryLamExpr (n::S) where
 --     UnaryLamExpr :: LamExpr n -> NaryLamExpr n
 --     NaryLamExpr :: Binder n l -> NaryLamExpr l -> NaryLamExpr n
 -- maybe we should at least make a pattern so we can use it either way.
-data NaryLamExpr (n::S) where
-  NaryLamExpr :: NonEmptyNest Binder n l -> EffectRow l -> Block l
-              -> NaryLamExpr n
+data NaryLamExpr (r::IR) (n::S) where
+  NaryLamExpr :: NonEmptyNest (Binder r) n l -> EffectRow l -> Block r l
+              -> NaryLamExpr r n
 
-data NaryPiType (n::S) where
-  NaryPiType :: NonEmptyNest PiBinder n l -> EffectRow l -> Type l
-             -> NaryPiType n
+data NaryPiType (r::IR) (n::S) where
+  NaryPiType :: NonEmptyNest (PiBinder r) n l -> EffectRow l -> Type r l
+             -> NaryPiType r n
 
-data PiBinding (n::S) = PiBinding Arrow (Type n)
+data PiBinding (r::IR) (n::S) = PiBinding Arrow (Type r n)
   deriving (Show, Generic)
 
-data PiBinder (n::S) (l::S) =
-  PiBinder (NameBinder AtomNameC n l) (Type n) Arrow
+data PiBinder (r::IR) (n::S) (l::S) =
+  PiBinder (AtomNameBinder n l) (Type r n) Arrow
   deriving (Show, Generic)
 
-data PiType  (n::S) where
-  PiType :: PiBinder n l -> EffectRow l -> Type l -> PiType n
+data PiType (r::IR) (n::S) where
+  PiType :: PiBinder r n l -> EffectRow l -> Type r l -> PiType r n
 
-data DepPairType (n::S) where
-  DepPairType :: Binder n l -> Type  l -> DepPairType n
+data DepPairType (r::IR) (n::S) where
+  DepPairType :: Binder r n l -> Type r l -> DepPairType r n
 
 data Projection
   = UnwrapCompoundNewtype  -- Unwrap TypeCon, record or variant
@@ -225,12 +257,12 @@ type Type = Atom
 type Kind = Type
 type Dict = Atom
 
-type TC  n = PrimTC  (Atom n)
-type Con n = PrimCon (Atom n)
-type Op  n = PrimOp  (Atom n)
-type Hof n = PrimHof (Atom n)
+type TC  r n = PrimTC  (Atom r n)
+type Con r n = PrimCon (Atom r n)
+type Op  r n = PrimOp  (Atom r n)
+type Hof r n = PrimHof (Atom r n)
 
-type AtomSubstVal = SubstVal AtomNameC Atom :: V
+type AtomSubstVal r = SubstVal AtomNameC (Atom r) :: V
 
 data EffectBinder n l where
   EffectBinder :: EffectRow n -> EffectBinder n n
@@ -240,79 +272,80 @@ instance GenericB EffectBinder where
   fromB (EffectBinder effs) = LiftB effs
   toB   (LiftB effs) = EffectBinder effs
 
-data BoxPtr n = BoxPtr (Atom n) (Block n)  -- ptrptr, size
-                deriving (Show, Generic)
+data BoxPtr (r::IR) (n::S) = BoxPtr (Atom r n) (Block r n)  -- ptrptr, size
+                             deriving (Show, Generic)
 
 -- A nest where the annotation of a binder cannot depend on the binders
 -- introduced before it. You can think of it as introducing a bunch of
 -- names into the scope in parallel, but since safer names only reasons
 -- about sequential scope extensions, we encode it differently.
-data NonDepNest ann n l = NonDepNest (Nest AtomNameBinder n l) [ann n]
-                          deriving (Generic)
+data NonDepNest r ann n l = NonDepNest (Nest AtomNameBinder n l) [ann n]
+                            deriving (Generic)
 
 -- === type classes ===
 
 data SuperclassBinders n l =
   SuperclassBinders
     { superclassBinders :: Nest AtomNameBinder n l
-    , superclassTypes   :: [Type n] }
+    , superclassTypes   :: [CType n] }
   deriving (Show, Generic)
 
 data ClassDef (n::S) where
   ClassDef
     :: SourceName
-    -> [SourceName]              -- method source names
-    -> Nest RolePiBinder n1 n2   -- parameters
-    ->   SuperclassBinders n2 n3 -- superclasses
-    ->   [MethodType n3]         -- method types
+    -> [SourceName]                       -- method source names
+    -> Nest (RolePiBinder CoreIR) n1 n2   -- parameters
+    ->   SuperclassBinders n2 n3          -- superclasses
+    ->   [MethodType n3]                  -- method types
     -> ClassDef n1
 
-data RolePiBinder n l = RolePiBinder (AtomNameBinder n l) (Type n) Arrow ParamRole
+data RolePiBinder r n l = RolePiBinder (AtomNameBinder n l) (Type r n) Arrow ParamRole
      deriving (Show, Generic)
 
 data InstanceDef (n::S) where
   InstanceDef
     :: ClassName n1
-    -> Nest RolePiBinder n1 n2 -- parameters (types and dictionaries)
-    ->   [Type n2]             -- class parameters
+    -> Nest (RolePiBinder CoreIR) n1 n2 -- parameters (types and dictionaries)
+    ->   [CType n2]                     -- class parameters
     ->   InstanceBody n2
     -> InstanceDef n1
 
 data InstanceBody (n::S) =
   InstanceBody
-    [Atom n]   -- superclasses dicts
-    [Block n]  -- method definitions
+    [Atom  CoreIR n]   -- superclasses dicts
+    [Block CoreIR n]  -- method definitions
   deriving (Show, Generic)
 
 data MethodType (n::S) =
   MethodType
-    [Bool]    -- indicates explicit args
-    (Type n)  -- actual method type
+    [Bool]     -- indicates explicit args
+    (CType n)  -- actual method type
  deriving (Show, Generic)
 
-data DictType (n::S) = DictType SourceName (ClassName n) [Type n]
+data DictType (r::IR) (n::S) = DictType SourceName (ClassName n) [Type r n]
      deriving (Show, Generic)
 
-data DictExpr (n::S) =
-   InstanceDict (InstanceName n) [Atom n]
+data DictExpr (r::IR) (n::S) =
+   InstanceDict (InstanceName n) [Atom r n]
    -- We use NonEmpty because givens without args can be represented using `Var`.
- | InstantiatedGiven (Atom n) (NonEmpty (Atom n))
- | SuperclassProj (Atom n) Int  -- (could instantiate here too, but we don't need it for now)
+ | InstantiatedGiven (Atom r n) (NonEmpty (Atom r n))
+ | SuperclassProj (Atom r n) Int  -- (could instantiate here too, but we don't need it for now)
    -- Special case for `Ix (Fin n)`  (TODO: a more general mechanism for built-in classes and instances)
- | IxFin (Atom n)
+ | IxFin (Atom r n)
    -- Used for dicts defined by top-level functions, which may take extra data parameters
-   -- TODO: consider bundling `(DictType n, [AtomName n])` as a top-level
+   -- TODO: consider bundling `(DictType n, [AtomName r n])` as a top-level
    -- binding for some `Name DictNameC` to make the IR smaller.
    -- TODO: the function atoms should be names. We could enforce that syntactically but then
    -- we can't derive `SubstE AtomSubstVal`. Maybe we should have a separate name color for
    -- top function names.
- | ExplicitMethods (SpecDictName n) [Atom n] -- dict type, names of parameterized method functions, parameters
+ | ExplicitMethods (SpecDictName n) [Atom r n] -- dict type, names of parameterized method functions, parameters
    deriving (Show, Generic)
 
 -- TODO: Use an IntMap
-newtype CustomRules (n::S) = CustomRules { customRulesMap :: M.Map (AtomName n) (AtomRules n) }
-                             deriving (Semigroup, Monoid, Store)
-data AtomRules (n::S) = CustomLinearize Int SymbolicZeros (Atom n)  -- number of implicit args, linearization function
+newtype CustomRules (n::S) =
+  CustomRules { customRulesMap :: M.Map (AtomName CoreIR n) (AtomRules n) }
+  deriving (Semigroup, Monoid, Store)
+data AtomRules (n::S) = CustomLinearize Int SymbolicZeros (CAtom n)  -- number of implicit args, linearization function
                         deriving (Generic)
 
 -- === envs and modules ===
@@ -399,12 +432,12 @@ data PartialTopEnvFrag n = PartialTopEnvFrag
   , fragLoadedModules   :: LoadedModules n
   , fragLoadedObjects   :: LoadedObjects n
   , fragLocalModuleEnv  :: ModuleEnv n
-  , fragFinishSpecializedDict :: SnocList (SpecDictName n, [NaryLamExpr n]) }
+  , fragFinishSpecializedDict :: SnocList (SpecDictName n, [NaryLamExpr SimpIR n]) }
 
 -- TODO: we could add a lot more structure for querying by dict type, caching, etc.
 -- TODO: make these `Name n` instead of `Atom n` so they're usable as cache keys.
 data SynthCandidates n = SynthCandidates
-  { lambdaDicts       :: [AtomName n]
+  { lambdaDicts       :: [AtomName CoreIR n]
   , instanceDicts     :: M.Map (ClassName n) [InstanceName n] }
   deriving (Show, Generic)
 
@@ -415,9 +448,9 @@ emptyImportStatus = ImportStatus mempty mempty
 -- compiler flags etc. We can have a map from those to this.
 
 data Cache (n::S) = Cache
-  { specializationCache :: EMap SpecializationSpec AtomName n
-  , ixDictCache :: EMap AbsDict SpecDictName n
-  , impCache  :: EMap AtomName ImpFunName n
+  { specializationCache :: EMap SpecializationSpec (AtomName CoreIR) n
+  , ixDictCache :: EMap (AbsDict CoreIR) SpecDictName n
+  , impCache  :: EMap (AtomName CoreIR) ImpFunName n
   , objCache  :: EMap ImpFunName FunObjCodeName n
     -- This is memoizing `parseAndGetDeps :: Text -> [ModuleSourceName]`. But we
     -- only want to store one entry per module name as a simple cache eviction
@@ -462,13 +495,13 @@ dynamicVarLinkMap dyvars = dyvars <&> \(v, ptr) -> (dynamicVarCName v, ptr)
 
 -- TODO: consider making this an open union via a typeable-like class
 data Binding (c::C) (n::S) where
-  AtomNameBinding   :: AtomBinding n                  -> Binding AtomNameC       n
-  DataDefBinding    :: DataDef n                      -> Binding DataDefNameC    n
-  TyConBinding      :: DataDefName n        -> Atom n -> Binding TyConNameC      n
-  DataConBinding    :: DataDefName n -> Int -> Atom n -> Binding DataConNameC    n
-  ClassBinding      :: ClassDef n                     -> Binding ClassNameC      n
-  InstanceBinding   :: InstanceDef n                  -> Binding InstanceNameC   n
-  MethodBinding     :: ClassName n   -> Int -> Atom n -> Binding MethodNameC     n
+  AtomNameBinding   :: AtomBinding CoreIR n            -> Binding AtomNameC       n
+  DataDefBinding    :: DataDef n                       -> Binding DataDefNameC    n
+  TyConBinding      :: DataDefName n        -> CAtom n -> Binding TyConNameC      n
+  DataConBinding    :: DataDefName n -> Int -> CAtom n -> Binding DataConNameC    n
+  ClassBinding      :: ClassDef n                      -> Binding ClassNameC      n
+  InstanceBinding   :: InstanceDef n                   -> Binding InstanceNameC   n
+  MethodBinding     :: ClassName n   -> Int -> CAtom n -> Binding MethodNameC     n
   EffectBinding     :: EffectDef n                    -> Binding EffectNameC     n
   HandlerBinding    :: HandlerDef n                   -> Binding HandlerNameC    n
   EffectOpBinding   :: EffectOpDef n                  -> Binding EffectOpNameC   n
@@ -516,23 +549,24 @@ instance HoistableE  EffectDef
 instance AlphaEqE EffectDef
 instance AlphaHashableE EffectDef
 instance SubstE Name EffectDef
-instance SubstE AtomSubstVal EffectDef
+instance SubstE (AtomSubstVal CoreIR) EffectDef
 deriving instance Show (EffectDef n)
 deriving via WrapE EffectDef n instance Generic (EffectDef n)
 
 data HandlerDef (n::S) where
   HandlerDef :: EffectName n
-             -> PiBinder n r -- body type arg
-             -> Nest PiBinder r l
+             -> PiBinder CoreIR n r -- body type arg
+             -> Nest (PiBinder CoreIR) r l
                -> EffectRow l
-               -> Type l     -- return type
-               -> [Block l]  -- effect operations
-               -> Block l    -- return body
+               -> CType l          -- return type
+               -> [Block CoreIR l] -- effect operations
+               -> Block CoreIR l   -- return body
              -> HandlerDef n
 
 instance GenericE HandlerDef where
   type RepE HandlerDef =
-    EffectName `PairE` Abs (PiBinder `PairB` Nest PiBinder) (EffectRow `PairE` Type `PairE` ListE Block `PairE` Block)
+    EffectName `PairE` Abs (PiBinder CoreIR `PairB` Nest (PiBinder CoreIR))
+      (EffectRow `PairE` CType `PairE` ListE (Block CoreIR) `PairE` Block CoreIR)
   fromE (HandlerDef name bodyTyArg bs effs ty ops ret) =
     name `PairE` Abs (bodyTyArg `PairB` bs) (effs `PairE` ty `PairE` ListE ops `PairE` ret)
   toE (name `PairE` Abs (bodyTyArg `PairB` bs) (effs `PairE` ty `PairE` ListE ops `PairE` ret)) =
@@ -543,16 +577,16 @@ instance HoistableE  HandlerDef
 instance AlphaEqE HandlerDef
 instance AlphaHashableE HandlerDef
 instance SubstE Name HandlerDef
--- instance SubstE AtomSubstVal HandlerDef
+-- instance SubstE (AtomSubstVal r) HandlerDef
 deriving instance Show (HandlerDef n)
 deriving via WrapE HandlerDef n instance Generic (HandlerDef n)
 
 data EffectOpType (n::S) where
-  EffectOpType :: UResumePolicy -> Type n -> EffectOpType n
+  EffectOpType :: UResumePolicy -> CType n -> EffectOpType n
 
 instance GenericE EffectOpType where
   type RepE EffectOpType =
-    LiftE UResumePolicy `PairE` Type
+    LiftE UResumePolicy `PairE` CType
   fromE (EffectOpType pol ty) = LiftE pol `PairE` ty
   toE (LiftE pol `PairE` ty) = EffectOpType pol ty
 
@@ -561,24 +595,24 @@ instance HoistableE  EffectOpType
 instance AlphaEqE EffectOpType
 instance AlphaHashableE EffectOpType
 instance SubstE Name EffectOpType
-instance SubstE AtomSubstVal EffectOpType
+instance SubstE (AtomSubstVal CoreIR) EffectOpType
 deriving instance Show (EffectOpType n)
 deriving via WrapE EffectOpType n instance Generic (EffectOpType n)
 
-type AbsDict = Abs (Nest Binder) Dict
+type AbsDict r = Abs (Nest (Binder r)) (Dict r)
 
 data SpecializedDictDef n =
    SpecializedDict
      -- Dict, abstracted over "data" params.
-     (AbsDict n)
+     (AbsDict CoreIR n)
      -- Methods (thunked if nullary), if they're available.
      -- We create specialized dict names during simplification, but we don't
      -- actually simplify/lower them until we return to TopLevel
-     (Maybe [NaryLamExpr n])
+     (Maybe [NaryLamExpr SimpIR n])
    deriving (Show, Generic)
 
 instance GenericE SpecializedDictDef where
-  type RepE SpecializedDictDef = AbsDict `PairE` MaybeE (ListE NaryLamExpr)
+  type RepE SpecializedDictDef = AbsDict CoreIR `PairE` MaybeE (ListE (NaryLamExpr SimpIR))
   fromE (SpecializedDict ab methods) = ab `PairE` methods'
     where methods' = case methods of Just xs -> LeftE (ListE xs)
                                      Nothing -> RightE UnitE
@@ -594,28 +628,28 @@ instance AlphaEqE       SpecializedDictDef
 instance AlphaHashableE SpecializedDictDef
 instance SubstE Name    SpecializedDictDef
 
-data AtomBinding (n::S) =
-   LetBound    (DeclBinding   n)
- | LamBound    (LamBinding    n)
- | PiBound     (PiBinding     n)
- | IxBound     (IxType        n)
- | MiscBound   (Type          n)
- | SolverBound (SolverBinding n)
+data AtomBinding (r::IR) (n::S) =
+   LetBound    (DeclBinding r  n)
+ | LamBound    (LamBinding  r  n)
+ | PiBound     (PiBinding   r  n)
+ | IxBound     (IxType      r  n)
+ | MiscBound   (Type        r  n)
+ | SolverBound (SolverBinding r n)
  | PtrLitBound PtrType (PtrName n)
- | TopFunBound (NaryPiType n) (TopFunBinding n)
+ | TopFunBound (NaryPiType r n) (TopFunBinding n)
    deriving (Show, Generic)
 
 data TopFunBinding (n::S) =
    -- This is for functions marked `@noinline`, before we've seen their use
    -- sites and discovered what arguments we need to specialize on.
-   AwaitingSpecializationArgsTopFun Int (Atom n)
+   AwaitingSpecializationArgsTopFun Int (CAtom n)
    -- Specification of a specialized function. We still need to simplify, lower,
    -- and translate-to-Imp this function. When we do that we'll store the result
    -- in the `impCache`. Or, if we're dealing with ix method specializations, we
    -- won't go all the way to Imp and we'll store the result in
    -- `ixLoweredCache`.
  | SpecializedTopFun (SpecializationSpec n)
- | LoweredTopFun     (NaryLamExpr n)
+ | LoweredTopFun     (NaryLamExpr SimpIR n)
  | FFITopFun         (ImpFunName n)
    deriving (Show, Generic)
 
@@ -623,11 +657,11 @@ data TopFunBinding (n::S) =
 data SpecializationSpec (n::S) =
    -- The additional binders are for "data" components of the specialization types, like
    -- `n` in `Fin n`.
-   AppSpecialization (AtomName n) (Abs (Nest Binder) (ListE Type) n)
+   AppSpecialization (AtomName CoreIR n) (Abs (Nest (Binder CoreIR)) (ListE CType) n)
    deriving (Show, Generic)
 
-atomBindingType :: Binding AtomNameC n -> Type n
-atomBindingType (AtomNameBinding b) = case b of
+atomBindingType :: AtomBinding r n -> Type r n
+atomBindingType b = case b of
   LetBound    (DeclBinding _ ty _) -> ty
   LamBound    (LamBinding  _ ty)   -> ty
   PiBound     (PiBinding   _ ty)   -> ty
@@ -639,9 +673,9 @@ atomBindingType (AtomNameBinding b) = case b of
   TopFunBound ty _ -> naryPiTypeAsType ty
 
 -- TODO: Move this to Inference!
-data SolverBinding (n::S) =
-   InfVarBound (Type n) SrcPosCtx
- | SkolemBound (Type n)
+data SolverBinding (r::IR) (n::S) =
+   InfVarBound (Type r n) SrcPosCtx
+ | SkolemBound (Type r n)
    deriving (Show, Generic)
 
 data EnvFrag (n::S) (l::S) =
@@ -724,14 +758,14 @@ bindingsFragToSynthCandidates (EnvFrag (RecSubstFrag frag) _) =
         go rest
 
 -- WARNING: This is not exactly faithful, because NaryPiType erases intermediate arrows!
-naryPiTypeAsType :: NaryPiType n -> Type n
+naryPiTypeAsType :: NaryPiType r n -> Type r n
 naryPiTypeAsType (NaryPiType (NonEmptyNest b bs) effs resultTy) = case bs of
   Empty -> Pi $ PiType b effs resultTy
   Nest b' rest -> Pi $ PiType b Pure restTy
     where restTy = naryPiTypeAsType $ NaryPiType (NonEmptyNest b' rest) effs resultTy
 
 -- WARNING: This is not exactly faithful, because NaryLamExpr erases intermediate arrows!
-naryLamExprAsAtom :: NaryLamExpr n -> Atom n
+naryLamExprAsAtom :: NaryLamExpr r n -> Atom r n
 naryLamExprAsAtom (NaryLamExpr (NonEmptyNest (b:>ty) bs) effs body) = case bs of
   Empty -> Lam $ LamExpr (LamBinder b ty PlainArrow effs) body
   Nest b' rest -> Lam $ LamExpr (LamBinder b ty PlainArrow Pure) (AtomicBlock restBody)
@@ -742,35 +776,42 @@ naryLamExprAsAtom (NaryLamExpr (NonEmptyNest (b:>ty) bs) effs body) = case bs of
 -- We're really just defining this so we can have a polymorphic `binderType`.
 -- But maybe we don't need one. Or maybe we can make one using just
 -- `BindsOneName b AtomNameC` and `BindsEnv b`.
-class BindsOneName b AtomNameC => BindsOneAtomName (b::B) where
-  binderType :: b n l -> Type n
+class BindsOneName b AtomNameC => BindsOneAtomName (r::IR) (b::B) | b -> r where
+  binderType :: b n l -> Type r n
+  -- binderAtomName :: b n l -> AtomName r l
 
-bindersTypes :: (Distinct l, ProvesExt b, BindsNames b, BindsOneAtomName b)
-             => Nest b n l -> [Type l]
+bindersTypes :: (Distinct l, ProvesExt b, BindsNames b, BindsOneAtomName r b)
+             => Nest b n l -> [Type r l]
 bindersTypes Empty = []
 bindersTypes n@(Nest b bs) = ty : bindersTypes bs
   where ty = withExtEvidence n $ sink (binderType b)
 
-instance BindsOneAtomName (BinderP AtomNameC Type) where
+instance BindsOneAtomName r (BinderP AtomNameC (Type r)) where
   binderType (_ :> ty) = ty
 
-instance BindsOneAtomName LamBinder where
+instance BindsOneAtomName r (LamBinder r) where
   binderType (LamBinder _ ty _ _) = ty
 
-instance BindsOneAtomName PiBinder where
+instance BindsOneAtomName r (PiBinder r) where
   binderType (PiBinder _ ty _) = ty
 
-instance BindsOneAtomName IxBinder where
+instance BindsOneAtomName r (IxBinder r) where
   binderType (_ :> IxType ty _) = ty
 
-instance BindsOneAtomName RolePiBinder where
+instance BindsOneAtomName r (RolePiBinder r) where
   binderType (RolePiBinder _ ty _ _) = ty
 
-toBinderNest :: BindsOneAtomName b => Nest b n l -> Nest Binder n l
+toBinderNest :: BindsOneAtomName r b => Nest b n l -> Nest (Binder r) n l
 toBinderNest Empty = Empty
 toBinderNest (Nest b bs) = Nest (asNameBinder b :> binderType b) (toBinderNest bs)
 
 -- === ToBinding ===
+
+atomBindingToBinding :: AtomBinding r n -> Binding AtomNameC n
+atomBindingToBinding b = AtomNameBinding $ unsafeCoerceIRE b
+
+bindingToAtomBinding :: Binding AtomNameC n -> AtomBinding r n
+bindingToAtomBinding (AtomNameBinding b) = unsafeCoerceIRE b
 
 class (SubstE Name e, SinkableE e) => ToBinding (e::E) (c::C) | e -> c where
   toBinding :: e n -> Binding c n
@@ -778,30 +819,30 @@ class (SubstE Name e, SinkableE e) => ToBinding (e::E) (c::C) | e -> c where
 instance Color c => ToBinding (Binding c) c where
   toBinding = id
 
-instance ToBinding AtomBinding AtomNameC where
-  toBinding = AtomNameBinding
+instance ToBinding (AtomBinding r) AtomNameC where
+  toBinding = atomBindingToBinding
 
-instance ToBinding DeclBinding AtomNameC where
+instance ToBinding (DeclBinding r) AtomNameC where
   toBinding = toBinding . LetBound
 
-instance ToBinding LamBinding AtomNameC where
+instance ToBinding (LamBinding r) AtomNameC where
   toBinding = toBinding . LamBound
 
-instance ToBinding PiBinding AtomNameC where
+instance ToBinding (PiBinding r) AtomNameC where
   toBinding = toBinding . PiBound
 
-instance ToBinding Atom AtomNameC where
+instance ToBinding (Atom r) AtomNameC where
   toBinding = toBinding . MiscBound
 
-instance ToBinding SolverBinding AtomNameC where
-  toBinding = toBinding . SolverBound
+instance ToBinding (SolverBinding r) AtomNameC where
+  toBinding = toBinding . SolverBound @ r
 
-instance ToBinding IxType AtomNameC where
+instance ToBinding (IxType r) AtomNameC where
   toBinding = toBinding . IxBound
 
 -- We don't need this for now and it seems a little annoying to implement.
 -- If you ever hit this, add a Type n to BoxPtr and return it here.
-instance ToBinding BoxPtr AtomNameC where
+instance ToBinding (BoxPtr r) AtomNameC where
   toBinding = error "not implemented!"
 
 instance (ToBinding e1 c, ToBinding e2 c) => ToBinding (EitherE e1 e2) c where
@@ -810,30 +851,31 @@ instance (ToBinding e1 c, ToBinding e2 c) => ToBinding (EitherE e1 e2) c where
 
 -- === HasArgType ===
 
-class HasArgType (e::E) where
-  argType :: e n -> Type n
+class HasArgType (e::E) (r::IR) | e -> r where
+  argType :: e n -> Type r n
 
-instance HasArgType PiType where
+instance HasArgType (PiType r) r where
   argType (PiType (PiBinder _ ty _) _ _) = ty
 
-instance HasArgType TabPiType where
+instance HasArgType (TabPiType r) r where
   argType (TabPiType (_:>IxType ty _) _) = ty
 
-instance HasArgType LamExpr where
+instance HasArgType (LamExpr r) r where
   argType (LamExpr (LamBinder _ ty _ _) _) = ty
 
-instance HasArgType TabLamExpr where
+instance HasArgType (TabLamExpr r) r where
   argType (TabLamExpr (_:>IxType ty _) _) = ty
 
 -- === Pattern synonyms ===
+
 pattern IdxRepScalarBaseTy :: ScalarBaseType
 pattern IdxRepScalarBaseTy = Word32Type
 
 -- Type used to represent indices and sizes at run-time
-pattern IdxRepTy :: Type n
+pattern IdxRepTy :: Type r n
 pattern IdxRepTy = TC (BaseType (Scalar Word32Type))
 
-pattern IdxRepVal :: Word32 -> Atom n
+pattern IdxRepVal :: Word32 -> Atom r n
 pattern IdxRepVal x = Con (Lit (Word32Lit x))
 
 pattern IIdxRepVal :: Word32 -> IExpr n
@@ -843,113 +885,113 @@ pattern IIdxRepTy :: IType
 pattern IIdxRepTy = Scalar Word32Type
 
 -- Type used to represent sum type tags at run-time
-pattern TagRepTy :: Type n
+pattern TagRepTy :: Type r n
 pattern TagRepTy = TC (BaseType (Scalar Word8Type))
 
-pattern TagRepVal :: Word8 -> Atom n
+pattern TagRepVal :: Word8 -> Atom r n
 pattern TagRepVal x = Con (Lit (Word8Lit x))
 
-pattern Word8Ty :: Type n
+pattern Word8Ty :: Type r n
 pattern Word8Ty = TC (BaseType (Scalar Word8Type))
 
-pattern ProdTy :: [Type n] -> Type n
+pattern ProdTy :: [Type r n] -> Type r n
 pattern ProdTy tys = TC (ProdType tys)
 
-pattern ProdVal :: [Atom n] -> Atom n
+pattern ProdVal :: [Atom r n] -> Atom r n
 pattern ProdVal xs = Con (ProdCon xs)
 
-pattern Record :: LabeledItems (Type n) -> [Atom n] -> Atom n
+pattern Record :: LabeledItems (Type r n) -> [Atom r n] -> Atom r n
 pattern Record ty xs = Con (Newtype (StaticRecordTy ty) (ProdVal xs))
 
-pattern SumTy :: [Type n] -> Type n
+pattern SumTy :: [Type r n] -> Type r n
 pattern SumTy cs = TC (SumType cs)
 
-pattern SumVal :: [Type n] -> Int -> Atom n -> Atom n
+pattern SumVal :: [Type r n] -> Int -> Atom r n -> Atom r n
 pattern SumVal tys tag payload = Con (SumCon tys tag payload)
 
-pattern PairVal :: Atom n -> Atom n -> Atom n
+pattern PairVal :: Atom r n -> Atom r n -> Atom r n
 pattern PairVal x y = Con (ProdCon [x, y])
 
-pattern PairTy :: Type n -> Type n -> Type n
+pattern PairTy :: Type r n -> Type r n -> Type r n
 pattern PairTy x y = TC (ProdType [x, y])
 
-pattern UnitVal :: Atom n
+pattern UnitVal :: Atom r n
 pattern UnitVal = Con (ProdCon [])
 
-pattern UnitTy :: Type n
+pattern UnitTy :: Type r n
 pattern UnitTy = TC (ProdType [])
 
-pattern BaseTy :: BaseType -> Type n
+pattern BaseTy :: BaseType -> Type r n
 pattern BaseTy b = TC (BaseType b)
 
-pattern PtrTy :: PtrType -> Type n
+pattern PtrTy :: PtrType -> Type r n
 pattern PtrTy ty = BaseTy (PtrType ty)
 
-pattern RefTy :: Atom n -> Type n -> Type n
+pattern RefTy :: Atom r n -> Type r n -> Type r n
 pattern RefTy r a = TC (RefType (Just r) a)
 
-pattern RawRefTy :: Type n -> Type n
+pattern RawRefTy :: Type r n -> Type r n
 pattern RawRefTy a = TC (RefType Nothing a)
 
-pattern TabTy :: IxBinder n l -> Type l -> Type n
+pattern TabTy :: IxBinder r n l -> Type r l -> Type r n
 pattern TabTy b body = TabPi (TabPiType b body)
 
-pattern FinTy :: Atom n -> Type n
+pattern FinTy :: Atom r n -> Type r n
 pattern FinTy n = TC (Fin n)
 
-pattern NatTy :: Type n
+pattern NatTy :: Type r n
 pattern NatTy = TC Nat
 
-pattern NatVal :: Word32 -> Atom n
+pattern NatVal :: Word32 -> Atom r n
 pattern NatVal n = Con (Newtype NatTy (IdxRepVal n))
 
-pattern TabVal :: IxBinder n l -> Block l -> Atom n
+pattern TabVal :: IxBinder r n l -> Block r l -> Atom r n
 pattern TabVal b body = TabLam (TabLamExpr b body)
 
-pattern TyKind :: Kind n
+pattern TyKind :: Kind r n
 pattern TyKind = TC TypeKind
 
-pattern EffKind :: Kind n
+pattern EffKind :: Kind r n
 pattern EffKind = TC EffectRowKind
 
-pattern LabeledRowKind :: Kind n
+pattern LabeledRowKind :: Kind r n
 pattern LabeledRowKind = TC LabeledRowKindTC
 
-pattern FinConst :: Word32 -> Type n
+pattern FinConst :: Word32 -> Type r n
 pattern FinConst n = TC (Fin (NatVal n))
 
-pattern BinaryFunTy :: PiBinder n l1 -> PiBinder l1 l2 -> EffectRow l2 -> Type l2 -> Type n
+pattern BinaryFunTy :: PiBinder r n l1 -> PiBinder r l1 l2 -> EffectRow l2 -> Type r l2 -> Type r n
 pattern BinaryFunTy b1 b2 eff ty <- Pi (PiType b1 Pure (Pi (PiType b2 eff ty)))
 
-pattern AtomicBlock :: Atom n -> Block n
+pattern AtomicBlock :: Atom r n -> Block r n
 pattern AtomicBlock atom <- Block _ Empty atom
   where AtomicBlock atom = Block NoBlockAnn Empty atom
 
-pattern BinaryLamExpr :: LamBinder n l1 -> LamBinder l1 l2 -> Block l2 -> LamExpr n
+pattern BinaryLamExpr :: LamBinder r n l1 -> LamBinder r l1 l2 -> Block r l2 -> LamExpr r n
 pattern BinaryLamExpr b1 b2 body = LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))
 
-pattern MaybeTy :: Type n -> Type n
+pattern MaybeTy :: Type r n -> Type r n
 pattern MaybeTy a = SumTy [UnitTy, a]
 
-pattern NothingAtom :: Type n -> Atom n
+pattern NothingAtom :: Type r n -> Atom r n
 pattern NothingAtom a = SumVal [UnitTy, a] 0 UnitVal
 
-pattern JustAtom :: Type n -> Atom n -> Atom n
+pattern JustAtom :: Type r n -> Atom r n -> Atom r n
 pattern JustAtom a x = SumVal [UnitTy, a] 1 x
 
-pattern BoolTy :: Type n
+pattern BoolTy :: Type r n
 pattern BoolTy = Word8Ty
 
-pattern FalseAtom :: Atom n
+pattern FalseAtom :: Atom r n
 pattern FalseAtom = Con (Lit (Word8Lit 0))
 
-pattern TrueAtom :: Atom n
+pattern TrueAtom :: Atom r n
 pattern TrueAtom = Con (Lit (Word8Lit 1))
 
-fieldRowElemsFromList :: [FieldRowElem n] -> FieldRowElems n
+fieldRowElemsFromList :: [FieldRowElem r n] -> FieldRowElems r n
 fieldRowElemsFromList = foldr prependFieldRowElem (UnsafeFieldRowElems [])
 
-prependFieldRowElem :: FieldRowElem n -> FieldRowElems n -> FieldRowElems n
+prependFieldRowElem :: FieldRowElem r n -> FieldRowElems r n -> FieldRowElems r n
 prependFieldRowElem e (UnsafeFieldRowElems els) = case e of
   DynField  _ _ -> UnsafeFieldRowElems $ e : els
   DynFields _   -> UnsafeFieldRowElems $ e : els
@@ -958,13 +1000,14 @@ prependFieldRowElem e (UnsafeFieldRowElems els) = case e of
     (StaticFields items':rest) -> UnsafeFieldRowElems $ StaticFields (items <> items') : rest
     _                          -> UnsafeFieldRowElems $ e : els
 
-extRowAsFieldRowElems :: ExtLabeledItems (Type n) (AtomName n) -> FieldRowElems n
+extRowAsFieldRowElems :: ExtLabeledItems (Type r n) (AtomName r n) -> FieldRowElems r n
 extRowAsFieldRowElems (Ext items ext) = UnsafeFieldRowElems $ itemsEl ++ extEl
   where
     itemsEl = if null items then [] else [StaticFields items]
     extEl = case ext of Nothing -> []; Just r -> [DynFields r]
 
-fieldRowElemsAsExtRow :: Alternative f => FieldRowElems n -> f (ExtLabeledItems (Type n) (AtomName n))
+fieldRowElemsAsExtRow
+  :: Alternative f => FieldRowElems r n -> f (ExtLabeledItems (Type r n) (AtomName r n))
 fieldRowElemsAsExtRow (UnsafeFieldRowElems els) = case els of
   []                                -> pure $ Ext mempty Nothing
   [DynFields r]                     -> pure $ Ext mempty (Just r)
@@ -972,7 +1015,7 @@ fieldRowElemsAsExtRow (UnsafeFieldRowElems els) = case els of
   [StaticFields items, DynFields r] -> pure $ Ext items  (Just r)
   _ -> empty
 
-_getAtMostSingleStatic :: Atom n -> Maybe (LabeledItems (Type n))
+_getAtMostSingleStatic :: Atom r n -> Maybe (LabeledItems (Type r n))
 _getAtMostSingleStatic = \case
   RecordTy (UnsafeFieldRowElems els) -> case els of
     [] -> Just mempty
@@ -980,18 +1023,18 @@ _getAtMostSingleStatic = \case
     _ -> Nothing
   _ -> Nothing
 
-pattern StaticRecordTy :: LabeledItems (Type n) -> Atom n
+pattern StaticRecordTy :: LabeledItems (Type r n) -> Atom r n
 pattern StaticRecordTy items <- (_getAtMostSingleStatic -> Just items)
   where StaticRecordTy items = RecordTy (fieldRowElemsFromList [StaticFields items])
 
-pattern RecordTyWithElems :: [FieldRowElem n] -> Atom n
+pattern RecordTyWithElems :: [FieldRowElem r n] -> Atom r n
 pattern RecordTyWithElems elems <- RecordTy (UnsafeFieldRowElems elems)
   where RecordTyWithElems elems = RecordTy $ fieldRowElemsFromList elems
 
 -- === Typeclass instances for Name and other Haskell libraries ===
 
 instance GenericE AtomRules where
-  type RepE AtomRules = (LiftE (Int, SymbolicZeros)) `PairE` Atom
+  type RepE AtomRules = (LiftE (Int, SymbolicZeros)) `PairE` CAtom
   fromE (CustomLinearize ni sz a) = LiftE (ni, sz) `PairE` a
   toE (LiftE (ni, sz) `PairE` a) = CustomLinearize ni sz a
 instance SinkableE AtomRules
@@ -1000,7 +1043,7 @@ instance AlphaEqE AtomRules
 instance SubstE Name AtomRules
 
 instance GenericE CustomRules where
-  type RepE CustomRules = ListE (PairE AtomName AtomRules)
+  type RepE CustomRules = ListE (PairE (AtomName CoreIR) AtomRules)
   fromE (CustomRules m) = ListE $ toPairE <$> M.toList m
   toE (ListE l) = CustomRules $ M.fromList $ fromPairE <$> l
 instance SinkableE CustomRules
@@ -1014,29 +1057,29 @@ instance ProvesExt  EffectBinder
 instance BindsNames EffectBinder
 instance SubstB Name EffectBinder
 
-instance GenericE DataDefParams where
-  type RepE DataDefParams = ListE (PairE (LiftE Arrow) Atom)
+instance GenericE (DataDefParams r) where
+  type RepE (DataDefParams r) = ListE (PairE (LiftE Arrow) (Atom r))
   fromE (DataDefParams xs) = ListE $ map toPairE $ map (onFst LiftE) xs
   {-# INLINE fromE #-}
   toE (ListE xs) = DataDefParams $ map (onFst fromLiftE) $ map fromPairE xs
   {-# INLINE toE #-}
 
 -- We ignore the dictionary parameters because we assume coherence
-instance AlphaEqE DataDefParams where
+instance AlphaEqE (DataDefParams r) where
   alphaEqE (DataDefParams params) (DataDefParams params') =
     alphaEqE (ListE $ plainArrows params) (ListE $ plainArrows params')
 
-instance AlphaHashableE DataDefParams where
+instance AlphaHashableE (DataDefParams r) where
   hashWithSaltE env salt (DataDefParams params) =
     hashWithSaltE env salt (ListE $ plainArrows params)
 
-instance SinkableE           DataDefParams
-instance HoistableE          DataDefParams
-instance SubstE Name         DataDefParams
-instance SubstE AtomSubstVal DataDefParams
+instance SinkableE           (DataDefParams r)
+instance HoistableE          (DataDefParams r)
+instance SubstE Name         (DataDefParams r)
+instance SubstE (AtomSubstVal r) (DataDefParams r)
 
 instance GenericE DataDef where
-  type RepE DataDef = PairE (LiftE SourceName) (Abs (Nest RolePiBinder) (ListE DataConDef))
+  type RepE DataDef = PairE (LiftE SourceName) (Abs (Nest (RolePiBinder CoreIR)) (ListE DataConDef))
   fromE (DataDef sourceName bs cons) = PairE (LiftE sourceName) (Abs bs (ListE cons))
   {-# INLINE fromE #-}
   toE   (PairE (LiftE sourceName) (Abs bs (ListE cons))) = DataDef sourceName bs cons
@@ -1047,12 +1090,12 @@ deriving via WrapE DataDef n instance Generic (DataDef n)
 instance SinkableE DataDef
 instance HoistableE  DataDef
 instance SubstE Name DataDef
-instance SubstE AtomSubstVal DataDef
+instance SubstE (AtomSubstVal CoreIR) DataDef
 instance AlphaEqE DataDef
 instance AlphaHashableE DataDef
 
 instance GenericE DataConDef where
-  type RepE DataConDef = (LiftE (SourceName, [[Projection]])) `PairE` Type
+  type RepE DataConDef = (LiftE (SourceName, [[Projection]])) `PairE` CType
   fromE (DataConDef name repTy idxs) = (LiftE (name, idxs)) `PairE` repTy
   {-# INLINE fromE #-}
   toE   ((LiftE (name, idxs)) `PairE` repTy) = DataConDef name repTy idxs
@@ -1060,12 +1103,12 @@ instance GenericE DataConDef where
 instance SinkableE DataConDef
 instance HoistableE  DataConDef
 instance SubstE Name DataConDef
-instance SubstE AtomSubstVal DataConDef
+instance SubstE (AtomSubstVal CoreIR) DataConDef
 instance AlphaEqE DataConDef
 instance AlphaHashableE DataConDef
 
-instance GenericE FieldRowElem where
-  type RepE FieldRowElem = EitherE3 (ExtLabeledItemsE Type UnitE) (AtomName `PairE` Type) AtomName
+instance GenericE (FieldRowElem r) where
+  type RepE (FieldRowElem r) = EitherE3 (ExtLabeledItemsE (Type r) UnitE) (AtomName r `PairE` (Type r)) (AtomName r)
   fromE = \case
     StaticFields items         -> Case0 $ ExtLabeledItemsE $ NoExt items
     DynField  labVarName labTy -> Case1 $ labVarName `PairE` labTy
@@ -1077,25 +1120,25 @@ instance GenericE FieldRowElem where
     Case2 n             -> DynFields n
     _ -> error "unreachable"
   {-# INLINE toE #-}
-instance SinkableE      FieldRowElem
-instance HoistableE     FieldRowElem
-instance SubstE Name    FieldRowElem
-instance AlphaEqE       FieldRowElem
-instance AlphaHashableE FieldRowElem
+instance SinkableE      (FieldRowElem r)
+instance HoistableE     (FieldRowElem r)
+instance SubstE Name    (FieldRowElem r)
+instance AlphaEqE       (FieldRowElem r)
+instance AlphaHashableE (FieldRowElem r)
 
-instance GenericE FieldRowElems where
-  type RepE FieldRowElems = ListE FieldRowElem
+instance GenericE (FieldRowElems r) where
+  type RepE (FieldRowElems r) = ListE (FieldRowElem r)
   fromE = ListE . fromFieldRowElems
   {-# INLINE fromE #-}
   toE = fieldRowElemsFromList . fromListE
   {-# INLINE toE #-}
-instance SinkableE FieldRowElems
-instance HoistableE FieldRowElems
-instance SubstE Name FieldRowElems
-instance AlphaEqE FieldRowElems
-instance AlphaHashableE FieldRowElems
-instance SubstE AtomSubstVal FieldRowElems where
-  substE :: forall i o. Distinct o => (Scope o, Subst AtomSubstVal i o) -> FieldRowElems i -> FieldRowElems o
+instance SinkableE   (FieldRowElems r)
+instance HoistableE  (FieldRowElems r)
+instance SubstE Name (FieldRowElems r)
+instance AlphaEqE    (FieldRowElems r)
+instance AlphaHashableE (FieldRowElems r)
+instance SubstE (AtomSubstVal r) (FieldRowElems r) where
+  substE :: forall i o. Distinct o => (Scope o, Subst (AtomSubstVal r) i o) -> FieldRowElems r i -> FieldRowElems r o
   substE env (UnsafeFieldRowElems els) = fieldRowElemsFromList $ foldMap substItem els
     where
       substItem = \case
@@ -1112,50 +1155,50 @@ instance SubstE AtomSubstVal FieldRowElems where
           _ -> error "ill-typed substitution"
         StaticFields items -> [StaticFields items']
           where ExtLabeledItemsE (NoExt items') = substE env
-                  (ExtLabeledItemsE (NoExt items) :: ExtLabeledItemsE Atom AtomName i)
+                  (ExtLabeledItemsE (NoExt items) :: ExtLabeledItemsE (Atom r) (AtomName r) i)
 
 newtype ExtLabeledItemsE (e1::E) (e2::E) (n::S) =
   ExtLabeledItemsE
    { fromExtLabeledItemsE :: ExtLabeledItems (e1 n) (e2 n) }
    deriving Show
 
-instance GenericE Atom where
+instance GenericE (Atom r) where
   -- As tempting as it might be to reorder cases here, the current permutation
   -- was chosen as to make GHC inliner confident enough to simplify through
   -- toE/fromE entirely. If you wish to modify the order, please consult the
   -- GHC Core dump to make sure you haven't regressed this optimization.
-  type RepE Atom =
+  type RepE (Atom r) =
       EitherE6
               (EitherE2
                    -- We isolate those few cases (and reorder them
                    -- compared to the data definition) because they need special
                    -- handling when you substitute with atoms. The rest just act
                    -- like containers
-  {- Var -}        AtomName
-  {- ProjectElt -} ( LiftE (NE.NonEmpty Projection) `PairE` AtomName )
+  {- Var -}        (AtomName r)
+  {- ProjectElt -} ( LiftE (NE.NonEmpty Projection) `PairE` AtomName r)
             ) (EitherE4
-  {- Lam -}        LamExpr
-  {- Pi -}         PiType
-  {- TabLam -}     TabLamExpr
-  {- TabPi -}      TabPiType
+  {- Lam -}        (LamExpr r)
+  {- Pi -}         (PiType r)
+  {- TabLam -}     (TabLamExpr r)
+  {- TabPi -}      (TabPiType r)
             ) (EitherE5
-  {- DepPairTy -}  DepPairType
-  {- DepPair -}    ( Atom `PairE` Atom `PairE` DepPairType)
-  {- TypeCon -}    ( LiftE SourceName `PairE` DataDefName `PairE` DataDefParams)
-  {- DictCon  -}   DictExpr
-  {- DictTy  -}    DictType
+  {- DepPairTy -}  (DepPairType r)
+  {- DepPair -}    ( Atom r `PairE` Atom r `PairE` DepPairType r)
+  {- TypeCon -}    ( LiftE SourceName `PairE` DataDefName `PairE` DataDefParams r)
+  {- DictCon  -}   (DictExpr r)
+  {- DictTy  -}    (DictType r)
             ) (EitherE3
-  {- LabeledRow -}     ( FieldRowElems )
-  {- RecordTy -}       ( FieldRowElems )
-  {- VariantTy -}      ( ExtLabeledItemsE Type AtomName )
+  {- LabeledRow -}     ( FieldRowElems r)
+  {- RecordTy -}       ( FieldRowElems r)
+  {- VariantTy -}      ( ExtLabeledItemsE (Type r) (AtomName r) )
             ) (EitherE4
-  {- Con -}        (ComposeE PrimCon Atom)
-  {- TC -}         (ComposeE PrimTC  Atom)
+  {- Con -}        (ComposeE PrimCon (Atom r))
+  {- TC -}         (ComposeE PrimTC  (Atom r))
   {- Eff -}        EffectRow
-  {- ACase -}      ( Atom `PairE` ListE (AltP Atom) `PairE` Type )
+  {- ACase -}      ( Atom r `PairE` ListE (AltP r (Atom r)) `PairE` Type r)
             ) (EitherE2
-  {- BoxedRef -}   ( Abs (NonDepNest BoxPtr) Atom )
-  {- DepPairRef -} ( Atom `PairE` Abs Binder Atom `PairE` DepPairType))
+  {- BoxedRef -}   ( Abs (NonDepNest r (BoxPtr r)) (Atom r) )
+  {- DepPairRef -} ( Atom r `PairE` Abs (Binder r) (Atom r) `PairE` DepPairType r))
 
   fromE atom = case atom of
     Var v -> Case0 (Case0 v)
@@ -1218,14 +1261,14 @@ instance GenericE Atom where
     _ -> error "impossible"
   {-# INLINE toE #-}
 
-instance SinkableE   Atom
-instance HoistableE  Atom
-instance AlphaEqE    Atom
-instance AlphaHashableE Atom
-instance SubstE Name Atom
+instance SinkableE   (Atom r)
+instance HoistableE  (Atom r)
+instance AlphaEqE    (Atom r)
+instance AlphaHashableE (Atom r)
+instance SubstE Name (Atom r)
 
 -- TODO: special handling of ACase too
-instance SubstE AtomSubstVal Atom where
+instance SubstE (AtomSubstVal r) (Atom r) where
   substE (scope, env) atom = case fromE atom of
     Case0 specialCase -> case specialCase of
       -- Var
@@ -1248,7 +1291,7 @@ instance SubstE AtomSubstVal Atom where
     Case6 rest -> (toE . Case6) $ substE (scope, env) rest
     Case7 rest -> (toE . Case7) $ substE (scope, env) rest
 
-getProjection :: HasCallStack => [Projection] -> Atom n -> Atom n
+getProjection :: HasCallStack => [Projection] -> Atom r n -> Atom r n
 getProjection [] a = a
 getProjection (i:is) a = case getProjection is a of
   Var name -> ProjectElt (i NE.:| []) name
@@ -1272,16 +1315,16 @@ getProjection (i:is) a = case getProjection is a of
       ProjectProduct i' -> i'
       _ -> error "Not a product projection"
 
-instance GenericE Expr where
-  type RepE Expr =
+instance GenericE (Expr r) where
+  type RepE (Expr r) =
      EitherE7
-        (Atom `PairE` Atom `PairE` ListE Atom)
-        (Atom `PairE` Atom `PairE` ListE Atom)
-        (Atom `PairE` ListE Alt `PairE` Type `PairE` EffectRow)
-        (Atom)
-        (ComposeE PrimOp Atom)
-        (ComposeE PrimHof Atom)
-        (HandlerName `PairE` ListE Atom `PairE` Block)
+        (Atom r `PairE` (Atom r) `PairE` ListE (Atom r))
+        (Atom r `PairE` (Atom r) `PairE` ListE (Atom r))
+        (Atom r `PairE` ListE (Alt r) `PairE` Type r `PairE` EffectRow)
+        (Atom r)
+        (ComposeE PrimOp  (Atom r))
+        (ComposeE PrimHof (Atom r))
+        (HandlerName `PairE` ListE (Atom r) `PairE` (Block r))
   fromE = \case
     App    f (x:|xs)  -> Case0 (f `PairE` x `PairE` ListE xs)
     TabApp f (x:|xs)  -> Case1 (f `PairE` x `PairE` ListE xs)
@@ -1302,12 +1345,12 @@ instance GenericE Expr where
     _ -> error "impossible"
   {-# INLINE toE #-}
 
-instance SinkableE Expr
-instance HoistableE  Expr
-instance AlphaEqE Expr
-instance AlphaHashableE Expr
-instance SubstE Name Expr
-instance SubstE AtomSubstVal Expr
+instance SinkableE      (Expr r)
+instance HoistableE     (Expr r)
+instance AlphaEqE       (Expr r)
+instance AlphaHashableE (Expr r)
+instance SubstE Name    (Expr r)
+instance SubstE (AtomSubstVal r) (Expr r)
 
 instance GenericE (ExtLabeledItemsE e1 e2) where
   type RepE (ExtLabeledItemsE e1 e2) = EitherE (ComposeE LabeledItems e1)
@@ -1325,7 +1368,7 @@ instance (AlphaEqE    e1, AlphaEqE    e2) => AlphaEqE    (ExtLabeledItemsE e1 e2
 instance (AlphaHashableE    e1, AlphaHashableE    e2) => AlphaHashableE    (ExtLabeledItemsE e1 e2)
 instance (SubstE Name e1, SubstE Name e2) => SubstE Name (ExtLabeledItemsE e1 e2)
 
-instance SubstE AtomSubstVal (ExtLabeledItemsE Atom AtomName) where
+instance SubstE (AtomSubstVal r) (ExtLabeledItemsE (Atom r) (AtomName r)) where
   substE (scope, env) (ExtLabeledItemsE (Ext items maybeExt)) = do
     let items' = fmap (substE (scope, env)) items
     let ext = case maybeExt of
@@ -1339,8 +1382,8 @@ instance SubstE AtomSubstVal (ExtLabeledItemsE Atom AtomName) where
                   _ -> error "Not a valid labeled row substitution"
     ExtLabeledItemsE $ prefixExtLabeledItems items' ext
 
-instance GenericE Block where
-  type RepE Block = PairE (MaybeE (PairE Type EffectRow)) (Abs (Nest Decl) Atom)
+instance GenericE (Block r) where
+  type RepE (Block r) = PairE (MaybeE (PairE (Type r) EffectRow)) (Abs (Nest (Decl r)) (Atom r))
   fromE (Block (BlockAnn ty effs) decls result) = PairE (JustE (PairE ty effs)) (Abs decls result)
   fromE (Block NoBlockAnn Empty result) = PairE NothingE (Abs Empty result)
   fromE _ = error "impossible"
@@ -1350,67 +1393,67 @@ instance GenericE Block where
   toE   _ = error "impossible"
   {-# INLINE toE #-}
 
-deriving instance Show (BlockAnn n l)
+deriving instance Show (BlockAnn r n l)
 
-instance SinkableE Block
-instance HoistableE  Block
-instance AlphaEqE Block
-instance AlphaHashableE Block
-instance SubstE Name Block
-instance SubstE AtomSubstVal Block
-deriving instance Show (Block n)
-deriving via WrapE Block n instance Generic (Block n)
+instance SinkableE      (Block r)
+instance HoistableE     (Block r)
+instance AlphaEqE       (Block r)
+instance AlphaHashableE (Block r)
+instance SubstE Name    (Block r)
+instance SubstE (AtomSubstVal r) (Block r)
+deriving instance Show (Block r n)
+deriving via WrapE (Block r) n instance Generic (Block r n)
 
-instance GenericE BoxPtr where
-  type RepE BoxPtr = Atom `PairE` Block
+instance GenericE (BoxPtr r) where
+  type RepE (BoxPtr r) = Atom r `PairE` Block r
   fromE (BoxPtr p s) = p `PairE` s
   {-# INLINE fromE #-}
   toE (p `PairE` s) = BoxPtr p s
   {-# INLINE toE #-}
-instance SinkableE BoxPtr
-instance HoistableE BoxPtr
-instance AlphaEqE BoxPtr
-instance AlphaHashableE BoxPtr
-instance SubstE Name BoxPtr
-instance SubstE AtomSubstVal BoxPtr
+instance SinkableE  (BoxPtr r)
+instance HoistableE (BoxPtr r)
+instance AlphaEqE   (BoxPtr r)
+instance AlphaHashableE (BoxPtr r)
+instance SubstE Name (BoxPtr r)
+instance SubstE (AtomSubstVal r) (BoxPtr r)
 
-instance GenericB (NonDepNest ann) where
-  type RepB (NonDepNest ann) = (LiftB (ListE ann)) `PairB` Nest AtomNameBinder
+instance GenericB (NonDepNest r ann) where
+  type RepB (NonDepNest r ann) = (LiftB (ListE ann)) `PairB` Nest AtomNameBinder
   fromB (NonDepNest bs anns) = LiftB (ListE anns) `PairB` bs
   {-# INLINE fromB #-}
   toB (LiftB (ListE anns) `PairB` bs) = NonDepNest bs anns
   {-# INLINE toB #-}
-instance ProvesExt (NonDepNest ann)
-instance BindsNames (NonDepNest ann)
-instance SinkableE ann => SinkableB (NonDepNest ann)
-instance HoistableE ann => HoistableB (NonDepNest ann)
-instance (SubstE Name ann, SinkableE ann) => SubstB Name (NonDepNest ann)
-instance (SubstE AtomSubstVal ann, SinkableE ann) => SubstB AtomSubstVal (NonDepNest ann)
-instance AlphaEqE ann => AlphaEqB (NonDepNest ann)
-instance AlphaHashableE ann => AlphaHashableB (NonDepNest ann)
-deriving instance (Show (ann n)) => Show (NonDepNest ann n l)
+instance ProvesExt (NonDepNest r ann)
+instance BindsNames (NonDepNest r ann)
+instance SinkableE ann => SinkableB (NonDepNest r ann)
+instance HoistableE ann => HoistableB (NonDepNest r ann)
+instance (SubstE Name ann, SinkableE ann) => SubstB Name (NonDepNest r ann)
+instance (SubstE (AtomSubstVal r) ann, SinkableE ann) => SubstB (AtomSubstVal r) (NonDepNest r ann)
+instance AlphaEqE ann => AlphaEqB (NonDepNest r ann)
+instance AlphaHashableE ann => AlphaHashableB (NonDepNest r ann)
+deriving instance (Show (ann n)) => Show (NonDepNest r ann n l)
 
 instance GenericB SuperclassBinders where
-  type RepB SuperclassBinders = PairB (LiftB (ListE Type)) (Nest AtomNameBinder)
+  type RepB SuperclassBinders = PairB (LiftB (ListE CType)) (Nest AtomNameBinder)
   fromB (SuperclassBinders bs tys) = PairB (LiftB (ListE tys)) bs
   toB   (PairB (LiftB (ListE tys)) bs) = SuperclassBinders bs tys
 
 instance BindsNameList SuperclassBinders AtomNameC where
   bindNameList (SuperclassBinders bs _) xs = bindNameList bs xs
 
-instance ProvesExt  SuperclassBinders
-instance BindsNames SuperclassBinders
-instance SinkableB SuperclassBinders
+instance ProvesExt   SuperclassBinders
+instance BindsNames  SuperclassBinders
+instance SinkableB   SuperclassBinders
 instance HoistableB  SuperclassBinders
 instance SubstB Name SuperclassBinders
-instance SubstB AtomSubstVal SuperclassBinders
+instance SubstB (AtomSubstVal CoreIR) SuperclassBinders
 instance AlphaEqB SuperclassBinders
 instance AlphaHashableB SuperclassBinders
 
 instance GenericE ClassDef where
   type RepE ClassDef =
     LiftE (SourceName, [SourceName])
-     `PairE` Abs (Nest RolePiBinder) (Abs SuperclassBinders (ListE MethodType))
+     `PairE` Abs (Nest (RolePiBinder CoreIR)) (Abs SuperclassBinders (ListE MethodType))
   fromE (ClassDef name names b scs tys) =
     LiftE (name, names) `PairE` Abs b (Abs scs (ListE tys))
   {-# INLINE fromE #-}
@@ -1423,13 +1466,13 @@ instance HoistableE  ClassDef
 instance AlphaEqE ClassDef
 instance AlphaHashableE ClassDef
 instance SubstE Name ClassDef
-instance SubstE AtomSubstVal ClassDef
+instance SubstE (AtomSubstVal CoreIR) ClassDef
 deriving instance Show (ClassDef n)
 deriving via WrapE ClassDef n instance Generic (ClassDef n)
 
 instance GenericE InstanceDef where
   type RepE InstanceDef =
-    ClassName `PairE` Abs (Nest RolePiBinder) (ListE Type `PairE` InstanceBody)
+    ClassName `PairE` Abs (Nest (RolePiBinder CoreIR)) (ListE CType `PairE` InstanceBody)
   fromE (InstanceDef name bs params body) =
     name `PairE` Abs bs (ListE params `PairE` body)
   toE (name `PairE` Abs bs (ListE params `PairE` body)) =
@@ -1440,12 +1483,12 @@ instance HoistableE  InstanceDef
 instance AlphaEqE InstanceDef
 instance AlphaHashableE InstanceDef
 instance SubstE Name InstanceDef
-instance SubstE AtomSubstVal InstanceDef
+instance SubstE (AtomSubstVal CoreIR) InstanceDef
 deriving instance Show (InstanceDef n)
 deriving via WrapE InstanceDef n instance Generic (InstanceDef n)
 
 instance GenericE InstanceBody where
-  type RepE InstanceBody = ListE Atom `PairE` ListE Block
+  type RepE InstanceBody = ListE CAtom `PairE` ListE (Block CoreIR)
   fromE (InstanceBody scs methods) = ListE scs `PairE` ListE methods
   toE   (ListE scs `PairE` ListE methods) = InstanceBody scs methods
 
@@ -1454,42 +1497,42 @@ instance HoistableE  InstanceBody
 instance AlphaEqE InstanceBody
 instance AlphaHashableE InstanceBody
 instance SubstE Name InstanceBody
-instance SubstE AtomSubstVal InstanceBody
+instance SubstE (AtomSubstVal CoreIR) InstanceBody
 
 instance GenericE MethodType where
-  type RepE MethodType = PairE (LiftE [Bool]) Type
+  type RepE MethodType = PairE (LiftE [Bool]) CType
   fromE (MethodType explicit ty) = PairE (LiftE explicit) ty
   toE   (PairE (LiftE explicit) ty) = MethodType explicit ty
 
-instance SinkableE MethodType
-instance HoistableE  MethodType
-instance AlphaEqE MethodType
+instance SinkableE      MethodType
+instance HoistableE     MethodType
+instance AlphaEqE       MethodType
 instance AlphaHashableE MethodType
 instance SubstE Name MethodType
-instance SubstE AtomSubstVal MethodType
+instance SubstE (AtomSubstVal CoreIR) MethodType
 
-instance GenericE DictType where
-  type RepE DictType = LiftE SourceName `PairE` ClassName `PairE` ListE Type
+instance GenericE (DictType r) where
+  type RepE (DictType r) = LiftE SourceName `PairE` ClassName `PairE` ListE (Type r)
   fromE (DictType sourceName className params) =
     LiftE sourceName `PairE` className `PairE` ListE params
   toE (LiftE sourceName `PairE` className `PairE` ListE params) =
     DictType sourceName className params
 
-instance SinkableE           DictType
-instance HoistableE          DictType
-instance AlphaEqE            DictType
-instance AlphaHashableE      DictType
-instance SubstE Name         DictType
-instance SubstE AtomSubstVal DictType
+instance SinkableE           (DictType r)
+instance HoistableE          (DictType r)
+instance AlphaEqE            (DictType r)
+instance AlphaHashableE      (DictType r)
+instance SubstE Name         (DictType r)
+instance SubstE (AtomSubstVal r) (DictType r)
 
-instance GenericE DictExpr where
-  type RepE DictExpr =
+instance GenericE (DictExpr r) where
+  type RepE (DictExpr r) =
     EitherE5
- {- InstanceDict -}      (PairE InstanceName (ListE Atom))
- {- InstantiatedGiven -} (PairE Atom (ListE Atom))
- {- SuperclassProj -}    (PairE Atom (LiftE Int))
- {- IxFin -}             (Atom)
- {- ExplicitMethods -}   (SpecDictName `PairE` ListE Atom)
+ {- InstanceDict -}      (PairE InstanceName (ListE (Atom r)))
+ {- InstantiatedGiven -} (PairE (Atom r) (ListE (Atom r)))
+ {- SuperclassProj -}    (PairE (Atom r) (LiftE Int))
+ {- IxFin -}             (Atom r)
+ {- ExplicitMethods -}   (SpecDictName `PairE` ListE (Atom r))
   fromE d = case d of
     InstanceDict v args -> Case0 $ PairE v (ListE args)
     InstantiatedGiven given (arg:|args) -> Case1 $ PairE given (ListE (arg:args))
@@ -1504,18 +1547,18 @@ instance GenericE DictExpr where
     Case4 (sd `PairE` ListE args) -> ExplicitMethods sd args
     _ -> error "impossible"
 
-instance SinkableE           DictExpr
-instance HoistableE          DictExpr
-instance AlphaEqE            DictExpr
-instance AlphaHashableE      DictExpr
-instance SubstE Name         DictExpr
-instance SubstE AtomSubstVal DictExpr
+instance SinkableE           (DictExpr r)
+instance HoistableE          (DictExpr r)
+instance AlphaEqE            (DictExpr r)
+instance AlphaHashableE      (DictExpr r)
+instance SubstE Name         (DictExpr r)
+instance SubstE (AtomSubstVal r) (DictExpr r)
 
 instance GenericE Cache where
   type RepE Cache =
-            EMap SpecializationSpec AtomName
-    `PairE` EMap AbsDict SpecDictName
-    `PairE` EMap AtomName ImpFunName
+            EMap SpecializationSpec (AtomName CoreIR)
+    `PairE` EMap (AbsDict CoreIR) SpecDictName
+    `PairE` EMap (AtomName CoreIR) ImpFunName
     `PairE` EMap ImpFunName FunObjCodeName
     `PairE` LiftE (M.Map ModuleSourceName (FileHash, [ModuleSourceName]))
     `PairE` ListE (        LiftE ModuleSourceName
@@ -1550,8 +1593,8 @@ instance Semigroup (Cache n) where
   Cache x1 x2 x3 x4 x5 x6 <> Cache y1 y2 y3 y4 y5 y6 =
     Cache (y1<>x1) (y2<>x2) (y3<>x3) (y4<>x4) (y5<>x5) (y6<>x6)
 
-instance GenericB LamBinder where
-  type RepB LamBinder =         LiftB (PairE Type (LiftE Arrow))
+instance GenericB (LamBinder r) where
+  type RepB (LamBinder r) =         LiftB (PairE (Type r) (LiftE Arrow))
                         `PairB` NameBinder AtomNameC
                         `PairB` LiftB EffectRow
   fromB (LamBinder b ty arr effs) = LiftB (PairE ty (LiftE arr))
@@ -1561,245 +1604,242 @@ instance GenericB LamBinder where
       `PairB` b
       `PairB` LiftB effs) = LamBinder b ty arr effs
 
-instance BindsAtMostOneName LamBinder AtomNameC where
+instance BindsAtMostOneName (LamBinder r) AtomNameC where
   LamBinder b _ _ _ @> x = b @> x
   {-# INLINE (@>) #-}
 
-instance BindsOneName LamBinder AtomNameC where
+instance BindsOneName (LamBinder r) AtomNameC where
   binderName (LamBinder b _ _ _) = binderName b
   {-# INLINE binderName #-}
 
-instance HasNameHint (LamBinder n l) where
+instance HasNameHint (LamBinder r n l) where
   getNameHint (LamBinder b _ _ _) = getNameHint b
   {-# INLINE getNameHint #-}
 
-instance ProvesExt  LamBinder
-instance BindsNames LamBinder
-instance SinkableB LamBinder
-instance HoistableB  LamBinder
-instance SubstB Name LamBinder
-instance SubstB AtomSubstVal LamBinder
-instance AlphaEqB LamBinder
-instance AlphaHashableB LamBinder
+instance ProvesExt   (LamBinder r)
+instance BindsNames  (LamBinder r)
+instance SinkableB   (LamBinder r)
+instance HoistableB  (LamBinder r)
+instance SubstB Name (LamBinder r)
+instance SubstB (AtomSubstVal r) (LamBinder r)
+instance AlphaEqB (LamBinder r)
+instance AlphaHashableB (LamBinder r)
 
-instance GenericE LamBinding where
-  type RepE LamBinding = PairE (LiftE Arrow) Type
+instance GenericE (LamBinding r) where
+  type RepE (LamBinding r) = PairE (LiftE Arrow) (Type r)
   fromE (LamBinding arr ty) = PairE (LiftE arr) ty
   {-# INLINE fromE #-}
   toE   (PairE (LiftE arr) ty) = LamBinding arr ty
   {-# INLINE toE #-}
 
-instance SinkableE LamBinding
-instance HoistableE  LamBinding
-instance SubstE Name LamBinding
-instance SubstE AtomSubstVal LamBinding
-instance AlphaEqE LamBinding
-instance AlphaHashableE LamBinding
+instance SinkableE     (LamBinding r)
+instance HoistableE    (LamBinding r)
+instance SubstE Name   (LamBinding r)
+instance SubstE (AtomSubstVal r) (LamBinding r)
+instance AlphaEqE       (LamBinding r)
+instance AlphaHashableE (LamBinding r)
 
-instance GenericE LamExpr where
-  type RepE LamExpr = Abs LamBinder Block
+instance GenericE (LamExpr r) where
+  type RepE (LamExpr r) = Abs (LamBinder r) (Block r)
   fromE (LamExpr b block) = Abs b block
   {-# INLINE fromE #-}
   toE   (Abs b block) = LamExpr b block
   {-# INLINE toE #-}
 
-instance SinkableE LamExpr
-instance HoistableE  LamExpr
-instance AlphaEqE LamExpr
-instance AlphaHashableE LamExpr
-instance SubstE Name LamExpr
-instance SubstE AtomSubstVal LamExpr
-deriving instance Show (LamExpr n)
-deriving via WrapE LamExpr n instance Generic (LamExpr n)
+instance SinkableE      (LamExpr r)
+instance HoistableE     (LamExpr r)
+instance AlphaEqE       (LamExpr r)
+instance AlphaHashableE (LamExpr r)
+instance SubstE Name    (LamExpr r)
+instance SubstE (AtomSubstVal r) (LamExpr r)
+deriving instance Show (LamExpr r n)
+deriving via WrapE (LamExpr r) n instance Generic (LamExpr r n)
 
-instance GenericE TabLamExpr where
-  type RepE TabLamExpr = Abs IxBinder Block
+instance GenericE (TabLamExpr r) where
+  type RepE (TabLamExpr r) = Abs (IxBinder r) (Block r)
   fromE (TabLamExpr b block) = Abs b block
   {-# INLINE fromE #-}
   toE   (Abs b block) = TabLamExpr b block
   {-# INLINE toE #-}
 
-instance SinkableE TabLamExpr
-instance HoistableE  TabLamExpr
-instance AlphaEqE TabLamExpr
-instance AlphaHashableE TabLamExpr
-instance SubstE Name TabLamExpr
-instance SubstE AtomSubstVal TabLamExpr
-deriving instance Show (TabLamExpr n)
-deriving via WrapE TabLamExpr n instance Generic (TabLamExpr n)
+instance SinkableE      (TabLamExpr r)
+instance HoistableE     (TabLamExpr r)
+instance AlphaEqE       (TabLamExpr r)
+instance AlphaHashableE (TabLamExpr r)
+instance SubstE Name    (TabLamExpr r)
+instance SubstE (AtomSubstVal r) (TabLamExpr r)
+deriving instance Show (TabLamExpr r n)
+deriving via WrapE (TabLamExpr r) n instance Generic (TabLamExpr r n)
 
-
-instance GenericE PiBinding where
-  type RepE PiBinding = PairE (LiftE Arrow) Type
+instance GenericE (PiBinding r) where
+  type RepE (PiBinding r) = PairE (LiftE Arrow) (Type r)
   fromE (PiBinding arr ty) = PairE (LiftE arr) ty
   {-# INLINE fromE #-}
   toE   (PairE (LiftE arr) ty) = PiBinding arr ty
   {-# INLINE toE #-}
 
-instance SinkableE PiBinding
-instance HoistableE  PiBinding
-instance SubstE Name PiBinding
-instance SubstE AtomSubstVal PiBinding
-instance AlphaEqE PiBinding
-instance AlphaHashableE PiBinding
+instance SinkableE   (PiBinding r)
+instance HoistableE  (PiBinding r)
+instance SubstE Name (PiBinding r)
+instance SubstE (AtomSubstVal r) (PiBinding r)
+instance AlphaEqE (PiBinding r)
+instance AlphaHashableE (PiBinding r)
 
-instance GenericB PiBinder where
-  type RepB PiBinder = BinderP AtomNameC (PairE Type (LiftE Arrow))
+instance GenericB (PiBinder r) where
+  type RepB (PiBinder r) = BinderP AtomNameC (PairE (Type r) (LiftE Arrow))
   fromB (PiBinder b ty arr) = b :> PairE ty (LiftE arr)
   toB   (b :> PairE ty (LiftE arr)) = PiBinder b ty arr
 
-instance BindsAtMostOneName PiBinder AtomNameC where
+instance BindsAtMostOneName (PiBinder r) AtomNameC where
   PiBinder b _ _ @> x = b @> x
   {-# INLINE (@>) #-}
 
-instance BindsOneName PiBinder AtomNameC where
+instance BindsOneName (PiBinder r) AtomNameC where
   binderName (PiBinder b _ _) = binderName b
   {-# INLINE binderName #-}
 
-instance HasNameHint (PiBinder n l) where
+instance HasNameHint (PiBinder r n l) where
   getNameHint (PiBinder b _ _) = getNameHint b
   {-# INLINE getNameHint #-}
 
-instance ProvesExt  PiBinder
-instance BindsNames PiBinder
-instance SinkableB PiBinder
-instance HoistableB  PiBinder
-instance SubstB Name PiBinder
-instance SubstB AtomSubstVal PiBinder
-instance AlphaEqB PiBinder
-instance AlphaHashableB PiBinder
+instance ProvesExt   (PiBinder r)
+instance BindsNames  (PiBinder r)
+instance SinkableB   (PiBinder r)
+instance HoistableB  (PiBinder r)
+instance SubstB Name (PiBinder r)
+instance SubstB (AtomSubstVal r) (PiBinder r)
+instance AlphaEqB (PiBinder r)
+instance AlphaHashableB (PiBinder r)
 
-instance GenericE PiType where
-  type RepE PiType = Abs PiBinder (PairE EffectRow Type)
+instance GenericE (PiType r) where
+  type RepE (PiType r) = Abs (PiBinder r) (PairE EffectRow (Type r))
   fromE (PiType b eff resultTy) = Abs b (PairE eff resultTy)
   {-# INLINE fromE #-}
   toE   (Abs b (PairE eff resultTy)) = PiType b eff resultTy
   {-# INLINE toE #-}
 
-instance SinkableE PiType
-instance HoistableE  PiType
-instance AlphaEqE PiType
-instance AlphaHashableE PiType
-instance SubstE Name PiType
-instance SubstE AtomSubstVal PiType
-deriving instance Show (PiType n)
-deriving via WrapE PiType n instance Generic (PiType n)
+instance SinkableE      (PiType r)
+instance HoistableE     (PiType r)
+instance AlphaEqE       (PiType r)
+instance AlphaHashableE (PiType r)
+instance SubstE Name    (PiType r)
+instance SubstE (AtomSubstVal r) (PiType r)
+deriving instance Show (PiType r n)
+deriving via WrapE (PiType r) n instance Generic (PiType r n)
 
-instance GenericB RolePiBinder where
-  type RepB RolePiBinder = BinderP AtomNameC (PairE Type (LiftE (Arrow, ParamRole)))
+instance GenericB (RolePiBinder r) where
+  type RepB (RolePiBinder r) = BinderP AtomNameC (PairE (Type r) (LiftE (Arrow, ParamRole)))
   fromB (RolePiBinder b ty arr role) = b :> PairE ty (LiftE (arr, role))
   {-# INLINE fromB #-}
   toB   (b :> PairE ty (LiftE (arr, role))) = RolePiBinder b ty arr role
   {-# INLINE toB #-}
 
-instance BindsAtMostOneName RolePiBinder AtomNameC where
-  RolePiBinder b _ _ _ @> x = b @> x
-  {-# INLINE (@>) #-}
-
-instance BindsOneName RolePiBinder AtomNameC where
-  binderName (RolePiBinder b _ _ _) = binderName b
-  {-# INLINE binderName #-}
-
-instance HasNameHint (RolePiBinder n l) where
+instance HasNameHint (RolePiBinder r n l) where
   getNameHint (RolePiBinder b _ _ _) = getNameHint b
   {-# INLINE getNameHint #-}
 
-instance ProvesExt  RolePiBinder
-instance BindsNames RolePiBinder
-instance SinkableB RolePiBinder
-instance HoistableB  RolePiBinder
-instance SubstB Name RolePiBinder
-instance SubstB AtomSubstVal RolePiBinder
-instance AlphaEqB RolePiBinder
-instance AlphaHashableB RolePiBinder
+instance BindsAtMostOneName (RolePiBinder r) AtomNameC where
+  RolePiBinder b _ _ _ @> x = b @> x
 
-instance GenericE IxType where
-  type RepE IxType = PairE Type IxDict
+instance BindsOneName (RolePiBinder r) AtomNameC where
+  binderName (RolePiBinder b _ _ _) = binderName b
+
+instance ProvesExt   (RolePiBinder r)
+instance BindsNames  (RolePiBinder r)
+instance SinkableB   (RolePiBinder r)
+instance HoistableB  (RolePiBinder r)
+instance SubstB Name (RolePiBinder r)
+instance SubstB (AtomSubstVal r) (RolePiBinder r)
+instance AlphaEqB (RolePiBinder r)
+instance AlphaHashableB (RolePiBinder r)
+
+instance GenericE (IxType r) where
+  type RepE (IxType r) = PairE (Type r) (IxDict r)
   fromE (IxType ty d) = PairE ty d
   {-# INLINE fromE #-}
   toE   (PairE ty d) = IxType ty d
   {-# INLINE toE #-}
 
-instance SinkableE IxType
-instance HoistableE  IxType
-instance SubstE Name IxType
-instance SubstE AtomSubstVal IxType
+instance SinkableE   (IxType r)
+instance HoistableE  (IxType r)
+instance SubstE Name (IxType r)
+instance SubstE (AtomSubstVal r) (IxType r)
 
-instance AlphaEqE IxType where
+instance AlphaEqE (IxType r) where
   alphaEqE (IxType t1 _) (IxType t2 _) = alphaEqE t1 t2
 
-instance AlphaHashableE IxType where
+instance AlphaHashableE (IxType r) where
   hashWithSaltE env salt (IxType t _) = hashWithSaltE env salt t
 
-instance GenericE TabPiType where
-  type RepE TabPiType = Abs IxBinder Type
+instance GenericE (TabPiType r) where
+  type RepE (TabPiType r) = Abs (IxBinder r) (Type r)
   fromE (TabPiType b resultTy) = Abs b resultTy
   {-# INLINE fromE #-}
   toE   (Abs b resultTy) = TabPiType b resultTy
   {-# INLINE toE #-}
 
-instance SinkableE TabPiType
-instance HoistableE  TabPiType
-instance AlphaEqE TabPiType
-instance AlphaHashableE TabPiType
-instance SubstE Name TabPiType
-instance SubstE AtomSubstVal TabPiType
-deriving instance Show (TabPiType n)
-deriving via WrapE TabPiType n instance Generic (TabPiType n)
+instance SinkableE      (TabPiType r)
+instance HoistableE     (TabPiType r)
+instance AlphaEqE       (TabPiType r)
+instance AlphaHashableE (TabPiType r)
+instance SubstE Name    (TabPiType r)
+instance SubstE (AtomSubstVal r) (TabPiType r)
+deriving instance Show (TabPiType r n)
+deriving via WrapE (TabPiType r) n instance Generic (TabPiType r n)
 
-instance GenericE NaryPiType where
-  type RepE NaryPiType = Abs (PairB PiBinder (Nest PiBinder)) (PairE EffectRow Type)
+instance GenericE (NaryPiType r) where
+  type RepE (NaryPiType r) = Abs (PairB (PiBinder r) (Nest (PiBinder r))) (PairE EffectRow (Type r))
   fromE (NaryPiType (NonEmptyNest b bs) eff resultTy) = Abs (PairB b bs) (PairE eff resultTy)
   {-# INLINE fromE #-}
   toE   (Abs (PairB b bs) (PairE eff resultTy)) = NaryPiType (NonEmptyNest b bs) eff resultTy
   {-# INLINE toE #-}
 
-instance SinkableE NaryPiType
-instance HoistableE  NaryPiType
-instance AlphaEqE NaryPiType
-instance AlphaHashableE NaryPiType
-instance SubstE Name NaryPiType
-instance SubstE AtomSubstVal NaryPiType
-deriving instance Show (NaryPiType n)
-deriving via WrapE NaryPiType n instance Generic (NaryPiType n)
-instance Store (NaryPiType n)
+instance SinkableE      (NaryPiType r)
+instance HoistableE     (NaryPiType r)
+instance AlphaEqE       (NaryPiType r)
+instance AlphaHashableE (NaryPiType r)
+instance SubstE Name (NaryPiType r)
+instance SubstE (AtomSubstVal r) (NaryPiType r)
+deriving instance Show (NaryPiType r n)
+deriving via WrapE (NaryPiType r) n instance Generic (NaryPiType r n)
+instance Store (NaryPiType r n)
 
-instance GenericE NaryLamExpr where
-  type RepE NaryLamExpr = Abs (PairB Binder (Nest Binder)) (PairE EffectRow Block)
+instance GenericE (NaryLamExpr r) where
+  type RepE (NaryLamExpr r) = Abs (PairB (Binder r) (Nest (Binder r))) (PairE EffectRow (Block r))
   fromE (NaryLamExpr (NonEmptyNest b bs) eff body) = Abs (PairB b bs) (PairE eff body)
   {-# INLINE fromE #-}
   toE   (Abs (PairB b bs) (PairE eff body)) = NaryLamExpr (NonEmptyNest b bs) eff body
   {-# INLINE toE #-}
 
-instance SinkableE NaryLamExpr
-instance HoistableE  NaryLamExpr
-instance AlphaEqE NaryLamExpr
-instance AlphaHashableE NaryLamExpr
-instance SubstE Name NaryLamExpr
-instance SubstE AtomSubstVal NaryLamExpr
-deriving instance Show (NaryLamExpr n)
-deriving via WrapE NaryLamExpr n instance Generic (NaryLamExpr n)
-instance Store (NaryLamExpr n)
+instance SinkableE (NaryLamExpr r)
+instance HoistableE  (NaryLamExpr r)
+instance AlphaEqE (NaryLamExpr r)
+instance AlphaHashableE (NaryLamExpr r)
+instance SubstE Name (NaryLamExpr r)
+instance SubstE (AtomSubstVal r) (NaryLamExpr r)
+deriving instance Show (NaryLamExpr r n)
+deriving via WrapE (NaryLamExpr r) n instance Generic (NaryLamExpr r n)
+instance Store (NaryLamExpr r n)
 
-instance GenericE DepPairType where
-  type RepE DepPairType = Abs Binder Type
+instance GenericE (DepPairType r) where
+  type RepE (DepPairType r) = Abs (Binder r) (Type r)
   fromE (DepPairType b resultTy) = Abs b resultTy
   {-# INLINE fromE #-}
   toE   (Abs b resultTy) = DepPairType b resultTy
   {-# INLINE toE #-}
 
-instance SinkableE   DepPairType
-instance HoistableE  DepPairType
-instance AlphaEqE    DepPairType
-instance AlphaHashableE DepPairType
-instance SubstE Name DepPairType
-instance SubstE AtomSubstVal DepPairType
-deriving instance Show (DepPairType n)
-deriving via WrapE DepPairType n instance Generic (DepPairType n)
+instance SinkableE   (DepPairType r)
+instance HoistableE  (DepPairType r)
+instance AlphaEqE    (DepPairType r)
+instance AlphaHashableE (DepPairType r)
+instance SubstE Name (DepPairType r)
+instance SubstE (AtomSubstVal r) (DepPairType r)
+deriving instance Show (DepPairType r n)
+deriving via WrapE (DepPairType r) n instance Generic (DepPairType r n)
 
 instance GenericE SynthCandidates where
   type RepE SynthCandidates =
-    ListE AtomName `PairE` ListE (PairE ClassName (ListE InstanceName))
+    ListE (AtomName CoreIR) `PairE` ListE (PairE ClassName (ListE InstanceName))
   fromE (SynthCandidates xs ys) = ListE xs `PairE` ListE ys'
     where ys' = map (\(k,vs) -> PairE k (ListE vs)) (M.toList ys)
   {-# INLINE fromE #-}
@@ -1813,19 +1853,19 @@ instance AlphaEqE       SynthCandidates
 instance AlphaHashableE SynthCandidates
 instance SubstE Name    SynthCandidates
 
-instance GenericE AtomBinding where
-  type RepE AtomBinding =
+instance GenericE (AtomBinding r) where
+  type RepE (AtomBinding r) =
      EitherE2
        (EitherE6
-          DeclBinding     -- LetBound
-          LamBinding      -- LamBound
-          PiBinding       -- PiBound
-          IxType          -- IxBound
-          Type            -- MiscBound
-          SolverBinding)  -- SolverBound
+          (DeclBinding   r)   -- LetBound
+          (LamBinding    r)   -- LamBound
+          (PiBinding     r)   -- PiBound
+          (IxType        r)   -- IxBound
+          (Type          r)   -- MiscBound
+          (SolverBinding r))  -- SolverBound
        (EitherE2
           (PairE (LiftE PtrType) PtrName)   -- PtrLitBound
-          (PairE NaryPiType TopFunBinding)) -- TopFunBound
+          (PairE (NaryPiType r) TopFunBinding)) -- TopFunBound
 
   fromE = \case
     LetBound    x -> Case0 $ Case0 x
@@ -1854,19 +1894,19 @@ instance GenericE AtomBinding where
     _ -> error "impossible"
   {-# INLINE toE #-}
 
-instance SinkableE AtomBinding
-instance HoistableE  AtomBinding
-instance SubstE Name AtomBinding
-instance SubstE AtomSubstVal AtomBinding
-instance AlphaEqE AtomBinding
-instance AlphaHashableE AtomBinding
+instance SinkableE   (AtomBinding r)
+instance HoistableE  (AtomBinding r)
+instance SubstE Name (AtomBinding r)
+instance SubstE (AtomSubstVal CoreIR) (AtomBinding CoreIR)
+instance AlphaEqE (AtomBinding r)
+instance AlphaHashableE (AtomBinding r)
 
 instance GenericE TopFunBinding where
   type RepE TopFunBinding = EitherE4
-    (LiftE Int `PairE` Atom)  -- AwaitingSpecializationArgsTopFun
-    SpecializationSpec        -- SpecializedTopFun
-    NaryLamExpr               -- LoweredTopFun
-    ImpFunName                -- FFITopFun
+    (LiftE Int `PairE` CAtom)  -- AwaitingSpecializationArgsTopFun
+    SpecializationSpec         -- SpecializedTopFun
+    (NaryLamExpr CoreIR)       -- LoweredTopFun
+    ImpFunName                 -- FFITopFun
   fromE = \case
     AwaitingSpecializationArgsTopFun n x  -> Case0 $ PairE (LiftE n) x
     SpecializedTopFun x -> Case1 x
@@ -1886,13 +1926,13 @@ instance GenericE TopFunBinding where
 instance SinkableE TopFunBinding
 instance HoistableE  TopFunBinding
 instance SubstE Name TopFunBinding
-instance SubstE AtomSubstVal TopFunBinding
+instance SubstE (AtomSubstVal CoreIR) TopFunBinding
 instance AlphaEqE TopFunBinding
 instance AlphaHashableE TopFunBinding
 
 instance GenericE SpecializationSpec where
   type RepE SpecializationSpec =
-         PairE AtomName (Abs (Nest Binder) (ListE Type))
+         PairE (AtomName CoreIR) (Abs (Nest (Binder CoreIR)) (ListE CType))
   fromE (AppSpecialization fname (Abs bs args)) = PairE fname (Abs bs args)
   {-# INLINE fromE #-}
   toE   (PairE fname (Abs bs args)) = AppSpecialization fname (Abs bs args)
@@ -1901,7 +1941,7 @@ instance GenericE SpecializationSpec where
 instance HasNameHint (SpecializationSpec n) where
   getNameHint (AppSpecialization f _) = getNameHint f
 
-instance SubstE AtomSubstVal SpecializationSpec where
+instance SubstE (AtomSubstVal CoreIR) SpecializationSpec where
   substE env (AppSpecialization f ab) = do
     let f' = case snd env ! f of
                Rename v -> v
@@ -1915,10 +1955,10 @@ instance SubstE Name SpecializationSpec
 instance AlphaEqE SpecializationSpec
 instance AlphaHashableE SpecializationSpec
 
-instance GenericE SolverBinding where
-  type RepE SolverBinding = EitherE2
-                              (PairE Type (LiftE SrcPosCtx))
-                              Type
+instance GenericE (SolverBinding r) where
+  type RepE (SolverBinding r) = EitherE2
+                                  (PairE (Type r) (LiftE SrcPosCtx))
+                                  (Type r)
   fromE = \case
     InfVarBound  ty ctx -> Case0 (PairE ty (LiftE ctx))
     SkolemBound  ty     -> Case1 ty
@@ -1930,24 +1970,24 @@ instance GenericE SolverBinding where
     _ -> error "impossible"
   {-# INLINE toE #-}
 
-instance SinkableE SolverBinding
-instance HoistableE  SolverBinding
-instance SubstE Name SolverBinding
-instance SubstE AtomSubstVal SolverBinding
-instance AlphaEqE SolverBinding
-instance AlphaHashableE SolverBinding
+instance SinkableE   (SolverBinding r)
+instance HoistableE  (SolverBinding r)
+instance SubstE Name (SolverBinding r)
+instance SubstE (AtomSubstVal r) (SolverBinding r)
+instance AlphaEqE       (SolverBinding r)
+instance AlphaHashableE (SolverBinding r)
 
 instance Color c => GenericE (Binding c) where
   type RepE (Binding c) =
     EitherE2
       (EitherE7
-          AtomBinding
+          (AtomBinding CoreIR)
           DataDef
-          (DataDefName `PairE` Atom)
-          (DataDefName `PairE` LiftE Int `PairE` Atom)
+          (DataDefName `PairE` CAtom)
+          (DataDefName `PairE` LiftE Int `PairE` CAtom)
           (ClassDef)
           (InstanceDef)
-          (ClassName `PairE` LiftE Int `PairE` Atom))
+          (ClassName `PairE` LiftE Int `PairE` CAtom))
       (EitherE8
           (ImpFunction)
           (LiftE FunObjCode `PairE` LinktimeNames)
@@ -2003,41 +2043,41 @@ instance Color c => SinkableE   (Binding c)
 instance Color c => HoistableE  (Binding c)
 instance Color c => SubstE Name (Binding c)
 
-instance GenericE DeclBinding where
-  type RepE DeclBinding = LiftE LetAnn `PairE` Type `PairE` Expr
+instance GenericE (DeclBinding r) where
+  type RepE (DeclBinding r) = LiftE LetAnn `PairE` Type r `PairE` Expr r
   fromE (DeclBinding ann ty expr) = LiftE ann `PairE` ty `PairE` expr
   {-# INLINE fromE #-}
   toE   (LiftE ann `PairE` ty `PairE` expr) = DeclBinding ann ty expr
   {-# INLINE toE #-}
 
-instance SinkableE DeclBinding
-instance HoistableE  DeclBinding
-instance SubstE Name DeclBinding
-instance SubstE AtomSubstVal DeclBinding
-instance AlphaEqE DeclBinding
-instance AlphaHashableE DeclBinding
+instance SinkableE (DeclBinding r)
+instance HoistableE  (DeclBinding r)
+instance SubstE Name (DeclBinding r)
+instance SubstE (AtomSubstVal r) (DeclBinding r)
+instance AlphaEqE (DeclBinding r)
+instance AlphaHashableE (DeclBinding r)
 
-instance GenericB Decl where
-  type RepB Decl = AtomBinderP DeclBinding
+instance GenericB (Decl r) where
+  type RepB (Decl r) = AtomBinderP (DeclBinding r)
   fromB (Let b binding) = b :> binding
   {-# INLINE fromB #-}
   toB   (b :> binding) = Let b binding
   {-# INLINE toB #-}
 
-instance SinkableB Decl
-instance HoistableB  Decl
-instance SubstB AtomSubstVal Decl
-instance SubstB Name Decl
-instance AlphaEqB Decl
-instance AlphaHashableB Decl
-instance ProvesExt  Decl
-instance BindsNames Decl
+instance SinkableB (Decl r)
+instance HoistableB  (Decl r)
+instance SubstB (AtomSubstVal r) (Decl r)
+instance SubstB Name (Decl r)
+instance AlphaEqB (Decl r)
+instance AlphaHashableB (Decl r)
+instance ProvesExt  (Decl r)
+instance BindsNames (Decl r)
 
-instance BindsAtMostOneName Decl AtomNameC where
+instance BindsAtMostOneName (Decl r) AtomNameC where
   Let b _ @> x = b @> x
   {-# INLINE (@>) #-}
 
-instance BindsOneName Decl AtomNameC where
+instance BindsOneName (Decl r) AtomNameC where
   binderName (Let b _) = binderName b
   {-# INLINE binderName #-}
 
@@ -2069,7 +2109,7 @@ instance GenericE PartialTopEnvFrag where
                               `PairE` LoadedModules
                               `PairE` LoadedObjects
                               `PairE` ModuleEnv
-                              `PairE` ListE (PairE SpecDictName (ListE NaryLamExpr))
+                              `PairE` ListE (PairE SpecDictName (ListE (NaryLamExpr SimpIR)))
   fromE (PartialTopEnvFrag cache rules loadedM loadedO env d) =
     cache `PairE` rules `PairE` loadedM `PairE` loadedO `PairE` env `PairE` d'
     where d' = ListE $ [name `PairE` ListE methods | (name, methods) <- toList d]
@@ -2148,7 +2188,7 @@ instance ExtOutMap Env TopEnvFrag where
 
       lookupModulePure v = case lookupEnvPure (Env newTopEnv mempty) v of ModuleBinding m -> m
 
-addMethods :: (SpecDictName n, [NaryLamExpr n]) -> Env n -> Env n
+addMethods :: (SpecDictName n, [NaryLamExpr CoreIR n]) -> Env n -> Env n
 addMethods (dName, methods) e = do
   let SpecializedDictBinding (SpecializedDict dAbs oldMethods) = lookupEnvPure e dName
   case oldMethods of
@@ -2275,39 +2315,39 @@ instance Hashable Projection
 instance Hashable IxMethod
 instance Hashable ParamRole
 
-instance Store (Atom n)
-instance Store (Expr n)
-instance Store (SolverBinding n)
-instance Store (AtomBinding n)
+instance Store (Atom r n)
+instance Store (Expr r n)
+instance Store (SolverBinding r n)
+instance Store (AtomBinding r n)
 instance Store (SpecializationSpec n)
 instance Store (TopFunBinding n)
-instance Store (LamBinding  n)
-instance Store (DeclBinding n)
-instance Store (FieldRowElem  n)
-instance Store (FieldRowElems n)
-instance Store (Decl n l)
-instance Store (RolePiBinder n l)
-instance Store (DataDefParams n)
+instance Store (LamBinding  r n)
+instance Store (DeclBinding r n)
+instance Store (FieldRowElem  r n)
+instance Store (FieldRowElems r n)
+instance Store (Decl r n l)
+instance Store (RolePiBinder r n l)
+instance Store (DataDefParams r n)
 instance Store (DataDef n)
 instance Store (DataConDef n)
-instance Store (Block n)
-instance Store (LamBinder n l)
-instance Store (LamExpr n)
-instance Store (IxType n)
-instance Store (TabLamExpr n)
-instance Store (PiBinding n)
-instance Store (PiBinder n l)
-instance Store (PiType n)
-instance Store (TabPiType n)
-instance Store (DepPairType  n)
+instance Store (Block r n)
+instance Store (LamBinder r n l)
+instance Store (LamExpr r n)
+instance Store (IxType r n)
+instance Store (TabLamExpr r n)
+instance Store (PiBinding r n)
+instance Store (PiBinder r n l)
+instance Store (PiType r n)
+instance Store (TabPiType r n)
+instance Store (DepPairType  r n)
 instance Store (SuperclassBinders n l)
 instance Store (AtomRules n)
 instance Store (ClassDef     n)
 instance Store (InstanceDef  n)
 instance Store (InstanceBody n)
 instance Store (MethodType   n)
-instance Store (DictType n)
-instance Store (DictExpr n)
+instance Store (DictType r n)
+instance Store (DictExpr r n)
 instance Store (EffectDef n)
 instance Store (EffectOpDef n)
 instance Store (HandlerDef n)
@@ -2319,8 +2359,8 @@ instance Store (ImportStatus n)
 instance Color c => Store (Binding c n)
 instance Store (ModuleEnv n)
 instance Store (SerializedEnv n)
-instance Store (BoxPtr n)
-instance (Store (ann n)) => Store (NonDepNest ann n l)
+instance Store (BoxPtr r n)
+instance (Store (ann n)) => Store (NonDepNest r ann n l)
 instance Store Projection
 instance Store IxMethod
 instance Store ParamRole
@@ -2329,7 +2369,7 @@ instance Store (SpecializedDictDef n)
 -- === Orphan instances ===
 -- TODO: Resolve this!
 
-instance SubstE AtomSubstVal (EffectRowP Name) where
+instance SubstE (AtomSubstVal r) (EffectRowP Name) where
   substE env (EffectRow effs tailVar) = do
     let effs' = S.fromList $ map (substE env) (S.toList effs)
     let tailEffRow = case tailVar of
@@ -2341,7 +2381,7 @@ instance SubstE AtomSubstVal (EffectRowP Name) where
             _ -> error "Not a valid effect substitution"
     extendEffRow effs' tailEffRow
 
-instance SubstE AtomSubstVal (EffectP Name) where
+instance SubstE (AtomSubstVal r) (EffectP Name) where
   substE (_, env) eff = case eff of
     RWSEffect rws Nothing -> RWSEffect rws Nothing
     RWSEffect rws (Just v) -> do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -49,8 +49,13 @@ import Types.Imp
 
 -- === IR variants ===
 
+-- CoreIR is the IR after inference and before simplification
 data IR = CoreIR
-type SimpIR = CoreIR  -- TODO: actually distinguish these two
+-- SimpIR is the IR after simplification
+-- TODO: until we make SimpIR and CoreIR separate types, `SimpIR` is just an
+-- alias for `CoreIR` and it doesn't mean anything beyond "Dougal thinks this
+-- thing has SimpIR vibes".
+type SimpIR = CoreIR
 
 type CAtom  = Atom CoreIR
 type CType  = Type CoreIR
@@ -125,7 +130,10 @@ data Decl (r::IR) (n::S) (l::S) = Let (AtomNameBinder n l) (DeclBinding r n)
      deriving (Show, Generic)
 type Decls r = Nest (Decl r)
 
--- TODO: make this a newtype with an unsafe constructor
+-- TODO: make this a newtype with an unsafe constructor The idea is that the `r`
+-- parameter will play a role a bit like the `c` parameter in names: if you have
+-- an `AtomName r n` and you look up its definition in the `Env`, you're sure to
+-- get an `AtomBinding r n`.
 type AtomName (r::IR) = Name AtomNameC
 type AtomNameBinder   = NameBinder AtomNameC
 


### PR DESCRIPTION
This implements just the first step of #1151: it adds the `IR` parameter to everything but doesn't let it bear any load yet. Should we merge it into main as it stands or should we first demonstrate that we can use it to distinguish e.g. core IR from simplified IR. It's a question of how convinced we are that this is the right path. I'm fairly sure that any precisely typed IR variant system will look basically like this, differing only in the details of what `IR` means. For me, the big unknown is whether the correctness benefits will outweigh the typing burden. Thoughts?
