### PR TITLE
Bring Export Imp path up to date with canonical representations.

### DIFF
--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -33,9 +33,9 @@ import TopLevel
 import Dex.Foreign.Util
 import Dex.Foreign.Context
 
-intAsCC :: CInt -> ExportCC
-intAsCC 0 = FlatExportCC
-intAsCC 1 = XLAExportCC
+intAsCC :: CInt -> CallingConvention
+intAsCC 0 = StandardCC
+intAsCC 1 = XLACC
 intAsCC _ = error "Unrecognized calling convention"
 
 dexCompile :: Ptr Context -> CInt -> Ptr AtomEx -> IO ExportNativeFunctionAddr

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -1206,8 +1206,8 @@ checkFFIFunTypeM (NaryPiType (NonEmptyNest b bs) eff resultTy) = do
       resultTys <- checkScalarOrPairType resultTy
       let cc = case length resultTys of
                  0 -> error "Not implemented"
-                 1 -> FFIFun
-                 _ -> FFIMultiResultFun
+                 1 -> FFICC
+                 _ -> FFIMultiResultCC
       return $ IFunType cc [argTy] resultTys
     Nest b' rest -> do
       let naryPiRest = NaryPiType (NonEmptyNest b' rest) eff resultTy

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -684,7 +684,7 @@ compileTopLevelFun :: (Topper m, Mut n) => CAtomName n -> m n ()
 compileTopLevelFun fname = do
   fPreSimp <- specializedFunPreSimpDefinition fname
   fSimp <- simplifyTopFunction fPreSimp
-  fImp <- toImpFunction CInternalFun fSimp
+  fImp <- toImpFunction StandardCC fSimp
   fImpName <- emitImpFunBinding (getNameHint fname) fImp
   extendImpCache fname fImpName
   fObj <- toCFunction (getNameHint fImpName) fImp
@@ -764,8 +764,8 @@ evalLLVM block = do
   backend <- backendName <$> getConfig
   logger  <- getFilteredLogger
   let (cc, _needsSync) =
-        case backend of LLVMCUDA -> (EntryFun CUDARequired   , True )
-                        _        -> (EntryFun CUDANotRequired, False)
+        case backend of LLVMCUDA -> (EntryFunCC CUDARequired   , True )
+                        _        -> (EntryFunCC CUDANotRequired, False)
   impFun <- checkPass ImpPass $ blockToImpFunction backend cc block
   let IFunType _ _ resultTypes = impFunType impFun
   (closedImpFun, reqFuns, reqPtrNames) <- abstractLinktimeObjects impFun

--- a/src/lib/Types/Imp.hs
+++ b/src/lib/Types/Imp.hs
@@ -63,11 +63,18 @@ instance IsBool IsCUDARequired where
   toBool CUDANotRequired = False
 
 data CallingConvention =
-   CEntryFun
- | CInternalFun
- | EntryFun IsCUDARequired
- | FFIFun
- | FFIMultiResultFun
+   -- Scalar args by value, arrays by pointer, dests allocated by caller and passed as pointers.
+   -- Used for standalone functions and for functions called from Python without XLA.
+   StandardCC
+   -- Used for functions called from within an XLA computation.
+ | XLACC
+   -- Dests allocated within the function and passed back to the caller (packed
+   -- in a number-of-results-length buffer supplied by the caller)
+ | EntryFunCC IsCUDARequired
+   -- Scalars only. Args as args, result as result. Used for calling C function
+   -- from Dex that return a single scalar.
+ | FFICC
+ | FFIMultiResultCC
  | CUDAKernelLaunch
  | MCThreadLaunch
    deriving (Show, Eq, Generic)


### PR DESCRIPTION
This turned out to be easier than expected! Happily, our canonical representation turned out to be identical to Adam's "flat" calling convention in case of the types handled by the Python interop.