### PR TITLE
Start adding predicates to IR variants.

### DIFF
--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -25,6 +25,9 @@ import Err
 import MTL1
 import QueryType
 
+-- TODO: we specialized to `SimpToImpIR` because that's the only place where
+-- it's currently used. But we should probably make it polymorphic in `r`.
+
 type PolyName = SAtomName
 type PolyBinder = NameBinder AtomNameC
 
@@ -42,8 +45,8 @@ newtype Polynomial (n::S) =
 -- This is the main entrypoint. Doing polynomial math sometimes lets
 -- us compute sums in closed form. This tries to compute
 -- `\sum_{i=0}^(lim-1) body`. `i`, `lim`, and `body` should all have type `Nat`.
-sumUsingPolys :: (Builder SimpIR m, Fallible1 m, Emits n)
-              => SAtom n -> Abs (Binder SimpIR) SBlock n -> m n (SAtom n)
+sumUsingPolys :: (Builder SimpToImpIR m, Fallible1 m, Emits n)
+              => Atom SimpToImpIR n -> Abs (Binder SimpToImpIR) (Block SimpToImpIR) n -> m n (Atom SimpToImpIR n)
 sumUsingPolys lim (Abs i body) = do
   sumAbs <- refreshAbs (Abs i body) \(i':>_) body' -> do
     blockAsPoly body' >>= \case
@@ -117,15 +120,15 @@ _showPoly (Polynomial p) =
 -- === core expressions as polynomials ===
 
 type PolySubstVal = SubstVal AtomNameC (MaybeE Polynomial)
-type BlockTraverserM i o a = SubstReaderT PolySubstVal (MaybeT1 (BuilderM SimpIR)) i o a
+type BlockTraverserM i o a = SubstReaderT PolySubstVal (MaybeT1 (BuilderM SimpToImpIR)) i o a
 
 blockAsPoly
   :: (EnvExtender m, EnvReader m)
-  => SBlock n -> m n (Maybe (Polynomial n))
+  => Block SimpToImpIR n -> m n (Maybe (Polynomial n))
 blockAsPoly (Block _ decls result) =
   liftBuilder $ runMaybeT1 $ runSubstReaderT idSubst $ blockAsPolyRec decls result
 
-blockAsPolyRec :: Nest (Decl SimpIR) i i' -> SAtom i' -> BlockTraverserM i o (Polynomial o)
+blockAsPolyRec :: Nest (Decl SimpToImpIR) i i' -> Atom SimpToImpIR i' -> BlockTraverserM i o (Polynomial o)
 blockAsPolyRec decls result = case decls of
   Empty -> atomAsPoly result
   Nest (Let b (DeclBinding _ _ expr)) restDecls -> do
@@ -133,13 +136,13 @@ blockAsPolyRec decls result = case decls of
     extendSubst (b@>SubstVal p) $ blockAsPolyRec restDecls result
 
   where
-    atomAsPoly :: SAtom i -> BlockTraverserM i o (Polynomial o)
+    atomAsPoly :: Atom SimpToImpIR i -> BlockTraverserM i o (Polynomial o)
     atomAsPoly = \case
       Var v       -> varAsPoly v
       IdxRepVal i -> return $ poly [((fromIntegral i) % 1, mono [])]
       _ -> empty
 
-    varAsPoly :: SAtomName i -> BlockTraverserM i o (Polynomial o)
+    varAsPoly :: AtomName SimpToImpIR i -> BlockTraverserM i o (Polynomial o)
     varAsPoly v = getSubst <&> (!v) >>= \case
       SubstVal NothingE   -> empty
       SubstVal (JustE cp) -> return cp
@@ -149,7 +152,7 @@ blockAsPolyRec decls result = case decls of
           IdxRepTy -> return $ poly [(1, mono [(v', 1)])]
           _ -> empty
 
-    exprAsPoly :: SExpr i -> BlockTraverserM i o (Polynomial o)
+    exprAsPoly :: Expr SimpToImpIR i -> BlockTraverserM i o (Polynomial o)
     exprAsPoly e = case e of
       Atom a -> atomAsPoly a
       Op (BinOp op x y) -> case op of
@@ -172,7 +175,7 @@ blockAsPolyRec decls result = case decls of
 -- coefficients. This is why we have to find the least common multiples and do the
 -- accumulation over numbers multiplied by that LCM. We essentially do fixed point
 -- fractional math here.
-emitPolynomial :: (Emits n, Builder SimpIR m) => Polynomial n -> m n (SAtom n)
+emitPolynomial :: (Emits n, Builder SimpToImpIR m) => Polynomial n -> m n (Atom SimpToImpIR n)
 emitPolynomial (Polynomial p) = do
   let constLCM = asAtom $ foldl lcm 1 $ fmap (denominator . snd) $ toList p
   monoAtoms <- flip traverse (toList p) $ \(m, c) -> do
@@ -186,12 +189,12 @@ emitPolynomial (Polynomial p) = do
     --       because it might be causing overflows due to all arithmetic being shifted.
     asAtom = IdxRepVal . fromInteger
 
-emitMonomial :: (Emits n, Builder SimpIR m) => Monomial n -> m n (SAtom n)
+emitMonomial :: (Emits n, Builder SimpToImpIR m) => Monomial n -> m n (Atom SimpToImpIR n)
 emitMonomial (Monomial m) = do
   varAtoms <- forM (toList m) \(v, e) -> ipow (Var v) e
   foldM imul (IdxRepVal 1) varAtoms
 
-ipow :: (Emits n, Builder SimpIR m) => SAtom n -> Int -> m n (SAtom n)
+ipow :: (Emits n, Builder SimpToImpIR m) => Atom SimpToImpIR n -> Int -> m n (Atom SimpToImpIR n)
 ipow x i = foldM imul (IdxRepVal 1) (replicate i x)
 
 -- === instances ===

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -280,7 +280,6 @@ linearizeAtom atom = case atom of
   -- Those should be gone after simplification
   Lam _            -> error "Unexpected non-table lambda"
   ACase _ _ _      -> error "Unexpected ACase"
-  BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   where emitZeroT = withZeroT $ substM atom
 

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -2366,6 +2366,7 @@ instance Store a => Store (LiftE a n)
 instance (Store (e UnsafeS), Generic (e UnsafeS)) => Store (LiftB e n l)
 instance Store (const n) => Store (ConstE const ignored n)
 instance (Color c, Store (ann n)) => Store (BinderP c ann n l)
+instance (forall a. Store a => Store (f a), Store (e n)) => Store (ComposeE f e n)
 
 instance ( forall c. Color c => Store (v c o')
          , forall c. Color c => Generic (v c o'))

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -515,7 +515,6 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
             extendSubst (b @> Rename xs) $
               simplifyAtom body
         return $ ACase e' alts' rTy'
-  BoxedRef _       -> error "Should only occur in Imp lowering"
   DepPairRef _ _ _ -> error "Should only occur in Imp lowering"
   ProjectElt idxs v -> getProjection (toList idxs) <$> simplifyVar v
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -300,7 +300,6 @@ transposeAtom atom ct = case atom of
   TC _            -> notTangent
   Eff _           -> notTangent
   ACase _ _ _     -> error "Unexpected ACase"
-  BoxedRef _       -> error "Unexpected ref"
   DepPairRef _ _ _ -> error "Unexpected ref"
   ProjectElt idxs v -> do
     lookupSubstM v >>= \case


### PR DESCRIPTION
To test it out I restricted the `BoxedRef` constructor to only be allowed during the simp-to-imp translation. It worked! GHC even gave warnings about all the now-inaccessible pattern-matching on `BoxedRef` we can now safely delete.