### PR TITLE
Add a `Data` constraint and apply it where needed

### DIFF
--- a/examples/linear-maps.dx
+++ b/examples/linear-maps.dx
@@ -141,7 +141,7 @@ data SkewSymmetricMap n [Ix n] =
 
 instance HasDeterminant (SkewSymmetricMap n) given {n}
   determinant' = case is_odd (size n) of
-    True -> zero
+    True -> const zero
     False -> \(MkSkewSymMap a).
       dense_rep = skew_symmetric_prod a eye
       determinant dense_rep  -- Naive algorithm, could be done with Pfaffian

--- a/examples/mcmc.dx
+++ b/examples/mcmc.dx
@@ -6,7 +6,7 @@ import plot
 
 LogProb : Type = Float
 
-def runChain {a}
+def runChain {a} [Data a]
       (initialize: Key -> a)
       (step: Key -> a -> a)
       (numSamples: Nat)

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -1,10 +1,10 @@
 ' # Monte Carlo Tree Search
 MCTS is the decision engine for the notable AlphaGo program.
-It samples rollouts to guide tree search. 
+It samples rollouts to guide tree search.
 The nice thing is Dex can in theory automatically parallelize leaf rollouts.
 
 ' We implement a variant of MCTS with minimax search and upper
-confidence bound for trees (uct) for the two-player mini-game `Count21`. 
+confidence bound for trees (uct) for the two-player mini-game `Count21`.
 This demo implements a doubly-linked tree structure as a Dex array,
 and traverses its branches by indexing.
 [reference](http://www.incompleteideas.net/609%20dropbox/other%20readings%20and%20resources/MCTS-survey.pdf)
@@ -27,13 +27,15 @@ def Tree (node_ix:Type) (a:Type) [Ix node_ix] : Type =
 
 def root_of {node_ix a} (tree:Tree node_ix a) : node_ix = 0@node_ix
 
-def is_leaf {node a} ((Branch _ _ children):Node node a) : Bool = 
+def is_leaf {node a} ((Branch _ _ children):Node node a) : Bool =
   list_length children == 0
 
 def init_tree {a} (max_size:Nat) (default_content:a): Tree (Fin max_size) a =
   root = Branch default_content Nothing (AsList 0 [])
-  nothings = for i:(Fin max_size). Nothing
-  init_array = yield_state nothings \ref. ref!(0@_) := (Just root)
+  init_array = for i:(Fin max_size).
+    if ordinal i == 0
+      then Just root
+      else Nothing
   (init_array, 0@_)
 
 ' ## Game and Node utilities
@@ -46,7 +48,7 @@ def Game (state:Type) (move:Type) : Type =
     game_over : state -> Bool &
   }
 
-def NodeStats (state:Type) : Type = 
+def NodeStats (state:Type) : Type =
   (Nat & Nat & Nat & state)
   -- (#winning rollouts for max/first player, #visit, level, state)
 
@@ -73,7 +75,7 @@ def node_level {node_ix state} (node:(Node node_ix (NodeStats state))) : Nat =
 
 ' ## MCTS functions
 
-' Let $n$ be a node. The upper confidence bound for trees (UCT) is a heuristic 
+' Let $n$ be a node. The upper confidence bound for trees (UCT) is a heuristic
 that balances exploration and exploitation, weighed by $1:\sqrt{2}$ here.
 The reward $Q(n)$ summarizes the performance of $n$'s subtree.
 $N(n)$ is the number of visits of $n$. $n_p$ is the parent of node $n$.
@@ -88,7 +90,7 @@ def uct (win:Nat) (n:Nat) (parent_n:Nat) : Float =
 
 def mcts_select {move state node_ix}
     (game: Game state move) (tree: Tree node_ix (NodeStats state)) (key: Key)
-    : node_ix = 
+    : node_ix =
     arr = fst tree
 
     yield_state (root_of tree) \ref. iter \i.
@@ -105,7 +107,7 @@ def mcts_select {move state node_ix}
             then
               criterion = \child.
                 not $ node_is_visited $ from_just arr.child
-              (AsList _ unvisited) = filter criterion children 
+              (AsList _ unvisited) = filter criterion children
               ref := unvisited.(rand_idx key)
               Done ()
             else
@@ -122,7 +124,7 @@ def mcts_select {move state node_ix}
 
 ' Expand the tree (in-place) by adding states one-move away from the current state.
 
-def mcts_expand {move state node_ix h}
+def mcts_expand {move state node_ix h} [Ix node_ix, Data state]
     (game: Game state move)
     (tree_ref: Ref h (Tree node_ix (NodeStats state)))
     (node: node_ix) : {State h} Unit =
@@ -156,7 +158,7 @@ def mcts_expand {move state node_ix h}
 ' Simulate the game starting at a given state until the game terminates and
 return the simulation result.
 
-def mcts_rollout {move state}
+def mcts_rollout {move state} [Data state]
     (game: Game state move)
     (key: Key) (curr_state: state) : Bool =
     -- output is w.r.t. current player
@@ -177,7 +179,7 @@ def mcts_rollout {move state}
 ' Update the record of a node and its chain of ancestors,
 based on the simulation result.
 
-def mcts_backpropagate {move state node_ix h} [Eq node_ix] 
+def mcts_backpropagate {move state node_ix h} [Eq node_ix, Data state]
     (game: Game state move)
     (tree_ref: Ref h (Tree node_ix (NodeStats state)))
     (node: node_ix) (new_rollout_wins: Nat) : {State h} Unit =
@@ -207,7 +209,7 @@ def mcts_backpropagate {move state node_ix h} [Eq node_ix]
 ' Wrap up the procedure for taking one sample and extend the tree.
 
 -- slow: every sample makes two copies of the tree array
-def mcts_sample {move state node_ix} [Eq node_ix]
+def mcts_sample {move state node_ix} [Eq node_ix, Data state]
     (game: Game state move) (key: Key)
     (tree: Tree node_ix (NodeStats state))
     : Tree node_ix (NodeStats state) =
@@ -253,7 +255,7 @@ has a winning strategy.
 key = new_key 0
 
 def test (key:Key) (current_state:Nat) : (Nat & Nat) =
-  init_node_stats : NodeStats Count21State = 
+  init_node_stats : NodeStats Count21State =
     (0, 0, 0, current_state)
   -- (0 wins, 0 visits, level 0, game state)
   start_tree = init_tree MAX_TREE_SIZE init_node_stats
@@ -283,15 +285,15 @@ test key 13
 test key 12
 > (286, 50)
 
-' We fix number of samples (SAMPLES=50) and rollouts (ROLLOUTS_PER_SAMPLE=10). Fully explored 
-trees (`current_state` close to 21) yields extreme win/visits ratios. 
-We also verify that the current player is disadvantaged when the current state 
+' We fix number of samples (SAMPLES=50) and rollouts (ROLLOUTS_PER_SAMPLE=10). Fully explored
+trees (`current_state` close to 21) yields extreme win/visits ratios.
+We also verify that the current player is disadvantaged when the current state
 is a multiple of three.
 
 ' ### A closer look at the game tree
 Say the current sum is 17, the winning move for the current player is to add 1.
-In the following tree, we see that adding 1 (the second node) is indeed 
-considered a more promising choice by `uct` and sees more rollouts than 
+In the following tree, we see that adding 1 (the second node) is indeed
+considered a more promising choice by `uct` and sees more rollouts than
 the alternative (adding 2, the third node).
 
 init_node_stats : NodeStats Count21State = (0, 0, 0, 17)

--- a/examples/md.dx
+++ b/examples/md.dx
@@ -276,12 +276,12 @@ bound for the list's size.
 
 -- TODO Can we encapsulate this BoundedList type as a `data` and still
 -- define in-place mutation operations on it?
-def BoundedList n [Ix n] a = (n & (n => a))
+def BoundedList n [Ix n] a [Data a] = (n & (n => a))
 
 def unsafe_next_index {n} [Ix n] (ix:n) : n =
   unsafe_from_ordinal n $ ordinal ix + 1
 
-def empty_bounded_list {n a} [Ix n] (dummy_val: a) : BoundedList n a =
+def empty_bounded_list {n a} [Ix n, Data a] (dummy_val: a) : BoundedList n a =
   (unsafe_from_ordinal _ 0, for _. dummy_val)
 
 -- The point of a `BoundedList` is O(1) push by in-place mutation
@@ -311,7 +311,7 @@ def GridIx dim grid_size [Ix dim] = dim => (Fin grid_size)
 'A cell list is now just a `BoundedList` of the (indices of) the atoms
 that appear in each cell in the grid.
 
-def CellTable dim grid_size bucket_size atom_ix [Ix dim] =
+def CellTable dim grid_size bucket_size atom_ix [Ix dim] [Data atom_ix] =
   GridIx dim grid_size => BoundedList (Fin bucket_size) atom_ix
 
 -- Compute the cell an atom should go into.

--- a/examples/particle-filter.dx
+++ b/examples/particle-filter.dx
@@ -13,7 +13,8 @@ def sample {a} (d: Distribution a) (k: Key) : a =
   (sampler, _) = d
   sampler k
 
-def simulate {s v} (model: Model s v) (t: Nat) (key: Key) : Fin t=>(s & v) =
+def simulate {s v} [Data s]
+    (model: Model s v) (t: Nat) (key: Key) : Fin t=>(s & v) =
   (init, dynamics, observe) = model
   [key, subkey] = split_key key
   s0 = sample init subkey
@@ -26,7 +27,7 @@ def simulate {s v} (model: Model s v) (t: Nat) (key: Key) : Fin t=>(s & v) =
       s_ref := s_next
       (s, v)
 
-def particleFilter {s a v}
+def particleFilter {s a v} [Data s]
     (num_particles: Nat) (num_timesteps: Nat)
     (model: Model s v)
     (summarize: (Fin num_particles => s) -> a)

--- a/examples/particle-swarm-optimizer.dx
+++ b/examples/particle-swarm-optimizer.dx
@@ -32,7 +32,7 @@ rosenbrock2 : ((Fin 2)=>Float) -> Float =
 
 def minbyfst {a} : (Float & a) -> (Float & a) -> (Float & a) = min_by fst
 
-def minimumbyfst {n a} : (n=>(Float & a)) -> (Float & a) = minimum_by fst
+def minimumbyfst {n a} [Data a] : (n=>(Float & a)) -> (Float & a) = minimum_by fst
 
 '### Rand helpers
 

--- a/examples/rejection-sampler.dx
+++ b/examples/rejection-sampler.dx
@@ -2,7 +2,7 @@
 
 'We implement rejection sampling from a Binomial distribution using a uniform proposal.
 
-def rejectionSample {a} (try: Key -> Maybe a) (k:Key) : a =
+def rejectionSample {a} [Data a] (try: Key -> Maybe a) (k:Key) : a =
   iter \i. case try $ hash k i of
     Nothing -> Continue
     Just x  -> Done x

--- a/examples/sierpinski.dx
+++ b/examples/sierpinski.dx
@@ -7,7 +7,7 @@ def update {n} (points:n=>Point) (key:Key) ((x,y):Point) : Point =
   (x', y') = points.(rand_idx key)
   (0.5 * (x + x'), 0.5 * (y + y'))
 
-def runChain {a} (n:Nat) (f:Key -> a -> a) (key:Key) (x0:a) : Fin n => a =
+def runChain {a} [Data a] (n:Nat) (f:Key -> a -> a) (key:Key) (x0:a) : Fin n => a =
   scan' x0 (many f key)
 
 trianglePoints : (Fin 3)=>Point = [(0.0, 0.0), (1.0, 0.0), (0.5, sqrt 0.75)]

--- a/lib/linalg.dx
+++ b/lib/linalg.dx
@@ -191,10 +191,12 @@ def backward_substitute {n v} [VSpace v] (a:UpperTriMat n Float) (b:n=>v) : n=>v
       sRef!i := (b.i - s) / (upper_tri_diag a).i
 
 -- Todo: get rid of these by writing a dependent indexing (!) operator.
-def lower_tri_mat {a b h} (ref:Ref h (LowerTriMat a b)) (i:a) (j:(..i)) : Ref h b =
+def lower_tri_mat {a b h} [Data a, Data b]
+    (ref:Ref h (LowerTriMat a b)) (i:a) (j:(..i)) : Ref h b =
   d = %indexRef ref i
   d!j
-def upper_tri_mat {a b h} (ref:Ref h (UpperTriMat a b)) (i:a) (j:(i..)) : Ref h b =
+def upper_tri_mat {a b h} [Data a, Data b]
+    (ref:Ref h (UpperTriMat a b)) (i:a) (j:(i..)) : Ref h b =
   d = %indexRef ref i
   d!j
 
@@ -230,7 +232,7 @@ def apply_permutation {n t} ((perm, _):Permutation n) (xs: n=>t) : n=>t =
 def identity_permutation {n} [Ix n] : Permutation n =
   (for i. i, 1.0)
 
-def swap_in_place {n h} (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
+def swap_in_place {n h} [Ix n] (pRef: Ref h (Permutation n)) (i:n) (j:n) : {State h} Unit =
   (permRef, signRef) = (fst_ref pRef, snd_ref pRef)
   tempj = get permRef!j
   permRef!j := get permRef!i

--- a/lib/parser.dx
+++ b/lib/parser.dx
@@ -92,7 +92,7 @@ def parse_digit : Parser Int = try $ MkParser \h.
 def optional {a} (p:Parser a) : Parser (Maybe a) =
   (MkParser \h. Just (parse h p)) <|> returnP Nothing
 
-def parse_many {a} (parser:Parser a) : Parser (List a) = MkParser \h.
+def parse_many {a} [Data a] (parser:Parser a) : Parser (List a) = MkParser \h.
   yield_state (AsList _ []) \results.
     iter \_.
       maybeVal = parse h $ optional parser

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -39,8 +39,8 @@ interface Data a
 
 def internal_cast {a} (b:Type) (x:a) : b = %cast b x
 
-def unsafe_coerce {a} (b:Type) (x:a) : b = %unsafeCoerce b x -- TODO: `Data` constraint
-def uninitialized_value {a} : a = %garbageVal a              -- TODO: `Data` constraint
+def unsafe_coerce {a} (b:Type) [Data a, Data b] (x:a) : b = %unsafeCoerce b x
+def uninitialized_value {a} [Data a] : a = %garbageVal a
 
 def f64_to_f (x : Float64) : Float   = internal_cast _ x
 def f32_to_f (x : Float32) : Float   = internal_cast _ x
@@ -520,6 +520,8 @@ def not  (x:Bool) : Bool =
 '## More Boolean operations
 TODO: move these with the others?
 
+-- Can't use `%select` because it lowers to `ISelect`, which requires
+-- `a` to be a `BaseTy`.
 def select {a} (p:Bool) (x:a) (y:a) : a = case p of
   True  -> x
   False -> y
@@ -2600,8 +2602,7 @@ def with_stack_internal (f : (h:Heap) ?-> Stack h Char -> {State h} Unit) : List
 
 def show_any {a} (x:a) : String = unsafe_coerce String $ %showAny x
 
--- TODO: data constraint
-def coerce_table {n a} (m:Type) [Ix m] (x:n=>a) : m => a =
+def coerce_table {n a} [Data a] (m:Type) [Ix m] (x:n=>a) : m => a =
   if size m == size n
     then unsafe_coerce (m=>a) x
     else error "mismatched sizes in table coercion"

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -32,6 +32,9 @@ Float = Float32
 
 def the (a:Type) (x:a) = x
 
+interface Data a
+  do_not_implement_this_interface_for_the_compiler_relies_on_the_invariant_it_protects : a -> a
+
 '### Casting
 
 def internal_cast {a} (b:Type) (x:a) : b = %cast b x

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -163,7 +163,7 @@ def high_word (x : Word64) : Word32 = internal_cast _ x
 Things that can be added.
 This defines the `Add` [group](https://en.wikipedia.org/wiki/Group_(mathematics)) and its operators.
 
-interface Add a
+interface [Data a] Add a
   add : a -> a -> a
   zero : a
 
@@ -225,17 +225,19 @@ instance Add Unit
 instance Sub Unit
   sub = \x y. ()
 
-instance Add (n->a) given {n a} [Add a]
-  add = \f g. \x. (f x) + (g x)
-  zero = \x. zero
-instance Sub (n->a) given {n a} [Sub a]
-  sub = \f g. \x. (f x) - (g x)
+-- Instances for Add that we could give to unary functions if we
+-- choose to: https://github.com/google-research/dex-lang/issues/1230
+-- instance Add (n->a) given {n a} [Add a]
+--   add = \f g. \x. (f x) + (g x)
+--   zero = \x. zero
+-- instance Sub (n->a) given {n a} [Sub a]
+--   sub = \f g. \x. (f x) - (g x)
 
 '#### Mul
 Things that can be multiplied.
 This defines the `Mul` [Monoid](https://en.wikipedia.org/wiki/Monoid), and its operator.
 
-interface Mul a
+interface [Data a] Mul a
   mul : a -> a -> a
   one : a
 
@@ -277,9 +279,11 @@ instance Mul Unit
   mul = \x y. ()
   one = ()
 
-instance Mul (n->a) given {n a} [Mul a]
-  mul = \f g. \x. (f x) * (g x)
-  one = \x. one
+-- Instance for Mul that we could give to unary functions if we
+-- choose to: https://github.com/google-research/dex-lang/issues/1230
+-- instance Mul (n->a) given {n a} [Mul a]
+--   mul = \f g. \x. (f x) * (g x)
+--   one = \x. one
 
 '#### Integral
 Integer-like things.
@@ -327,7 +331,7 @@ instance Fractional Float32
 
 '## Index set interface and instances
 
-interface Ix n
+interface [Data n] Ix n
   size n : Nat
   ordinal : n -> Nat
   unsafe_from_ordinal n : Nat -> n
@@ -481,8 +485,10 @@ instance VSpace ((i:n) => (..<i) => a) given {a n} [VSpace a]
 instance VSpace ((i:n) => (i<..) => a) given {a n} [VSpace a]
   scale_vec = \s xs. for i. s .* xs.i
 
-instance VSpace (n->a) given {a n} [VSpace a]
-  scale_vec = \s f. \x. s .* (f x)
+-- Instance for VSpace that we could give to unary functions if we
+-- choose to: https://github.com/google-research/dex-lang/issues/1230
+-- instance VSpace (n->a) given {a n} [VSpace a]
+--   scale_vec = \s f. \x. s .* (f x)
 
 instance VSpace Unit
   scale_vec = \_ _. ()
@@ -648,7 +654,7 @@ named-instance MulMonoid : Monoid a given (a:Type) [Mul a]
 
 '## Effects
 
-def Ref (r:Heap) (a:Type) : Type = %Ref r a
+def Ref (r:Heap) (a:Type) [Data a] : Type = %Ref r a
 def get  {h s} (ref:Ref h s)       : {State h} s    = %get  ref
 def (:=) {h s} (ref:Ref h s) (x:s) : {State h} Unit = %put  ref x
 
@@ -670,12 +676,12 @@ def (+=) {h w} [am:AccumMonoid h w] (ref:Ref h w) (x:w) : {Accum h} Unit =
   combine = %projMethod1 bm
   %mextend ref empty (\x y. combine x y) x
 
-def (!) {h n a} (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
-def fst_ref {h a b} (ref: Ref h (a & b)) : Ref h a = %fstRef ref
-def snd_ref {h a b} (ref: Ref h (a & b)) : Ref h b = %sndRef ref
+def (!) {h n a} [Data a] (ref:Ref h (n=>a)) (i:n) : Ref h a = %indexRef ref i
+def fst_ref {h a b} [Data a] (ref: Ref h (a & b)) : Ref h a = %fstRef ref
+def snd_ref {h a b} [Data b] (ref: Ref h (a & b)) : Ref h b = %sndRef ref
 
 def run_reader
-      {r a eff}
+      {r a eff} [Data r]
       (init:r)
       (action: ((h:Heap) ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
@@ -683,7 +689,7 @@ def run_reader
     %runReader init explicitAction
 
 def with_reader
-      {r a eff}
+      {r a eff} [Data r]
       (init:r)
       (action: ((h:Heap) ?-> Ref h r -> {Read h|eff} a))
       : {|eff} a =
@@ -695,7 +701,7 @@ named-instance mk_accum_monoid : AccumMonoid h w given {h w} (d:AccumMonoidData 
   getAccumMonoidData = d
 
 def run_accum
-      {a b w eff}
+      {a b w eff} [Data w]
       [mlift:MonoidLifter b w]
       (bm:Monoid b)
       (action: ((h:Heap) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
@@ -710,7 +716,7 @@ def run_accum
   %runWriter empty (\x y. combine x y) explicitAction
 
 def yield_accum
-      {a b w eff}
+      {a b w eff} [Data w]
       [mlift:MonoidLifter b w]
       (m:Monoid b)
       (action: ((h:Heap) ?-> AccumMonoid h b ?=> Ref h w -> {Accum h|eff} a))
@@ -718,7 +724,7 @@ def yield_accum
   snd $ run_accum m action
 
 def run_state
-      {a s eff}
+      {a s eff} [Data s]
       (init:s)
       (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} (a & s) =
@@ -726,13 +732,13 @@ def run_state
   %runState init explicitAction
 
 def with_state
-      {a s eff}
+      {a s eff} [Data s]
       (init:s)
       (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} a = fst $ run_state init action
 
 def yield_state
-      {a s eff}
+      {a s eff} [Data s]
       (init:s)
       (action: (h:Heap) ?-> Ref h s -> {State h |eff} a)
       : {|eff} s = snd $ run_state init action
@@ -752,7 +758,7 @@ def unreachable {a} (():Unit) : a = unsafe_io do
 Equatable.
 Things that we can tell if they are equal or not to other things.
 
-interface Eq a
+interface [Data a] Eq a
   (==) : a -> a -> Bool
 
 def (/=) {a} [Eq a] (x:a) (y:a) : Bool = not $ x == y
@@ -911,14 +917,15 @@ instance NonEmpty (a|b) given {a b} [Ix b, NonEmpty a]
 instance NonEmpty (Maybe a) given {a} [Ix a]
   first_ix = unsafe_from_ordinal _ 0
 
-def scan {a b n} [Ix n] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
+def scan {a b n} [Ix n, Data a] (init:a) (body:n->a->(a&b)) : (a & n=>b) =
   swap $ run_state init \s. for i.
     c = get s
     (c', y) = body i c
     s := c'
     y
 
-def fold {a n} [Ix n] (init:a) (body:(n->a->a)) : a = fst $ scan init \i x. (body i x, ())
+def fold {a n} [Ix n, Data a] (init:a) (body:(n->a->a)) : a =
+  fst $ scan init \i x. (body i x, ())
 
 def compare {a} [Ord a] (x:a) (y:a) : Ordering =
   if x < y
@@ -1246,12 +1253,13 @@ def reindex {a b v} [Ix b] (ixr: b -> a) (tab: a=>v) : b=>v = for i. tab.(ixr i)
 
 -- `combine` should be a commutative and associative, and form a
 -- commutative monoid with `identity`
-def reduce {a n} (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
+def reduce {a n} [Data a] (identity:a) (combine:(a->a->a)) (xs:n=>a) : a =
   -- TODO: implement with the accumulator effect
   fold identity (\i c. combine c xs.i)
 
 -- TODO: call this `scan` and call the current `scan` something else
-def scan' {a n} [Ix n] (init:a) (body:n->a->a) : n=>a = snd $ scan init \i x. dup (body i x)
+def scan' {a n} [Ix n, Data a] (init:a) (body:n->a->a) : n=>a =
+  snd $ scan init \i x. dup (body i x)
 -- TODO: allow tables-via-lambda and get rid of this
 def fsum {n} (xs:n=>Float) : Float = yield_accum (AddMonoid Float) \ref. for i. ref += xs.i
 def sum  {n v} [Add v] (xs:n=>v) : v = reduce zero (+) xs
@@ -1263,7 +1271,7 @@ def all {n} (xs:n=>Bool) : Bool = reduce True  (&&) xs
 
 '### apply_n
 
-def apply_n {a} (n:Nat) (x:a) (f:a -> a) : a =
+def apply_n {a} [Data a] (n:Nat) (x:a) (f:a -> a) : a =
   yield_state x \ref. for _:(Fin n).
     ref := f (get ref)
 
@@ -1772,7 +1780,7 @@ def while {eff} (body: Unit -> {|eff} Bool) : {|eff} Unit =
   body' : Unit -> {|eff} Word8 = \_. b_to_w8 $ body ()
   %while body'
 
-data IterResult a =
+data IterResult a [Data a] =
   Continue
   Done a
 
@@ -2144,9 +2152,9 @@ def max_by {a o} [Ord o] (f:a->o) (x:a) (y:a) : a = select (f x > f y) x y
 def min {o} [Ord o] (x1: o) (x2: o) : o = min_by id x1 x2
 def max {o} [Ord o] (x1: o) (x2: o) : o = max_by id x1 x2
 
-def minimum_by {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
+def minimum_by {a n o} [Data a, Ord o] (f:a->o) (xs:n=>a) : a =
   reduce xs.(0@_) (min_by f) xs
-def maximum_by {a n o} [Ord o] (f:a->o) (xs:n=>a) : a =
+def maximum_by {a n o} [Data a, Ord o] (f:a->o) (xs:n=>a) : a =
   reduce xs.(0@_) (max_by f) xs
 
 def minimum {n o} [Ord o] (xs:n=>o) : o = minimum_by id xs
@@ -2155,7 +2163,7 @@ def maximum {n o} [Ord o] (xs:n=>o) : o = maximum_by id xs
 '### argmin/argmax
 TODO: put in same section as `searchsorted`
 
-def argscan {n o} (comp:o->o->Bool) (xs:n=>o) : n =
+def argscan {n o} [Data o] (comp:o->o->Bool) (xs:n=>o) : n =
   zeroth = (0@_, xs.(0@_))
   compare = \(idx1, x1) (idx2, x2).
     select (comp x1 x2) (idx1, x1) (idx2, x2)
@@ -2303,7 +2311,7 @@ def natlog2 (x:Nat) : Nat =
           False
   unsafe_nat_diff tmp 1  -- TODO: something less horrible
 
-def general_integer_power {a} (times:a->a->a) (one:a) (base:a) (power:Nat) : a =
+def general_integer_power {a} [Data a] (times:a->a->a) (one:a) (base:a) (power:Nat) : a =
   iters = if power == 0 then 0 else 1 + natlog2 power
   -- Implements exponentiation by squaring.
   -- This could be nicer if there were a way to explicitly
@@ -2523,8 +2531,7 @@ instance NonEmpty (a=>b) given {a b} [Ix a, NonEmpty b]
 '### stack
 -- TODO: replace `DynBuffer` with this?
 
--- TODO: `Data` constraint
-def Stack (h:Heap) (a:Type) = Ref h (Nat & List a)
+def Stack (h:Heap) (a:Type) [Data a] = Ref h (Nat & List a)
 
 def stack_size {h a} (stack:Stack h a) : {State h} Nat = get $ fst_ref stack
 
@@ -2552,7 +2559,7 @@ def read_stack {h a} (stack:Stack h a) : {State h} (List a) =
   AsList n (get buf)
 
 @noinline
-def stack_push {a h} (stack:Stack h a) (x:a) : {State h} Unit =
+def stack_push {a} [Data a] {h} (stack:Stack h a) (x:a) : {State h} Unit =
   n_old = stack_size stack
   n_new = n_old + 1
   ensure_size_at_least stack n_new
@@ -2563,8 +2570,10 @@ def stack_push {a h} (stack:Stack h a) (x:a) : {State h} Unit =
 -- TODO: we need to put the arguments in this order because the compiler
 -- currently requires the non-data args to come before the data args. We should
 -- fix that.
+-- In particular, we cannot rely on the Data and Ix constraints to be auto-inferred,
+-- because of Issue 1229 https://github.com/google-research/dex-lang/issues/1229.
 @noinline
-def stack_extend {a n} [Ix n] {h} (stack:Stack h a) (x:n=>a) : {State h} Unit =
+def stack_extend {a n} [Data a, Ix n] {h} (stack:Stack h a) (x:n=>a) : {State h} Unit =
   n_old = stack_size stack
   n_new = n_old + size n
   ensure_size_at_least stack n_new
@@ -2574,7 +2583,7 @@ def stack_extend {a n} [Ix n] {h} (stack:Stack h a) (x:n=>a) : {State h} Unit =
   fst_ref stack := n_new
 
 stack_init_size = 16
-def with_stack {r eff} (a:Type) (f : (h:Heap) ?-> Stack h a -> {State h|eff} r) : {|eff} r =
+def with_stack {r eff} (a:Type) [Data a] (f : (h:Heap) ?-> Stack h a -> {State h|eff} r) : {|eff} r =
   init_stack = to_list for i:(Fin stack_init_size). uninitialized_value
   with_state (0, init_stack) \ref . f ref
 
@@ -2589,7 +2598,7 @@ def with_stack_internal (f : (h:Heap) ?-> Stack h Char -> {State h} Unit) : List
     f stack
     read_stack stack
 
-def show_any {a} (x:a) : String = unsafe_coerce String %showAny x
+def show_any {a} (x:a) : String = unsafe_coerce String $ %showAny x
 
 -- TODO: data constraint
 def coerce_table {n a} (m:Type) [Ix m] (x:n=>a) : m => a =

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -264,6 +264,7 @@ instance CheaplyReducibleE CoreIR DictExpr CAtom where
       cheapReduceE (App f xs) <|> justSubst
     InstanceDict _ _ -> justSubst
     IxFin _          -> justSubst
+    DataData ty      -> DictCon . DataData <$> cheapReduceE ty
     where justSubst = DictCon <$> substM d
 
 instance CheaplyReducibleE CoreIR DataDefParams DataDefParams where

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -420,6 +420,7 @@ dictExprType e = case e of
   IxFin n -> do
     n' <- checkTypeE NatTy n
     liftM DictTy $ ixDictType $ NewtypeTyCon $ Fin n'
+  DataData ty -> DictTy <$> (dataDictType =<< checkTypeE TyKind ty)
 
 instance HasType CoreIR DictExpr where
   getTypeE e = dictExprType e

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -195,7 +195,8 @@ instance GenericallyTraversableE CoreIR DictExpr where
     InstanceDict v args -> InstanceDict <$> substM v <*> mapM tge args
     InstantiatedGiven given args -> InstantiatedGiven <$> tge given <*> mapM tge args
     SuperclassProj subclass i -> SuperclassProj <$> tge subclass <*> pure i
-    IxFin n ->  IxFin <$> tge n
+    IxFin n     -> IxFin <$> tge n
+    DataData ty -> DataData <$> tge ty
 
 instance GenericallyTraversableE r (IxDict r) where
   traverseGenericE = \case

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -257,6 +257,7 @@ instance Pretty (DictExpr n) where
     InstantiatedGiven v args -> "Given" <+> p v <+> p (toList args)
     SuperclassProj d' i -> "SuperclassProj" <+> p d' <+> p i
     IxFin n -> "Ix (Fin" <+> p n <> ")"
+    DataData a -> "Data " <+> p a
 
 instance IRRep r => Pretty (IxDict r n) where
   pretty = \case

--- a/src/lib/RuntimePrint.hs
+++ b/src/lib/RuntimePrint.hs
@@ -145,7 +145,7 @@ showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
   DictHole _ _ -> error "shouldn't have DictHole past inference"
   DepPairTy _ -> parens do
     (x, y) <- fromPair atom
-    rec x >> emitLit ",> " >> rec y
+    rec x >> emitLit " ,> " >> rec y
   -- Done well, this could let you inspect the results of dictionary synthesis
   -- and maybe even debug synthesis failures.
   DictTy _ -> printAsConstant

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -343,7 +343,8 @@ def getFst3 {b:Type} {n:Type} (xs:n=>b) : b =
 :p getFst3 [1,2,3]
 > 1
 
-def triRefIndex {h n} (ref:Ref h ((i':n)=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
+def triRefIndex {h n} [Ix n, Data ((i':n)=>(..i')=>Float)]
+  (ref:Ref h ((i':n)=>(..i')=>Float)) (i:n) : Ref h ((..i)=>Float) =
   %indexRef ref i
 
 (for i:(Fin 5). for j:(i..). 0.0).(0@_)
@@ -557,14 +558,16 @@ def transpose_ix {n} [Ix n] (i:n) (j:(i..)) : (i:n &> ..i) =
 -- :p transpose_lower_to_upper dpair
 -- > [[1, 2, 4], [3, 5], [6]]
 
-'### Tests for function VSpace
+-- '### Tests for function VSpace
+-- that we could restore if we choose to:
+-- https://github.com/google-research/dex-lang/issues/1230
 
-:p (sin + cos) 5.0 ~~ (\x. sin x + cos x) 5.0
-> True
-:p (sin * cos) 5.0 ~~ (\x. sin x * cos x) 5.0
-> True
-:p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
-> True
+-- :p (sin + cos) 5.0 ~~ (\x. sin x + cos x) 5.0
+-- > True
+-- :p (sin * cos) 5.0 ~~ (\x. sin x * cos x) 5.0
+-- > True
+-- :p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
+-- > True
 
 '### Miscellany
 

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -531,7 +531,7 @@ pair = (5 ,> buffer) :: tp
 if False
   then (5 ,> buffer) :: tp
   else (3 ,> for i:(Fin 3). (ordinal i) * 2) :: tp
-> (3,> [0, 2, 4])
+> (3 ,> [0, 2, 4])
 
 '### Tests for dependent pair pattern match
 

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -250,3 +250,31 @@ instance Ix TwoMorePoints
 
 :p for i:TwoMorePoints. ordinal i
 > [0, 1]
+
+----------------- Data constraint synthesis -----------------
+
+def data_id {a} [Data a] (x:a) : a = x
+
+data_id 4
+> 4
+
+data_id Int
+> Type error:Couldn't synthesize a class dictionary for: (Data Type)
+>
+> data_id Int
+> ^^^^^^^^
+
+data_id (5, Int)
+> Type error:Couldn't synthesize a class dictionary for: (Data (Nat & Type))
+>
+> data_id (5, Int)
+> ^^^^^^^^
+
+data_id (5, 8)
+> (5, 8)
+
+data_id [4, 5, 6]
+> [4, 5, 6]
+
+data_id (the (n:Nat &> (Fin n) => Nat) (3 ,> [5, 6, 7]))
+> (3 ,> [5, 6, 7])


### PR DESCRIPTION
Makes progress on Issue #1150; fixes #609.

Other, more minor uses for `Data` remain unannotated (e.g., uninitialized_value)