### PR TITLE
Add a HeapType type and HeapVal value for the heap parameter.

### DIFF
--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -21,10 +21,10 @@ def index_list {a} (l:List a) (i:Nat) : {Except} a =
 
 '## The Parser type
 
-def ParserHandle (h:Type) : Type = (String & Ref h Nat)
+def ParserHandle (h:Heap) : Type = (String & Ref h Nat)
 
 data Parser a:Type =
-  MkParser ((h:Type) ?-> ParserHandle h -> {Except, State h} a)
+  MkParser ((h:Heap) ?-> ParserHandle h -> {Except, State h} a)
 
 def parse {a h} (handle:ParserHandle h) (parser:Parser a) : {Except, State h} a =
   (MkParser f) = parser

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -8,6 +8,7 @@
 
 Unit = %UnitType
 Type = %TyKind
+Heap = %HeapType
 Effects = %EffKind
 Fields = %LabeledRowKind
 
@@ -639,16 +640,15 @@ named-instance MulMonoid : Monoid a given (a:Type) [Mul a]
 
 '## Effects
 
-def Ref (r:Type) (a:Type) : Type = %Ref r a
+def Ref (r:Heap) (a:Type) : Type = %Ref r a
 def get  {h s} (ref:Ref h s)       : {State h} s    = %get  ref
 def (:=) {h s} (ref:Ref h s) (x:s) : {State h} Unit = %put  ref x
 
 def ask  {h r} (ref:Ref h r)       : {Read  h} r    = %ask  ref
 
-data AccumMonoidData h w =
-  UnsafeMkAccumMonoidData b:Type (Monoid b)
+data AccumMonoidData (h:Heap) w = UnsafeMkAccumMonoidData b:Type (Monoid b)
 
-interface AccumMonoid h w
+interface AccumMonoid (h:Heap) w
   getAccumMonoidData : AccumMonoidData h w
 
 instance AccumMonoid h (n=>w) given {n h w} [Ix n] [am : AccumMonoid h w]
@@ -669,31 +669,34 @@ def snd_ref {h a b} (ref: Ref h (a & b)) : Ref h b = %sndRef ref
 def run_reader
       {r a eff}
       (init:r)
-      (action: ((h:Type) ?-> Ref h r -> {Read h|eff} a))
+      (action: ((h:Heap) ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
-    def explicitAction (h':Type) (ref:Ref h' r) : {Read h'|eff} a = action ref
+    def explicitAction (h':Heap) (ref:Ref h' r) : {Read h'|eff} a = action ref
     %runReader init explicitAction
 
 def with_reader
       {r a eff}
       (init:r)
-      (action: ((h:Type) ?-> Ref h r -> {Read h|eff} a))
+      (action: ((h:Heap) ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
     run_reader init action
 
-def MonoidLifter (b:Type) (w:Type) : Type = (h:Type) ?-> AccumMonoid h b ?=> AccumMonoid h w
+def MonoidLifter (b:Type) (w:Type) : Type = (h:Heap) ?-> AccumMonoid h b ?=> AccumMonoid h w
+
+named-instance mk_accum_monoid : AccumMonoid h w given {h w} (d:AccumMonoidData h w)
+  getAccumMonoidData = d
 
 def run_accum
       {a b w eff}
       [mlift:MonoidLifter b w]
       (bm:Monoid b)
-      (action: ((h:Type) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
+      (action: ((h:Heap) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} (a & w) =
   empty = %projMethod0 bm
   combine = %projMethod1 bm
-  def explicitAction (h':Type) (ref:Ref h' w) : {Accum h'|eff} a =
+  def explicitAction (h':Heap) (ref:Ref h' w) : {Accum h'|eff} a =
     accumMonoidData : (AccumMonoidData h' b) = UnsafeMkAccumMonoidData b bm
-    accumBaseMonoid = %explicitDict (AccumMonoid h' b) accumMonoidData
+    accumBaseMonoid = mk_accum_monoid accumMonoidData
     action' = %explicitApply (%explicitApply action h') accumBaseMonoid
     action' ref
   %runWriter empty (\x y. combine x y) explicitAction
@@ -702,28 +705,28 @@ def yield_accum
       {a b w eff}
       [mlift:MonoidLifter b w]
       (m:Monoid b)
-      (action: ((h:Type) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
+      (action: ((h:Heap) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
       : {|eff} w =
   snd $ run_accum m action
 
 def run_state
       {a s eff}
       (init:s)
-      (action: (h:Type) ?-> Ref h s -> {State h |eff} a)
+      (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} (a & s) =
-  def explicitAction (h':Type) (ref:Ref h' s) : {State h'|eff} a = action ref
+  def explicitAction (h':Heap) (ref:Ref h' s) : {State h'|eff} a = action ref
   %runState init explicitAction
 
 def with_state
       {a s eff}
       (init:s)
-      (action: (h:Type) ?-> Ref h s -> {State h |eff} a)
+      (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} a = fst $ run_state init action
 
 def yield_state
       {a s eff}
       (init:s)
-      (action: (h:Type) ?-> Ref h s -> {State h |eff} a)
+      (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} s = snd $ run_state init action
 
 def unsafe_io {a eff} (f: Unit -> {IO|eff} a) : {|eff} a =

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -975,14 +975,14 @@ buildEffLam
   -> m n (LamExpr r n)
 buildEffLam rws hint ty body = do
   eff <- getAllowedEffects
-  withFreshBinder noHint TyKind \h -> do
+  withFreshBinder noHint (TC HeapType) \h -> do
     let ty' = RefTy (Var $ binderName h) (sink ty)
     withFreshBinder hint (LamBinding PlainArrow ty') \b -> do
       let ref = binderName b
       hVar <- sinkM $ binderName h
       let eff' = extendEffect (RWSEffect rws (Just hVar)) (sink eff)
       body' <- withAllowedEffects eff' $ buildBlock $ body (sink hVar) $ sink ref
-      return $ LamExpr (BinaryNest (h:>TyKind) (b:>ty')) body'
+      return $ LamExpr (BinaryNest (h:>TC HeapType) (b:>ty')) body'
 
 buildForAnn
   :: (Emits n, ScopableBuilder r m)

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -478,9 +478,9 @@ instance SubstE (AtomSubstVal r) (EffectP Name) where
     RWSEffect rws Nothing -> RWSEffect rws Nothing
     RWSEffect rws (Just v) -> do
       let v' = case env ! v of
-                 Rename        v''  -> Just v''
-                 SubstVal UnitTy    -> Nothing  -- used at runtime/imp-translation-time
-                 SubstVal (Var v'') -> Just v''
+                 Rename   v''           -> Just v''
+                 SubstVal (Con HeapVal) -> Nothing
+                 SubstVal (Var v'')     -> Just v''
                  SubstVal _ -> error "Heap parameter must be a name"
       RWSEffect rws v'
     ExceptionEffect -> ExceptionEffect

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -979,6 +979,7 @@ primNames = M.fromList
   , ("Ref"       , UPrimTC $ RefType (Just ()) ())
   , ("PairType"  , UPrimTC $ ProdType [(), ()])
   , ("UnitType"  , UPrimTC $ ProdType [])
+  , ("HeapType"  , UPrimTC $ HeapType)
   , ("EffKind"   , UPrimTC $ EffectRowKind)
   , ("LabeledRowKind", UPrimTC $ LabeledRowKindTC)
   , ("fstRef"     , UProjRef 0)

--- a/src/lib/Generalize.hs
+++ b/src/lib/Generalize.hs
@@ -150,6 +150,7 @@ traverseTyParams ty f = getDistinct >>= \Distinct -> case ty of
     EffectRowKind    -> return EffectRowKind
     LabeledRowKindTC -> return LabeledRowKindTC
     LabelType        -> return LabelType
+    HeapType         -> return HeapType
   _ -> error $ "Not implemented: " ++ pprint ty
 {-# INLINE traverseTyParams #-}
 

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -567,7 +567,7 @@ toImpHof maybeDest hof = do
       r' <- substM r
       rDest <- allocDest =<< getType r'
       storeAtom rDest r'
-      extendSubst (h @> SubstVal UnitTy <.> ref @> SubstVal (destToAtom rDest)) $
+      extendSubst (h @> SubstVal (Con HeapVal) <.> ref @> SubstVal (destToAtom rDest)) $
         translateBlock maybeDest body
     RunWriter d (BaseMonoid e _) f -> do
       BinaryLamExpr h ref body <- return f
@@ -583,7 +583,7 @@ toImpHof maybeDest hof = do
         PairE accTy' e'' <- sinkM $ PairE accTy e'
         liftMonoidEmpty accTy' e''
       storeAtom wDest emptyVal
-      void $ extendSubst (h @> SubstVal UnitTy <.> ref @> SubstVal (destToAtom wDest)) $
+      void $ extendSubst (h @> SubstVal (Con HeapVal) <.> ref @> SubstVal (destToAtom wDest)) $
         translateBlock (Just aDest) body
       PairVal <$> loadAtom aDest <*> loadAtom wDest
     RunState d s f -> do
@@ -596,7 +596,7 @@ toImpHof maybeDest hof = do
           sDest <- atomToDest =<< substM d'
           return (aDest, sDest)
       storeAtom sDest =<< substM s
-      void $ extendSubst (h @> SubstVal UnitTy <.> ref @> SubstVal (destToAtom sDest)) $
+      void $ extendSubst (h @> SubstVal (Con HeapVal) <.> ref @> SubstVal (destToAtom sDest)) $
         translateBlock (Just aDest) body
       PairVal <$> loadAtom aDest <*> loadAtom sDest
     RunIO body-> translateBlock maybeDest body

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -517,6 +517,7 @@ linearizePrimCon con = case con of
   LabelCon _     -> error "Unexpected label"
   ExplicitDict  _ _ -> error "Unexpected ExplicitDict"
   DictHole _ _ -> error "Unexpected DictHole"
+  HeapVal -> error "Unexpected HeapVal"
   where emitZeroT = withZeroT $ injSubstM $ Con con
 
 linearizeHof :: Emits o => Hof SimpIR i -> LinM i o CAtom CAtom

--- a/src/lib/OccAnalysis.hs
+++ b/src/lib/OccAnalysis.hs
@@ -202,6 +202,7 @@ summary atom = case atom of
       Newtype _ e -> summary e
       ExplicitDict _ _ -> invalid "ExplicitDict"
       DictHole _ _ -> invalid "DictHole"
+      HeapVal -> invalid "HeapVal"
 
 unknown :: HoistableE e => e n -> OCCM n (IxExpr n)
 unknown _ = return IxAll

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -989,6 +989,7 @@ instance PrettyPrec e => PrettyPrec (PrimTC r e) where
     RefType (Just h) a -> atPrec AppPrec $ pAppArg "Ref" [h, a]
     RefType Nothing a  -> atPrec AppPrec $ pAppArg "Ref" [a]
     TypeKind -> atPrec ArgPrec "Type"
+    HeapType -> atPrec ArgPrec "Heap"
     EffectRowKind -> atPrec ArgPrec "EffKind"
     LabeledRowKindTC -> atPrec ArgPrec "Fields"
     LabelType -> atPrec ArgPrec "Label"
@@ -1024,6 +1025,7 @@ prettyPrecPrimCon con = case con of
   LabelCon name -> atPrec ArgPrec $ "##" <> p name
   ExplicitDict _ _ -> atPrec ArgPrec $ "ExplicitDict"
   DictHole _ e -> atPrec LowestPrec $ "synthesize" <+> pApp e
+  HeapVal -> atPrec ArgPrec "HeapValue"
 
 instance PrettyPrec e => Pretty (PrimOp e) where pretty = prettyFromPrettyPrec
 instance PrettyPrec e => PrettyPrec (PrimOp e) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -359,6 +359,7 @@ getTypePrimCon con = case con of
   LabelCon _   -> return $ TC $ LabelType
   ExplicitDict dictTy _ -> substM dictTy
   DictHole _ ty -> substM ty
+  HeapVal       -> return $ TC HeapType
 
 dictExprType :: DictExpr r i -> TypeQueryM r i o (Type r o)
 dictExprType e = case e of
@@ -807,9 +808,9 @@ deleteEff eff (EffectRow effs t) = EffectRow (S.delete eff effs) t
 getMaybeHeapVar :: Type r o -> Maybe (AtomName r o)
 getMaybeHeapVar (TC (RefType h _)) = case h of
   Just (Var h') -> Just h'
-  Just UnitTy   -> Nothing
-  Nothing       -> Nothing
-  _ -> error "expect heap parameter to be a var or UnitTy"
+  Just (Con HeapVal) -> Nothing
+  Nothing            -> Nothing
+  _ -> error "expect heap parameter to be a var or HeapVal"
 getMaybeHeapVar refTy = error $ "not a ref type: " ++ pprint refTy
 
 -- === singleton types ===

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -481,7 +481,6 @@ testIfDataAtom x = do
 -- TODO: implement this using a safe traversal rather than just coercing after
 -- performing the isData check.
 coreToSimpAtom :: EnvReader m => CAtom n -> m n (SAtom n)
-coreToSimpAtom TyKind = return TyKind -- TODO: figure out why we need this
 coreToSimpAtom x = do
   testIfDataAtom x >>= \case
     Just x' -> return x'

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -349,6 +349,7 @@ transposeCon con ct = case con of
   LabelCon _     -> notTangent
   ExplicitDict _ _ -> notTangent
   DictHole _ _ -> notTangent
+  HeapVal -> notTangent
   where notTangent = error $ "Not a tangent atom: " ++ pprint (Con con)
 
 notImplemented :: HasCallStack => a

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -50,6 +50,7 @@ data PrimTC (r::IR) (e:: *) where
   EffectRowKind    ::                   PrimTC r e
   LabeledRowKindTC ::                   PrimTC r e
   LabelType        ::                   PrimTC r e
+  HeapType         ::                   PrimTC r e
   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 traversePrimTC :: Applicative f => (e -> f e') -> PrimTC r e -> f (PrimTC r e')
@@ -68,6 +69,7 @@ data PrimCon (r::IR) (e:: *) where
   ExplicitDict :: e -> e            -> PrimCon r e
   -- Only used during type inference
   DictHole     :: AlwaysEqual SrcPosCtx -> e -> PrimCon r e
+  HeapVal      ::                      PrimCon r e
         deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 data MemOp e =

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -1,21 +1,21 @@
 
 :p
-   def m {h:Type} (ref:Ref h Int) : {State h} Int = get ref
+   def m {h:Heap} (ref:Ref h Int) : {State h} Int = get ref
    run_state 2 m
 > (2, 2)
 
 :p
-   def m {h:Type} (ref:Ref h Int) : {State h} Unit = ref := 3
+   def m {h:Heap} (ref:Ref h Int) : {State h} Unit = ref := 3
    run_state 0 m
 > ((), 3)
 
 :p
-   def m {h:Type} (ref:Ref h Int) : {Read h} Int = ask ref
+   def m {h:Heap} (ref:Ref h Int) : {Read h} Int = ask ref
    with_reader 5 m
 > 5
 
 :p
-  def stateAction {h:Type} (ref:Ref h Float) : {State h} Unit =
+  def stateAction {h:Heap} (ref:Ref h Float) : {State h} Unit =
      x = get ref
      ref := (x + 2.0)
      z = get ref
@@ -26,7 +26,7 @@
 
 :p
   def rwsAction
-        {rh:Type} {wh:Type} {sh:Type}
+        {rh:Heap} {wh:Heap} {sh:Heap}
         [AccumMonoid wh Float]
         (r:Ref rh Int) (w:Ref wh Float) (s:Ref sh Bool)
         : {Read rh, Accum wh, State sh} Int =
@@ -44,7 +44,7 @@
 > ((4, 6.), False)
 
 :p
-   def m {h:Type} (s:Ref h (Fin 3=>Int)) : {State h} Unit =
+   def m {h:Heap} (s:Ref h (Fin 3=>Int)) : {State h} Unit =
      s!(from_ordinal _ 0) := 10
      s!(from_ordinal _ 2) := 20
      x = get (s!(from_ordinal _ 0))
@@ -56,7 +56,7 @@
 > 2
 
 :p
-  def m {wh:Type} {sh:Type}
+  def m {wh:Heap} {sh:Heap}
         [AccumMonoid wh Float]
         (w:Ref wh Float) (s:Ref sh Float)
         : {Accum wh, State sh} Unit =
@@ -74,7 +74,7 @@ def myAction {hw hr} [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : 
 > ((), 3.5)
 
 :p
-  def m {h1:Type} {h2:Type}
+  def m {h1:Heap} {h2:Heap}
         [AccumMonoid h1 Float] [AccumMonoid h2 Float]
         (w1:Ref h1 Float) (w2:Ref h2 Float)
         : {Accum h1, Accum h2} Unit =
@@ -84,7 +84,7 @@ def myAction {hw hr} [AccumMonoid hw Float] (w:Ref hw Float) (r:Ref hr Float) : 
   run_accum (AddMonoid Float) \w1. run_accum (AddMonoid Float) \w2. m w1 w2
 > (((), 3.), 2.)
 
-def foom {h:Type} (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
+def foom {h:Heap} (s:Ref h ((Fin 3)=>Int)) : {State h} Unit =
   s!(from_ordinal _ 0) := 1
   s!(from_ordinal _ 2) := 2
 


### PR DESCRIPTION
Previously we just used `h:Type` (leftover from ST monad inspiration) and `UnitTy` as its "runtime" value. But that meant SimpIR had to contain vars of type Type, which we want to rule out statically.