### PR TITLE
Report more error information when inference detects a leaked local variable.

### DIFF
--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -2608,7 +2608,7 @@ type B = S -> S -> *  -- binder-y things, covariant in the first param and
 type V = C -> E       -- value-y things that we might look up in an environment
                       -- with a `Name c n`, parameterized by the name's color.
 
--- We use SubstItem for ColorRep to be able ot unsafeCoerce scopes into name sets in O(1).
+-- We use SubstItem for ColorRep to be able to unsafeCoerce scopes into name sets in O(1).
 type ColorRep = SubstItem GHC.Exts.Any UnsafeS
 type NameSet (n::S) = RawNameMap ColorRep
 

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -197,6 +197,10 @@ def passthrough {a b} {eff:Effects} (f:(a -> {|eff} b)) (x:a) : {|eff} b = f x
   f : (aa:Type) -> aa -> aa = \bb. \x. myId x
   f Int 1
 > Leaked local variables:[bb]
+> Failed to exchage binders in buildAbsInf
+> Pending emissions:
+> Defaults: 
+> Solver substitution: [(_.4, bb)]
 >
 >   f : (aa:Type) -> aa -> aa = \bb. \x. myId x
 >                               ^^^^^^^^^^^^^^^


### PR DESCRIPTION
In particular, the case that occurred in Issue #1176 is now very verbose, in hopes of making it easier to intuit the fix suggested there.

But perhaps there is a way to make the variable not leak in the first place?