### PR TITLE
Add pop function for stack, and some tests.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2584,6 +2584,16 @@ def stack_extend {a n} [Data a, Ix n] {h} (stack:Stack h a) (x:n=>a) : {State h}
   buf_slice := x
   fst_ref stack := n_new
 
+def stack_pop {a h} [Data a] (stack:Stack h a) : {State h} Maybe a =
+  n_old = stack_size stack
+  case n_old == 0 of
+    True -> Nothing
+    False ->
+      n_new = unsafe_nat_diff n_old 1
+      buf = unsafe_get_stack_buffer stack
+      fst_ref stack := n_new
+      Just $ get buf!(unsafe_from_ordinal _ n_new)
+
 stack_init_size = 16
 def with_stack {r eff} (a:Type) [Data a] (f : (h:Heap) ?-> Stack h a -> {State h|eff} r) : {|eff} r =
   init_stack = to_list for i:(Fin stack_init_size). uninitialized_value

--- a/makefile
+++ b/makefile
@@ -224,7 +224,7 @@ test-names = uexpr-tests print-tests adt-tests type-tests cast-tests eval-tests 
              standalone-function-tests \
              ad-tests parser-tests serialize-tests parser-combinator-tests \
              record-variant-tests typeclass-tests complex-tests trig-tests \
-             linalg-tests set-tests fft-tests stats-tests
+             linalg-tests set-tests fft-tests stats-tests stack-tests
 
 doc-names = conditionals functions
 

--- a/tests/stack-tests.dx
+++ b/tests/stack-tests.dx
@@ -1,0 +1,22 @@
+
+with_stack Nat \stack.
+  stack_push stack 10
+  stack_push stack 11
+  stack_pop  stack
+  stack_pop  stack
+> (Just 10)
+
+with_stack Nat \stack.
+  stack_push stack 10
+  stack_push stack 11
+  stack_pop  stack
+  stack_pop  stack
+  stack_pop  stack     -- Check that popping an empty stack is OK.
+  stack_push stack 20
+  stack_push stack 21
+  stack_pop  stack
+> (Just 21)
+
+with_stack Nat \stack.
+  stack_pop stack
+> Nothing


### PR DESCRIPTION
I'm not sure whether `@noinline` is appropriate for this one.  But adding it gives a compiler error related to the `Data` constraint, so I left it off for now.

I also think it might make sense to spin off all the stack functions into their own library file.

I'm halfway through a rewrite of `sort` to be a very type-safe demo of quicksort, but it's currently stalled, so in the meantime I thought I'd add this utility function.