### PR TITLE
[WIP] Use destination-passing style at the top level, not just for internal calls

### DIFF
--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -19,8 +19,8 @@ def arange_f {n} (off:Nat) : (Fin n)=>Int = for i. id' $ (n_to_i $ ordinal i + o
 m = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
 
 %passes imp
-m' = m ** m
--- CHECK: alloc Float32[10000]
+:p
+  m' = m ** m
 -- CHECK-NOT: alloc
 
 "basic destination passing for scalar array literals"


### PR DESCRIPTION
This avoids the atom reconstruction we had to do after the imp pass, which was always a pain to maintain. It should let us merge the different compilation paths into one, standardizing on FOMO functions as the core compilation unit.