### PR TITLE
Generalize `StringSetIx` to any element type, and rename it `Element`.

### DIFF
--- a/lib/set.dx
+++ b/lib/set.dx
@@ -79,37 +79,33 @@ def set_intersect {a}
   UnsafeAsSet _ intersection
 
 
-'## Index set for sets of strings
+'## Sets as a type, whose inhabitants can index arrays
 
--- Todo: Make polymorphic in type.  Waiting on a bugfix.
--- data SetIx a l:(Set a) [Ord a] =
+-- TODO Implicit arguments to data definitions
+-- (Probably `a` should be implicit)
+data Element a:Type [Ord a] set:(Set a) = UnsafeElement Nat
 
-data StringSetIx l:(Set String) =
-  MkSetIx Nat   -- TODO: Use (Fin (setSize l)) instead.
+-- TODO The set argument could be implicit (inferred from the Element
+-- type), but maybe it's easier to read if it's explicit.
+def member {a} (x:a) (set:(Set a)) : Maybe (Element a set) =
+  (UnsafeAsSet _ elts) = set
+  case search_sorted elts x of
+    Just n -> Just $ UnsafeElement $ ordinal n
+    Nothing -> Nothing
 
-instance Ix (StringSetIx set) given {set}
+def value {a} {set:(Set a)} (x:Element a set) : a =
+  (UnsafeAsSet _ elts) = set
+  UnsafeElement ix = x
+  elts.(unsafe_from_ordinal _ ix)
+
+instance Ix (Element a set) given {a} {set:(Set a)}
   size = set_size set
-  ordinal = \(MkSetIx i). i
-  unsafe_from_ordinal = \k. MkSetIx k
+  ordinal = \(UnsafeElement n). n
+  unsafe_from_ordinal = \n. UnsafeElement n
 
-instance Eq (StringSetIx set) given {set}
+instance Eq (Element a set) given {a} {set:(Set a)}
   (==) = \ix1 ix2. ordinal ix1 == ordinal ix2
 
--- Todo: Add an interface for converting to and from integer indices.
--- Compiler can't handle the associated type yet.
--- interface AssocIx n  -- index sets where indices have data associated with them
---   IxValueType : Type
---   ixValue  : n -> IxValueType n
---   lookupIx : IxValueType n -> n
-
-def string_to_set_ix {set:Set String} (s:String) : Maybe (StringSetIx set) =
-  (UnsafeAsSet n elements) = set
-  maybeIx = search_sorted elements s
-  case maybeIx of
-    Nothing -> Nothing
-    Just i -> Just $ MkSetIx (ordinal i)
-
-def set_ix_to_string {set:Set String} (ix:StringSetIx set) : String =
-  (UnsafeAsSet n elements) = set
-  elements.(unsafe_from_ordinal _ (ordinal ix))
-
+instance Ord (Element a set) given {a} {set:(Set a)}
+  (<) = \ix1 ix2. ordinal ix1 < ordinal ix2
+  (>) = \ix1 ix2. ordinal ix1 > ordinal ix2

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -52,27 +52,29 @@ emptyset = to_set ([]::(Fin 0)=>String)
 
 names2 = to_set ["Bob", "Alice", "Charlie", "Alice"]
 
-:p size (StringSetIx names2)
+Person = (Element String names2)
+
+:p size Person
 > 3
 
 -- Check that ordinal and unsafeFromOrdinal are inverses.
-roundTrip = for i:(StringSetIx names2).
+roundTrip = for i:Person.
   i == (unsafe_from_ordinal _ (ordinal i))
 :p all roundTrip
 > True
 
--- Check that index to string and string to index are inverses.
-roundTrip2 = for i:(StringSetIx names2).
-  s = set_ix_to_string i
-  ix = string_to_set_ix s
+-- Check that member and value are inverses.
+roundTrip2 = for i:Person.
+  s = value i
+  ix = member s names2
   i == from_just ix
 :p all roundTrip2
 > True
 
-setix : StringSetIx names2 = from_just $ string_to_set_ix "Bob"
+setix : Person = from_just $ member "Bob" names2
 :p setix
-> (MkSetIx 1)
+> (UnsafeElement 1)
 
-setix2 : StringSetIx names2 = from_just $ string_to_set_ix "Charlie"
+setix2 : Person = from_just $ member "Charlie" names2
 :p setix2
-> (MkSetIx 2)
+> (UnsafeElement 2)


### PR DESCRIPTION
Usage example:

```
people = to_set <a bunch of strings>
Person = Element String people
for i:Person.
  ...
```

At runtime, `Person` is an integer indexing into the array backing the set.  You can compare them for equality and ordering, and use them as indices into other arrays (TODO and hash them) without having to mess with the actual strings; but the strings are there if you ever need them.

Tagline: The code book is in the type.