### PR TITLE
Add a built-in "print absolutely anything" function

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -80,6 +80,7 @@ library
                      , PPrint
                      , RawName
                      , Runtime
+                     , RuntimePrint
                      , Serialize
                      , Simplify
                      , Subst

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2525,15 +2525,17 @@ def unsafe_get_stack_buffer {h a} (stack:Stack h a) : {State h} (Ref h (Fin 0 =>
 def stack_buf_size {h a} (stack:Stack h a) : {State h} Nat =
   get $ fst_ref $ unsafe_coerce (Ref h (Nat & (Ref h (Fin 0 => a)))) (snd_ref stack)
 
-def grow_stack_buffer {h a} (stack:Stack h a) : {State h} Unit =
-  buf = unsafe_get_stack_buffer stack
-  logical_size = stack_size stack
-  cur_data = get $ unsafe_coerce (Ref h (Fin logical_size => a)) buf
-  new_buf_size = stack_buf_size stack * 2
-  snd_ref stack := to_list for i:(Fin new_buf_size).
-    case to_ix (Fin logical_size) (ordinal i) of
-      Just i' -> cur_data.i'
-      Nothing -> uninitialized_value
+def ensure_size_at_least {h a} (stack:Stack h a) (req_size:Nat) : {State h} Unit =
+  if req_size > stack_buf_size stack then
+    -- TODO: maybe this should use integer arithmetic?
+    new_buf_size = f_to_n $ pow 2.0 (ceil $ log2 $ n_to_f req_size)
+    buf = unsafe_get_stack_buffer stack
+    logical_size = stack_size stack
+    cur_data = get $ unsafe_coerce (Ref h (Fin logical_size => a)) buf
+    snd_ref stack := to_list for i:(Fin new_buf_size).
+      case to_ix (Fin logical_size) (ordinal i) of
+        Just i' -> cur_data.i'
+        Nothing -> uninitialized_value
 
 def read_stack {h a} (stack:Stack h a) : {State h} (List a) =
   n = stack_size stack
@@ -2544,7 +2546,7 @@ def read_stack {h a} (stack:Stack h a) : {State h} (List a) =
 def stack_push {a h} (stack:Stack h a) (x:a) : {State h} Unit =
   n_old = stack_size stack
   n_new = n_old + 1
-  if n_new > stack_buf_size stack then grow_stack_buffer stack
+  ensure_size_at_least stack n_new
   buf = unsafe_get_stack_buffer stack
   buf ! (unsafe_from_ordinal _ n_old) := x
   fst_ref stack := n_new
@@ -2556,7 +2558,7 @@ def stack_push {a h} (stack:Stack h a) (x:a) : {State h} Unit =
 def stack_extend {a n} [Ix n] {h} (stack:Stack h a) (x:n=>a) : {State h} Unit =
   n_old = stack_size stack
   n_new = n_old + size n
-  if n_new > stack_buf_size stack then grow_stack_buffer stack
+  ensure_size_at_least stack n_new
   buf = unsafe_get_stack_buffer stack
   buf_slice = unsafe_coerce (Ref h (n=>a)) (buf ! (unsafe_from_ordinal _ n_old))
   buf_slice := x

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2566,3 +2566,14 @@ stack_init_size = 16
 def with_stack {r} (a:Type) (f : (h:Heap) ?-> Stack h a -> {State h} r) : r =
   init_stack = to_list for i:(Fin stack_init_size). uninitialized_value
   with_state (0, init_stack) \ref . f ref
+
+def stack_extend_internal {n h} (stack:Stack h Char) (x:Fin n=>Char) : {State h} Unit =
+  stack_extend stack x
+
+def with_stack_internal (f : (h:Heap) ?-> Stack h Char -> {State h} Unit) : List Char =
+  with_stack Char \stack.
+    f stack
+    read_stack stack
+
+def show_any {a} (x:a) : String =
+  unsafe_coerce String (%showAny x)

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2577,5 +2577,4 @@ def with_stack_internal (f : (h:Heap) ?-> Stack h Char -> {State h} Unit) : List
     f stack
     read_stack stack
 
-def show_any {a} (x:a) : String =
-  unsafe_coerce String (%showAny x)
+def show_any {a} (x:a) : String = %showAny x

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -59,7 +59,7 @@ data AtomEx where
 
 dexCreateContext :: IO (Ptr Context)
 dexCreateContext = do
-  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing Optimize
+  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing Optimize PrintLegacy
   cachedEnv <- loadCache
   envMVar      <- newMVar cachedEnv
   ptrTableMVar <- newMVar mempty

--- a/src/lib/AbstractSyntax.hs
+++ b/src/lib/AbstractSyntax.hs
@@ -121,7 +121,7 @@ runSyntaxM act = case runFallibleM act of
 sourceBlock' :: CSourceBlock' -> SyntaxM SourceBlock'
 sourceBlock' (CTopDecl (WithSrc _ (CDecl ann (ExprDecl e)))) = do
   when (ann /= PlainLet) $ fail "Cannot annotate expressions"
-  Command (EvalExpr Printed) <$> expr e
+  Command (EvalExpr (Printed Nothing)) <$> expr e
 sourceBlock' (CTopDecl d) = EvalUDecl <$> topDecl d
 sourceBlock' (CCommand typ b) = Command typ <$> block b
 sourceBlock' (CDeclareForeign foreignName dexName ty) =

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -649,6 +649,7 @@ typeCheckMiscOp = \case
   OutputStream ->
     return $ BaseTy $ hostPtrTy $ Scalar Word8Type
     where hostPtrTy ty = PtrType (CPU, ty)
+  ShowAny x -> checkE x >> strType
   ThrowError ty -> ty|:TyKind >> renameM ty
   ThrowException ty -> do
     declareEff ExceptionEffect

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -650,6 +650,9 @@ typeCheckMiscOp = \case
     return $ BaseTy $ hostPtrTy $ Scalar Word8Type
     where hostPtrTy ty = PtrType (CPU, ty)
   ShowAny x -> checkE x >> strType
+  ShowScalar x -> do
+    BaseTy (Scalar _) <- getTypeE x
+    PairTy IdxRepTy <$> finTabType (NatVal showStringBufferSize) CharRepTy
   ThrowError ty -> ty|:TyKind >> renameM ty
   ThrowException ty -> do
     declareEff ExceptionEffect

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -365,7 +365,9 @@ explicitCommand :: Parser CSourceBlock'
 explicitCommand = do
   cmdName <- char ':' >> nameString
   cmd <- case cmdName of
-    "p"       -> return $ EvalExpr Printed
+    "p"       -> return $ EvalExpr (Printed Nothing)
+    "pp"      -> return $ EvalExpr (Printed (Just PrintHaskell))
+    "pcodegen"-> return $ EvalExpr (Printed (Just PrintCodegen))
     "t"       -> return $ GetType
     "html"    -> return $ EvalExpr RenderHtml
     "export"  -> ExportFun <$> nameString

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -1001,6 +1001,7 @@ primNames = M.fromList
   , ("garbageVal"    , miscOp $ GarbageVal ())
   , ("select"        , miscOp $ Select () () ())
   , ("showAny"       , miscOp $ ShowAny ())
+  , ("showScalar"    , miscOp $ ShowScalar ())
   , ("projNewtype" , UProjBaseNewtype)
   , ("projMethod0" , UProjMethod 0)
   , ("projMethod1" , UProjMethod 1)

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -1000,6 +1000,7 @@ primNames = M.fromList
   , ("unsafeCoerce"  , miscOp $ UnsafeCoerce () ())
   , ("garbageVal"    , miscOp $ GarbageVal ())
   , ("select"        , miscOp $ Select () () ())
+  , ("showAny"       , miscOp $ ShowAny ())
   , ("projNewtype" , UProjBaseNewtype)
   , ("projMethod0" , UProjMethod 0)
   , ("projMethod1" , UProjMethod 1)

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -475,11 +475,8 @@ toImpMiscOp maybeDest op = case op of
     destRep <- getRepBaseTypes resultTy
     assertEq srcRep destRep $
       "representation types don't match: " ++ pprint srcRep ++ "  !=  " ++ pprint destRep
-    -- TODO: we ought to be able to do this without forcing a copy. (But this is
-    -- easier for now.)
-    dest@(Dest _ destTree) <- maybeAllocDest maybeDest resultTy
-    storeAtom (Dest srcTy destTree) x
-    loadAtom dest
+    RepVal _ tree <- atomToRepVal x
+    returnVal $ RepValAtom $ RepVal resultTy tree
   GarbageVal resultTy -> do
     dest <- maybeAllocDest maybeDest resultTy
     loadAtom dest
@@ -512,6 +509,15 @@ toImpMiscOp maybeDest op = case op of
   OutputStream -> returnIExprVal =<< emitInstr IOutputStream
   ThrowException _ -> error "shouldn't have ThrowException left" -- also, should be replaced with user-defined errors
   ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
+  ShowScalar x -> do
+    resultTy <- getType $ PrimOp $ MiscOp op
+    Dest (PairTy sizeTy tabTy) (Branch [sizeTree, tabTree@(Leaf tabPtr)]) <- maybeAllocDest maybeDest resultTy
+    xScalar <- fromScalarAtom x
+    size <- emitInstr $ IShowScalar tabPtr xScalar
+    let size' = toScalarAtom size
+    storeAtom (Dest sizeTy sizeTree) size'
+    tab <- loadAtom $ Dest tabTy tabTree
+    return $ PairVal size' tab
   where
     fsa = fromScalarAtom
     returnIExprVal x = returnVal $ toScalarAtom x
@@ -1549,6 +1555,7 @@ impInstrTypes instr = case instr of
   IPtrLoad ref -> return [ty]  where PtrType (_, ty) = getIType ref
   IPtrOffset ref _ -> return [PtrType (addr, ty)]  where PtrType (addr, ty) = getIType ref
   IOutputStream    -> return [hostPtrTy $ Scalar Word8Type]
+  IShowScalar _ _  -> return [Scalar Word32Type]
   where hostPtrTy ty = PtrType (CPU, ty)
 
 instance CheckableE ImpFunction where

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -511,6 +511,7 @@ toImpMiscOp maybeDest op = case op of
     _ -> error $ "Not an enum: " ++ pprint ty
   OutputStream -> returnIExprVal =<< emitInstr IOutputStream
   ThrowException _ -> error "shouldn't have ThrowException left" -- also, should be replaced with user-defined errors
+  ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
   where
     fsa = fromScalarAtom
     returnIExprVal x = returnVal $ toScalarAtom x

--- a/src/lib/ImpToLLVM.hs
+++ b/src/lib/ImpToLLVM.hs
@@ -518,6 +518,19 @@ compileInstr instr = case instr of
   DebugPrint fmtStr x -> [] <$ do
     x' <- compileExpr x
     debugPrintf fmtStr x'
+  IShowScalar resultPtr x -> (:[]) <$> do
+    resultPtr' <- compileExpr resultPtr
+    x'         <- compileExpr x
+    ~(Scalar b) <- return $ getIType x
+    let fname = getShowScalarFunStrName b
+    let spec = ExternFunSpec (L.mkName fname) i32 [] [] [hostVoidp, typeOf x']
+    emitExternCall spec [resultPtr', x']
+    where
+      getShowScalarFunStrName :: ScalarBaseType -> String
+      getShowScalarFunStrName = \case
+        Float32Type -> "showFloat32_internal"
+        Int32Type   -> "showInt32_internal"
+        b -> error $ "not implemented: " ++ pprint b
 
 -- TODO: use a careful naming discipline rather than strings
 -- (this is only used on the CUDA path which is currently broken anyway)

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -427,6 +427,7 @@ linearizeMiscOp op = case op of
   ThrowError _     -> emitZeroT
   OutputStream     -> emitZeroT
   ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
+  ShowScalar _ -> error "Shouldn't have ShowScalar in simplified IR"
   where
     emitZeroT = withZeroT $ liftM Var $ emit =<< injSubstM (PrimOp $ MiscOp op)
     la = linearizeAtom

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -426,6 +426,7 @@ linearizeMiscOp op = case op of
   ThrowException _ -> notImplemented
   ThrowError _     -> emitZeroT
   OutputStream     -> emitZeroT
+  ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
   where
     emitZeroT = withZeroT $ liftM Var $ emit =<< injSubstM (PrimOp $ MiscOp op)
     la = linearizeAtom

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -947,6 +947,7 @@ instance Pretty (ImpInstr n)  where
     IUnOp  op x   -> opDefault (UPrimOp $ UnOp  op ()   ) [x]
     ISelect x y z -> opDefault (UPrimOp $ MiscOp (Select () () ())) [x, y, z]
     IOutputStream -> "outputStream"
+    IShowScalar ptr x -> "show_scalar" <+> p ptr <+> p x
     where opDefault name xs = prettyOpDefault name xs $ AppPrec
 
 sizeStr :: IExpr n -> Doc ann

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -18,7 +18,7 @@ module QueryType (
   projectionIndices, sourceNameType, typeBinOp, typeUnOp,
   isSingletonType, singletonTypeVal, ixDictType, getSuperclassDicts, ixTyFromDict,
   isNewtype, instantiateHandlerType, getDestBlockType,
-  getNaryLamExprType
+  getNaryLamExprType, strType, finTabType
   ) where
 
 import Control.Category ((>>>))
@@ -39,7 +39,7 @@ import Core
 import CheapReduction
 import Err
 import LabeledItems
-import Name
+import Name hiding (withFreshM)
 import Subst
 import Util
 import PPrint ()
@@ -513,6 +513,7 @@ instance HasType r (ComposeE PrimOp (Atom r)) where
       OutputStream ->
         return $ BaseTy $ hostPtrTy $ Scalar Word8Type
         where hostPtrTy ty = PtrType (CPU, ty)
+      ShowAny _ -> strType
     VectorOp op -> case op of
       VectorBroadcast _ vty -> substM vty
       VectorIota vty -> substM vty
@@ -696,6 +697,22 @@ ixTyFromDict dict = do
     DictTy (DictType "Ix" _ [iTy]) -> return $ IxType iTy dict
     _ -> error $ "Not an Ix dict: " ++ pprint dict
 
+strType :: EnvReader m => m n (Type r n)
+strType = constructPreludeType "List" $ DataDefParams [(PlainArrow, CharRepTy)]
+
+finTabType :: EnvReader m => Atom r n -> Atom r n -> m n (Type r n)
+finTabType n eltTy = IxType (TC (Fin n )) (DictCon (IxFin n)) ==> eltTy
+
+constructPreludeType :: EnvReader m => String -> DataDefParams r n -> m n (Type r n)
+constructPreludeType sourceName params = do
+  lookupSourceMap sourceName >>= \case
+    Just uvar -> case uvar of
+      UTyConVar v -> lookupEnv v >>= \case
+        TyConBinding def _ -> return $ TypeCon sourceName def params
+      _ -> notfound
+    Nothing -> notfound
+ where notfound = error $ "Type constructor not defined: " ++ sourceName
+
 -- === querying effects implementation ===
 
 class HasEffectsE (e::E) (r::IR) | e -> r where
@@ -759,6 +776,7 @@ exprEffects expr = case expr of
       SumTag _         -> return Pure
       ToEnum _ _       -> return Pure
       OutputStream     -> return Pure
+      ShowAny _        -> return Pure
   DAMOp op -> case op of
     Place    _ _  -> return $ OneEffect InitEffect
     Seq _ _ _ f      -> functionEffs f

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -514,6 +514,7 @@ instance HasType r (ComposeE PrimOp (Atom r)) where
         return $ BaseTy $ hostPtrTy $ Scalar Word8Type
         where hostPtrTy ty = PtrType (CPU, ty)
       ShowAny _ -> strType
+      ShowScalar _ -> PairTy IdxRepTy <$> finTabType (NatVal showStringBufferSize) CharRepTy
     VectorOp op -> case op of
       VectorBroadcast _ vty -> substM vty
       VectorIota vty -> substM vty
@@ -777,6 +778,7 @@ exprEffects expr = case expr of
       ToEnum _ _       -> return Pure
       OutputStream     -> return Pure
       ShowAny _        -> return Pure
+      ShowScalar _     -> return Pure
   DAMOp op -> case op of
     Place    _ _  -> return $ OneEffect InitEffect
     Seq _ _ _ f      -> functionEffs f

--- a/src/lib/RuntimePrint.hs
+++ b/src/lib/RuntimePrint.hs
@@ -49,6 +49,12 @@ emitLit s = stringLitAsCharTab s >>= emitCharTab
 
 showAnyRec :: Emits n => CAtom n -> Print n
 showAnyRec atom = getType atom >>= \case
+  TC (BaseType (Scalar _)) -> do
+    (n, tab) <- fromPair =<< emitExpr (PrimOp $ MiscOp $ ShowScalar atom)
+    let n' = Con (Newtype NatTy n)
+    logicalTabTy <- finTabType n' CharRepTy
+    tab' <- emitExpr $ PrimOp $ MiscOp $ UnsafeCoerce logicalTabTy tab
+    emitCharTab tab'
   TC (ProdType _) -> do
     xs <- getUnpacked atom
     parens $ sepBy ", " $ map rec xs

--- a/src/lib/RuntimePrint.hs
+++ b/src/lib/RuntimePrint.hs
@@ -1,0 +1,103 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module RuntimePrint (showAny) where
+
+import Control.Monad.Reader
+import Builder
+import Core
+import Err
+import IRVariants
+import MTL1
+import Name
+import Types.Core
+import Types.Source
+import Types.Primitives
+import QueryType
+
+newtype Printer (n::S) (a :: *) = Printer { runPrinter' :: ReaderT1 (Atom CoreIR) (BuilderM CoreIR) n a }
+        deriving ( Functor, Applicative, Monad, EnvReader, MonadReader (Atom CoreIR n)
+                 , Fallible, ScopeReader, MonadFail, EnvExtender, Builder CoreIR)
+
+showAny :: EnvReader m => Type CoreIR n -> Atom CoreIR n -> m n (Block CoreIR n)
+showAny ty x = liftPrinter $ showAnyRec (sink x) (sink ty)
+
+liftPrinter
+  :: EnvReader m
+  => (forall l. (DExt n l, Emits l) => Printer l ())
+  -> m n (CBlock n)
+liftPrinter cont = liftBuilder $ buildBlock $ withBuffer \buf ->
+  runReaderT1 buf (runPrinter' cont)
+
+getBuffer :: Printer n (CAtom n)
+getBuffer = ask
+
+emitCharTab :: Emits n => CAtom n -> Printer n ()
+emitCharTab tab = do
+  buf <- getBuffer
+  extendBuffer buf tab
+
+emitLit :: Emits n => String -> Printer n ()
+emitLit s = stringLitAsCharTab s >>= emitCharTab
+
+showAnyRec :: Emits n => CAtom n -> CType n -> Printer n ()
+showAnyRec _ = \case
+  _ -> emitLit "TESTING"
+
+-- === Builder helpers (consider moving these to Builder.hs) ===
+
+withBuffer
+  :: (Emits n, IsCore r)
+  => (forall l . (Emits l, DExt n l) => Atom r l -> BuilderM r l ())
+  -> BuilderM r n (Atom r n)
+withBuffer cont = do
+  lam <- withFreshBinder "h" (TC HeapType) \h -> do
+    bufTy <- bufferTy (Var $ binderName h)
+    withFreshBinder "buf" bufTy \b -> do
+      let eff = OneEffect (RWSEffect State (Just $ sink $ binderName h))
+      body <- withAllowedEffects eff $ buildBlock do
+        cont $ sink $ Var $ binderName b
+        return UnitVal
+      let hB   = h :> TC HeapType
+      let bufB = b :> bufTy
+      let eff1 = Abs hB   Pure
+      let eff2 = Abs bufB eff
+      return $
+        Lam (UnaryLamExpr hB
+              (AtomicBlock (Lam (UnaryLamExpr bufB body) PlainArrow eff2)))
+            ImplicitArrow eff1
+  applyPreludeFunction "with_stack_internal" [lam]
+
+bufferTy :: EnvReader m => Atom r n -> m n (Type r n)
+bufferTy h = do
+  t <- strType
+  return $ RefTy h (PairTy NatTy t)
+
+-- argument has type `Fin n => Char`
+extendBuffer :: (Emits n, Builder r m) => Atom r n -> Atom r n -> m n ()
+extendBuffer buf tab = do
+  TC (RefType (Just h) _) <- getType buf
+  TabTy (_:>IxType (FinTy n) _) _ <- getType tab
+  void $ applyPreludeFunction "stack_extend_internal" [n, h, buf, tab]
+
+stringLitAsCharTab :: (Emits n, Builder r m) => String -> m n (Atom r n)
+stringLitAsCharTab s = do
+  t <- finTabType (NatVal (fromIntegral $ length s)) CharRepTy
+  emitExpr $ TabCon t (map charRepVal s)
+
+getPreludeFunction :: EnvReader m => String -> m n (Atom r n)
+getPreludeFunction sourceName = do
+  lookupSourceMap sourceName >>= \case
+    Just uvar -> case uvar of
+      UAtomVar v -> return $ Var v
+      _ -> notfound
+    Nothing -> notfound
+ where notfound = error $ "Function not defined: " ++ sourceName
+
+applyPreludeFunction :: (Emits n, Builder r m) => String -> [Atom r n] -> m n (Atom r n)
+applyPreludeFunction name args = do
+  f <- getPreludeFunction name
+  naryApp f args

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -791,9 +791,7 @@ simplifyOp op = case op of
     x <- coreToSimpAtom x'
     y <- coreToSimpAtom y'
     injectCore <$> select c x y
-  MiscOp (ShowAny x) -> do
-    ty <- getType x
-    dropSubst $ showAny ty x >>= simplifyBlock
+  MiscOp (ShowAny x) -> dropSubst $ showAny x >>= simplifyBlock
   _ -> injectCore <$> fallback
   where
     fallback = do

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -33,6 +33,7 @@ import Name
 import Subst
 import Optimize (peepholeOp)
 import QueryType
+import RuntimePrint
 import Transpose
 import Types.Core
 import Types.Primitives
@@ -790,6 +791,9 @@ simplifyOp op = case op of
     x <- coreToSimpAtom x'
     y <- coreToSimpAtom y'
     injectCore <$> select c x y
+  MiscOp (ShowAny x) -> do
+    ty <- getType x
+    dropSubst $ showAny ty x >>= simplifyBlock
   _ -> injectCore <$> fallback
   where
     fallback = do

--- a/src/lib/Subst.hs
+++ b/src/lib/Subst.hs
@@ -241,12 +241,6 @@ data SubstVal (cMatch::C) (atom::E) (c::C) (n::S) where
   SubstVal :: atom n   -> SubstVal c      atom c n
   Rename   :: Name c n -> SubstVal cMatch atom c n
 
-withFreshM :: (ScopeExtender m, Color c)
-           => NameHint
-           -> (forall o'. (DExt o o') => NameBinder c o o' -> m o' a)
-           -> m o a
-withFreshM hint cont = refreshAbsScope (newName hint) \b _ -> cont b
-
 class ColorsNotEqual a b where
   notEqProof :: ColorsEqual a b -> r
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -256,6 +256,7 @@ transposeMiscOp op _ = case op of
   BitcastOp    _ _      -> notImplemented
   UnsafeCoerce _ _      -> notImplemented
   GarbageVal _          -> notImplemented
+  ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
   where
     notLinear = error $ "Can't transpose a non-linear operation: " ++ show op
 

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -257,6 +257,7 @@ transposeMiscOp op _ = case op of
   UnsafeCoerce _ _      -> notImplemented
   GarbageVal _          -> notImplemented
   ShowAny _ -> error "Shouldn't have ShowAny in simplified IR"
+  ShowScalar _ -> error "Shouldn't have ShowScalar in simplified IR"
   where
     notLinear = error $ "Can't transpose a non-linear operation: " ++ show op
 

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -914,6 +914,12 @@ pattern TagRepTy = TC (BaseType (Scalar Word8Type))
 pattern TagRepVal :: Word8 -> Atom r n
 pattern TagRepVal x = Con (Lit (Word8Lit x))
 
+pattern CharRepTy :: Type r n
+pattern CharRepTy = Word8Ty
+
+charRepVal :: Char -> Atom r n
+charRepVal c = Con (Lit (Word8Lit (fromIntegral $ fromEnum c)))
+
 pattern Word8Ty :: Type r n
 pattern Word8Ty = TC (BaseType (Scalar Word8Type))
 

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -123,7 +123,6 @@ data MiscOp e =
  | BitcastOp e e                -- (2) Type, then value. See CheckType.hs for valid coercions.
  | UnsafeCoerce e e             -- type, then value. Assumes runtime representation is the same.
  | GarbageVal e                 -- type of value (assume `Data` constraint)
- | ShowAny e
  -- Effects
  | ThrowError e                 -- (1) Hard error (parameterized by result type)
  | ThrowException e             -- (1) Catchable exceptions (unlike `ThrowError`)
@@ -131,9 +130,16 @@ data MiscOp e =
  | SumTag e
  -- Create an enum (payload-free ADT) from a Word8
  | ToEnum e e
- -- stdout-like output stream
+ -- printing
  | OutputStream
+ | ShowAny e    -- implemented in Simplify
+ | ShowScalar e -- Implemented in Imp. Result is a pair of an `IdxRepValTy`
+                -- giving the logical size of the result and a fixed-size table,
+                -- `Fin showStringBufferSize => Char`, assumed to have sufficient space.
    deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
+
+showStringBufferSize :: Word32
+showStringBufferSize = 32
 
 data VectorOp e =
    VectorBroadcast e e  -- value, vector type

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -123,6 +123,7 @@ data MiscOp e =
  | BitcastOp e e                -- (2) Type, then value. See CheckType.hs for valid coercions.
  | UnsafeCoerce e e             -- type, then value. Assumes runtime representation is the same.
  | GarbageVal e                 -- type of value (assume `Data` constraint)
+ | ShowAny e
  -- Effects
  | ThrowError e                 -- (1) Hard error (parameterized by result type)
  | ThrowException e             -- (1) Catchable exceptions (unlike `ThrowError`)

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -41,7 +41,7 @@ import Types.Primitives
 
 data SourceNameOr (a::E) (n::S) where
   -- Only appears before renaming pass
-  SourceName :: SourceName -> SourceNameOr a VoidS
+  SourceName :: SourceName -> SourceNameOr a n
   -- Only appears after renaming pass
   -- We maintain the source name for user-facing error messages.
   InternalName :: SourceName -> a n -> SourceNameOr a n
@@ -364,7 +364,17 @@ data LogLevel = LogNothing | PrintEvalTime | PrintBench String
               | LogPasses [PassName] | LogAll
                 deriving  (Show, Generic)
 
-data OutFormat = Printed | RenderHtml  deriving (Show, Eq, Generic)
+data PrintBackend =
+   PrintCodegen  -- Soon-to-be default path based on `PrintAny`
+ | PrintLegacy   -- Old path based on Serialize.hs, soon to be deleted
+ | PrintHaskell  -- Backup path for debugging in case the codegen path breaks.
+                 -- Uses PPrint.hs directly and doesn't make any attempt to
+                 -- hide internals: SumAsProd, TabLam, AtomRepVal, etc
+                 -- are printed as they are. Also accessible via `:pp`.
+
+ deriving (Show, Eq, Generic)
+
+data OutFormat = Printed (Maybe PrintBackend) | RenderHtml  deriving (Show, Eq, Generic)
 
 data PassName = Parse | RenamePass | TypePass | SynthPass | SimpPass | ImpPass | JitPass
               | LLVMOpt | AsmPass | JAXPass | JAXSimpPass | LLVMEval | LowerOptPass | LowerPass

--- a/src/lib/dexrt.cpp
+++ b/src/lib/dexrt.cpp
@@ -176,6 +176,12 @@ void encodePNG(char **resultPtr, int8_t* pixels, int32_t width, int32_t height) 
 // The string buffer size used for converting integer and floating-point types.
 static constexpr int showStringBufferSize = 32;
 
+
+// TODO: replace `showFloat32` with `showFloat32_internal` and so on
+int32_t showFloat32_internal(char *resultPtr, float x) {
+  return snprintf(resultPtr, showStringBufferSize, "%.*g", __FLT_DECIMAL_DIG__, x);
+}
+
 void showNat32(char **resultPtr, uint32_t x) {
   auto buffer = reinterpret_cast<char *>(malloc_dex(showStringBufferSize));
   auto length = snprintf(buffer, showStringBufferSize, "%" PRId32, x);

--- a/tests/unit/ConstantCastingSpec.hs
+++ b/tests/unit/ConstantCastingSpec.hs
@@ -22,6 +22,7 @@ import TopLevel
 import Types.Core
 import Types.Imp
 import Types.Primitives
+import Types.Source
 import Util
 
 castOp :: ScalarBaseType -> LitVal -> PrimOp (SAtom VoidS)
@@ -38,7 +39,7 @@ evalBlock block = lowerFullySequential block >>= evalLLVM
 
 evalClosedExpr :: SExpr VoidS -> IO LitVal
 evalClosedExpr expr = do
-  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing NoOptimize
+  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing NoOptimize PrintLegacy
   env <- initTopState
   fst <$> runTopperM cfg env do
     block <- exprToBlock $ unsafeCoerceE expr

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -36,7 +36,7 @@ sourceTextToBlocks source = do
 sourceBlockToBlock :: (Topper m, Mut n) => SourceBlock -> m n (Maybe (SBlock n))
 sourceBlockToBlock block = case sbContents block of
   Misc (ImportModule moduleName)  -> importModule moduleName >> return Nothing
-  Command (EvalExpr Printed) expr -> Just <$> uExprToBlock expr
+  Command (EvalExpr (Printed _)) expr -> Just <$> uExprToBlock expr
   UnParseable _ s -> throw ParseErr s
   _ -> error $ "Unexpected SourceBlock " ++ pprint block ++ " in unit tests"
 
@@ -67,7 +67,7 @@ analyze cfg env code = fst <$> runTopperM cfg env do
 
 spec :: Spec
 spec = do
-  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing Optimize
+  let cfg = EvalConfig LLVM [LibBuiltinPath] Nothing Nothing Nothing Optimize PrintLegacy
   -- or just initTopState, to always compile the prelude during unit tests?
   init_env <- runIO loadCache
   (_, env) <- runIO $ runTopperM cfg init_env $ ensureModuleLoaded Prelude


### PR DESCRIPTION
The goal is to make this the default printing path and remove Interepreter/Serialize to unblock #1188. It'll also let us debug-print any dex value at runtime. There's still work to do in adding all the cases but I think it's worth merging this for now.