### PR TITLE
Split up primops into groups so they can be allowed/denied at the group level

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -62,6 +62,7 @@ library
                      , Inference
                      , Inline
                      , Interpreter
+                     , IRVariants
                      , LLVM.Link
                      , LLVM.Compile
                      , LLVM.CUDA

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -1123,18 +1123,18 @@ instance Storable Word8
   storage_size = 1
 
 instance Storable Int32
-  store = \(MkPtr ptr) x. %ptrStore (internal_cast %Int32Ptr ptr) x
-  load  = \(MkPtr ptr)  . %ptrLoad  (internal_cast %Int32Ptr ptr)
+  store = \(MkPtr ptr) x. %ptrStore (internal_cast (%Int32Ptr) ptr) x
+  load  = \(MkPtr ptr)  . %ptrLoad  (internal_cast (%Int32Ptr) ptr)
   storage_size = 4
 
 instance Storable Word32
-  store = \(MkPtr ptr) x. %ptrStore (internal_cast %Word32Ptr ptr) x
-  load  = \(MkPtr ptr)  . %ptrLoad  (internal_cast %Word32Ptr ptr)
+  store = \(MkPtr ptr) x. %ptrStore (internal_cast (%Word32Ptr) ptr) x
+  load  = \(MkPtr ptr)  . %ptrLoad  (internal_cast (%Word32Ptr) ptr)
   storage_size = 4
 
 instance Storable Float32
-  store = \(MkPtr ptr) x. %ptrStore (internal_cast %Float32Ptr ptr) x
-  load = \(MkPtr ptr)   . %ptrLoad  (internal_cast %Float32Ptr ptr)
+  store = \(MkPtr ptr) x. %ptrStore (internal_cast (%Float32Ptr) ptr) x
+  load = \(MkPtr ptr)   . %ptrLoad  (internal_cast (%Float32Ptr) ptr)
   storage_size = 4
 
 instance Storable Nat
@@ -1143,8 +1143,8 @@ instance Storable Nat
   storage_size = storage_size NatRep
 
 instance Storable (Ptr a) given {a}
-  store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internal_cast %PtrPtr ptr) x
-  load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internal_cast %PtrPtr ptr)
+  store = \(MkPtr ptr) (MkPtr x).         %ptrStore (internal_cast (%PtrPtr) ptr) x
+  load  = \(MkPtr ptr)          . MkPtr $ %ptrLoad  (internal_cast (%PtrPtr) ptr)
   storage_size = 8  -- TODO: something more portable?
 
 -- TODO: Storable instances for other types

--- a/src/lib/AbstractSyntax.hs
+++ b/src/lib/AbstractSyntax.hs
@@ -203,7 +203,7 @@ optAnnotatedBinder (lhs, rhs) = do
   rhs' <- mapM expr rhs
   return $ UAnnBinder (maybe UIgnore fromString lhs')
     $ fromMaybe tyKind rhs'
-  where tyKind = ns $ UPrimExpr $ TCExpr TypeKind
+  where tyKind = ns $ UPrim (UPrimTC TypeKind) []
 
 multiIfaceBinder :: Group -> SyntaxM [UAnnBinder AtomNameC VoidS VoidS]
 multiIfaceBinder = dropSrc \case
@@ -431,8 +431,7 @@ expr = propagateSrcE expr' where
   expr' CEmpty              = return   UHole
   -- Binders (e.g., in pi types) should not hit this case
   expr' (CIdentifier name)  = return $ fromString name
-  expr' (CPrim prim)        = UPrimExpr <$> mapM expr prim
-  expr' (CPrimApp prim xs)  = UPrimApp prim <$> mapM expr xs
+  expr' (CPrim prim xs)     = UPrim prim <$> mapM expr xs
   expr' (CNat word)         = return $ UNatLit word
   expr' (CInt int)          = return $ UIntLit int
   expr' (CString str)       = return $ UApp (fromString "to_list")
@@ -541,10 +540,10 @@ expr = propagateSrcE expr' where
   expr' (CDo blk) = ULam . (ULamExpr PlainArrow (UPatAnn (nsB $ UPatUnit UnitB) Nothing)) <$> block blk
 
 charExpr :: Char -> (UExpr' VoidS)
-charExpr c = UPrimExpr $ ConExpr $ Lit $ Word8Lit $ fromIntegral $ fromEnum c
+charExpr c = UPrim (UPrimCon $ Lit $ Word8Lit $ fromIntegral $ fromEnum c) []
 
 unitExpr :: UExpr' VoidS
-unitExpr = UPrimExpr $ ConExpr $ ProdCon []
+unitExpr = UPrim (UPrimCon $ ProdCon []) []
 
 labelExpr :: LabelPrefix -> String -> UExpr' VoidS
 labelExpr PlainLabel str = ULabel str

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -163,7 +163,7 @@ blockAsPolyRec decls result = case decls of
     exprAsPoly :: Expr SimpToImpIR i -> BlockTraverserM i o (Polynomial o)
     exprAsPoly e = case e of
       Atom a -> atomAsPoly a
-      Op (BinOp op x y) -> case op of
+      PrimOp (BinOp op x y) -> case op of
         IAdd -> add <$> atomAsPoly x <*> atomAsPoly y
         IMul -> mul <$> atomAsPoly x <*> atomAsPoly y
         -- XXX: we rely on the wrapping behavior of subtraction on unsigned ints

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Builder (
-  emit, emitHinted, emitOp, emitUnOp,
+  emit, emitHinted, emitOp, emitExpr, emitUnOp,
   buildPureLam, BuilderT (..), Builder (..), ScopableBuilder (..),
   buildScopedAssumeNoDecls,
   Builder2, BuilderM, ScopableBuilder2,
@@ -84,6 +84,7 @@ import LabeledItems
 import Util (enumerate, transitiveClosureM, bindM2, toSnocList)
 import Err
 import Types.Core
+import Types.Primitives
 import Core
 
 -- === Ordinary (local) builder class ===
@@ -109,9 +110,13 @@ emitHinted :: (Builder r m, Emits n) => NameHint -> Expr r n -> m n (AtomName r 
 emitHinted hint expr = emitDecl hint PlainLet expr
 {-# INLINE emitHinted #-}
 
-emitOp :: (Builder r m, Emits n) => Op r n -> m n (Atom r n)
-emitOp op = Var <$> emit (Op op)
+emitOp :: (Builder r m, Emits n) => PrimOp (Atom r n) -> m n (Atom r n)
+emitOp op = Var <$> emit (PrimOp op)
 {-# INLINE emitOp #-}
+
+emitExpr :: (Builder r m, Emits n) => Expr r n -> m n (Atom r n)
+emitExpr expr = Var <$> emit expr
+{-# INLINE emitExpr #-}
 
 emitUnOp :: (Builder r m, Emits n) => UnOp -> Atom r n -> m n (Atom r n)
 emitUnOp op x = emitOp $ UnOp op x
@@ -944,15 +949,15 @@ buildCase scrut resultTy indexedAltBody = do
           eff <- getEffects blk
           return $ blk `PairE` eff
         return (Abs b' body, ignoreHoistFailure $ hoist b' eff')
-      liftM Var $ emit $ Case scrut alts resultTy $ mconcat effs
+      emitExpr $ Case scrut alts resultTy $ mconcat effs
 
-buildSplitCase :: (Emits n, ScopableBuilder r m)
+buildSplitCase :: (Emits n, ScopableBuilder r m, IsCore r)
                => LabeledItems (Type r n) -> Atom r n -> Type r n
                -> (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
                -> (forall l. (Emits l, DExt n l) => Atom r l -> m l (Atom r l))
                -> m n (Atom r n)
 buildSplitCase tys scrut resultTy match fallback = do
-  split <- emitOp $ VariantSplit tys scrut
+  split <- emitExpr $ RecordVariantOp $ VariantSplit tys scrut
   buildCase split resultTy \i v ->
     case i of
       0 -> match v
@@ -985,7 +990,7 @@ buildForAnn hint ann ixTy@(IxType iTy ixDict) body = do
     let v = binderName b
     body' <- buildBlock $ body $ sink v
     return $ LamExpr (UnaryNest (b:>iTy)) body'
-  liftM Var $ emit $ Hof $ For ann ixDict lam
+  emitExpr $ Hof $ For ann ixDict lam
 
 buildFor :: (Emits n, ScopableBuilder r m)
          => NameHint -> Direction -> IxType r n
@@ -1009,7 +1014,7 @@ emitRunWriter
   -> m n (Atom r n)
 emitRunWriter hint accTy bm body = do
   lam <- buildEffLam Writer hint accTy \h ref -> body h ref
-  liftM Var $ emit $ Hof $ RunWriter Nothing bm lam
+  emitExpr $ Hof $ RunWriter Nothing bm lam
 
 emitRunState
   :: (Emits n, ScopableBuilder r m)
@@ -1019,7 +1024,7 @@ emitRunState
 emitRunState hint initVal body = do
   stateTy <- getType initVal
   lam <- buildEffLam State hint stateTy \h ref -> body h ref
-  liftM Var $ emit $ Hof $ RunState Nothing initVal lam
+  emitExpr $ Hof $ RunState Nothing initVal lam
 
 emitRunReader
   :: (Emits n, ScopableBuilder r m)
@@ -1029,7 +1034,7 @@ emitRunReader
 emitRunReader hint r body = do
   rTy <- getType r
   lam <- buildEffLam Reader hint rTy \h ref -> body h ref
-  liftM Var $ emit $ Hof $ RunReader r lam
+  emitExpr $ Hof $ RunReader r lam
 
 -- === vector space (ish) type class ===
 
@@ -1174,7 +1179,7 @@ makeMethodGetter className explicit methodIdx = liftBuilder do
   buildPureNaryLam (EmptyAbs $ zipPiBinders arrows paramBs) \params -> do
     let dictTy = DictTy $ DictType sourceName (sink className') (map Var params)
     buildPureLam noHint ClassArrow dictTy \dict ->
-      emitOp $ ProjMethod (Var dict) methodIdx
+      emitExpr $ ProjMethod (Var dict) methodIdx
   where
     zipPiBinders :: [Arrow] -> Nest (RolePiBinder r') i i' -> Nest (PiBinder r) i i'
     zipPiBinders = zipNest \arr (RolePiBinder b ty _ _) -> PiBinder b (unsafeCoerceIRE ty) arr
@@ -1236,7 +1241,7 @@ isub x y = emitOp $ BinOp ISub x y
 
 select :: (Builder r m, Emits n) => Atom r n -> Atom r n -> Atom r n -> m n (Atom r n)
 select (Con (Lit (Word8Lit p))) x y = return $ if p /= 0 then x else y
-select p x y = emitOp $ Select p x y
+select p x y = emitOp $ MiscOp $ Select p x y
 
 div' :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 div' x y = emitOp $ BinOp FDiv x y
@@ -1285,7 +1290,7 @@ getNaryProjRef [] ref = return ref
 getNaryProjRef (i:is) ref = getProjRef i =<< getNaryProjRef is ref
 
 getProjRef :: (Builder r m, Emits n) => Int -> Atom r n -> m n (Atom r n)
-getProjRef i r = emitOp $ ProjRef i r
+getProjRef i r = emitExpr $ RefOp r $ ProjRef i
 
 -- XXX: getUnpacked must reduce its argument to enforce the invariant that
 -- ProjectElt atoms are always fully reduced (to avoid type errors between two
@@ -1338,20 +1343,20 @@ naryTabAppHinted hint f xs = case nonEmpty xs of
   Just xs' -> Var <$> emitHinted hint (TabApp f xs')
 
 indexRef :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
-indexRef ref i = emitOp $ IndexRef ref i
+indexRef ref i = emitExpr $ RefOp ref $ IndexRef i
 
 naryIndexRef :: (Builder r m, Emits n) => Atom r n -> [Atom r n] -> m n (Atom r n)
 naryIndexRef ref is = foldM indexRef ref is
 
 ptrOffset :: (Builder r m, Emits n) => Atom r n -> Atom r n -> m n (Atom r n)
 ptrOffset x (IdxRepVal 0) = return x
-ptrOffset x i = emitOp $ PtrOffset x i
+ptrOffset x i = emitOp $ MemOp $ PtrOffset x i
 {-# INLINE ptrOffset #-}
 
 unsafePtrLoad :: (Builder r m, Emits n) => Atom r n -> m n (Atom r n)
 unsafePtrLoad x = do
-  body <- liftEmitBuilder $ buildBlock $ emitOp . PtrLoad =<< sinkM x
-  liftM Var $ emit $ Hof $ RunIO body
+  body <- liftEmitBuilder $ buildBlock $ emitOp . MemOp . PtrLoad =<< sinkM x
+  emitExpr $ Hof $ RunIO body
 
 -- === index set type class ===
 
@@ -1378,7 +1383,7 @@ applyIxMethod dict method args = case dict of
           _    -> params ++ args
     emitBlock =<< applySubst (bs @@> fmap SubstVal args') body
   _ -> do
-    methodImpl <- emitOp $ ProjMethod dict (fromEnum method)
+    methodImpl <- emitExpr $ ProjMethod dict (fromEnum method)
     naryApp methodImpl args
 
 -- This works with `Nat` instead of `IndexRepTy` because it's used alongside
@@ -1425,7 +1430,7 @@ emitIf :: (Emits n, ScopableBuilder r m)
        -> (forall l. (Emits l, DExt n l) => m l (Atom r l))
        -> m n (Atom r n)
 emitIf predicate resultTy trueCase falseCase = do
-  predicate' <- emitOp $ ToEnum (SumTy [UnitTy, UnitTy]) predicate
+  predicate' <- emitOp $ MiscOp $ ToEnum (SumTy [UnitTy, UnitTy]) predicate
   buildCase predicate' resultTy \i _ ->
     case i of
       0 -> falseCase
@@ -1449,7 +1454,7 @@ fromJustE :: (Emits n, Builder r m) => Atom r n -> m n (Atom r n)
 fromJustE x = liftEmitBuilder do
   MaybeTy a <- getType x
   emitMaybeCase x a
-    (emitOp $ ThrowError $ sink a)
+    (emitOp $ MiscOp $ ThrowError $ sink a)
     (return)
 
 -- Maybe a -> Bool
@@ -1465,7 +1470,7 @@ reduceE monoid xs = liftEmitBuilder do
   getSnd =<< emitRunWriter noHint a' monoid \_ ref ->
     buildFor noHint Fwd (sink ty) \i -> do
       x <- tabApp (sink xs) (Var i)
-      liftM Var $ emit $ PrimEffect (sink $ Var ref) $ MExtend (sink monoid) x
+      emitExpr $ RefOp (sink $ Var ref) $ MExtend (sink monoid) x
 
 andMonoid :: EnvReader m => m n (BaseMonoid r n)
 andMonoid = liftM (BaseMonoid TrueAtom) $ liftBuilder $
@@ -1522,7 +1527,7 @@ runMaybeWhile body = do
     emitWhile do
       ans <- body
       emitMaybeCase ans Word8Ty
-        (emit (PrimEffect (sink $ Var ref) $ MPut TrueAtom) >> return FalseAtom)
+        (emit (RefOp (sink $ Var ref) $ MPut TrueAtom) >> return FalseAtom)
         (return)
     return UnitVal
   emitIf hadError (MaybeTy UnitTy)

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -259,7 +259,7 @@ instance CheaplyReducibleE r (Expr r) (Atom r) where
         _ -> empty
     -- TODO: Make sure that this wraps correctly
     -- TODO: Other casts?
-    Op (CastOp ty' val') -> do
+    PrimOp (MiscOp (CastOp ty' val')) -> do
       ty <- cheapReduceE ty'
       case ty of
         BaseTy (Scalar Word32Type) -> do
@@ -268,7 +268,7 @@ instance CheaplyReducibleE r (Expr r) (Atom r) where
             Con (Lit (Word64Lit v)) -> return $ Con $ Lit $ Word32Lit $ fromIntegral v
             _ -> empty
         _ -> empty
-    Op (ProjMethod dict i) -> do
+    ProjMethod dict i -> do
       cheapReduceE dict >>= \case
         DictCon (InstanceDict instanceName args) -> dropSubst do
           args' <- mapM cheapReduceE args

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -32,6 +32,7 @@ import qualified Data.Map.Strict       as M
 
 import Name
 import Err
+import IRVariants
 
 import Types.Core
 import Types.Imp

--- a/src/lib/IRVariants.hs
+++ b/src/lib/IRVariants.hs
@@ -1,0 +1,68 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module IRVariants
+  ( IR (..), IRPredicate (..), Sat, Sat', IsCore, IsCore', IsLowered, IsLowered'
+  , unsafeCoerceIRE, unsafeCoerceFromAnyIR, unsafeCoerceIRB, injectIRE
+  , CovariantInIR, InferenceIR) where
+
+import GHC.Exts (Constraint)
+import Name
+import qualified Unsafe.Coerce as TrulyUnsafe
+
+data IR =
+   CoreIR       -- used after inference and before simplification
+ | SimpIR       -- used after simplification
+ | SimpToImpIR  -- only used during the Simp-to-Imp translation
+ | AnyIR        -- used for deserialization only
+
+data IRFeature =
+  DAMOps
+
+-- TODO: make this a hard distinctions
+type InferenceIR = CoreIR  -- used during type inference only
+
+data IRPredicate =
+   Is IR
+ -- TODO: find a way to make this safe and derive it automatically. For now, we
+ -- assert it manually for the valid cases we know about.
+ | IsSubsetOf IR
+ | HasFeature IRFeature
+
+type Sat (r::IR) (p::IRPredicate) = (Sat' r p ~ True) :: Constraint
+type family Sat' (r::IR) (p::IRPredicate) where
+  Sat' r (Is r)                              = True
+  Sat' SimpIR (IsSubsetOf SimpToImpIR)       = True
+  Sat' SimpIR (IsSubsetOf CoreIR)            = True
+  Sat' SimpIR      (HasFeature DAMOps)       = True
+  Sat' SimpToImpIR (HasFeature DAMOps)       = True
+  Sat' _ _ = False
+
+type IsCore  r = r `Sat`  Is CoreIR
+type IsCore' r = r `Sat'` Is CoreIR
+type IsLowered  r = r `Sat`  HasFeature DAMOps
+type IsLowered' r = r `Sat'` HasFeature DAMOps
+
+-- XXX: the intention is that we won't have to use these much
+unsafeCoerceIRE :: forall (r'::IR) (r::IR) (e::IR->E) (n::S). e r n -> e r' n
+unsafeCoerceIRE = TrulyUnsafe.unsafeCoerce
+
+-- XXX: the intention is that we won't have to use these much
+unsafeCoerceFromAnyIR :: forall (r::IR) (e::IR->E) (n::S). e AnyIR n -> e r n
+unsafeCoerceFromAnyIR = unsafeCoerceIRE
+
+unsafeCoerceIRB :: forall (r'::IR) (r::IR) (b::IR->B) (n::S) (l::S) . b r n l -> b r' n l
+unsafeCoerceIRB = TrulyUnsafe.unsafeCoerce
+
+class CovariantInIR (e::IR->E)
+-- For now we're "implementing" this instances manually as needed because we
+-- don't actually need very many of them, but we should figure out a more
+-- uniform way to do it.
+
+-- This is safe, assuming the constraints have been implemented correctly.
+injectIRE :: (CovariantInIR e, r `Sat` IsSubsetOf r') => e r n -> e r' n
+injectIRE = unsafeCoerceIRE
+

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -16,6 +16,7 @@ import LabeledItems
 import Name
 import Occurrence hiding (Var)
 import Syntax
+import Types.Core
 
 -- === External API ===
 
@@ -282,7 +283,7 @@ inlineName ctx name =
     SubstVal (DoneEx expr) -> dropSubst $ inlineExpr ctx expr
     SubstVal (SuspEx expr s') -> withSubst s' $ inlineExpr ctx expr
 
-instance Inlinable (PrimEffect SimpIR) where
+instance Inlinable (RefOp SimpIR) where
   inline ctx e = (inline Stop (fromE e) <&> toE) >>= reconstruct ctx
   {-# INLINE inline #-}
 
@@ -397,11 +398,11 @@ instance Inlinable e => Inlinable (ComposeE PrimOp e) where
   inline ctx (ComposeE op) =
     (ComposeE <$> traverse (inline Stop) op) >>= reconstruct ctx
   {-# INLINE inline #-}
-instance Inlinable e => Inlinable (ComposeE PrimCon e) where
+instance Inlinable e => Inlinable (ComposeE (PrimCon SimpIR) e) where
   inline ctx (ComposeE con) =
     (ComposeE <$> traverse (inline Stop) con) >>= reconstruct ctx
   {-# INLINE inline #-}
-instance Inlinable e => Inlinable (ComposeE PrimTC e) where
+instance Inlinable e => Inlinable (ComposeE (PrimTC SimpIR) e) where
   inline ctx (ComposeE tc) =
     (ComposeE <$> traverse (inline Stop) tc) >>= reconstruct ctx
   {-# INLINE inline #-}
@@ -423,6 +424,7 @@ instance Inlinable (DictType SimpIR)
 instance Inlinable (FieldRowElems SimpIR)
 instance Inlinable (FieldRowElem SimpIR)
 instance Inlinable (DataDefParams SimpIR)
+instance Inlinable (DAMOp SimpIR)
 
 instance (Inlinable e1, Inlinable e2) => Inlinable (PairE e1 e2) where
   inline ctx (PairE l r) =

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -21,6 +21,7 @@ import QueryType
 import Util (bindM2)
 import PPrint
 import Types.Core
+import Types.Primitives
 import Core
 
 -- === linearization monad ===
@@ -132,13 +133,6 @@ seqLin ms = do
   let xs = ms' <&> \(WithTangent x _) -> x
   return $ WithTangent (ComposeE xs) do
     ComposeE <$> forM ms' \(WithTangent _ t) -> t
-
-traverseLin
-  :: Traversable f
-  => (a -> LinM i o e e)
-  -> f a
-  -> LinM i o (ComposeE f e) (ComposeE f e)
-traverseLin f xs = seqLin $ fmap f xs
 
 liftTangentM :: TangentArgs o -> TangentM o a -> PrimalM i o a
 liftTangentM args m = liftSubstReaderT $ lift11 $ runReaderT1 args m
@@ -350,17 +344,21 @@ linearizeExpr expr = case expr of
   TabApp x idxs -> do
     zipLin (linearizeAtom x) (pureLin $ ListE $ map injectCore $ toList idxs) `bindLin`
       \(PairE x' (ListE idxs')) -> naryTabApp x' idxs'
-  Op op      -> linearizeOp op
-  PrimEffect ref m -> case m of
-    MAsk -> linearizeAtom ref `bindLin` \ref' -> liftM Var $ emit $ PrimEffect ref' MAsk
+  PrimOp op      -> linearizeOp op
+  RefOp ref m -> case m of
+    MAsk -> linearizeAtom ref `bindLin` \ref' -> liftM Var $ emit $ RefOp ref' MAsk
     MExtend monoid x -> do
       -- TODO: check that we're dealing with a +/0 monoid
       monoid' <- injSubstM monoid
       zipLin (linearizeAtom ref) (linearizeAtom x) `bindLin` \(PairE ref' x') ->
-        liftM Var $ emit $ PrimEffect ref' $ MExtend (sink monoid') x'
-    MGet   -> linearizeAtom ref `bindLin` \ref' -> liftM Var $ emit $ PrimEffect ref' MGet
+        liftM Var $ emit $ RefOp ref' $ MExtend (sink monoid') x'
+    MGet   -> linearizeAtom ref `bindLin` \ref' -> liftM Var $ emit $ RefOp ref' MGet
     MPut x -> zipLin (linearizeAtom ref) (linearizeAtom x) `bindLin` \(PairE ref' x') ->
-                liftM Var $ emit $ PrimEffect ref' $ MPut x'
+                liftM Var $ emit $ RefOp ref' $ MPut x'
+
+    IndexRef i -> zipLin (la ref) (pureLin (injectCore i)) `bindLin`
+                    \(PairE ref' i') -> emitExpr $ RefOp ref' $ IndexRef i'
+    ProjRef i -> la ref `bindLin` \ref' -> emitExpr $ RefOp ref' $ ProjRef i
   Hof e      -> linearizeHof e
   Case e alts resultTy _ -> do
     e' <- injectCore <$> substM e
@@ -377,31 +375,33 @@ linearizeExpr expr = case expr of
           extendSubst (b @> x') $ withTangentFunAsLambda $ linearizeBlock body
         return $ WithTangent ans do
           applyLinToTangents $ sink linLam
-  Handle _ _ _ -> error "handlers should be gone by now"
-
-linearizeOp :: Emits o => Op SimpIR i -> LinM i o CAtom CAtom
-linearizeOp op = case op of
-  UnOp  uop x       -> linearizeUnOp  uop x
-  BinOp bop x y     -> linearizeBinOp bop x y
-  IndexRef ref i -> zipLin (la ref) (pureLin (injectCore i)) `bindLin`
-                      \(PairE ref' i') -> emitOp $ IndexRef ref' i'
-  ProjRef i ref -> la ref `bindLin` \ref' -> emitOp $ ProjRef i ref'
-  Select p t f -> (pureLin (injectCore p) `zipLin` la t `zipLin` la f) `bindLin`
-                     \(p' `PairE` t' `PairE` f') -> emitOp $ Select p' t' f'
-  -- XXX: This assumes that pointers are always constants
-  PtrLoad _              -> emitZeroT
-  PtrStore _ _           -> emitZeroT
-  PtrOffset _ _          -> emitZeroT
-  IOAlloc _ _            -> emitZeroT
-  IOFree _               -> emitZeroT
-  ThrowError _           -> emitZeroT
-  SumTag _               -> emitZeroT
-  ToEnum _ _             -> emitZeroT
   TabCon ty xs -> do
     ty' <- injSubstM ty
     seqLin (map linearizeAtom xs) `bindLin` \(ComposeE xs') ->
-      emitOp $ TabCon (sink ty') xs'
-  CastOp t v             -> do
+      emitExpr $ TabCon (sink ty') xs'
+  ProjMethod _ _ -> error "shouldn't occur here"
+  DAMOp _        -> error "shouldn't occur here"
+  where
+    la = linearizeAtom
+
+linearizeOp :: Emits o => PrimOp (Atom SimpIR i) -> LinM i o CAtom CAtom
+linearizeOp op = case op of
+  UnOp  uop x       -> linearizeUnOp  uop x
+  BinOp bop x y     -> linearizeBinOp bop x y
+  -- XXX: This assumes that pointers are always constants
+  MemOp _      -> emitZeroT
+  MiscOp miscOp -> linearizeMiscOp miscOp
+  VectorOp _ -> error "not implemented"
+  where
+    emitZeroT = withZeroT $ liftM Var $ emit =<< injSubstM (PrimOp op)
+
+linearizeMiscOp :: Emits o => MiscOp (Atom SimpIR i) -> LinM i o CAtom CAtom
+linearizeMiscOp op = case op of
+  SumTag _     -> emitZeroT
+  ToEnum _ _   -> emitZeroT
+  Select p t f -> (pureLin (injectCore p) `zipLin` la t `zipLin` la f) `bindLin`
+                     \(p' `PairE` t' `PairE` f') -> emitOp $ MiscOp $ Select p' t' f'
+  CastOp t v -> do
     vt <- getType =<< injSubstM v
     t' <- injSubstM t
     vtTangentType <- tangentType vt
@@ -409,34 +409,21 @@ linearizeOp op = case op of
     ((&&) <$> (vtTangentType `alphaEq` vt)
           <*> (tTangentType  `alphaEq` t')) >>= \case
       True -> do
-        linearizeAtom v `bindLin` \v' -> emitOp $ CastOp (sink t') v'
+        linearizeAtom v `bindLin` \v' -> emitOp $ MiscOp $ CastOp (sink t') v'
       False -> do
         WithTangent x xt <- linearizeAtom v
         yt <- case (vtTangentType, tTangentType) of
           (_     , UnitTy) -> return $ UnitVal
           (UnitTy, tt    ) -> zeroAt tt
           _                -> error "Expected at least one side of the CastOp to have a trivial tangent type"
-        y <- emitOp $ CastOp t' x
+        y <- emitOp $ MiscOp $ CastOp t' x
         return $ WithTangent y do xt >> return (sink yt)
-  BitcastOp _ _ -> notImplemented
-  RecordCons l r ->
-    zipLin (la l) (la r) `bindLin` \(PairE l' r') ->
-      emitOp $ RecordCons l' r'
-  RecordSplit f r ->
-    zipLin (la f) (la r) `bindLin` \(PairE f' r') ->
-      emitOp $ RecordSplit f' r'
-  VariantLift ts v ->
-    zipLin (traverseLin pureLin (fmap injectCore ts)) (la v) `bindLin`
-      \(PairE (ComposeE ts') v') -> emitOp $ VariantLift ts' v'
-  VariantSplit ts v ->
-    zipLin (traverseLin pureLin (fmap injectCore ts)) (la v) `bindLin`
-      \(PairE (ComposeE ts') v') -> emitOp $ VariantSplit ts' v'
-  ThrowException _       -> notImplemented
-  SumToVariant _         -> notImplemented
-  OutputStream           -> emitZeroT
-  _ -> notImplemented
+  BitcastOp _ _    -> notImplemented
+  ThrowException _ -> notImplemented
+  ThrowError _     -> emitZeroT
+  OutputStream     -> emitZeroT
   where
-    emitZeroT = withZeroT $ liftM Var $ emit =<< injSubstM (Op op)
+    emitZeroT = withZeroT $ liftM Var $ emit =<< injSubstM (PrimOp $ MiscOp op)
     la = linearizeAtom
 
 linearizeUnOp :: Emits o => UnOp -> SAtom i -> LinM i o CAtom CAtom

--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -27,6 +27,7 @@ import Types.Primitives
 
 import Err
 import Name
+import IRVariants
 import MTL1
 import Core
 import Builder
@@ -89,7 +90,7 @@ instance HoistableState LFS where
 -- annotations manually... The only interesting cases below are really For and TabCon.
 instance GenericTraverser SimpIR UnitB LFS where
   traverseExpr expr = case expr of
-    Op (TabCon ty els) -> traverseTabCon Nothing ty els
+    TabCon ty els -> traverseTabCon Nothing ty els
     Hof (For dir ixDict body) -> traverseFor Nothing dir ixDict body
     Case _ _ _ _ -> do
       Case e alts ty _ <- traverseExprDefault expr
@@ -112,20 +113,20 @@ traverseFor maybeDest dir ixDict lam@(UnaryLamExpr (ib:>ty) body) = do
       body' <- buildUnaryLamExpr noHint (PairTy ty' UnitTy) \b' -> do
         (i, _) <- fromPair $ Var b'
         extendSubst (ib @> SubstVal i) $ traverseBlock body $> UnitVal
-      void $ emit $ Hof $ Seq dir ixDict' UnitVal body'
+      void $ emit $ DAMOp $ Seq dir ixDict' UnitVal body'
       Atom . fromJust <$> singletonTypeVal ansTy
     False -> do
       initDest <- ProdVal . (:[]) <$> case maybeDest of
         Just  d -> return d
-        Nothing -> emitOp $ AllocDest ansTy
+        Nothing -> emitExpr $ DAMOp $ AllocDest ansTy
       destTy <- getType initDest
       body' <- buildUnaryLamExpr noHint (PairTy ty' destTy) \b' -> do
         (i, destProd) <- fromPair $ Var b'
         let dest = getProjection [ProjectProduct 0] destProd
-        idest <- emitOp $ IndexRef dest i
+        idest <- emitExpr $ RefOp dest $ IndexRef i
         extendSubst (ib @> SubstVal i) $ traverseBlockWithDest idest body $> UnitVal
-      let seqHof = Hof $ Seq dir ixDict' initDest body'
-      Op . Freeze . ProjectElt (ProjectProduct 0 NE.:| []) <$> emit seqHof
+      let seqHof = DAMOp $ Seq dir ixDict' initDest body'
+      DAMOp . Freeze . ProjectElt (ProjectProduct 0 NE.:| []) <$> emit seqHof
 traverseFor _ _ _ _ = error "expected a unary lambda expression"
 
 traverseTabCon :: Emits o => Maybe (Dest SimpIR o) -> SType i -> [SAtom i] -> LowerM i o (SExpr o)
@@ -133,7 +134,7 @@ traverseTabCon maybeDest tabTy elems = do
   tabTy'@(TabPi (TabPiType (_:>ixTy') _)) <- substM tabTy
   dest <- case maybeDest of
     Just  d -> return d
-    Nothing -> emitOp $ AllocDest tabTy'
+    Nothing -> emitExpr $ DAMOp $ AllocDest tabTy'
   Abs bord ufoBlock <- buildAbs noHint IdxRepTy \ord -> do
     buildBlock $ unsafeFromOrdinal (sink ixTy') $ Var $ sink ord
   forM_ (enumerate elems) \(ord, e) -> do
@@ -141,7 +142,7 @@ traverseTabCon maybeDest tabTy elems = do
       traverseBlock ufoBlock
     idest <- indexRef dest i
     place (FullDest idest) =<< traverseAtom e
-  return $ Op $ Freeze dest
+  return $ DAMOp $ Freeze dest
 
 
 -- Destination-passing traversals
@@ -220,7 +221,7 @@ traverseDeclNestWithDestS destMap s = \case
 
 traverseExprWithDest :: forall i o. Emits o => Maybe (ProjDest o) -> SExpr i -> LowerM i o (SExpr o)
 traverseExprWithDest dest expr = case expr of
-  Op (TabCon ty els) -> traverseTabCon tabDest ty els
+  TabCon ty els -> traverseTabCon tabDest ty els
   Hof (For dir ixDict body) -> traverseFor tabDest dir ixDict body
   Hof (RunWriter Nothing m body) -> traverseRWS Writer body \ref' body' -> do
     m' <- traverseGenericE m
@@ -273,8 +274,8 @@ traverseExprWithDest dest expr = case expr of
 
 place :: Emits o => ProjDest o -> SAtom o -> LowerM i o ()
 place pd x = case pd of
-  FullDest d -> void $ emitOp $ Place d x
-  ProjDest p d -> void $ emitOp $ Place d $ getProjection (NE.toList p) x
+  FullDest d   -> void $ emitExpr $ DAMOp $ Place d x
+  ProjDest p d -> void $ emitExpr $ DAMOp $ Place d $ getProjection (NE.toList p) x
 
 -- === Vectorization ===
 
@@ -342,13 +343,13 @@ vectorizeLoopsRec frag nest =
       narrowestTypeByteWidth <- getNarrowestTypeByteWidth expr'
       let loopWidth = vectorByteWidth `div` narrowestTypeByteWidth
       v <- case expr of
-        Hof (Seq dir (DictCon (IxFin (NatVal n))) dest@(ProdVal [_]) body)
+        DAMOp (Seq dir (DictCon (IxFin (NatVal n))) dest@(ProdVal [_]) body)
           | n `mod` loopWidth == 0 -> (do
               Distinct <- getDistinct
               let vn = NatVal $ n `div` loopWidth
               body' <- vectorizeSeq loopWidth (TC $ Fin vn) frag body
               dest' <- applySubst frag dest
-              emit $ Hof $ Seq dir (DictCon $ IxFin vn) dest' body')
+              emit $ DAMOp $ Seq dir (DictCon $ IxFin vn) dest' body')
             `catchErr` \errs -> do
                 let msg = "In `vectorizeLoopsRec`:\nExpr:\n" ++ pprint expr
                     ctx = mempty { messageCtx = [msg] }
@@ -356,7 +357,7 @@ vectorizeLoopsRec frag nest =
                 modify (<> errs')
                 dest' <- applySubst frag dest
                 body' <- applySubst frag body
-                emit $ Hof $ Seq dir (DictCon $ IxFin $ NatVal n) dest' body'
+                emit $ DAMOp $ Seq dir (DictCon $ IxFin $ NatVal n) dest' body'
         _ -> emitDecl (getNameHint b) ann =<< applySubst frag expr
       vectorizeLoopsRec (frag <.> b @> v) rest
 
@@ -426,7 +427,9 @@ vectorizeExpr :: Emits o => SExpr i -> VectorizeM i o (VAtom o)
 vectorizeExpr expr = addVectErrCtx "vectorizeExpr" ("Expr:\n" ++ pprint expr) do
   case expr of
     Atom atom -> vectorizeAtom atom
-    Op op -> vectorizeOp op
+    PrimOp op -> vectorizePrimOp op
+    DAMOp op -> vectorizeDAMOp op
+    RefOp ref op -> vectorizeRefOp ref op
     -- Vectorizing IO might not always be safe! Here, we depend on vectorizeOp
     -- being picky about the IO-inducing ops it supports, and expect it to
     -- complain about FFI calls and the like.
@@ -438,36 +441,39 @@ vectorizeExpr expr = addVectErrCtx "vectorizeExpr" ("Expr:\n" ++ pprint expr) do
       body' <- absToBlock =<< computeAbsEffects (Abs decls yWithTy)
       VVal vy . Var <$> emit (Hof (RunIO body'))
     _ -> throwVectErr $ "Cannot vectorize expr: " ++ pprint expr
-    -- Hof (RunIO (Lam (LamExpr (LamBinder b UnitTy PlainArrow _) body))) -> do
-    --   -- TODO: buildBlockAux?
-    --   (vy, lam') <- withFreshBinder (getNameHint b) UnitTy \b' -> do
-    --     Abs decls (LiftE vy `PairE` yWithTy) <- buildScoped do
-    --       VVal vy y <- extendSubst (b @> VVal Uniform UnitVal) $ vectorizeBlock body
-    --       PairE (LiftE vy) <$> withType y
-    --     body' <- absToBlock =<< computeAbsEffects (Abs decls yWithTy)
-    --     effs' <- getEffects body'
-    --     return (vy, LamExpr (LamBinder b' UnitTy PlainArrow effs') body')
-    --   VVal vy . Var <$> emit (Hof (RunIO (Lam lam')))
-    -- _ -> throwVectErr $ "Cannot vectorize expr: " ++ pprint expr
 
-vectorizeOp :: Emits o => Op SimpIR i -> VectorizeM i o (VAtom o)
-vectorizeOp op = do
-  op' <- (inline traversePrimOp) vectorizeAtom op
-  case op' of
-    IndexRef (VVal Uniform ref) (VVal Contiguous i) -> do
+vectorizeDAMOp :: Emits o => DAMOp SimpIR i -> VectorizeM i o (VAtom o)
+vectorizeDAMOp op =
+  case op of
+    Place ref' val' -> do
+      VVal vref ref <- vectorizeAtom ref'
+      sval@(VVal vval val) <- vectorizeAtom val'
+      VVal Uniform <$> case (vref, vval) of
+        (Uniform   , Uniform   ) -> emitExpr $ DAMOp $ Place ref val
+        (Uniform   , _         ) -> throwVectErr "Write conflict? This should never happen!"
+        (Varying   , _         ) -> throwVectErr "Vector scatter not implemented"
+        (Contiguous, Varying   ) -> emitExpr $ DAMOp $ Place ref val
+        (Contiguous, Contiguous) -> emitExpr . DAMOp . Place ref =<< ensureVarying sval
+        _ -> throwVectErr "Not implemented yet"
+    _ -> throwVectErr $ "Can't vectorize op: " ++ pprint op
+
+vectorizeRefOp :: Emits o => SAtom i -> RefOp SimpIR i -> VectorizeM i o (VAtom o)
+vectorizeRefOp ref' op =
+  case op of
+    IndexRef i' -> do
+      VVal Uniform ref <- vectorizeAtom ref'
+      VVal Contiguous i <- vectorizeAtom i'
       TC (RefType _ (TabTy tb a)) <- getType ref
       vty <- getVectorType =<< case hoist tb a of
         HoistSuccess a' -> return a'
         HoistFailure _  -> throwVectErr "Can't vectorize dependent table application"
-      VVal Contiguous <$> emitOp (VectorSubref ref i vty)
-    Place (VVal vref ref) sval@(VVal vval val) -> do
-      VVal Uniform <$> case (vref, vval) of
-        (Uniform   , Uniform   ) -> emitOp $ Place ref val
-        (Uniform   , _         ) -> throwVectErr "Write conflict? This should never happen!"
-        (Varying   , _         ) -> throwVectErr "Vector scatter not implemented"
-        (Contiguous, Varying   ) -> emitOp $ Place ref val
-        (Contiguous, Contiguous) -> emitOp . Place ref =<< ensureVarying sval
-        _ -> throwVectErr "Not implemented yet"
+      VVal Contiguous <$> emitOp (VectorOp $ VectorSubref ref i vty)
+    _ -> throwVectErr $ "Can't vectorize op: " ++ pprint (RefOp ref' op)
+
+vectorizePrimOp :: Emits o => PrimOp (Atom SimpIR i) -> VectorizeM i o (VAtom o)
+vectorizePrimOp op = do
+  op' <- (inline traversePrimOp) vectorizeAtom op
+  case op' of
     UnOp opk sx@(VVal vx x) -> do
       let v = case vx of Uniform -> Uniform; _ -> Varying
       x' <- if vx /= v then ensureVarying sx else return x
@@ -477,20 +483,20 @@ vectorizeOp op = do
       x' <- if vx /= v then ensureVarying sx else return x
       y' <- if vy /= v then ensureVarying sy else return y
       VVal v <$> emitOp (BinOp opk x' y')
-    CastOp (VVal Uniform ty) (VVal vx x) -> do
+    MiscOp (CastOp (VVal Uniform ty) (VVal vx x)) -> do
       ty' <- case vx of
         Uniform    -> return ty
         Varying    -> getVectorType ty
         Contiguous -> return ty
         ProdStability _ -> throwVectErr "Unexpected cast of product type"
-      VVal vx <$> emitOp (CastOp ty' x)
-    PtrOffset (VVal Uniform ptr) (VVal Contiguous off) -> do
-      VVal Contiguous <$> emitOp (PtrOffset ptr off)
-    PtrLoad (VVal Contiguous ptr) -> do
+      VVal vx <$> emitOp (MiscOp $ CastOp ty' x)
+    MemOp (PtrOffset (VVal Uniform ptr) (VVal Contiguous off)) -> do
+      VVal Contiguous <$> emitOp (MemOp $ PtrOffset ptr off)
+    MemOp (PtrLoad (VVal Contiguous ptr)) -> do
       BaseTy (PtrType (addrSpace, a)) <- getType ptr
       BaseTy av <- getVectorType $ BaseTy a
-      ptr' <- emitOp $ CastOp (BaseTy $ PtrType (addrSpace, av)) ptr
-      VVal Varying <$> emitOp (PtrLoad ptr')
+      ptr' <- emitOp $ MiscOp $ CastOp (BaseTy $ PtrType (addrSpace, av)) ptr
+      VVal Varying <$> emitOp (MemOp $ PtrLoad ptr')
     _ -> throwVectErr $ "Can't vectorize op: " ++ pprint op'
 
 vectorizeAtom :: SAtom i -> VectorizeM i o (VAtom o)
@@ -542,15 +548,15 @@ ensureVarying (VVal s val) = case s of
   Varying -> return val
   Uniform -> do
     vty <- getVectorType =<< getType val
-    emitOp $ VectorBroadcast val vty
+    emitOp $ VectorOp $ VectorBroadcast val vty
   -- Note that the implementation of this case will depend on val's type.
   Contiguous -> do
     ty <- getType val
     vty <- getVectorType ty
     case ty of
       BaseTy (Scalar sbt) -> do
-        bval <- emitOp $ VectorBroadcast val vty
-        iota <- emitOp $ VectorIota vty
+        bval <- emitOp $ VectorOp $ VectorBroadcast val vty
+        iota <- emitOp $ VectorOp $ VectorIota vty
         emitOp $ BinOp (if isIntegral sbt then IAdd else FAdd) bval iota
       _ -> throwVectErr "Not implemented"
   ProdStability _ -> throwVectErr "Not implemented"
@@ -600,10 +606,11 @@ instance HoistableState Word32' where
 
 instance GenericTraverser SimpIR UnitB Word32' where
   traverseExpr expr = case expr of
-    Op _ -> do expr' <- substM expr
-               ty <- getType expr'
-               modify (min $ typeByteWidth ty)
-               return expr'
+    PrimOp _ -> do
+      expr' <- substM expr
+      ty <- getType expr'
+      modify (min $ typeByteWidth ty)
+      return expr'
     _ -> traverseExprDefault expr
 
 typeByteWidth :: SType n -> Word32' n

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -226,8 +226,7 @@ instance SourceRenamableE UExpr' where
     UHole -> return UHole
     UTypeAnn e ty -> UTypeAnn <$> sourceRenameE e <*> sourceRenameE ty
     UTabCon xs -> UTabCon <$> mapM sourceRenameE xs
-    UPrimExpr e -> UPrimExpr <$> mapM sourceRenameE e
-    UPrimApp p xs -> UPrimApp p <$> mapM sourceRenameE xs
+    UPrim p xs -> UPrim p <$> mapM sourceRenameE xs
     ULabel name -> return $ ULabel name
     URecord elems -> URecord <$> mapM sourceRenameE elems
     UVariant types label val ->

--- a/src/lib/Syntax.hs
+++ b/src/lib/Syntax.hs
@@ -27,14 +27,14 @@ module Syntax (
     pattern StaticRecordTy, pattern RecordTyWithElems,
     Expr (..), Atom (..), Arrow (..), plainArrows, PrimTC (..), Abs (..),
     DictExpr (..), DictType (..),
-    PrimExpr (..), PrimCon (..), LitVal (..), PtrLitVal (..), PtrSnapshot (..),
+    PrimCon (..), LitVal (..), PtrLitVal (..), PtrSnapshot (..),
     AlwaysEqual (..),
-    PrimEffect (..), PrimOp (..), Hof (..),
+    RefOp (..), PrimOp (..), Hof (..),
     LamBinding (..), LamExpr (..), EffAbs, lamExprToAtom, naryLamExprToAtom, blockEffects,
     PiBinding (..), PiBinder (..), RolePiBinder (..), ParamRole (..),
     PiType (..), DepPairType (..), LetAnn (..),
     BinOp (..), UnOp (..), CmpOp (..), SourceMap (..), SourceNameDef (..), LitProg,
-    ForAnn, Val, Op, Con, TC, SuperclassBinders (..),
+    ForAnn, Val, Con, TC, SuperclassBinders (..),
     ClassDef (..), InstanceDef (..), InstanceBody (..), MethodType (..),
     EffectDef (..), EffectOpType (..), EffectName,
     SynthCandidates (..), Env (..), TopEnv (..), ModuleEnv (..), SerializedEnv (..),
@@ -91,7 +91,7 @@ module Syntax (
     getLambdaDicts, getInstanceDicts,
     getAllowedEffects, withAllowedEffects, todoSinkableProof,
     freeAtomVarsList,
-    IExpr (..), IBinder (..), IPrimOp, IVal, IType, Size, IFunType (..),
+    IExpr (..), IBinder (..), IVal, IType, Size, IFunType (..),
     ImpFunction (..), ImpBlock (..), ImpDecl (..), ClosedImpFunction (..),
     ImpInstr (..), iBinderType, ImpName, PtrBinder (..), RepVal (..), DRepVal (..),
     ImpFunName, IFunVar, CallingConvention (..), CUDAKernel (..), Backend (..),
@@ -122,10 +122,11 @@ module Syntax (
     pattern SISourceName, pattern SIInternalName,
     pattern OneEffect, pattern UnaryLamExpr, pattern BinaryLamExpr,
     (-->), (?-->), (--@), (==>),
-    IR (..),
+    IR (..), IRPredicate (..), Sat, Sat', IsCore, IsCore',
+    unsafeCoerceIRE, unsafeCoerceFromAnyIR, unsafeCoerceIRB, injectIRE,
+    CovariantInIR,
     CAtom, CType, CExpr, CBlock, CDecl, CDecls, CAtomSubstVal, CAtomName,
-    SAtom, SType, SExpr, SBlock, SDecl, SDecls, SAtomSubstVal, SAtomName,
-    unsafeCoerceIRE, unsafeCoerceIRB
+    SAtom, SType, SExpr, SBlock, SDecl, SDecls, SAtomSubstVal, SAtomName
     ) where
 
 import Data.List.NonEmpty (NonEmpty (..), nonEmpty)
@@ -135,6 +136,7 @@ import GHC.Generics (Generic (..))
 
 import Name
 import Err
+import IRVariants
 import Logging
 
 import Core

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -643,7 +643,7 @@ ixMethodType :: IxMethod -> AbsDict CoreIR n -> EnvReaderM n (NaryPiType CoreIR 
 ixMethodType method absDict = do
   refreshAbs absDict \extraArgBs dict -> do
     let extraArgBs' = fmapNest plainPiBinder extraArgBs
-    getType (Op $ ProjMethod dict (fromEnum method)) >>= \case
+    getType (ProjMethod dict (fromEnum method)) >>= \case
       Pi (PiType b _ resultTy) -> do
         let allBs = extraArgBs' >>> Nest b Empty
         return $ NaryPiType allBs Pure resultTy

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -32,6 +32,7 @@ import GHC.Generics (Generic (..))
 import Data.Store (Store (..))
 
 import Name
+import IRVariants
 import Err
 import LabeledItems
 import Util (File (..))
@@ -100,8 +101,7 @@ data UExpr' (n::S) =
  | UHole
  | UTypeAnn (UExpr n) (UExpr n)
  | UTabCon [UExpr n]
- | UPrimExpr (PrimExpr (UExpr n))
- | UPrimApp PrimName [UExpr n]
+ | UPrim PrimName [UExpr n]
  | ULabel String
  | URecord (UFieldRowElems n)                        -- {@v=x, a=y, b=z, ...rest}
  | UVariant (LabeledItems ()) Label (UExpr n)        -- {|a|b| a=x |}
@@ -112,7 +112,7 @@ data UExpr' (n::S) =
  | UNatLit   Word64
  | UIntLit   Int
  | UFloatLit Double
-  deriving (Show, Generic)
+   deriving (Show, Generic)
 
 type UFieldRowElems (n::S) = [UFieldRowElem n]
 data UFieldRowElem (n::S)
@@ -393,10 +393,16 @@ data EnvQuery =
 -- === Primitive names ===
 
 data PrimName =
-    UMAsk | UMExtend | UMGet | UMPut
+    UPrimTC  (PrimTC CoreIR ())
+  | UPrimCon (PrimCon CoreIR ())
+  | UPrimOp  (PrimOp ())
+  | URecordVariantOp (RecordVariantOp ())
+  | UMAsk | UMExtend | UMGet | UMPut
   | UWhile | ULinearize | UTranspose
   | URunReader | URunWriter | URunState | URunIO | UCatchException
-  deriving (Show, Enum)
+  | UProjBaseNewtype | UExplicitApply | UMonoLiteral
+  | UIndexRef | UProjRef Int | UProjMethod Int
+    deriving (Show, Eq)
 
 -- === instances ===
 


### PR DESCRIPTION
I initially tried giving IR predicates to each primop individually. Unfortunately, that means we have to pattern-match on every allowable primop when we do an IR-changing transformation, so that GHC knows that you've handled all the required cases. Previously we could have a fallback case, but that no longer typechecks. With the grouped design, you still have to pattern-match on each top-level case, but you can handle entire subtrees generically.