### PR TITLE
Trim the last UnitTy off the end of captured telescopes

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -963,7 +963,7 @@ simplifyHof _hint hof = case hof of
         liftM (SimpInCore . TabLam resultTy) $
           buildAbs noHint ixTypeSimp \i -> buildScoped do
             i' <- sinkM i
-            xs <- unpackTelescope =<< tabApp (sink ans) (Var i')
+            xs <- unpackTelescope bsClosure =<< tabApp (sink ans) (Var i')
             applySubst (bIx@>Rename i' <.> bsClosure @@> map SubstVal xs) reconResult
   While body -> do
     SimplifiedBlock body' (CoerceRecon resultTy) <- buildSimplifiedBlock $ simplifyBlock body

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -611,7 +611,7 @@ execUDecl mname decl = do
           applyRename (b@>v) sm >>= emitSourceMap
     UDeclResultBindPattern hint block (Abs bs sm) -> do
       result <- evalBlock block
-      xs <- unpackTelescope result
+      xs <- unpackTelescope bs result
       vs <- forM xs \x -> emitTopLet hint PlainLet (Atom x)
       applyRename (bs@@>vs) sm >>= emitSourceMap
     UDeclResultDone sourceMap' -> emitSourceMap sourceMap'


### PR DESCRIPTION
This doesn't seem to make much difference for compile times, but at least it makes code dumps a little less noisy.