### PR TITLE
Replace ReifiedSat with WhenE for IR-dependent generic representations.

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -30,7 +30,7 @@ module Name (
   IsVoidS (..), UnitE (..), VoidE, PairE (..), toPairE, fromPairE,
   ListE (..), ComposeE (..), MapE (..), NonEmptyListE (..),
   EitherE (..), leftsE, rightsE, forgetEitherE,
-  LiftE (..), EqE, EqV, EqB, OrdE, OrdV, OrdB, VoidB,
+  LiftE (..), WhenE (..), EqE, EqV, EqB, OrdE, OrdV, OrdB, VoidB,
   EitherB (..), forgetEitherB, BinderP (..),
   LiftB, pattern LiftB,
   HashMapE (..), HashableE, nestToNames,
@@ -627,6 +627,16 @@ newtype LiftE (a:: *) (n::S) = LiftE { fromLiftE :: a }
 newtype ComposeE (f :: * -> *) (e::E) (n::S) =
   ComposeE { fromComposeE :: (f (e n)) }
   deriving (Show, Eq, Generic)
+
+data WhenE (p::Bool) (e::E) (n::S) where
+  WhenE :: (p ~ True) => e n -> WhenE p e n
+
+newtype WrapWithTrue (p::Bool) r = WrapWithTrue { fromWrapWithTrue :: (p ~ True) => r }
+
+withFabricatedTruth :: forall p a. (p ~ True => a) -> a
+withFabricatedTruth cont = fromWrapWithTrue
+  (TrulyUnsafe.unsafeCoerce (WrapWithTrue cont :: WrapWithTrue p a
+                                             ) :: WrapWithTrue True a)
 
 data UnitB (n::S) (l::S) where
   UnitB :: UnitB n n
@@ -1305,6 +1315,9 @@ instance (AlphaHashableB b1, AlphaHashableB b2)
 
 instance AlphaHashableE VoidE where
   hashWithSaltE _ _ _ = error "impossible"
+
+instance (p ~ True => AlphaHashableE e) => AlphaHashableE (WhenE p e) where
+  hashWithSaltE env val (WhenE e) = hashWithSaltE env val e
 
 -- === wrapper for E-kinded things suitable for use as keys ===
 
@@ -2281,6 +2294,18 @@ instance SubstE v e => SubstE v (ListE e) where
 instance SubstE v e => SubstE v (NonEmptyListE e) where
   substE env (NonEmptyListE xs) = NonEmptyListE $ fmap (substE env) xs
 
+instance (p ~ True => SinkableE e) => SinkableE (WhenE p e) where
+  sinkingProofE rename (WhenE e) = WhenE $ sinkingProofE rename e
+
+instance (p ~ True => HoistableE e) => HoistableE (WhenE p e) where
+  freeVarsE (WhenE e) = freeVarsE e
+
+instance (p ~ True => SubstE v e, FromName v) => SubstE v (WhenE p e) where
+  substE (scope, subst) (WhenE e) = WhenE $ substE (scope, subst) e
+
+instance (p ~ True => AlphaEqE e) => AlphaEqE (WhenE p e) where
+  alphaEqE (WhenE e1) (WhenE e2) = alphaEqE e1 e2
+
 instance (PrettyB b, PrettyE e) => Pretty (Abs b e n) where
   pretty (Abs b body) = group $
     "(Abs " <> nest 2 (pretty b <> line <> pretty body) <> line <> ")"
@@ -2382,6 +2407,11 @@ instance ( forall c. Color c => Store (v c o)
          => Store (RecSubst v o)
 instance Store (Scope n)
 deriving instance (forall c n. Pretty (v c n)) => Pretty (RecSubstFrag v o o')
+
+instance (p ~ True => Store (e n)) => Store (WhenE p e n) where
+  size = VarSize \(WhenE e) -> getSize e
+  peek = withFabricatedTruth @p (WhenE <$> peek)
+  poke (WhenE e) = poke e
 
 
 -- We often have high-degree sum types that need GenericE instances, and

--- a/src/lib/OccAnalysis.hs
+++ b/src/lib/OccAnalysis.hs
@@ -567,6 +567,8 @@ instance HasOCC UnitE where
 instance HasOCC e => HasOCC (ListE e) where
   occ _ (ListE xs) = ListE <$> traverse (occ accessOnce) xs
   {-# INLINE occ #-}
+instance (p ~ True => HasOCC e) => HasOCC (WhenE p e) where
+  occ a (WhenE e) = WhenE <$> occ a e
 
 -- See Note [Confuse GHC] from Simplify.hs
 confuseGHC :: EnvReader m => m n (DistinctEvidence n)

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -522,6 +522,8 @@ instance (Traversable f, HasDCE e) => HasDCE (ComposeE f e) where
 instance HasDCE e => HasDCE (ListE e) where
   dce (ListE xs) = ListE <$> traverse dce xs
   {-# INLINE dce #-}
+instance (p ~ True => HasDCE e) => HasDCE (WhenE p e) where
+  dce (WhenE e) = WhenE <$> dce e
 
 -- See Note [Confuse GHC] from Simplify.hs
 confuseGHC :: EnvReader m => m n (DistinctEvidence n)


### PR DESCRIPTION
The difference is that `ReifiedSat` was just an object carrying a Sat constraint, whereas `WhenE` carries a payload as well---but if and only if the predicate holds.

The goal is to reduce the instance burden on generically-derived traversals over inhabitants of specific IRs.  To wit, consider defining a class `Foo` that's meant to be implemented generically on `Atom SimpIR`:
```
class Foo e where
  method :: ...
  default method :: (GenericE e, Foo (RepE e)) => ...
  method = ...

instance Foo (Atom SimpIR)
```
We know Atom has constructors that cannot occur in SimpIR (e.g., `BoxedRef`).  Those constructors may (and in this case do) mention types that occur nowhere else in Atom (e.g., `Abs (NonDepNest ...) (Atom r)`). More to the point, the RepE for Atom includes such types, due to that constructor.  Therefore, for GHC to generate the `Foo (Atom SimpIR)` instance generically, it needs an instance of `Foo` that covers `Abs (NonDepNest ...) (Atom r)`, even though such an `Abs` can never appear in an `Atom SimpIR`.

Replacing `ReifiedSat` with `WhenE` solves this problem.  Instead of supplying an instance of `Foo` for every impossible sub-type in Atom, it suffices to add a single pair of boilerplate instances of `Foo` for `WhenE`, of the form

```
instance Foo e => Foo (WhenE True e) where
  method (WhenE e) = method e  -- Adjusting types mutatis mutandis
instance Foo (WhenE False e) where
  method _ = error "Unreachable"
```

This came up now because the inliner contains such a class. Specifically, I'm trying to write a generic `Abs` instance, that suffices to cover a fairly generic `Atom` instance, but I only want to deal with one binder at a time; and `BoxedRef` is the only `Atom` constructor that has an `Abs` with more than one binder.

Two notes:

- `WhenE` imposes some cost (in the form of boilerplate instances) on classes that are parameterically polymorphic in the IR (like `instance AlphaHashableE (Atom r)`), but it's the same as the cost of `PairE` or `UnitE` or similar.

- This mechanism does not, as far as I know, help classes that are meant to be conditionally polymorphic in the IR, such as a hypothetical `instance (Sat r SomePredicate) => Bar (Atom r)`.  Even if `SomePredicate` logically implies that some sub-type cannot appear in `Atom r`, GHC may not be smart enough to figure out that the corresponding instance of `Bar` is not necessary.