### PR TITLE
Generalize our generalization system to handle data arguments.

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -612,7 +612,6 @@ instance SubstB AtomSubstVal RolePiBinder
 instance IRRep r => SubstE AtomSubstVal (TabPiType r)
 instance IRRep r => SubstE AtomSubstVal (NaryPiType r)
 instance IRRep r => SubstE AtomSubstVal (DepPairType r)
-instance SubstE AtomSubstVal NoInlineDef
 instance SubstE AtomSubstVal SolverBinding
 instance IRRep r => SubstE AtomSubstVal (DeclBinding r)
 instance IRRep r => SubstB AtomSubstVal (Decl r)

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -8,9 +8,8 @@ module CheckType (
   CheckableE (..), CheckableB (..),
   checkTypes, checkTypesM, checkHasType,
   checkExtends, checkedApplyClassParams,
-  tryGetType,
-  checkUnOp, checkBinOp,
-  isData, asFirstOrderFunction, asSpecializableFunction, asFFIFunType,
+  tryGetType, checkUnOp, checkBinOp,
+  isData, asFirstOrderFunction, asFFIFunType,
   asNaryPiType
   ) where
 
@@ -1127,30 +1126,6 @@ checkScalarOrPairType (PairTy a b) = do
   return $ tys1 ++ tys2
 checkScalarOrPairType (BaseTy ty) = return [ty]
 checkScalarOrPairType ty = throw TypeErr $ pprint ty
-
--- TODO: consider effects
--- TODO: check that the remaining args and result are "data"
--- TODO: determine the static args lazily, at the use sites
-asSpecializableFunction :: EnvReader m => CType n -> m n (Maybe (Int, [Arrow], NaryPiType CoreIR n))
-asSpecializableFunction ty =
-  case asNaryPiType ty of
-    Just (arrs, piTy@(NaryPiType bs _ _)) -> do
-      let n = numStaticArgs bs
-      return $ Just (n, arrs, piTy)
-    Nothing -> return Nothing
-  where
-    numStaticArgs :: Nest (Binder CoreIR) n l -> Int
-    numStaticArgs Empty = 0
-    numStaticArgs (Nest b rest) =
-      if isStaticArg b
-        then 1 + numStaticArgs rest
-        else 0
-
-    isStaticArg :: Binder CoreIR n l -> Bool
-    isStaticArg b = case binderType b of
-      TyKind   -> True
-      DictTy _ -> True
-      _        -> False
 
 -- TODO: consider effects
 asFirstOrderFunction :: EnvReader m => Type CoreIR n -> m n (Maybe ([Arrow], NaryPiType CoreIR n))

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -425,7 +425,7 @@ zonkAtomBindingWithOutMap outMap = \case
  PiBound     e -> PiBound     $ zonkWithOutMap outMap e
  MiscBound   e -> MiscBound   $ zonkWithOutMap outMap e
  SolverBound e -> SolverBound $ zonkWithOutMap outMap e
- NoinlineFun e   -> NoinlineFun (zonkWithOutMap outMap e)
+ NoinlineFun t e -> NoinlineFun (zonkWithOutMap outMap t) (zonkWithOutMap outMap e)
  FFIFunBound x y -> FFIFunBound (zonkWithOutMap outMap x) (zonkWithOutMap outMap y)
 
 -- TODO: Wouldn't it be faster to carry the set of inference-emitted names in the out map?

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -484,7 +484,7 @@ instance IRRep r => Pretty (AtomBinding r n) where
     MiscBound   t -> p t
     SolverBound b -> p b
     FFIFunBound s _ -> p s
-    NoinlineFun (NoInlineDef _ _ _ ty _) -> "Top function with type: " <+> p ty
+    NoinlineFun ty _ -> "Top function with type: " <+> p ty
     TopDataBound (RepVal ty _) -> "Top data with type: " <+> p ty
 
 instance Pretty (SpecializationSpec n) where

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -873,6 +873,16 @@ def f5 (x:Int) : Int = f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ x
 @noinline
 def f6 (x:Int) : Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 
+
+-- regression test for #1229 - checks that constraints and data args can be interleaved
+@noinline
+def interleave_args {n} (x:Float) (xs:n=>Float) : Float =
+  x + sum xs
+
+interleave_args 1.0 [2.0, 3.0]
+> 6.
+
+
 -- This will compile extremely slowly if non-inlining is broken
 :p f6 0
 > 100000


### PR DESCRIPTION
This treats ordinary data arguments as a special case of static type/dict args where "generalization" just means hoisting the entire argument to become a runtime arg. It's both more general and less code than before! Now we can interleave data/non-data args in @noinline functions. Fixes #1229 and gets us closer to being able to put @noinline on everything default.