### PR TITLE
[fix] unbreak the nix code and make it slightly nicer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,3 +37,4 @@ julia/deps/build.log
 examples/t10k-images-idx3-ubyte
 examples/t10k-labels-idx1-ubyte
 examples/camera.ppm
+result*

--- a/default.nix
+++ b/default.nix
@@ -1,72 +1,66 @@
-{ pkgs ? import <nixpkgs> {},
-  llvm-hs-src ? pkgs.fetchFromGitHub {
+{ pkgs ? import <nixpkgs> { }
+, llvm-hs-src ? pkgs.fetchFromGitHub {
     owner = "llvm-hs";
     repo = "llvm-hs";
     rev = "llvm-12";
     sha256 = "IG4Mh89bY+PtBJtzlXKYsPljfHP7OSQk03pV6fSmdRY=";
-  },
-  cudaPackage ? pkgs.cudaPackages.cudatoolkit_11,
-  cuda ? false,
-  optimized ? true,
-  live ? true,
+  }
+, cudaPackage ? pkgs.cudaPackages.cudatoolkit_11
+, cudaSupport ? false
+, optimized ? true
+, live ? true
+,
 }:
 let
-  llvm-hs-pure = pkgs.haskellPackages.callCabal2nix "llvm-hs-pure" "${llvm-hs-src}/llvm-hs-pure" {
-  };
-  llvm-hs = (pkgs.haskellPackages.callCabal2nix "llvm-hs" "${llvm-hs-src}/llvm-hs" {
-    inherit llvm-hs-pure;
-  }).overrideAttrs (oldAttrs: rec {
-    buildInputs = oldAttrs.buildInputs ++ [
-      pkgs.llvm_12
-    ];
-  });
-  buildFlags = pkgs.lib.optionals optimized [
-    "-foptimized"
-  ] ++ pkgs.lib.optionals live [
-    "-flive"
-  ] ++ pkgs.lib.optionals cuda [
-    "-fcuda"
-    "--extra-include-dirs=${cudaPackage}/include"
-    "--extra-lib-dirs=${cudaPackage}/lib64/stubs"
-  ];
-  cxxFlags = [
-    "-fPIC"
-    "-std=c++11"
-    "-fno-exceptions"
-    "-fno-rtti"
-  ] ++ pkgs.lib.optional cuda "-DDEX_CUDA"
-    ++ pkgs.lib.optional live "-DDEX_LIVE";
-  buildRuntimeCommand =  ''
-      ${pkgs.clang_9}/bin/clang++ \
-      ${builtins.concatStringsSep " " cxxFlags} \
-      -c \
-      -emit-llvm  \
-      -I${pkgs.libpng}/include \
-      src/lib/dexrt.cpp  \
-      -o src/lib/dexrt.bc
-  '';
+  inherit (pkgs.lib) optionals;
+  configureFlags =
+    optionals optimized [ "-foptimized" ]
+    ++ optionals live [ "-flive" ]
+    ++ optionals cudaSupport [ "-fcuda" "--extra-include-dirs=${cudaPackage}/include" "--extra-lib-dirs=${cudaPackage}/lib64/stubs" ];
+  cxxFlags =
+    [ "-fPIC" "-std=c++11" "-fno-exceptions" "-fno-rtti" ]
+    ++ pkgs.lib.optionals cudaSupport [ "-DDEX_CUDA" ]
+    ++ pkgs.lib.optionals live [ "-DDEX_LIVE" ];
+  dexRuntime =
+    pkgs.stdenv.mkDerivation {
+      name = "dex-runtime";
+      src = ./src/lib;
+      nativeBuildInputs =
+        [ pkgs.clang_9 pkgs.libpng ]
+        ++ optionals cudaSupport [ cudaPackage ];
+      buildPhase =
+        ''
+          set -x
+          clang++ \
+          ${ builtins.concatStringsSep " " cxxFlags } \
+          -c \
+          -emit-llvm  \
+          dexrt.cpp  \
+          -o dexrt.bc
+          set +x
+        '';
+      installPhase =
+        ''
+          mkdir -p $out/src/lib
+          cp dexrt.bc $out/src/lib/dexrt.bc
+        '';
+    };
+  patchedSrc =
+    pkgs.symlinkJoin {
+      name = "src-with-dex-runtime";
+      paths = [ ./. dexRuntime ];
+    };
+  hpkgs =
+    pkgs.haskellPackages.override {
+      overrides = hself: hsuper: with pkgs.haskell.lib.compose; {
+        # FIXME: IFD should probably reducedd
+        llvm-hs-pure = doJailbreak (hself.callCabal2nix "llvm-hs-pure" "${llvm-hs-src}/llvm-hs-pure" { });
+        llvm-hs = addBuildDepends [ pkgs.llvm_12 ] (hself.callCabal2nix "llvm-hs" "${llvm-hs-src}/llvm-hs" { });
+        floating-bits = dontCheck (markUnbroken hsuper.floating-bits);
+        dex =
+          addBuildDepends [ (pkgs.lib.optional cudaSupport cudaPackage) dexRuntime ]
+            (appendConfigureFlags configureFlags (hself.callCabal2nix "dex" patchedSrc { }));
+      };
+    };
 in
-  # `callCabal2nix` converts `dex.cabal` into a Nix file and builds it.
-  # Before we do the Haskell build though, we need to first compile the Dex runtime
-  # so it's properly linked in when compiling Dex. Normally the makefile does this,
-  # so we instead sneak compiling the runtime in the configuration phase for the Haskell build.
-  (pkgs.haskellPackages.callCabal2nix "dex" ./. {
-    inherit llvm-hs;
-    inherit llvm-hs-pure;
-  }).overrideAttrs (attrs: {
-    configurePhase = ''
-    # Compile the Dex runtime
-    echo 'Compiling the Dex runtime...'
-    set -x
-    ${buildRuntimeCommand}
-    set +x
-    echo 'Done compiling the Dex runtime.'
-
-    # Run the Haskell configuration phase
-    ${attrs.configurePhase}
-    '';
-    configureFlags = builtins.concatStringsSep " " buildFlags;
-    buildInputs = attrs.buildInputs ++ (pkgs.lib.optional cuda
-      cudaPackage
-    );
-  })
+hpkgs.dex

--- a/dex.cabal
+++ b/dex.cabal
@@ -129,6 +129,8 @@ library
                        -- Serialization
                      , aeson
                      , store
+  if impl(ghc < 9.2.2)
+    build-depends:
                        -- Floating-point pedanticness (correcting for GHC < 9.2.2)
                      , floating-bits
   if flag(live)

--- a/flake.lock
+++ b/flake.lock
@@ -18,11 +18,11 @@
     "llvm-hs-src": {
       "flake": false,
       "locked": {
-        "lastModified": 1644009200,
-        "narHash": "sha256-IG4Mh89bY+PtBJtzlXKYsPljfHP7OSQk03pV6fSmdRY=",
+        "lastModified": 1665495332,
+        "narHash": "sha256-JKrpUmHJ1nsNiCoHhV5FCcdQGlNFfD37Oiu5kSmghfM=",
         "owner": "llvm-hs",
         "repo": "llvm-hs",
-        "rev": "eda85a2bbe362a0b89df5adce0cb65e4e755eac5",
+        "rev": "423220bffac4990d019fc088c46c5f25310d5a33",
         "type": "github"
       },
       "original": {

--- a/shell.nix
+++ b/shell.nix
@@ -1,16 +1,7 @@
-{ pkgs ? import <nixpkgs> {} }:
-pkgs.stdenv.mkDerivation {
-  name = "dex";
-  buildInputs = with pkgs; [
-    cabal-install
-    cacert
-    clang_12
-    git
-    haskell.compiler.ghc884
-    libpng
-    llvm_12
-    pkg-config
-    stack
-    zlib
-  ];
+{ pkgs ? import <nixpkgs> { }
+}:
+pkgs.mkShell
+{
+  buildInputs =
+    with pkgs; [ cabal-install cacert clang_12 git haskellPackages.ghc libpng llvm_12 pkg-config stack zlib ];
 }


### PR DESCRIPTION
## Fixes 
- [x] `dex` builds
- [x] `dex-cuda` builds
- [x] `dex` tests pass
- [ ] `dex-cuda` tests pass (see *Warning*, I don't have an nvidia graphics card)


## Additions 
- nix formatter can be run with `nix fmt` 
- replaced old `devShell` and `package` argument with `<output>.<system>.default`
- don't build the `dex` runtime in the `configurePhase` but instead build it as a 
  separate `drv` 
- made a couple of things more idiomatic

--- 

> **Note**
> the packages of `llvm-hs`, `llvm-hs-pure` and the `dex` package should probably
> be materalized, I'll perhaps at this as a PR at a later point 
> 
> at some point we should probably make the legacy nix code properly follow the flake inputs 
> I didn't update this but as `nixpkgs` is not pinned anyways, I don't think it makes sense 
> to half-ass it. 

---

> **Warning** 
> before merging this, someone with an nvidia graphics card should probably check whether 
> this builds by running `nix build github:mangoiv/dex-lang#dex-cuda` on their system with 
> an nvidia graphics card and ld library path properly set
> 
> be aware that `dex` does not build with current `nixpkgs-unstable` as `floating-bits` is 
> broken for a while, similarly to `llvm-hs/*`
