### PR TITLE
Use flat products instead of nested pairs in non-dependent telescopes.

### DIFF
--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -224,17 +224,17 @@ type LinLam = SLam
 type LinLamAbs = MaybeReconAbs LinLam
 
 data MaybeReconAbs (e::E) (n::S) =
-   ReconWithData (NaryAbs (AtomNameC SimpIR) e n)
+   ReconWithData (ReconAbs SimpIR e n)
  | TrivialRecon (e n)
 
 data ObligateReconAbs (e::E) (n::S) =
-   ObligateRecon (SType n) (NaryAbs (AtomNameC SimpIR) e n)
+   ObligateRecon (SType n) (ReconAbs SimpIR e n)
 
 instance ReconFunctor MaybeReconAbs where
   capture locals original toCapture = do
     (reconVal, recon) <- telescopicCapture locals toCapture
     case recon of
-      Abs Empty toCapture' -> return (original, TrivialRecon toCapture')
+      Abs (ReconBinders _ Empty) toCapture' -> return (original, TrivialRecon toCapture')
       _ -> return (PairVal original reconVal, ReconWithData recon)
 
   reconstruct primalAux recon = case recon of
@@ -734,7 +734,7 @@ instance AlphaEqE    TangentArgs
 instance RenameE     TangentArgs
 
 instance GenericE (MaybeReconAbs e) where
-  type RepE (MaybeReconAbs e) = EitherE (NaryAbs (AtomNameC SimpIR) e) e
+  type RepE (MaybeReconAbs e) = EitherE (ReconAbs SimpIR e) e
   fromE = \case
     ReconWithData ab -> LeftE ab
     TrivialRecon e   -> RightE e

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -1254,7 +1254,6 @@ instance GenericE ReconstructAtom where
 
 instance SinkableE  ReconstructAtom
 instance HoistableE ReconstructAtom
-instance AlphaEqE   ReconstructAtom
 instance RenameE    ReconstructAtom
 
 instance Pretty (ReconstructAtom n) where


### PR DESCRIPTION
Partly this is just to make the IR more readable. But it might have some compile-time performance advantages too. Linearization can produce intermediate telescopes with hundreds of components. Indexing these as nested pairs means an "atom" can have hundreds `ProjectElt` layers. I wouldn't be surprised if some operations like type checking end up being quadratic in that depth.