### PR TITLE
Use concrete/grouped syntax in SourceBlock instead of abstract syntax

### DIFF
--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -29,6 +29,7 @@ import Data.ByteString    qualified as BS
 import Data.Text.Encoding qualified as T
 
 import AbstractSyntax
+import ConcreteSyntax
 import Builder
 import Core
 import Err

--- a/src/dex.hs
+++ b/src/dex.hs
@@ -26,8 +26,8 @@ import PPrint (toJSONStr, printResult)
 import TopLevel
 import Err
 import Name
-import ConcreteSyntax (keyWordStrs)
-import AbstractSyntax (parseTopDeclRepl, preludeImportBlock)
+import AbstractSyntax (parseTopDeclRepl)
+import ConcreteSyntax (keyWordStrs, preludeImportBlock)
 #ifdef DEX_LIVE
 import RenderHtml
 import Live.Terminal (runTerminal)

--- a/src/lib/Live/Eval.hs
+++ b/src/lib/Live/Eval.hs
@@ -19,7 +19,7 @@ import Data.Aeson qualified as A
 import Data.Text.Prettyprint.Doc
 import System.Directory (getModificationTime)
 
-import AbstractSyntax
+import ConcreteSyntax
 import Actor
 import RenderHtml (ToMarkup, pprintHtml)
 import TopLevel

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -32,8 +32,7 @@ import System.IO.Unsafe
 import qualified System.Environment as E
 import Numeric
 
-import ConcreteSyntax hiding (Equal)
-import ConcreteSyntax qualified as C
+import ConcreteSyntax
 import Err
 import LabeledItems
 import IRVariants
@@ -1176,30 +1175,26 @@ instance ToJSON Result where
           , "run_time"     .= toJSON runTime ]
         out -> ["result" .= String (fromString $ pprint out)]
 
-instance Pretty SourceBlock' where
-  pretty (EvalUDecl d) = fromString $ show d
-  pretty b = fromString $ show b
-
 -- === Concrete syntax rendering ===
 
-instance Pretty CSourceBlock' where
-  pretty (CTopDecl decl) = p decl
+instance Pretty SourceBlock' where
+  pretty (TopDecl decl) = p decl
   pretty d = fromString $ show d
 
 instance Pretty CTopDecl where
   pretty (WithSrc _ d) = p d
 
 instance Pretty CTopDecl' where
-  pretty (C.CDecl ann decl) = annDoc <> p decl
+  pretty (CSDecl ann decl) = annDoc <> p decl
     where annDoc = case ann of
             PlainLet -> mempty
             _ -> p ann <> " "
   pretty d = fromString $ show d
 
-instance Pretty C.CDecl where
+instance Pretty CSDecl where
   pretty (WithSrc _ d) = p d
 
-instance Pretty C.CDecl' where
+instance Pretty CSDecl' where
   pretty (CLet pat blk) = pArg pat <+> "=" <+> p blk
   pretty (CBind pat blk) = pArg pat <+> "<-" <+> p blk
   pretty (CDef name args (Just ty) blk) =
@@ -1218,9 +1213,9 @@ instance Pretty C.CDecl' where
       _ -> " given" <+> p givens <> " "
   pretty (CExpr e) = p e
 
-instance Pretty C.CBlock where
+instance Pretty CSBlock where
   pretty (ExprBlock g) = pArg g
-  pretty (CBlock decls) = nest 2 $ prettyLines decls
+  pretty (CSBlock decls) = nest 2 $ prettyLines decls
 
 instance PrettyPrec Group where
   prettyPrec (WithSrc _ g) = prettyPrec g
@@ -1272,4 +1267,4 @@ instance Pretty Bin' where
   pretty FatArrow = "=>"
   pretty Question = "?"
   pretty Pipe = "|"
-  pretty C.Equal = "="
+  pretty CSEqual = "="

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -11,7 +11,8 @@ import Data.Maybe (catMaybes)
 import Data.Text
 import Test.Hspec
 
-import AbstractSyntax (parseUModule)
+import ConcreteSyntax (parseUModule)
+import AbstractSyntax (parseBlock)
 import Err
 import Inference (inferTopUExpr, synthTopBlock)
 import Name
@@ -34,7 +35,7 @@ sourceTextToBlocks source = do
 sourceBlockToBlock :: (Topper m, Mut n) => SourceBlock -> m n (Maybe (SBlock n))
 sourceBlockToBlock block = case sbContents block of
   Misc (ImportModule moduleName)  -> importModule moduleName >> return Nothing
-  Command (EvalExpr (Printed _)) expr -> Just <$> uExprToBlock expr
+  Command (EvalExpr (Printed _)) expr -> Just <$> (parseBlock expr >>= uExprToBlock)
   UnParseable _ s -> throw ParseErr s
   _ -> error $ "Unexpected SourceBlock " ++ pprint block ++ " in unit tests"
 


### PR DESCRIPTION
The abstract syntax isn't needed at the top level. Meanwhile, the grouped representation is closer to the actual source text, which makes it the best place to extract the spanning trees, which we will need at the top level.