### PR TITLE
Poking at JVP-matmul performance

### DIFF
--- a/benchmarks/vjp_matmul.dx
+++ b/benchmarks/vjp_matmul.dx
@@ -6,9 +6,9 @@ m2 = rand_mat n n randn (new_key 1)
 def mmp' {l m n} (m1:l=>m=>Float) (m2:m=>n=>Float) : l=>n=>Float =
   snd (vjp ((**) (transpose m1)) (for _ _. 0.0)) m2
 
-%bench "jvp_matmul"
+%bench "vjp_matmul"
 res = mmp' m1 m2
 >
-> jvp_matmul
+> vjp_matmul
 > Compile time: 130.231 ms
 > Run time:     7.178 us 	(based on 1 run)

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -266,6 +266,8 @@ inlineExpr ctx = \case
 inlineAtom :: Emits o => Context SExpr e o -> SAtom i -> InlineM i o (e o)
 inlineAtom ctx = \case
   Var name -> inlineName ctx name
+  ProjectElt idxs v ->
+    getProjection (NE.toList idxs) <$> inline Stop (Var v) >>= reconstruct ctx . Atom
   atom -> (inline Stop (fromE atom) <&> Atom . toE) >>= reconstruct ctx
 
 inlineName :: Emits o => Context SExpr e o -> SAtomName i -> InlineM i o (e o)

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -604,7 +604,9 @@ evalBlock typed = do
   SimplifiedBlock simp recon <- return simplifiedBlock
   analyzed <- whenOpt simp $ checkPass OccAnalysisPass . analyzeOccurrences
   inlined <- whenOpt analyzed $ checkPass InlinePass . inlineBindings
-  opt <- whenOpt inlined $ checkPass OptPass . optimize
+  analyzed2 <- whenOpt inlined $ checkPass OccAnalysisPass . analyzeOccurrences
+  inlined2 <- whenOpt analyzed2 $ checkPass InlinePass . inlineBindings
+  opt <- whenOpt inlined2 $ checkPass OptPass . optimize
   result <- case opt of
     AtomicBlock result -> return result
     _ -> do

--- a/tests/inline-tests.dx
+++ b/tests/inline-tests.dx
@@ -1,3 +1,8 @@
+-- The "=== inline ===" strings below are a hack around the fact that
+-- Dex currently does two passes of inlining and prints the results of
+-- both.  Surrounding the CHECK block with these commands constrains
+-- the body to occur in the output from the first inlining pass.
+
 @noinline
 def id' (x:Nat) : Nat = x
 
@@ -8,16 +13,20 @@ def id' (x:Nat) : Nat = x
 :p
   xs = for i:(Fin 10). ordinal i
   for j. xs.j + 2
+-- CHECK: === inline ===
 -- CHECK: for
 -- CHECK-NOT: for
+-- CHECK: === inline ===
 
 -- CHECK-LABEL: Inline for into sum
 "Inline for into sum"
 
 %passes inline
 sum for i:(Fin 10). ordinal i
+-- CHECK: === inline ===
 -- CHECK: for
 -- CHECK-NOT: for
+-- CHECK: === inline ===
 
 -- CHECK-LABEL: Inline nested for into for
 "Inline nested for into for"
@@ -26,8 +35,10 @@ sum for i:(Fin 10). ordinal i
 :p
   xs = for i:(Fin 10). for j:(Fin 20). ordinal i * ordinal j
   for j i. xs.i.j + 2
+-- CHECK: === inline ===
 -- CHECK: for
 -- CHECK-NOT: for
+-- CHECK: === inline ===
 
 -- CHECK-LABEL: Inlining does not reorder effects
 "Inlining does not reorder effects"
@@ -44,8 +55,10 @@ run_state 0 \ct.
   for j.
     ct := (get ct) * 2
     xs.j + 2
+-- CHECK: === inline ===
 -- CHECK: for
 -- CHECK: for
+-- CHECK: === inline ===
 
 -- CHECK-LABEL: Inlining does not duplicate the inlinee through beta reduction
 "Inlining does not duplicate the inlinee through beta reduction"
@@ -56,8 +69,10 @@ run_state 0 \ct.
 :p
   ix = (id' 20)@(Fin 100)
   (for i:(Fin 100). ordinal i + ordinal i).ix
+-- CHECK: === inline ===
 -- CHECK: runIO
 -- CHECK-NOT: runIO
+-- CHECK: === inline ===
 
 -- CHECK-LABEL: Inlining does not violate type IR through beta reduction
 "Inlining does not violate type IR through beta reduction"


### PR DESCRIPTION
Improved the inliner to eliminate an unnecessary intermediate array; performance slightly improves, and additional opportunities for improvement become more obvious.