### PR TITLE
Fix box memory management

### DIFF
--- a/src/Dex/Foreign/Serialize.hs
+++ b/src/Dex/Foreign/Serialize.hs
@@ -67,7 +67,7 @@ instance Storable CAtom where
         Float32Lit v -> val @Word64 1 4 >> val 2 v
         Word32Lit  v -> val @Word64 1 5 >> val 2 v
         Word64Lit  v -> val @Word64 1 6 >> val 2 v
-        PtrLit     _ -> error "Unsupported"
+        PtrLit   _ _ -> error "Unsupported"
     CRectArray _ _ _ -> error "Unsupported"
     where
       val :: forall a. Storable a => Int -> a -> IO ()

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -398,9 +398,10 @@ emitObjFile hint objFile names = do
 
 lookupPtrName :: EnvReader m => PtrName n -> m n (PtrType, Ptr ())
 lookupPtrName v = lookupEnv v >>= \case
-  PtrBinding p -> case p of
-    PtrLitVal ty ptr -> return (ty, ptr)
-    PtrSnapshot _ _ -> error "this case is only for serialization"
+  PtrBinding ty p -> case p of
+    PtrLitVal ptr -> return (ty, ptr)
+    PtrSnapshot _ -> error "this case is only for serialization"
+    NullPtr       -> error "not implemented"
 
 getCache :: EnvReader m => m n (Cache n)
 getCache = withEnv $ envCache . topEnv

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -167,7 +167,7 @@ instance Color c => CheckableE (Binding c) where
     ImpFunBinding     f                 -> ImpFunBinding     <$> substM f
     FunObjCodeBinding objfile m         -> FunObjCodeBinding <$> pure objfile <*> substM m
     ModuleBinding     md                -> ModuleBinding     <$> substM md
-    PtrBinding        ptr               -> PtrBinding        <$> return ptr
+    PtrBinding        ty ptr            -> PtrBinding        <$> return ty <*> return ptr
     -- TODO(alex): consider checkE below?
     EffectBinding     eff               -> EffectBinding     <$> substM eff
     HandlerBinding    h                 -> HandlerBinding    <$> substM h
@@ -249,7 +249,7 @@ instance HasType r (Atom r) where
     TC tyCon -> typeCheckPrimTC  tyCon
     Eff eff  -> checkE eff $> EffKind
     PtrVar v -> substM v >>= lookupEnv >>= \case
-      PtrBinding p -> return $ PtrTy $ ptrLitType p
+      PtrBinding ty _ -> return $ PtrTy ty
     TypeCon _ defName params -> do
       def <- lookupDataDef =<< substM defName
       params' <- checkE params

--- a/src/lib/Interpreter.hs
+++ b/src/lib/Interpreter.hs
@@ -193,7 +193,7 @@ evalOp expr = mapM evalAtom expr >>= \case
   PtrOffset p (IdxRepVal 0) -> return p
   PtrOffset ptrAtom (IdxRepVal i) -> do
     ((a, t), p) <- inlinePtrLit ptrAtom
-    return $ Con $ Lit $ PtrLit (PtrLitVal (a, t) $ p `plusPtr` (sizeOf t * fromIntegral i))
+    return $ Con $ Lit $ PtrLit (a, t) (PtrLitVal $ p `plusPtr` (sizeOf t * fromIntegral i))
   PtrLoad ptrAtom -> do
     ((a, t), p) <- inlinePtrLit ptrAtom
     case a of
@@ -363,9 +363,9 @@ indicesLimit sizeReq ixTy = unsafeLiftInterpM $ do
 
 inlinePtrLit :: (Fallible1 m, EnvReader m) => Atom r n -> m n (PtrType, Ptr ())
 inlinePtrLit (PtrVar v) = do
-  ~(PtrBinding (PtrLitVal t p)) <- lookupEnv v
+  ~(PtrBinding t (PtrLitVal p)) <- lookupEnv v
   return (t, p)
-inlinePtrLit (Con (Lit (PtrLit (PtrLitVal t p)))) = return (t, p)
+inlinePtrLit (Con (Lit (PtrLit t (PtrLitVal p)))) = return (t, p)
 inlinePtrLit _ = fail "not a pointer literal"
 
 -- === Helpers for function evaluation over fixed-width types ===

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -93,7 +93,7 @@ peepholeOp op = case op of
       Word64Lit i  -> lit $ Int32Lit  $ fromIntegral i
       Float32Lit _ -> noop
       Float64Lit _ -> noop
-      PtrLit     _ -> noop
+      PtrLit   _ _ -> noop
     Int64Type -> case l of
       Int32Lit  i  -> lit $ Int64Lit  $ fromIntegral i
       Int64Lit  _  -> lit l
@@ -102,7 +102,7 @@ peepholeOp op = case op of
       Word64Lit i  -> lit $ Int64Lit  $ fromIntegral i
       Float32Lit _ -> noop
       Float64Lit _ -> noop
-      PtrLit     _ -> noop
+      PtrLit   _ _ -> noop
     Word8Type -> case l of
       Int32Lit  i  -> lit $ Word8Lit  $ fromIntegral i
       Int64Lit  i  -> lit $ Word8Lit  $ fromIntegral i
@@ -111,7 +111,7 @@ peepholeOp op = case op of
       Word64Lit i  -> lit $ Word8Lit  $ fromIntegral i
       Float32Lit _ -> noop
       Float64Lit _ -> noop
-      PtrLit     _ -> noop
+      PtrLit   _ _ -> noop
     Word32Type -> case l of
       Int32Lit  i  -> lit $ Word32Lit $ fromIntegral i
       Int64Lit  i  -> lit $ Word32Lit $ fromIntegral i
@@ -120,7 +120,7 @@ peepholeOp op = case op of
       Word64Lit i  -> lit $ Word32Lit $ fromIntegral i
       Float32Lit _ -> noop
       Float64Lit _ -> noop
-      PtrLit     _ -> noop
+      PtrLit   _ _ -> noop
     Word64Type -> case l of
       Int32Lit  i  -> lit $ Word64Lit $ fromIntegral (fromIntegral i :: Word32)
       Int64Lit  i  -> lit $ Word64Lit $ fromIntegral i
@@ -129,7 +129,7 @@ peepholeOp op = case op of
       Word64Lit _  -> lit l
       Float32Lit _ -> noop
       Float64Lit _ -> noop
-      PtrLit     _ -> noop
+      PtrLit   _ _ -> noop
     _ -> noop
   -- TODO: Support more unary and binary ops.
   BinOp IAdd l r -> return $ case (l, r) of

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -13,7 +13,7 @@ module QueryType (
   getMethodIndex,
   instantiateDataDef, applyDataConAbs, dataDefRep,
   instantiateNaryPi, instantiateDepPairTy, instantiatePi, instantiateTabPi,
-  litType, lamExprTy, ptrLitType,
+  litType, lamExprTy,
   numNaryPiArgs, naryLamExprType, specializedFunType,
   projectionIndices, sourceNameType, typeBinOp, typeUnOp,
   isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict,
@@ -184,11 +184,7 @@ litType v = case v of
   Word64Lit  _ -> Scalar Word64Type
   Float64Lit _ -> Scalar Float64Type
   Float32Lit _ -> Scalar Float32Type
-  PtrLit p     -> PtrType $ ptrLitType p
-
-ptrLitType :: PtrLitVal -> PtrType
-ptrLitType (PtrSnapshot t _) = t
-ptrLitType (PtrLitVal   t _) = t
+  PtrLit ty _  -> PtrType ty
 
 lamExprTy :: LamBinder r n l -> Type r l -> Type r n
 lamExprTy (LamBinder b ty arr eff) bodyTy =
@@ -346,7 +342,7 @@ instance HasType r (Atom r) where
     TC _ -> return TyKind
     Eff _ -> return EffKind
     PtrVar v -> substM v >>= lookupEnv >>= \case
-      PtrBinding p -> return $ PtrTy $ ptrLitType p
+      PtrBinding ty _ -> return $ PtrTy ty
     TypeCon _ _ _ -> return TyKind
     DictCon dictExpr -> getTypeE dictExpr
     DictTy (DictType _ _ _) -> return TyKind

--- a/src/lib/Runtime.hs
+++ b/src/lib/Runtime.hs
@@ -125,7 +125,9 @@ loadLitVal ptr (Scalar ty) = liftIO case ty of
   Float32Type -> Float32Lit <$> peek (castPtr ptr)
 loadLitVal ptrPtr (PtrType t) = do
   ptr <- liftIO $ peek $ castPtr ptrPtr
-  return $ PtrLit $ PtrLitVal t ptr
+  PtrLit t <$> if ptr == nullPtr
+    then return NullPtr
+    else return $ PtrLitVal ptr
 loadLitVal _ (Vector _ _) = error "Vector loads not implemented"
 
 storeLitVal :: MonadIO m => Ptr () -> LitVal -> m ()
@@ -135,7 +137,7 @@ storeLitVal ptr val = liftIO case val of
   Word8Lit   x -> poke (castPtr ptr) x
   Float64Lit x -> poke (castPtr ptr) x
   Float32Lit x -> poke (castPtr ptr) x
-  PtrLit (PtrLitVal _ x) -> poke (castPtr ptr) x
+  PtrLit _ (PtrLitVal x) -> poke (castPtr ptr) x
   _ -> error "not implemented"
 
 foreign import ccall "free_dex"

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -567,7 +567,7 @@ data Binding (c::C) (n::S) where
   FunObjCodeBinding :: FunObjCode -> LinktimeNames n  -> Binding FunObjCodeNameC n
   ModuleBinding     :: Module n                       -> Binding ModuleNameC     n
   -- TODO: add a case for abstracted pointers, as used in `ClosedImpFunction`
-  PtrBinding        :: PtrLitVal                      -> Binding PtrNameC        n
+  PtrBinding        :: PtrType -> PtrLitVal           -> Binding PtrNameC        n
   SpecializedDictBinding :: SpecializedDictDef n      -> Binding SpecializedDictNameC n
   ImpNameBinding    :: BaseType                       -> Binding ImpNameC n
 deriving instance Show (Binding c n)
@@ -2085,7 +2085,7 @@ instance Color c => GenericE (Binding c) where
           (ImpFunction)
           (LiftE FunObjCode `PairE` LinktimeNames)
           (Module)
-          (LiftE PtrLitVal)
+          (LiftE (PtrType, PtrLitVal))
           (EffectDef)
           (HandlerDef)
           (EffectOpDef))
@@ -2104,7 +2104,7 @@ instance Color c => GenericE (Binding c) where
     ImpFunBinding     fun               -> Case1 $ Case0 $ fun
     FunObjCodeBinding x y               -> Case1 $ Case1 $ LiftE x `PairE` y
     ModuleBinding m                     -> Case1 $ Case2 $ m
-    PtrBinding p                        -> Case1 $ Case3 $ LiftE p
+    PtrBinding ty p                     -> Case1 $ Case3 $ LiftE (ty,p)
     EffectBinding   effDef              -> Case1 $ Case4 $ effDef
     HandlerBinding  hDef                -> Case1 $ Case5 $ hDef
     EffectOpBinding opDef               -> Case1 $ Case6 $ opDef
@@ -2123,7 +2123,7 @@ instance Color c => GenericE (Binding c) where
     Case1 (Case0 fun)                                       -> fromJust $ tryAsColor $ ImpFunBinding     fun
     Case1 (Case1 (LiftE x `PairE` y))                       -> fromJust $ tryAsColor $ FunObjCodeBinding x y
     Case1 (Case2 m)                                         -> fromJust $ tryAsColor $ ModuleBinding     m
-    Case1 (Case3 (LiftE ptr))                               -> fromJust $ tryAsColor $ PtrBinding        ptr
+    Case1 (Case3 (LiftE (ty,p)))                            -> fromJust $ tryAsColor $ PtrBinding        ty p
     Case1 (Case4 effDef)                                    -> fromJust $ tryAsColor $ EffectBinding     effDef
     Case1 (Case5 hDef)                                      -> fromJust $ tryAsColor $ HandlerBinding    hDef
     Case1 (Case6 opDef)                                     -> fromJust $ tryAsColor $ EffectOpBinding   opDef

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -51,36 +51,12 @@ char* malloc_dex(int64_t nbytes) {
   return ptr + alignment;
 }
 
-char* dex_malloc_initialized(int64_t nbytes) {
-  char *ptr = malloc_dex(nbytes);
-  memset(ptr, 0, nbytes);
-  return ptr;
-}
-
 void free_dex(char* ptr) {
   free(ptr - alignment);
 }
 
 int64_t dex_allocation_size (char* ptr) {
   return *(reinterpret_cast<int64_t*>(ptr - alignment));
-}
-
-void deep_copy_dex(int64_t depth, char* dest, char* src, int64_t numbytes) {
-  if (depth == 1) {
-    memcpy(dest, src, numbytes);
-  } else {
-    for (int64_t i=0; i < (numbytes / sizeof(char*)); i++) {
-      char* sub_src  = *(((char**)src)  + i);
-      // don't do a copy if the buffer isn't initialized (indicated by a null pointer)
-      if (sub_src) {
-        int64_t box_size = dex_allocation_size(sub_src);
-        char* sub_dest = dex_malloc_initialized(box_size);
-        deep_copy_dex(depth - 1, sub_dest, sub_src, box_size);
-        *(((char**)dest) + i) = sub_dest;
-        // TODO: free the old dest
-      }
-    }
-  }
 }
 
 void* dex_pthread_key_create () {


### PR DESCRIPTION
The bug: we use null pointers to represent uninitialized boxes. These can occur in the unused side of a sum type, for example the value `Nothing : Maybe (List Float)` will have a null pointer for the `List Float` side. We check whether the pointer is null before doing a copy. Not only would it be bad to dereference the null pointer, but allocating the memory for the result would also fail because we'd be determining the allocation size based on the garbage value in the "size" part of the `List Float`. Previously in the null case we just didn't do any copy, but actually we need to go further than that to maintain the invariant that "garbage size implies null pointer". We need to explicitly put a null pointer in the destination because the current value might be non-null. Note that this is not because it might contain uninitialized memory -- the initialization we do at allocation time handles that -- but because it might have had a legitimate non-null pointer stored there, such as if a `Ref (Maybe (List Float))` previously contained the `Just` case.

In implementing the fix, it ended up being easier to just clean up the way we handle boxed memory generally. A few changes:
  * Move the logic for null-intializing pointer-containing memory to Imp.hs which is where it belongs, (since that's where the rest of the box memory management happens), rather than in ImpToLLVM.hs.
  * Codegen the deep copy rather than calling out to a C++ runtime function. The deep copies are rare enough that I'm not worried about code blowup and this lets us keep all the logic in one place.
  * Add an explicit `NullPtr` case to our pointer literals. We generally want to avoid compiling code that contains pointer literals but the null pointer is a special case.
  * Actually do the freeing of inaccessible boxes! This is a TODO we've had since we first had dependent pairs. The memory leak probably isn't too bad in practice because nested boxes are rare, but it's good to fix it even so!