### PR TITLE
First inliner.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ test-script.cd
 .stack-work-dbg
 .stack-work-prof
 .stack-work-test
+.stack-work-test-dbg
 .stack-work-ffis
 garbage.hs
 *.lock

--- a/dex.cabal
+++ b/dex.cabal
@@ -58,9 +58,10 @@ library
                      , GenericTraversal
                      , Generalize
                      , Imp
-                     , Interpreter
-                     , Inference
                      , ImpToLLVM
+                     , Inference
+                     , Inline
+                     , Interpreter
                      , LLVM.Link
                      , LLVM.Compile
                      , LLVM.CUDA

--- a/makefile
+++ b/makefile
@@ -290,6 +290,9 @@ unit-tests:
 watch-unit-tests:
 	$(STACK) test --work-dir .stack-work-test $(STACK_FLAGS) --file-watch
 
+unit-tests-dbg:
+	$(STACK) test --work-dir .stack-work-test-dbg --trace $(STACK_FLAGS)
+
 opt-tests: just-build
 	misc/file-check tests/opt-tests.dx $(dex) -O script
 

--- a/makefile
+++ b/makefile
@@ -295,6 +295,7 @@ unit-tests-dbg:
 
 opt-tests: just-build
 	misc/file-check tests/opt-tests.dx $(dex) -O script
+	misc/file-check tests/inline-tests.dx $(dex) -O script
 
 doc-format-test: $(doc-files) $(example-files) $(lib-files)
 	python3 misc/build-web-index "$(doc-files)" "$(example-files)" "$(lib-files)" > /dev/null

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -1,0 +1,483 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Inline where
+
+import Data.List.NonEmpty qualified as NE
+
+import Data.Functor
+
+import Builder
+import Err
+import LabeledItems
+import Name
+import Occurrence hiding (Var)
+import Syntax
+
+data InlineExpr (o::S) where
+  DoneEx :: SExpr o -> InlineExpr o
+  SuspEx :: SExpr i -> Subst InlineSubstVal i o -> InlineExpr o
+
+instance Show (InlineExpr n) where
+  show = \case
+    DoneEx e -> "finished " ++ show e
+    SuspEx e _ -> "unfinished " ++ show e
+
+instance SubstE Name InlineExpr where
+  substE (scope, subst) = \case
+    DoneEx e -> DoneEx $ substE (scope, subst) e
+    SuspEx e s -> SuspEx e $ substE (scope, subst) s
+
+instance SinkableE InlineExpr where
+  sinkingProofE rename = \case
+    DoneEx e   -> DoneEx $ sinkingProofE rename e
+    SuspEx e s -> SuspEx e $ sinkingProofE rename s
+
+type InlineSubstVal = SubstVal AtomNameC InlineExpr
+
+newtype InlineM (i::S) (o::S) (a:: *) = InlineM
+  { runInlineM :: SubstReaderT InlineSubstVal (BuilderM SimpIR) i o a }
+  deriving ( Functor, Applicative, Monad, MonadFail, Fallible, ScopeReader
+           , EnvExtender, EnvReader, SubstReader InlineSubstVal, (Builder SimpIR)
+           , (ScopableBuilder SimpIR))
+
+data SizePreservationInfo =
+  -- Explicit noinline, or inlining doesn't preserve work
+    NoInline
+  -- Used once, ergo size-preserving to inline.  In Secrets, this corresponds to
+  -- either OnceSafe, or OnceUnsafe with whnfOrBot == True
+  | UsedOnce
+  -- Used more than once, ergo potentially size-increasing to inline.  In
+  -- Secrets, this corresponds to either MultiSafe, or MultiUnsafe with
+  -- whnfOrBot == True
+  | UsedMulti
+  deriving (Eq, Show)
+
+inlineDecls :: Emits o => Nest SDecl i i' -> InlineM i' o a -> InlineM i o a
+inlineDecls decls cont = do
+  s <- inlineDeclsSubst decls
+  withSubst s cont
+{-# INLINE inlineDecls #-}
+
+inlineDeclsSubst :: Emits o => Nest SDecl i i' -> InlineM i o (Subst InlineSubstVal i' o)
+inlineDeclsSubst = \case
+  Empty -> getSubst
+  Nest (Let b (DeclBinding ann _ expr)) rest -> do
+    if preInlineUnconditionally ann then do
+      s <- getSubst
+      extendSubst (b @> SubstVal (SuspEx expr s)) $ inlineDeclsSubst rest
+    else do
+      expr' <- inlineExpr Stop expr
+      -- If the inliner starts moving effectful expressions, it may become
+      -- necessary to query the effects of the new expression here.
+      let presInfo = resolveWorkConservation ann expr'
+      -- A subtlety from the Secrets paper.  In Haskell, it is feasible to have
+      -- a binding whose occurrence information indicates multiple uses, but
+      -- which does a small, bounded amount of runtime work.  GHC will inline
+      -- such a binding, but not into contexts where GHC knows that no further
+      -- optimizations are possible.  The example given in the paper is
+      --   f = \x -> E
+      --   g = \ys -> map f ys
+      -- Inlining f here is useless because it's not applied, and mildly costly
+      -- because it causes the closure to be allocated at every call to g rather
+      -- than just once.
+      -- TODO If we want to track this subtlety, we should make room for it in
+      -- the SizePreservationInfo ADT (maybe rename it), maybe with a
+      -- OnceButDuplicatesBoundedWork constructor.  Then only the true UsedOnce
+      -- would be inlined unconditionally here, and the
+      -- OnceButDuplicatesBoundedWork constructor could be inlined or not
+      -- depending on its usage context.  (This would correspond to the case
+      -- OnceUnsafe with whnfOrBot == True in the Secrets paper.)
+      if presInfo == UsedOnce then do
+        let substVal = case expr' of
+             Atom (Var name') -> Rename name'
+             _ -> SubstVal (DoneEx expr')
+        extendSubst (b @> substVal) $ inlineDeclsSubst rest
+      else do
+        -- expr' can't be Atom (Var x) here
+        name' <- emitDecl (getNameHint b) (dropOccInfo ann) expr'
+        extendSubst (b @> Rename name') do
+          -- TODO For now, this inliner does not do any conditional inlining.
+          -- In order to do it, we would need to augment the environment at this
+          -- point, associating name' to (expr', presInfo) so name' could be
+          -- inlined at use sites.
+          --
+          -- Conditional inlining is different in Dex vs Haskell because Dex is
+          -- strict.  To wit, once we have emitted the bidning for `expr'`, we
+          -- are committed to doing the work it represents unless it's inlined
+          -- _everywhere_.  For example,
+          --   xs = <something>
+          --   case <foo> of
+          --     Nothing -> xs  -- ok to inline here
+          --     Just _ -> xs ... xs  -- not ok here
+          -- If this were Haskell, it would be work-preserving for GHC to inline
+          -- `xs` into the `Nothing` arm, but in Dex it's not, unless we first
+          -- explicitly push the binding into the case like
+          --   case <foo> of
+          --     Nothing -> xs = <something>; xs
+          --     Just _ -> xs = <something>; xs ... xs
+          --
+          -- That said, the Secrets paper says that GHC only conditionally
+          -- inlines zero-work bindings anyway (or, more precisely, "bounded
+          -- finite work" bindings).  All the heuristics about whether to inline
+          -- at a particular site are about code size and not increasing it
+          -- overmuch.  But, of course, inlining even zero-work bindings can
+          -- help runtime performance because it can unblock other optimizations
+          -- that otherwise could not occur across the binding.
+          inlineDeclsSubst rest
+  where
+    dropOccInfo PlainLet = PlainLet
+    dropOccInfo NoInlineLet = NoInlineLet
+    dropOccInfo (OccInfoPure _) = PlainLet
+    dropOccInfo (OccInfoImpure _) = PlainLet
+    resolveWorkConservation PlainLet _ =
+      NoInline  -- No occurrence info, assume the worst
+    resolveWorkConservation NoInlineLet _ = NoInline
+    -- Quick hack to always unconditionally inline renames, until we get
+    -- a better story about measuring the sizes of atoms and expressions.
+    resolveWorkConservation (OccInfoPure _) (Atom (Var _)) = UsedOnce
+    resolveWorkConservation (OccInfoPure (UsageInfo s (ixDepth, d))) expr
+      | d <= One = case ixDepthExpr expr >= ixDepth of
+        True -> if s <= One then UsedOnce else UsedMulti
+        False -> NoInline
+    resolveWorkConservation (OccInfoPure (UsageInfo s _)) (Atom _) =
+      if s <= One then UsedOnce else UsedMulti
+    -- TODO In Haskell, inlining expressions that are guaranteed to be bottom is
+    -- also work-preserving, and profitable because it can avoid allocating
+    -- thunks.  Do we care about that case here?  (It can also change the
+    -- semantics in a strict language, from "error" to "no error" (or to
+    -- "different error").)
+    resolveWorkConservation (OccInfoPure _) _ = NoInline
+    -- TODO Tagging impure expressions "noinline" here misses two potential
+    -- opportunities.
+    -- - The OccInfo annotation is from the target expression before inlining.
+    --   It's conceivable that inlining will expose a peephole optimization that
+    --   removes the effect, making the post-inlining expression pure.  It would
+    --   be nice to be able to inline it here in this case, but (i) as of this
+    --   writing, the inliner does not remove effects, and (ii) even if it did,
+    --   we could recover the end state by running another inlining pass.
+    -- - More interestingly, the inliner could reorder provably-independent
+    --   effects, like `State` on two different heap parameters.  For that,
+    --   however, we would need to know something about the locations into which
+    --   an effectful binding could be moved, and whether doing so reorders
+    --   effects that should not be reordered.  And because the inliner inlines
+    --   multiple bindings in one pass, we may also need to be careful about any
+    --   effectful bindings that are already in the substitution.
+    resolveWorkConservation (OccInfoImpure _) _ = NoInline
+    -- This function for detecting available indexing depth reports all decls as
+    -- aborting indexing, even if the decl will be inlined away later.
+    --
+    -- For example, the binding
+    --   xs = for i.
+    --     ys = for j. <something>
+    --     for k. ys.k
+    -- really does have two available indexing levels, because the ys binding is
+    -- inlinable into the result of the outer `for`; but the below function will
+    -- not detect it, and thus we will decline to inline `xs` into a context
+    -- where two levels of indexing are required.  However, we can recover the
+    -- desired effect by running a second pass of occurrence analysis and
+    -- inlining.
+    --
+    -- A more subtle case occurs with
+    --   xs = for i.
+    --     ys = for j. <something>
+    --     view k. ys.k
+    -- (note the `view`).  In this case, if we went ahead and inlined `xs` into
+    -- a context that required two levels of indexing, we would temporarily
+    -- duplicate work, but a second pass of occurence analysis and inlining
+    -- would fix it by inlining `ys`.  However, if we decline to inline here,
+    -- running inlining on the body of `for i.` will not inline into the `view`,
+    -- because in general views are supposed to be duplicable all over.  Maybe
+    -- the solution is to just not have view atoms in the IR by this point,
+    -- since their main purpose is to force inlining in the simplifier, and if
+    -- one just stuck like this it has become equivalent to a `for` anyway.
+    ixDepthExpr :: Expr r n -> Int
+    ixDepthExpr (Hof (For _ _ (Lam (LamExpr _ body)))) = 1 + ixDepthBlock body
+    ixDepthExpr (Atom (TabLam (TabLamExpr _ body))) = 1 + ixDepthBlock body
+    ixDepthExpr _ = 0
+    ixDepthBlock :: Block r n -> Int
+    ixDepthBlock (exprBlock -> (Just expr)) = ixDepthExpr expr
+    ixDepthBlock (AtomicBlock result) = ixDepthExpr $ Atom result
+    ixDepthBlock _ = 0
+
+-- Should we decide to inline this binding wherever it appears, before we even
+-- know the expression?  "Yes" only if we know it only occurs once, and in a
+-- context where inlining it does not duplicate work.
+preInlineUnconditionally :: LetAnn -> Bool
+preInlineUnconditionally = \case
+  PlainLet -> False  -- "Missing occurrence annotation"
+  NoInlineLet -> False
+  OccInfoPure (UsageInfo s (0, d)) | s <= One && d <= One -> True
+  OccInfoPure _ -> False
+  OccInfoImpure _ -> False
+
+-- A context in which an E-kinded thing is to be reconstructed.  This amounts to
+-- a defunctionalization of the interesting part of rebuilding an expression,
+-- which supports now-local optimizations in `reconstruct`.  Read `reconstruct`
+-- together with this data type: `reconstruct` is an interpreter for it.
+--
+-- Note: This pattern of inserting an object into a context can do local
+-- optimizations that would otherwise be hidden from a peephole optimizer by
+-- intervening bindings.  For example, table indexing only permits an Atom in
+-- the array position, but `reconstruct` can check whether it's trying to insert
+-- a `for` expression into that spot and perform the beta reduction immediately,
+-- instead of emitting the binding.
+data Context (from::E) (to::E) (o::S) where
+  Stop :: Context e e o
+  TabAppCtx :: NonEmpty (SAtom i) -> Subst InlineSubstVal i o
+            -> Context SExpr e o -> Context SExpr e o
+  EmitToAtomCtx :: Context SAtom e o -> Context SExpr e o
+  EmitToNameCtx :: Context SAtomName e o -> Context SAtom e o
+  RepWrap :: GenericE e1 => Context e1 e2 o -> Context (RepE e1) e2 o
+
+class Inlinable (e1::E) where
+  inline :: Emits o => Context e1 e2 o -> e1 i -> InlineM i o (e2 o)
+  default inline :: (GenericE e1, Inlinable (RepE e1), Emits o)
+    => Context e1 e2 o -> e1 i -> InlineM i o (e2 o)
+  inline ctx e = confuseGHC >>= \_ -> inline (RepWrap ctx) (fromE e)
+
+inlineExpr :: Emits o => Context SExpr e o -> SExpr i -> InlineM i o (e o)
+inlineExpr ctx = \case
+  Atom atom -> inlineAtom ctx atom
+  TabApp tbl ixs -> do
+    s <- getSubst
+    inlineAtom (TabAppCtx ixs s ctx) tbl
+  expr -> (inline Stop (fromE expr) <&> toE) >>= reconstruct ctx
+
+inlineAtom :: Emits o => Context SExpr e o -> SAtom i -> InlineM i o (e o)
+inlineAtom ctx = \case
+  Var name -> inlineName ctx name
+  atom -> (inline Stop (fromE atom) <&> Atom . toE) >>= reconstruct ctx
+
+inlineName :: Emits o => Context SExpr e o -> SAtomName i -> InlineM i o (e o)
+inlineName ctx name =
+  lookupSubstM name >>= \case
+    Rename name' -> do
+      -- This is the considerInline function from the Secrets paper; this
+      -- is where we decide whether to inline a binding that isn't to be
+      -- inlined unconditionally.
+      -- For now, we just don't.  If we did, we would want to start with
+      -- something like
+      -- lookupEnv name' >>= \case
+      --   (expr', presInfo) | inline presInfo expr' ctx -> inline
+      --   no info -> do not inline (as now)
+      reconstruct ctx (Atom $ Var name')
+    SubstVal (DoneEx expr) -> dropSubst $ inlineExpr ctx expr
+    SubstVal (SuspEx expr s') -> withSubst s' $ inlineExpr ctx expr
+
+instance Inlinable SAtomName where
+  inline ctx a = inlineName (EmitToAtomCtx $ EmitToNameCtx ctx) a
+
+instance Inlinable SAtom where
+  inline ctx a = inlineAtom (EmitToAtomCtx ctx) a
+
+instance Inlinable SBlock where
+  inline ctx (Block ann decls ans) = case (ann, decls) of
+    (NoBlockAnn, Empty) ->
+      (Block NoBlockAnn Empty <$> inline Stop ans) >>= reconstruct ctx
+    (NoBlockAnn, _) -> error "should be unreachable"
+    (BlockAnn ty effs, _) -> do
+      (Abs decls' ans') <- buildScoped $ inlineDecls decls $ inline Stop ans
+      ty' <- inline Stop ty
+      effs' <- inline Stop effs  -- TODO Really?
+      reconstruct ctx $ Block (BlockAnn ty' effs') decls' ans'
+
+-- Still using InlineM because we may call back into inlining, and we wish to
+-- retain our output binding environment.
+reconstruct :: Emits o => Context e1 e2 o -> e1 o -> InlineM i o (e2 o)
+reconstruct ctx e = case ctx of
+  Stop -> return e
+  TabAppCtx ixs s ctx' -> withSubst s $ reconstructTabApp ctx' e ixs
+  EmitToAtomCtx ctx' -> emitExprToAtom e >>= reconstruct ctx'
+  EmitToNameCtx ctx' -> emitAtomToName noHint e >>= reconstruct ctx'
+  RepWrap ctx' -> reconstruct ctx' $ toE e
+{-# INLINE reconstruct #-}
+
+reconstructTabApp :: Emits o
+  => Context SExpr e o -> SExpr o -> NonEmpty (SAtom i) -> InlineM i o (e o)
+reconstructTabApp ctx expr ixs =
+  case fromNaryForExpr (NE.length ixs) expr of
+    Just (bsCount, NaryLamExpr bs _ (Block _ decls result)) -> do
+      let (ixsPref, ixsRest) = NE.splitAt bsCount ixs
+      -- Note: There's a decision here.  Is it ok to inline the atoms in
+      -- `ixsPref` into the body `decls`?  If so, should we pre-process them and
+      -- carry them in `DoneEx`, or suspend them in `SuspEx`?  (If not, we can
+      -- emit fresh bindings and use `Rename`.)  This decision affects the
+      -- runtime of the inliner and the code size of the IR the inliner
+      -- produces; since `ixsPref` are atoms, no decision made here can
+      -- duplicate work.
+      -- - Tried going with `SuspEx`, in the interest of "launch and iterate".
+      -- - This creates a bug: what if I'm beta-reducing a body that
+      --   uses one of these binders somewhere I refuse to substitute into,
+      --   like a type annotation?
+      --     (for i:(Fin 2) j:(..i). <stuff>).(<something>)
+      --   The inliner crashes because the substitution is not rename-only.
+      -- - Failed over to "emit fresh bindings and rename".
+      ixsPref' <- mapM (inline $ EmitToNameCtx Stop) ixsPref
+      s <- getSubst
+      let moreSubst = bs @@> map Rename ixsPref'
+      dropSubst $ extendSubst moreSubst do
+        -- Decision here.  These decls have already been processed by the
+        -- inliner once, so their occurrence information is stale (and should
+        -- have been erased).  Do we rerun occurrence analysis, or just complete
+        -- the pass without inlining any of them?
+        -- - Con rerunning: Slower
+        -- - Con completing: No detection of erroneous lack of occurrence info
+        -- For now went with "completing"; to detect erroneous lack of
+        -- occurrence info, change the relevant PlainLet cases above.
+        --
+        -- There's also a missed opportunity here to do more inlining in one
+        -- pass: we lost the occurrence information of the bindings, so we lost
+        -- the ability to inline them into the result, so in the common case
+        -- that the result is a variable reference, we will find ourselves
+        -- emitting a rename, _which will inhibit downstream inlining_ because a
+        -- rename is not indexable.
+        inlineDecls decls do
+          let ctx' = case nonEmpty ixsRest of
+                Just rest' -> TabAppCtx rest' s ctx
+                Nothing -> ctx
+          inlineAtom ctx' result
+    Nothing -> do
+      array' <- emitExprToAtom expr
+      ixs' <- mapM (inline Stop) ixs
+      reconstruct ctx $ TabApp array' ixs'
+
+-- === The generic instances ===
+
+instance Inlinable (Name DataDefNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name ClassNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name InstanceNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name PtrNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name EffectNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name HandlerNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+instance Inlinable (Name SpecializedDictNameC) where
+  inline ctx n = substM n >>= reconstruct ctx
+
+instance Inlinable e => Inlinable (ComposeE PrimHof e) where
+  inline ctx (ComposeE hof) =
+    (ComposeE <$> traverse (inline Stop) hof) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (ComposeE PrimOp e) where
+  inline ctx (ComposeE op) =
+    (ComposeE <$> traverse (inline Stop) op) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (ComposeE PrimCon e) where
+  inline ctx (ComposeE con) =
+    (ComposeE <$> traverse (inline Stop) con) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (ComposeE PrimTC e) where
+  inline ctx (ComposeE tc) =
+    (ComposeE <$> traverse (inline Stop) tc) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (ComposeE LabeledItems e) where
+  inline ctx (ComposeE items) =
+    (ComposeE <$> traverse (inline Stop) items) >>= reconstruct ctx
+  {-# INLINE inline #-}
+
+instance (Inlinable e1, Inlinable e2) => Inlinable (ExtLabeledItemsE e1 e2)
+instance Inlinable (LamExpr SimpIR)
+instance Inlinable (PiType SimpIR)
+instance Inlinable (TabLamExpr SimpIR)
+instance Inlinable (TabPiType SimpIR)
+instance Inlinable (DepPairType SimpIR)
+instance Inlinable EffectRow
+instance Inlinable Effect
+instance Inlinable (DictExpr SimpIR)
+instance Inlinable (DictType SimpIR)
+instance Inlinable (FieldRowElems SimpIR)
+instance Inlinable (FieldRowElem SimpIR)
+instance Inlinable (DataDefParams SimpIR)
+
+instance (Inlinable e1, Inlinable e2) => Inlinable (PairE e1 e2) where
+  inline ctx (PairE l r) =
+    (PairE <$> inline Stop l <*> inline Stop r) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance (Inlinable e1, Inlinable e2) => Inlinable (EitherE e1 e2) where
+  inline ctx = \case
+    LeftE  l -> (LeftE  <$> inline Stop l) >>= reconstruct ctx
+    RightE r -> (RightE <$> inline Stop r) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance ( Inlinable e1, Inlinable e2, Inlinable e3, Inlinable e4
+         , Inlinable e5, Inlinable e6, Inlinable e7, Inlinable e8
+         ) => Inlinable (EitherE8 e1 e2 e3 e4 e5 e6 e7 e8) where
+  inline ctx = \case
+    Case0 x -> (Case0 <$> inline Stop x) >>= reconstruct ctx
+    Case1 x -> (Case1 <$> inline Stop x) >>= reconstruct ctx
+    Case2 x -> (Case2 <$> inline Stop x) >>= reconstruct ctx
+    Case3 x -> (Case3 <$> inline Stop x) >>= reconstruct ctx
+    Case4 x -> (Case4 <$> inline Stop x) >>= reconstruct ctx
+    Case5 x -> (Case5 <$> inline Stop x) >>= reconstruct ctx
+    Case6 x -> (Case6 <$> inline Stop x) >>= reconstruct ctx
+    Case7 x -> (Case7 <$> inline Stop x) >>= reconstruct ctx
+  {-# INLINE inline #-}
+
+instance (SubstB Name b, BindsEnv b) => Inlinable (Abs b (Atom SimpIR)) where
+  inline ctx (Abs b body) = do
+    s <- getSubst
+    babs <- runSubstReaderT (asRenameSubst s) $ substM (Abs b (idSubstFrag b))
+    abs' <- refreshAbs babs \b' frag ->
+      extendSubst frag $ do
+        Abs b' <$> (buildScopedAssumeNoDecls $ inline Stop body)
+    reconstruct ctx abs'
+
+instance (SubstB Name b, BindsEnv b) => Inlinable (Abs b (Block SimpIR)) where
+  inline ctx (Abs b body) = do
+    s <- getSubst
+    babs <- runSubstReaderT (asRenameSubst s) $ substM (Abs b (idSubstFrag b))
+    abs' <- refreshAbs babs \b' frag ->
+      extendSubst frag $ do
+        Abs b' <$> (buildBlock $ (inline Stop body >>= emitBlock))
+    reconstruct ctx abs'
+
+asRenameSubst :: (Color c, ShowE e) => Subst (SubstVal c e) i o -> Subst Name i o
+asRenameSubst s = newSubst $ assumingRenameOnly s where
+  assumingRenameOnly :: (Color c, Color c1, ShowE e)
+    => Subst (SubstVal c1 e) i o -> Name c i -> Name c o
+  assumingRenameOnly subst n = case subst ! n of
+    Rename n' -> n'
+    SubstVal v -> error $ "Unexpected non-rename substitution "
+      ++ "maps " ++ (show n) ++ " to " ++ (show v)
+
+instance (SubstB Name b, BindsEnv b)
+  => Inlinable (Abs b (PairE EffectRow (Atom SimpIR))) where
+  inline ctx (Abs b body) = do
+    s <- getSubst
+    babs <- runSubstReaderT (asRenameSubst s) $ substM (Abs b (idSubstFrag b))
+    abs' <- refreshAbs babs \b' frag ->
+      extendSubst frag $ do
+        Abs b' <$> (buildScopedAssumeNoDecls $ inline Stop body)
+    reconstruct ctx abs'
+
+instance Inlinable (LiftE a) where
+  inline ctx (LiftE a) = reconstruct ctx (LiftE a)
+  {-# INLINE inline #-}
+instance Inlinable VoidE where
+  inline _ _ = error "impossible"
+  {-# INLINE inline #-}
+instance Inlinable UnitE where
+  inline ctx UnitE = reconstruct ctx UnitE
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (ListE e) where
+  inline ctx (ListE items) =
+    (ListE <$> traverse (inline Stop) items) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable e => Inlinable (WhenE True e) where
+  inline ctx (WhenE e) = (WhenE <$> inline Stop e) >>= reconstruct ctx
+  {-# INLINE inline #-}
+instance Inlinable (WhenE False e) where
+  inline _ _ = error "Unreachable"
+  {-# INLINE inline #-}
+
+-- See Note [Confuse GHC] from Simplify.hs
+confuseGHC :: EnvReader m => m n (DistinctEvidence n)
+confuseGHC = getDistinct
+{-# INLINE confuseGHC #-}

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -629,7 +629,7 @@ newtype ComposeE (f :: * -> *) (e::E) (n::S) =
   deriving (Show, Eq, Generic)
 
 data WhenE (p::Bool) (e::E) (n::S) where
-  WhenE :: (p ~ True) => e n -> WhenE p e n
+  WhenE :: e n -> WhenE True e n
 
 newtype WrapWithTrue (p::Bool) r = WrapWithTrue { fromWrapWithTrue :: (p ~ True) => r }
 

--- a/src/lib/OccAnalysis.hs
+++ b/src/lib/OccAnalysis.hs
@@ -136,12 +136,12 @@ getAccessInfo name = fromMaybe zero <$> gets (lookupNameMapE name . freeVars)
 countFreeVarsAsOccurrences :: (HoistableE e) => e n -> OCCM n ()
 countFreeVarsAsOccurrences obj =
   forM_ (freeAtomVarsList obj) \name -> do
-    modify (<> FV (singletonNameMapE name $ AccessInfo 1 accessOnce))
+    modify (<> FV (singletonNameMapE name $ AccessInfo One accessOnce))
 
 countFreeVarsAsOccurrencesB :: (HoistableB b) => b n l -> OCCM n ()
 countFreeVarsAsOccurrencesB obj =
   forM_ (freeAtomVarsList $ Abs obj UnitE) \name -> do
-    modify (<> FV (singletonNameMapE name $ AccessInfo 1 accessOnce))
+    modify (<> FV (singletonNameMapE name $ AccessInfo One accessOnce))
 
 -- Run the given action with its own FV state, and return the FVs it
 -- accumulates for post-processing.
@@ -221,7 +221,7 @@ class HasOCC (e::E) where
   occ a e = confuseGHC >>= \_ -> toE <$> occ a (fromE e)
 
 instance HasOCC (Name AtomNameC) where
-  occ a n = modify (<> FV (singletonNameMapE n $ AccessInfo 1 a)) $> n
+  occ a n = modify (<> FV (singletonNameMapE n $ AccessInfo One a)) $> n
   {-# INLINE occ #-}
 instance HasOCC (Name HandlerNameC ) where occ _ n = return n
 instance HasOCC (Name DataDefNameC ) where occ _ n = return n

--- a/src/lib/OccAnalysis.hs
+++ b/src/lib/OccAnalysis.hs
@@ -283,7 +283,14 @@ occNest a decls ans = case decls of
         -- occurrence analysis, and each binding is considered for
         -- inlining separately.
         DeclBinding _ ty expr <- occ accessOnce binding'
-        let binding'' = DeclBinding (OccInfo usage) ty expr
+        -- We save effects information here because the inliner will want to
+        -- query the effects of an expression before it is substituted, and the
+        -- type querying subsystem is not set up to do that.
+        effs <- getEffects expr
+        let ann = if effs == Pure
+              then OccInfoPure usage
+              else OccInfoImpure usage
+        let binding'' = DeclBinding ann ty expr
         return $ Abs (Nest (Let b' binding'') ds'') ans''
 
 checkAllFreeVariablesMentioned :: HoistableE e => e n -> OCCM n ()

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -1092,7 +1092,7 @@ instance Pretty LetAnn where
 
 instance Pretty UsageInfo where
   pretty (UsageInfo static (ixDepth, ct)) =
-    "occurs in" <+> p (show static) <+> "places, read"
+    "occurs in" <+> p static <+> "places, read"
     <+> p ct <+> "times, to depth" <+> p (show ixDepth)
 
 instance Pretty Count where

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -1085,9 +1085,10 @@ instance Pretty CallingConvention where
 
 instance Pretty LetAnn where
   pretty ann = case ann of
-    PlainLet      -> ""
-    NoInlineLet   -> "%noinline"
-    OccInfo u     -> p u <> line
+    PlainLet        -> ""
+    NoInlineLet     -> "%noinline"
+    OccInfoPure   u -> p u <> line
+    OccInfoImpure u -> p u <> ", impure" <> line
 
 instance Pretty UsageInfo where
   pretty (UsageInfo static (ixDepth, ct)) =

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -102,7 +102,7 @@ module Syntax (
     IsCUDARequired (..),
     NaryLamExpr (..), NaryPiType (..), fromNaryLam,
     fromNaryTabLam, fromNaryTabLamExact,
-    fromNaryLamExact, fromNaryPiType,
+    fromNaryLamExact, fromNaryForExpr, fromNaryPiType,
     NonEmpty (..), nonEmpty,
     naryLamExprAsAtom, naryPiTypeAsType,
     WithCNameInterface (..), FunObjCode, FunObjCodeName, IFunBinder (..),

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -121,7 +121,7 @@ module Syntax (
     pattern ProdTy, pattern ProdVal,
     pattern SumTy, pattern SumVal, pattern MaybeTy, pattern BinaryFunTy,
     pattern BinaryLamExpr,
-    pattern NothingAtom, pattern JustAtom, pattern AtomicBlock,
+    pattern NothingAtom, pattern JustAtom, pattern AtomicBlock, exprBlock,
     pattern BoolTy, pattern FalseAtom, pattern TrueAtom,
     pattern SISourceName, pattern SIInternalName,
     pattern OneEffect,

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -62,6 +62,7 @@ import CheckType (checkTypesM)
 #endif
 import SourceRename
 import Inference
+import Inline
 import Simplify
 import OccAnalysis
 import Lower
@@ -600,7 +601,8 @@ evalBlock typed = do
   simplifiedBlock <- checkPass SimpPass $ simplifyTopBlock synthed
   SimplifiedBlock simp recon <- return simplifiedBlock
   analyzed <- whenOpt simp $ checkPass OccAnalysisPass . analyzeOccurrences
-  opt <- whenOpt analyzed $ checkPass OptPass . optimize
+  inlined <- whenOpt analyzed $ checkPass InlinePass . inlineBindings
+  opt <- whenOpt inlined $ checkPass OptPass . optimize
   result <- case opt of
     AtomicBlock result -> return result
     _ -> do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -1027,7 +1027,14 @@ pattern AtomicBlock :: Atom r n -> Block r n
 pattern AtomicBlock atom <- Block _ Empty atom
   where AtomicBlock atom = Block NoBlockAnn Empty atom
 
+exprBlock :: Block r n -> Maybe (Expr r n)
+exprBlock (Block _ (Nest (Let b (DeclBinding _ _ expr)) Empty) (Var n))
+  | n == binderName b = Just expr
+exprBlock _ = Nothing
+{-# INLINE exprBlock #-}
+
 pattern BinaryLamExpr :: LamBinder r n l1 -> LamBinder r l1 l2 -> Block r l2 -> LamExpr r n
+
 pattern BinaryLamExpr b1 b2 body = LamExpr b1 (AtomicBlock (Lam (LamExpr b2 body)))
 
 pattern MaybeTy :: Type r n -> Type r n

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -257,11 +257,19 @@ instance Pretty Arrow where
     ImplicitArrow  -> "?->"
     ClassArrow     -> "?=>"
 
-data LetAnn = PlainLet
-            | NoInlineLet
-            | OccInfoPure UsageInfo
-            | OccInfoImpure UsageInfo
-              deriving (Show, Eq, Generic)
+data LetAnn =
+  -- Binding with no additional information
+    PlainLet
+  -- Binding explicitly tagged "do not inline"
+  | NoInlineLet
+  -- Bound expression is pure, and the binding's occurrences are summarized by
+  -- the UsageInfo
+  | OccInfoPure UsageInfo
+  -- Bound expression is impure, and the binding's occurrences are summarized by
+  -- the UsageInfo.  For now, the inliner does not distinguish different effects,
+  -- so no additional information on effects is needed.
+  | OccInfoImpure UsageInfo
+  deriving (Show, Eq, Generic)
 
 -- === Primitive scalar values and base types ===
 

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -259,7 +259,8 @@ instance Pretty Arrow where
 
 data LetAnn = PlainLet
             | NoInlineLet
-            | OccInfo UsageInfo
+            | OccInfoPure UsageInfo
+            | OccInfoImpure UsageInfo
               deriving (Show, Eq, Generic)
 
 -- === Primitive scalar values and base types ===

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -368,6 +368,7 @@ data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
               | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval | LowerOptPass | LowerPass
               | ResultPass | JaxprAndHLO | EarlyOptPass | OptPass | OccAnalysisPass
+              | InlinePass
                 deriving (Ord, Eq, Bounded, Enum, Generic)
 
 instance Show PassName where
@@ -380,6 +381,7 @@ instance Show PassName where
     LLVMEval -> "llvmeval" ; JaxprAndHLO -> "jaxprhlo";
     LowerOptPass -> "lower-opt"; LowerPass -> "lower"
     EarlyOptPass -> "early-opt"; OptPass -> "opt"; OccAnalysisPass -> "occ-analysis"
+    InlinePass -> "inline"
 
 data EnvQuery =
    DumpSubst

--- a/tests/inline-tests.dx
+++ b/tests/inline-tests.dx
@@ -1,0 +1,73 @@
+@noinline
+def id' (x:Nat) : Nat = x
+
+-- CHECK-LABEL: Inline for into for
+"Inline for into for"
+
+%passes inline
+:p
+  xs = for i:(Fin 10). ordinal i
+  for j. xs.j + 2
+-- CHECK: for
+-- CHECK-NOT: for
+
+-- CHECK-LABEL: Inline for into sum
+"Inline for into sum"
+
+%passes inline
+sum for i:(Fin 10). ordinal i
+-- CHECK: for
+-- CHECK-NOT: for
+
+-- CHECK-LABEL: Inline nested for into for
+"Inline nested for into for"
+
+%passes inline
+:p
+  xs = for i:(Fin 10). for j:(Fin 20). ordinal i * ordinal j
+  for j i. xs.i.j + 2
+-- CHECK: for
+-- CHECK-NOT: for
+
+-- CHECK-LABEL: Inlining does not reorder effects
+"Inlining does not reorder effects"
+
+-- Note that it _would be_ legal to reorder independent effects, but
+-- the inliner currently does not do that.  But the effect in this
+-- example is not legal to reorder in any case.
+
+%passes inline
+run_state 0 \ct.
+  xs = for i:(Fin 10).
+    ct := (get ct) + 1
+    ordinal i
+  for j.
+    ct := (get ct) * 2
+    xs.j + 2
+-- CHECK: for
+-- CHECK: for
+
+-- CHECK-LABEL: Inlining does not duplicate the inlinee through beta reduction
+"Inlining does not duplicate the inlinee through beta reduction"
+
+-- The runIO is the error message in the dynamic check that `ix` has
+-- type `Fin 100`.
+%passes inline
+:p
+  ix = (id' 20)@(Fin 100)
+  (for i:(Fin 100). ordinal i + ordinal i).ix
+-- CHECK: %runIO
+-- CHECK-NOT: %runIO
+
+-- CHECK-LABEL: Inlining does not violate type IR through beta reduction
+"Inlining does not violate type IR through beta reduction"
+
+-- Beta reducing this ix into the `i` index of the `for` should stop
+-- before it produces anything a type expression can't handle, and
+-- thus execute.
+
+:p
+  ix = (1@(Fin 2))
+  sum (for i:(Fin 2) j:(..i). ordinal j).ix
+-- CHECK: 1
+-- CHECK-NOT: Compiler bug

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -49,7 +49,6 @@ yield_state 0 \ref.
   (x0, x2)
 -- CHECK: === Result ===
 -- CHECK: [[x0:.*]]:Int32 = id{{.*}} 2
--- CHECK-NEXT: occurs in 1 place
 -- CHECK-NEXT: [[x2:.*]]:Int32 = id{{.*}} 4
 -- CHECK-NEXT: ([[x0]], [[x2]])
 
@@ -88,7 +87,9 @@ _ = for i:(Fin 100). one_f32
 %passes lower-opt
 _ = for i:(Fin 10).
   n = ordinal i + 2
-  for j:(Fin 4). sum for k:(Fin n). ordinal j
+  for j:(Fin 4).
+    xs = for k:(Fin n). ordinal j
+    (sum xs, sum xs)  -- Two uses of xs to defeat the inliner
 -- The alloc for the (ordinal i + 2)-sized array should happen in the i loop,
 -- not in the j loop
 -- CHECK: [[n:v#[0-9]+]]:Word32 = %iadd {{.*}} 0x2

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -78,35 +78,35 @@ spec = do
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  xs"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (0,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (0, One))
     it "counts indexing in a for as one use" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  for i. xs.i"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     it "counts indexing depth in nested fors" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  for i j. xs.i.j"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (2, One))
     it "counts two array uses" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  (for i. xs.i, for j. xs.j)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, Two))
     it "counts array and non-array uses" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  (for i. xs.i, xs)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, Two))
     it "counts different case arms as static but not dynamic uses" do
       ann <- analyze cfg env
         [ ":p"
@@ -115,28 +115,28 @@ spec = do
         , "    then for i. xs.i"
         , "    else for j. xs.j"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, One))
     it "understands one index injection" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : ((Fin 10) | (Fin 4)) => Float = unreachable ()"
         , "  for j. xs.(Left j)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     it "understands distinct index injections" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : ((Fin 10) | (Fin 4)) => Float = unreachable ()"
         , "  (for i. xs.(Left i), for j. xs.(Right j))"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, One))
     it "detects and eschews index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => Float = unreachable ()"
         , "  for i:(Fin 3). xs.((ordinal i + 1)@_)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "detects non-nested single-uses cases despite index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
@@ -146,21 +146,21 @@ spec = do
       -- Arguably, should be able to prove that zero levels of exposed indexing
       -- (not one) suffice for inlining xs to be safe here, but the current
       -- occurrence analysis doesn't prove it yet.
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     it "detects nested single-uses cases despite index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => (Fin 3) => Float = unreachable ()"
         , "  for i:(Fin 3). xs.((ordinal i + 1)@_).i"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (2, One))
     it "detects repeated access" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => Float = unreachable ()"
         , "  for i j:(Fin 5). xs.i"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "does not count the `trace` pattern as repeated access" do
       ann <- analyze cfg env
         [ ":p"
@@ -170,7 +170,7 @@ spec = do
       -- Arguably, should be able to prove that only one level of exposed
       -- indexing (not two) suffice for inlining xs to be safe here, but doesn't
       -- prove it yet.
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (2, One))
     it "solves safe sum-over-max" do
       ann <- analyze cfg env
         [ ":p"
@@ -185,7 +185,7 @@ spec = do
         , "      else xs.(Right (Right j))"
         , "  (ys, zs)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 4 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo (Bounded 4) (1, One))
     it "solves unsafe sum-over-max" do
       ann <- analyze cfg env
         [ ":p"
@@ -201,7 +201,7 @@ spec = do
         , "  (ys, zs)"
         ]
       -- One of the code paths hits the same elements(s)
-      ann `shouldBe` OccInfoPure (UsageInfo 4 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo (Bounded 4) (1, Two))
     it "does not penalize referring to indices in scope" do
       ann <- analyze cfg env
         [ ":p"
@@ -212,7 +212,7 @@ spec = do
       -- Arguably, should be able to prove that only one level of exposed
       -- indexing (not two) suffice for inlining xs to be safe here, but doesn't
       -- prove it yet.
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (2, One))
     it "is conservative about potential collisions between indices in scope" do
       ann <- analyze cfg env
         [ ":p"
@@ -221,7 +221,7 @@ spec = do
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  (for i. xs.i.j, for i. xs.i.k)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (2,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (2, Two))
     it "is not confused by potential collisions at an early indexing depth" do
       ann <- analyze cfg env
         [ ":p"
@@ -230,7 +230,7 @@ spec = do
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  (for i. xs.j.i, for i. xs.k.i)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (2,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (2, Two))
     it "does not crash on indexing by case-bound binders" do
       ann <- analyze cfg env
         [ ":p"
@@ -252,7 +252,7 @@ spec = do
       -- albeit at different iterations of the `i` loop.  To analyze this
       -- correctly, we would need to know that `j` and `k` may collide across
       -- `case` arms, though not within an arm.
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, Unbounded))
     it "does not crash on indexing by state-effect-bound binders" do
       ann <- analyze cfg env
         [ ":p"
@@ -260,7 +260,7 @@ spec = do
         , "  with_state (0 @ Fin 10) \\ref."
         , "    xs.(get ref)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     it "assumes state references touch everything" do
       ann <- analyze cfg env
         [ ":p"
@@ -269,7 +269,7 @@ spec = do
         , "    for i:(Fin 3)."
         , "      xs.(get ref)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "assumes state references touch everything even if the initializer doesn't" do
       ann <- analyze cfg env
         [ ":p"
@@ -278,7 +278,7 @@ spec = do
         , "    with_state i \\ref."
         , "      xs.(get ref)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "analyzes through accum effects" do
       ann <- analyze cfg env
         [ ":p"
@@ -287,7 +287,7 @@ spec = do
         , "    for i."
         , "      ref += xs.i"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     -- TODO Should probably construct an example of indexing with the ref of a
     -- run_accum (and, for that matter, with the handle of a run_state or
     -- run_accum), but I'm not sure how to make either of those well-typed.
@@ -298,7 +298,7 @@ spec = do
         , "  with_reader (0 @ Fin 10) \\ref."
         , "    xs.(ask ref)"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, One))
     it "understands that while loops access repeatedly" do
       ann <- analyze cfg env
         [ ":p"
@@ -310,7 +310,7 @@ spec = do
         , "        ref := (get ref) + xs.i"
         , "      False"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "does not crash on index-defining bindings" do
       ann <- analyze cfg env
         [ ":p"
@@ -319,14 +319,14 @@ spec = do
         , "    j = Left (unsafe_from_ordinal _ $ ordinal i)"
         , "    xs.j"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo One (1, Unbounded))
     it "understands indexing by literals" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10 | Fin 3) => Float = unreachable ()"
         , "  (xs.(0@_), xs.(0@_))"
         ]
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, Two))
     it "is conservative about distict literal indices" do
       ann <- analyze cfg env
         [ ":p"
@@ -335,4 +335,14 @@ spec = do
         ]
       -- TODO In this case, we should be able to detect non-collision of
       -- indexing by 0 and by 1; but assuming they may collide is safe.
-      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo Two (1, Two))
+    it "is conservative about ix dicts" do
+      ann <- analyze cfg env
+        [ ":p"
+        , "  n : Nat = unreachable ()"
+        , "  xs : (Fin n) => Nat = iota (Fin n)"
+        , "  sum xs"
+        ]
+      -- We consider `n` statically unbounded because we assume that its ix dict
+      -- may be inlined uncontrollably later.
+      ann `shouldBe` OccInfoPure (UsageInfo Unbounded (0, Unbounded))

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -78,35 +78,35 @@ spec = do
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  xs"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (0,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (0,Bounded 1))
     it "counts indexing in a for as one use" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  for i. xs.i"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     it "counts indexing depth in nested fors" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  for i j. xs.i.j"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
     it "counts two array uses" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  (for i. xs.i, for j. xs.j)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
     it "counts array and non-array uses" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10) => Float = unreachable ()"
         , "  (for i. xs.i, xs)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
     it "counts different case arms as static but not dynamic uses" do
       ann <- analyze cfg env
         [ ":p"
@@ -115,28 +115,28 @@ spec = do
         , "    then for i. xs.i"
         , "    else for j. xs.j"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 1))
     it "understands one index injection" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : ((Fin 10) | (Fin 4)) => Float = unreachable ()"
         , "  for j. xs.(Left j)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     it "understands distinct index injections" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : ((Fin 10) | (Fin 4)) => Float = unreachable ()"
         , "  (for i. xs.(Left i), for j. xs.(Right j))"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 1))
     it "detects and eschews index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => Float = unreachable ()"
         , "  for i:(Fin 3). xs.((ordinal i + 1)@_)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "detects non-nested single-uses cases despite index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
@@ -146,21 +146,21 @@ spec = do
       -- Arguably, should be able to prove that zero levels of exposed indexing
       -- (not one) suffice for inlining xs to be safe here, but the current
       -- occurrence analysis doesn't prove it yet.
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     it "detects nested single-uses cases despite index arithmetic" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => (Fin 3) => Float = unreachable ()"
         , "  for i:(Fin 3). xs.((ordinal i + 1)@_).i"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
     it "detects repeated access" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 4) => Float = unreachable ()"
         , "  for i j:(Fin 5). xs.i"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "does not count the `trace` pattern as repeated access" do
       ann <- analyze cfg env
         [ ":p"
@@ -170,7 +170,7 @@ spec = do
       -- Arguably, should be able to prove that only one level of exposed
       -- indexing (not two) suffice for inlining xs to be safe here, but doesn't
       -- prove it yet.
-      ann `shouldBe` OccInfo (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
     it "solves safe sum-over-max" do
       ann <- analyze cfg env
         [ ":p"
@@ -185,7 +185,7 @@ spec = do
         , "      else xs.(Right (Right j))"
         , "  (ys, zs)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 4 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 4 (1,Bounded 1))
     it "solves unsafe sum-over-max" do
       ann <- analyze cfg env
         [ ":p"
@@ -201,7 +201,7 @@ spec = do
         , "  (ys, zs)"
         ]
       -- One of the code paths hits the same elements(s)
-      ann `shouldBe` OccInfo (UsageInfo 4 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 4 (1,Bounded 2))
     it "does not penalize referring to indices in scope" do
       ann <- analyze cfg env
         [ ":p"
@@ -212,7 +212,7 @@ spec = do
       -- Arguably, should be able to prove that only one level of exposed
       -- indexing (not two) suffice for inlining xs to be safe here, but doesn't
       -- prove it yet.
-      ann `shouldBe` OccInfo (UsageInfo 1 (2,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (2,Bounded 1))
     it "is conservative about potential collisions between indices in scope" do
       ann <- analyze cfg env
         [ ":p"
@@ -221,7 +221,7 @@ spec = do
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  (for i. xs.i.j, for i. xs.i.k)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (2,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (2,Bounded 2))
     it "is not confused by potential collisions at an early indexing depth" do
       ann <- analyze cfg env
         [ ":p"
@@ -230,7 +230,7 @@ spec = do
         , "  xs : (Fin 10) => (Fin 3) => Float = unreachable ()"
         , "  (for i. xs.j.i, for i. xs.k.i)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (2,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (2,Bounded 2))
     it "does not crash on indexing by case-bound binders" do
       ann <- analyze cfg env
         [ ":p"
@@ -252,7 +252,7 @@ spec = do
       -- albeit at different iterations of the `i` loop.  To analyze this
       -- correctly, we would need to know that `j` and `k` may collide across
       -- `case` arms, though not within an arm.
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Unbounded))
     it "does not crash on indexing by state-effect-bound binders" do
       ann <- analyze cfg env
         [ ":p"
@@ -260,7 +260,7 @@ spec = do
         , "  with_state (0 @ Fin 10) \\ref."
         , "    xs.(get ref)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     it "assumes state references touch everything" do
       ann <- analyze cfg env
         [ ":p"
@@ -269,7 +269,7 @@ spec = do
         , "    for i:(Fin 3)."
         , "      xs.(get ref)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "assumes state references touch everything even if the initializer doesn't" do
       ann <- analyze cfg env
         [ ":p"
@@ -278,7 +278,7 @@ spec = do
         , "    with_state i \\ref."
         , "      xs.(get ref)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "analyzes through accum effects" do
       ann <- analyze cfg env
         [ ":p"
@@ -287,7 +287,7 @@ spec = do
         , "    for i."
         , "      ref += xs.i"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     -- TODO Should probably construct an example of indexing with the ref of a
     -- run_accum (and, for that matter, with the handle of a run_state or
     -- run_accum), but I'm not sure how to make either of those well-typed.
@@ -298,7 +298,7 @@ spec = do
         , "  with_reader (0 @ Fin 10) \\ref."
         , "    xs.(ask ref)"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Bounded 1))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Bounded 1))
     it "understands that while loops access repeatedly" do
       ann <- analyze cfg env
         [ ":p"
@@ -310,7 +310,7 @@ spec = do
         , "        ref := (get ref) + xs.i"
         , "      False"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "does not crash on index-defining bindings" do
       ann <- analyze cfg env
         [ ":p"
@@ -319,14 +319,14 @@ spec = do
         , "    j = Left (unsafe_from_ordinal _ $ ordinal i)"
         , "    xs.j"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 1 (1,Unbounded))
+      ann `shouldBe` OccInfoPure (UsageInfo 1 (1,Unbounded))
     it "understands indexing by literals" do
       ann <- analyze cfg env
         [ ":p"
         , "  xs : (Fin 10 | Fin 3) => Float = unreachable ()"
         , "  (xs.(0@_), xs.(0@_))"
         ]
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))
     it "is conservative about distict literal indices" do
       ann <- analyze cfg env
         [ ":p"
@@ -335,4 +335,4 @@ spec = do
         ]
       -- TODO In this case, we should be able to detect non-collision of
       -- indexing by 0 and by 1; but assuming they may collide is safe.
-      ann `shouldBe` OccInfo (UsageInfo 2 (1,Bounded 2))
+      ann `shouldBe` OccInfoPure (UsageInfo 2 (1,Bounded 2))


### PR DESCRIPTION
The inliner follows the architecture of the GHC inliner, as described in [Secrets of the Glasgow Haskell Compiler Inliner](https://www.microsoft.com/en-us/research/wp-content/uploads/2002/07/inline.pdf), with a few notable differences:

- For now, I simply ignore the possibility of inlining a binding at some use sites but not others.  It's only safe to do that in Dex for zero-work bindings, so I would want to think about it more to adapt the Secrets algorithm to our situation.
- Unlike Secrets, this inliner takes pains to try to inline non-zero-work bindings into loops --- that's how we get loop fusion!  This makes the required occurrence analysis significantly more elaborate.
- For now, this inliner does not actually measure code size, effectively assuming that anything more than a variable reference is "large"; and therefore hesitates to inline it into more than one place.  This misses opportunities to inline into the arms of case statements, etc.
- For now, this inliner only does one local optimization during inlining, namely beta reduction of table indexing expressions (which is necessary for the inliner to be work-preserving).  Per Secrets, it's probably a good idea to do more, so that fewer passes of inlining + peephole optimization suffice for convergence.
- For now, Dex only runs the inliner once, immediately after simplification and before any other passes.  We should iterate on that, measuring compile-time and run-time performance.

This inliner also leaves at least one known Dex-specific opportunity on the table, one we might call "pointless-array elimination".  To wit, consider an array whose body is an atom, `xs = for i. <atom>`.  This array is not an atom itself, and will do work if materialized at runtime, allocating and filling the array.  But, if it's inlined into positions where it is indexed, it becomes an atom, which we treat as zero work.  Ergo, such an inlining is profitable in more situations than the current setup can identify, such as `for j k. xs.k`.  (If the body of `xs` did work, inlining `xs` would duplicate that work.  If `xs` wasn't indexed at all, then inlining would duplicate the work or array creation regardless of the body.  And right now the inliner can't detect the situation where a binding does work if not beta-reduced but does no work if beta-reduced, partly because that situation does not arise in GHC core.)