### PR TITLE
Potentially better error message for the situation from Issue #1076.

### DIFF
--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -198,8 +198,8 @@ def passthrough {a b} {eff:Effects} (f:(a -> {|eff} b)) (x:a) : {|eff} b = f x
   f Int 1
 > Leaked local variables:[bb]
 > Failed to exchage binders in buildAbsInf
-> Pending emissions:
-> Defaults: 
+> Pending emissions: 
+> Defaults:  
 > Solver substitution: [(_.4, bb)]
 >
 >   f : (aa:Type) -> aa -> aa = \bb. \x. myId x


### PR DESCRIPTION
To wit, the error message now includes the type variable solver state that led to the error, but I'm not completely convinced that this state is any more informative than not seeing it.