### PR TITLE
Stop extending synthesis givens everywhere.

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -588,7 +588,6 @@ instance SubstE AtomSubstVal EffectOpType
 instance SubstE AtomSubstVal IExpr
 instance IRRep r => SubstE AtomSubstVal (RepVal r)
 instance SubstE AtomSubstVal DataDefParams
-instance SubstE AtomSubstVal DataDef
 instance SubstE AtomSubstVal DataConDef
 instance IRRep r => SubstE AtomSubstVal (BaseMonoid r)
 instance SubstE AtomSubstVal UserEffectOp
@@ -597,18 +596,13 @@ instance IRRep r => SubstE AtomSubstVal (Hof r)
 instance IRRep r => SubstE AtomSubstVal (RefOp r)
 instance IRRep r => SubstE AtomSubstVal (Expr r)
 instance IRRep r => SubstE AtomSubstVal (Block r)
-instance SubstE AtomSubstVal InstanceDef
 instance SubstE AtomSubstVal InstanceBody
 instance SubstE AtomSubstVal MethodType
 instance SubstE AtomSubstVal DictType
 instance SubstE AtomSubstVal DictExpr
-instance SubstE AtomSubstVal LamBinding
 instance IRRep r => SubstE AtomSubstVal (LamExpr r)
 instance IRRep r => SubstE AtomSubstVal (DestBlock r)
-instance SubstE AtomSubstVal PiBinding
-instance SubstB AtomSubstVal PiBinder
 instance SubstE AtomSubstVal PiType
-instance SubstB AtomSubstVal RolePiBinder
 instance IRRep r => SubstE AtomSubstVal (TabPiType r)
 instance IRRep r => SubstE AtomSubstVal (NaryPiType r)
 instance IRRep r => SubstE AtomSubstVal (DepPairType r)
@@ -619,6 +613,10 @@ instance SubstE AtomSubstVal NewtypeTyCon
 instance SubstE AtomSubstVal NewtypeCon
 instance IRRep r => SubstE AtomSubstVal (IxDict r)
 instance IRRep r => SubstE AtomSubstVal (IxType r)
+
+instance SubstB AtomSubstVal RolePiBinder where
+  substB env (RolePiBinder b ty arr role) cont =
+    substB env (b:>ty) \env' (b':>ty') -> cont env' $ RolePiBinder b' ty' arr role
 
 -- XXX: we need a special instance here because `SuperclassBinder` have all
 -- their types at the level of the top binder, rather than interleaving them

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -210,13 +210,6 @@ instance (IRRep r, SinkableE ann, ToBinding ann (AtomNameC r)) => BindsEnv (NonD
         Nest (b:>a) $ zipNest bs $ sinkList anns
       zipNest _ _ = error "Mismatched lengths in NonDepNest"
 
-instance BindsEnv PiBinder where
-  toEnvFrag :: Distinct l => PiBinder n l -> EnvFrag n l
-  toEnvFrag (PiBinder b ty arr) =
-    withExtEvidence b do
-      let binding = toBinding $ sink $ PiBinding arr ty
-      EnvFrag (RecSubstFrag $ b @> binding)
-
 instance IRRep r => BindsEnv (Decl r) where
   toEnvFrag (Let b binding) = toEnvFrag $ b :> binding
   {-# INLINE toEnvFrag #-}
@@ -229,7 +222,7 @@ instance BindsEnv EnvFrag where
   {-# INLINE toEnvFrag #-}
 
 instance BindsEnv RolePiBinder where
-  toEnvFrag (RolePiBinder b ty arr _) = toEnvFrag (PiBinder b ty arr)
+  toEnvFrag (RolePiBinder b ty _ _) = toEnvFrag (b:>ty)
   {-# INLINE toEnvFrag #-}
 
 instance BindsEnv (RecSubstFrag Binding) where
@@ -393,15 +386,6 @@ withFreshBinders (binding:rest) cont = do
       cont (Nest b bs)
            (sink (binderName b) : vs)
 
-piBinderAsBinder :: PiBinder n l -> Binder CoreIR n l
-piBinderAsBinder (PiBinder b ty _) = b:>ty
-
-plainPiBinder :: Binder CoreIR n l -> PiBinder n l
-plainPiBinder (b:>ty) = PiBinder b ty PlainArrow
-
-classPiBinder :: Binder CoreIR n l -> PiBinder n l
-classPiBinder (b:>ty) = PiBinder b ty ClassArrow
-
 getLambdaDicts :: EnvReader m => m n [AtomName CoreIR n]
 getLambdaDicts = do
   env <- withEnv moduleEnv
@@ -419,7 +403,7 @@ nonDepPiType :: ScopeReader m
 nonDepPiType arr argTy eff resultTy =
   toConstAbs (PairE eff resultTy) >>= \case
     Abs b (PairE eff' resultTy') ->
-      return $ PiType (PiBinder b argTy arr) eff' resultTy'
+      return $ PiType (b:>argTy) arr eff' resultTy'
 
 nonDepTabPiType :: (IRRep r, ScopeReader m) => IxType r n -> Type r n -> m n (TabPiType r n)
 nonDepTabPiType argTy resultTy =
@@ -427,14 +411,14 @@ nonDepTabPiType argTy resultTy =
     Abs b resultTy' -> return $ TabPiType (b:>argTy) resultTy'
 
 considerNonDepPiType :: PiType n -> Maybe (Arrow, CType n, EffectRow CoreIR n, CType n)
-considerNonDepPiType (PiType (PiBinder b argTy arr) eff resultTy) = do
+considerNonDepPiType (PiType (b:>argTy) arr eff resultTy) = do
   HoistSuccess (PairE eff' resultTy') <- return $ hoist b (PairE eff resultTy)
   return (arr, argTy, eff', resultTy')
 
 fromNonDepPiType :: (IRRep r, ScopeReader m, MonadFail1 m)
                  => Arrow -> Type r n -> m n (Type r n, EffectRow r n, Type r n)
 fromNonDepPiType arr ty = do
-  Pi (PiType (PiBinder b argTy arr') eff resultTy) <- return ty
+  Pi (PiType (b:>argTy) arr' eff resultTy) <- return ty
   unless (arr == arr') $ fail "arrow type mismatch"
   HoistSuccess (PairE eff' resultTy') <- return $ hoist b (PairE eff resultTy)
   return $ (argTy, eff', resultTy')
@@ -568,11 +552,11 @@ fromNaryForExpr maxDepth = \case
 fromNaryPiType :: Int -> Type r n -> Maybe (NaryPiType r n)
 fromNaryPiType n _ | n <= 0 = error "expected positive number of args"
 fromNaryPiType 1 ty = case ty of
-  Pi (PiType (PiBinder b argTy _) effs resultTy) -> Just $ NaryPiType (Nest (b:>argTy) Empty) effs resultTy
+  Pi (PiType b _ effs resultTy) -> Just $ NaryPiType (Nest b Empty) effs resultTy
   _ -> Nothing
-fromNaryPiType n (Pi (PiType (PiBinder b1 argTy1 _) Pure piTy)) = do
+fromNaryPiType n (Pi (PiType b1 _ Pure piTy)) = do
   NaryPiType (Nest b2 bs) effs resultTy <- fromNaryPiType (n-1) piTy
-  Just $ NaryPiType (Nest (b1:>argTy1) (Nest b2 bs)) effs resultTy
+  Just $ NaryPiType (Nest b1 (Nest b2 bs)) effs resultTy
 fromNaryPiType _ _ = Nothing
 
 mkConsListTy :: [Type r n] -> Type r n

--- a/src/lib/Generalize.hs
+++ b/src/lib/Generalize.hs
@@ -37,7 +37,7 @@ generalizeArgs fTy argsTop = liftGeneralizerM $ runSubstReaderT idSubst do
   where
     go :: CType i -> [Atom CoreIR n]
        -> SubstReaderT AtomSubstVal GeneralizerM i n [Atom CoreIR n]
-    go (Pi (PiType (PiBinder b ty arr) _ resultTy)) (arg:args) = do
+    go (Pi (PiType (b:>ty) arr _ resultTy)) (arg:args) = do
       ty' <- substM ty
       arg' <- case ty' of
         TyKind -> liftSubstReaderT $ generalizeType arg

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -108,17 +108,17 @@ traverseAtomDefault atom = confuseGHC >>= \_ -> case atom of
   Var _ -> substM atom
   Lam (UnaryLamExpr (b:>ty) body) arr (Abs bEff effs) -> do
     ty' <- tge ty
-    withFreshBinder (getNameHint b) (LamBinding arr ty') \(b':>_) -> do
+    withFreshBinder (getNameHint b) ty' \b' -> do
       effs' <- extendRenamer (bEff@>binderName b') $ substM effs
       extendRenamer (b@>binderName b') do
         body' <- tge body
-        return $ Lam (UnaryLamExpr (b':>ty') body') arr (Abs (b':>ty') effs')
+        return $ Lam (UnaryLamExpr b' body') arr (Abs b' effs')
   Lam _ _ _ -> error "expected a unary lambda expression"
-  Pi (PiType (PiBinder b ty arr) eff resultTy) -> do
+  Pi (PiType (b:>ty) arr eff resultTy) -> do
     ty' <- tge ty
-    withFreshBinder (getNameHint b) (PiBinding arr ty') \(b':>_) -> do
+    withFreshBinder (getNameHint b) ty' \b' -> do
       extendRenamer (b@>binderName b') $
-        Pi <$> (PiType (PiBinder b' ty' arr) <$> substM eff <*> tge resultTy)
+        Pi <$> (PiType b' arr <$> substM eff <*> tge resultTy)
   TabPi (TabPiType (b:>ty) resultTy) -> do
     ty' <- tge ty
     withFreshBinder (getNameHint b) ty' \b' -> do

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -1643,6 +1643,17 @@ instance ( ExtOutMap b d1, OutFrag d1
   unsafeGetScope = liftDoubleInplaceT unsafeGetScope
   {-# INLINE unsafeGetScope #-}
 
+extendDoubleInplaceTLocal
+  :: (ExtOutMap b d1, ExtOutMap b d2, OutFrag d1, OutFrag d2, Monad m)
+  => (b n -> b n)
+  -> DoubleInplaceT b d1 d2 m n a
+  -> DoubleInplaceT b d1 d2 m n a
+extendDoubleInplaceTLocal f cont =
+  UnsafeMakeDoubleInplaceT $ StateT \(topScope, d1Prev) ->
+    UnsafeMakeInplaceT \env d2 ->
+      unsafeRunInplaceT (runStateT (unsafeRunDoubleInplaceT cont) (topScope, d1Prev)) (f env) d2
+{-# INLINE extendDoubleInplaceTLocal #-}
+
 -- === name hints ===
 
 instance HasNameHint (BinderP c ann n l) where

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -233,13 +233,6 @@ instance IRRep r => Pretty (NaryPiType r n) where
   pretty (NaryPiType bs effs resultTy) =
     (spaced $ fromNest $ bs) <+> "->" <+> "{" <> p effs <> "}" <+> p resultTy
 
-instance Pretty (PiBinder n l) where
-  pretty (PiBinder b ty arrow) = case arrow of
-    PlainArrow    -> p (b:>ty)
-    ClassArrow    -> "[" <> p (b:>ty) <> "]"
-    ImplicitArrow -> "{" <> p (b:>ty) <> "}"
-    LinArrow      -> p (b:>ty)
-
 instance IRRep r => Pretty (LamExpr r n) where pretty = prettyFromPrettyPrec
 instance IRRep r => PrettyPrec (LamExpr r n) where
   prettyPrec (LamExpr bs body) = atPrec LowestPrec $ prettyLam (p bs) body
@@ -371,7 +364,7 @@ forStr Fwd = "for"
 forStr Rev = "rof"
 
 instance Pretty (PiType n) where
-  pretty (PiType (PiBinder b ty arr) eff body) = let
+  pretty (PiType (b:>ty) arr eff body) = let
     prettyBinder = prettyBinderHelper (b:>ty) (PairE eff body)
     prettyBody = case body of
       Pi subpi -> pretty subpi
@@ -479,8 +472,6 @@ instance PrettyPrec (Name s n) where prettyPrec = atPrec ArgPrec . pretty
 instance IRRep r => Pretty (AtomBinding r n) where
   pretty binding = case binding of
     LetBound    b -> p b
-    LamBound    b -> p b
-    PiBound     b -> p b
     MiscBound   t -> p t
     SolverBound b -> p b
     FFIFunBound s _ -> p s
@@ -493,14 +484,6 @@ instance Pretty (SpecializationSpec n) where
 
 instance Pretty IxMethod where
   pretty method = p $ show method
-
-instance Pretty (LamBinding n) where
-  pretty (LamBinding arr ty) =
-    "Lambda binding. Type:" <+> p ty <+> "  Arrow" <+> p arr
-
-instance Pretty (PiBinding n) where
-  pretty (PiBinding arr ty) =
-    "Pi binding. Type:" <+> p ty <+> "  Arrow" <+> p arr
 
 instance Pretty (SolverBinding n) where
   pretty (InfVarBound  ty _) = "Inference variable of type:" <+> p ty


### PR DESCRIPTION
We only need the givens during the inference and synthesis passes so we can just track them there instead. This lets us delete a bunch of code and might improve compile times. It also sets the stage for a top-level env simplification I want to try.