### PR TITLE
Make Dex functions callable from Haskell

### DIFF
--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -28,7 +28,6 @@ import Data.Map.Strict    qualified as M
 import Data.ByteString    qualified as BS
 import Data.Text.Encoding qualified as T
 
-import AbstractSyntax
 import ConcreteSyntax
 import Builder
 import Core

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -25,6 +25,7 @@ import Foreign.Marshal.Alloc
 import Data.Functor
 import qualified Data.Map.Strict as M
 
+import Builder
 import Export
 import Name
 import TopLevel
@@ -46,7 +47,8 @@ dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
   runTopperMFromContext ctxPtr do
     -- TODO: Check if atom is compatible with context! Use module name?
     (impFunc, nativeSignature) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
-    nativeFunction <- toCFunction "userFunc" impFunc >>= loadObject
+    (nativeCode, linknames) <- toCFunction "userFunc" impFunc
+    nativeFunction <- emitObjFile "userFunc" nativeCode linknames >>= loadObject
     let funcPtr = nativeFunPtr $ nativeFunction
     let exportNativeFunction = ExportNativeFunction nativeFunction nativeSignature
     liftIO $ insertIntoNativeFunctionTable ctxPtr funcPtr exportNativeFunction

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -46,12 +46,11 @@ dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
   let cc = intAsCC ccInt
   runTopperMFromContext ctxPtr do
     -- TODO: Check if atom is compatible with context! Use module name?
-    (impFunc, nativeSignature) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
-    (nativeCode, linknames) <- toCFunction "userFunc" impFunc
-    nativeFunction <- emitObjFile "userFunc" nativeCode linknames >>= loadObject
-    let funcPtr = nativeFunPtr $ nativeFunction
-    let exportNativeFunction = ExportNativeFunction nativeFunction nativeSignature
-    liftIO $ insertIntoNativeFunctionTable ctxPtr funcPtr exportNativeFunction
+    (impFunc, nativeSig) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
+    nativeFun <- toCFunction "userFunc" impFunc >>= emitObjFile >>= loadObject
+    let funcPtr = nativeFunPtr $ nativeFun
+    let exportNativeFun = ExportNativeFunction nativeFun nativeSig
+    liftIO $ insertIntoNativeFunctionTable ctxPtr funcPtr exportNativeFun
     return funcPtr
 
 dexGetFunctionSignature :: Ptr Context -> ExportNativeFunctionAddr -> IO (Ptr (ExportedSignature 'VoidS))

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -25,10 +25,8 @@ import Foreign.Marshal.Alloc
 import Data.Functor
 import qualified Data.Map.Strict as M
 
-import Builder
 import Export
 import Name
-import TopLevel
 import Types.Core
 import Types.Imp
 
@@ -46,8 +44,7 @@ dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
   let cc = intAsCC ccInt
   runTopperMFromContext ctxPtr do
     -- TODO: Check if atom is compatible with context! Use module name?
-    (impFunc, nativeSig) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
-    nativeFun <- toCFunction "userFunc" impFunc >>= emitObjFile >>= loadObject
+    (nativeFun, nativeSig) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
     let funcPtr = nativeFunPtr $ nativeFun
     let exportNativeFun = ExportNativeFunction nativeFun nativeSig
     liftIO $ insertIntoNativeFunctionTable ctxPtr funcPtr exportNativeFun

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -355,7 +355,7 @@ queryObjCache v = lookupEnv v >>= \case
   _ -> return Nothing
 
 emitObjFile :: (Mut n, TopBuilder m) => CFunction n -> m n (FunObjCodeName n)
-emitObjFile fun@CFunction{..} = do
+emitObjFile fun@CFunction{nameHint} = do
   emitBinding nameHint $ FunObjCodeBinding fun
 
 lookupPtrName :: EnvReader m => PtrName n -> m n (PtrType, Ptr ())

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -354,12 +354,9 @@ queryObjCache v = lookupEnv v >>= \case
   TopFunBinding (DexTopFun _ _ _ (Finished impl)) -> return $ Just $ topFunObjCode impl
   _ -> return Nothing
 
-emitObjFile
-  :: (Mut n, TopBuilder m)
-  => NameHint -> FunObjCode -> LinktimeNames  n
-  -> m n (FunObjCodeName n)
-emitObjFile hint objFile names = do
-  emitBinding hint $ FunObjCodeBinding objFile names
+emitObjFile :: (Mut n, TopBuilder m) => CFunction n -> m n (FunObjCodeName n)
+emitObjFile fun@CFunction{..} = do
+  emitBinding nameHint $ FunObjCodeBinding fun
 
 lookupPtrName :: EnvReader m => PtrName n -> m n (PtrType, Ptr ())
 lookupPtrName v = lookupEnv v >>= \case

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -313,8 +313,8 @@ lookupModule :: EnvReader m => ModuleName n -> m n (Module n)
 lookupModule name = lookupEnv name >>= \case ModuleBinding m -> return m
 {-# INLINE lookupModule #-}
 
-lookupFunObjCode :: EnvReader m => FunObjCodeName n -> m n (FunObjCode, LinktimeNames n)
-lookupFunObjCode name = lookupEnv name >>= \case FunObjCodeBinding obj m -> return (obj, m)
+lookupFunObjCode :: EnvReader m => FunObjCodeName n -> m n (CFunction n)
+lookupFunObjCode name = lookupEnv name >>= \case FunObjCodeBinding cFun -> return cFun
 {-# INLINE lookupFunObjCode #-}
 
 lookupDataDef :: EnvReader m => DataDefName n -> m n (DataDef n)

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -21,8 +21,6 @@ import CheckType (asFirstOrderFunction)
 import Core
 import Err
 import IRVariants
-import Imp
-import Lower (lowerFullySequential)
 import Name
 import QueryType
 import Simplify
@@ -52,10 +50,7 @@ prepareFunctionForExport cc f = do
     Failure err -> throwErrs err
   f' <- asNaryLam naryPi f
   fSimp <- simplifyTopFunction f'
-  fOpt <- simpOptimizations fSimp
-  fLower <- lowerFullySequential fOpt
-  flOpt <- loweredOptimizations fLower
-  fImp <- toImpFunction cc flOpt
+  fImp <- compileTopLevelFun cc fSimp
   return (fImp, sig)
 
   where

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -35,8 +35,8 @@ exportFunctions :: FilePath -> [(String, CAtom n)] -> Env n -> IO ()
 exportFunctions = error "Not implemented"
 {-# SCC exportFunctions #-}
 
-prepareFunctionForExport
-  :: (Mut n, Topper m) => CallingConvention -> CAtom n -> m n (ImpFunction n, ExportedSignature VoidS)
+prepareFunctionForExport :: (Mut n, Topper m)
+  => CallingConvention -> CAtom n -> m n (NativeFunction, ExportedSignature VoidS)
 prepareFunctionForExport cc f = do
   (arrs, naryPi) <- getType f >>= asFirstOrderFunction >>= \case
     Nothing  -> throw TypeErr "Only first-order functions can be exported"
@@ -51,7 +51,8 @@ prepareFunctionForExport cc f = do
   f' <- asNaryLam naryPi f
   fSimp <- simplifyTopFunction f'
   fImp <- compileTopLevelFun cc fSimp
-  return (fImp, sig)
+  nativeFun <- toCFunction "userFunc" fImp >>= emitObjFile >>= loadObject
+  return (nativeFun, sig)
 
   where
     naryPiToExportSig :: (EnvReader m, EnvExtender m, Fallible1 m)

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -9,7 +9,7 @@
 {-# OPTIONS_GHC -Wno-orphans #-}
 
 module Imp
-  ( blockToImpFunction, toImpFunction
+  ( toImpFunction
   , impFunType, getIType, abstractLinktimeObjects
   , repValFromFlatList, addImpTracing
   -- These are just for the benefit of serialization/printing. otherwise we wouldn't need them
@@ -46,42 +46,52 @@ import Types.Imp
 import Types.Primitives
 import Util (forMFilter, Tree (..), zipTrees, enumerate)
 
-blockToImpFunction :: EnvReader m
-  => Backend -> CallingConvention -> DestBlock SimpIR n -> m n (ImpFunction n)
-blockToImpFunction _ cc absBlock = liftImpM $ translateTopLevel cc absBlock
-
-toImpFunction
-  :: EnvReader m
+toImpFunction :: EnvReader m
   => CallingConvention -> DestLamExpr SimpIR n -> m n (ImpFunction n)
 toImpFunction cc lam = do
   (DestLamExpr bs bodyAbs) <- return lam
   ty <- getNaryDestLamExprType lam
   impArgTys <- getNaryLamImpArgTypesWithCC cc ty
   liftImpM $ buildImpFunction cc (zip (repeat noHint) impArgTys) \vs -> do
-    (argAtoms, resultDest) <- interpretImpArgsWithCC cc (sink ty) vs
-    extendSubst (bs @@> (SubstVal <$> argAtoms)) do
-      (DestBlock destb body) <- return bodyAbs
-      extendSubst (destb @> SubstVal (destToAtom (sink resultDest))) do
-        void $ translateBlock Nothing body
-        return []
+    case cc of
+      EntryFunCC _ -> do
+        argAtoms <- interpretImpArgs (sink $ EmptyAbs bs) vs
+        extendSubst (bs @@> (SubstVal <$> argAtoms)) do
+          DestBlock (destb:>destTy) body <- return bodyAbs
+          dest <- case destTy of
+            RefTy _ ansTy -> allocDestUnmanaged =<< substM ansTy
+            _ -> error "Expected a reference type for body destination"
+          extendSubst (destb @> SubstVal (destToAtom dest)) do
+            void $ translateBlock Nothing body
+          resultAtom <- loadAtom dest
+          repValToList <$> atomToRepVal resultAtom
+      _ -> do
+        (argAtoms, resultDest) <- interpretImpArgsWithCC cc (sink ty) vs
+        extendSubst (bs @@> (SubstVal <$> argAtoms)) do
+          (DestBlock destb body) <- return bodyAbs
+          extendSubst (destb @> SubstVal (destToAtom (sink resultDest))) do
+            void $ translateBlock Nothing body
+            return []
 
-getNaryLamImpArgTypesWithCC
-  :: EnvReader m => CallingConvention
-  -> NaryPiType SimpIR n -> m n [BaseType]
+getNaryLamImpArgTypesWithCC :: EnvReader m
+  => CallingConvention -> NaryPiType SimpIR n -> m n [BaseType]
 getNaryLamImpArgTypesWithCC XLACC _ = return [i8pp, i8pp]
   where i8pp = PtrType (CPU, PtrType (CPU, Scalar Word8Type))
+getNaryLamImpArgTypesWithCC (EntryFunCC _) t =
+  concat . fst <$> getNaryLamImpArgTypes t
 getNaryLamImpArgTypesWithCC _ t = do
   (argTyss, destTys) <- getNaryLamImpArgTypes t
   return $ concat argTyss ++ destTys
 
-getImpFunType :: EnvReader m => CallingConvention -> NaryPiType SimpIR n -> m n IFunType
+getImpFunType :: EnvReader m
+  => CallingConvention -> NaryPiType SimpIR n -> m n IFunType
 getImpFunType StandardCC piTy = do
   argTys <- getNaryLamImpArgTypesWithCC StandardCC piTy
   return $ IFunType StandardCC argTys []
 getImpFunType cc _ = error $ "unsupported calling convention: " ++ pprint cc
 
-interpretImpArgsWithCC
-  :: Emits n => CallingConvention -> NaryPiType SimpIR n
+interpretImpArgsWithCC :: Emits n
+  => CallingConvention -> NaryPiType SimpIR n
   -> [IExpr n] -> SubstImpM i n ([SAtom n], Dest n)
 interpretImpArgsWithCC XLACC t [outsPtr, insPtr] = do
   (argBaseTys, resultBaseTys) <- getNaryLamImpArgTypes t
@@ -95,14 +105,15 @@ interpretImpArgsWithCC XLACC t [outsPtr, insPtr] = do
       forM (enumerate resultBaseTys) \(i, ty) -> case ty of
         PtrType (_, pointeeTy) -> loadPtr outsPtr i pointeeTy
         _ -> error "Destination arguments should all have pointer types"
-  interpretImpArgs t (argVals ++ resultPtrs)
+  interpretImpArgsWithDest t (argVals ++ resultPtrs)
   where
     loadPtr base i pointeeTy = do
       ptr <- load =<< impOffset base (IIdxRepVal $ fromIntegral i)
       cast ptr (PtrType (CPU, pointeeTy))
-interpretImpArgsWithCC _ t xsAll = interpretImpArgs t xsAll
+interpretImpArgsWithCC _ t xsAll = interpretImpArgsWithDest t xsAll
 
-getNaryLamImpArgTypes :: EnvReader m => NaryPiType SimpIR n -> m n ([[BaseType]], [BaseType])
+getNaryLamImpArgTypes :: EnvReader m
+  => NaryPiType SimpIR n -> m n ([[BaseType]], [BaseType])
 getNaryLamImpArgTypes t = liftEnvReaderM $ go t where
   go :: NaryPiType SimpIR n -> EnvReaderM n ([[BaseType]], [BaseType])
   go (NaryPiType bs effs resultTy) = case bs of
@@ -113,24 +124,40 @@ getNaryLamImpArgTypes t = liftEnvReaderM $ go t where
         return (ts:argTys, resultTys)
     Empty -> ([],) <$> getDestBaseTypes resultTy
 
-interpretImpArgs :: EnvReader m => NaryPiType SimpIR n -> [IExpr n] -> m n ([SAtom n], Dest n)
-interpretImpArgs t xsAll = liftEnvReaderM $ runSubstReaderT idSubst $ go t xsAll where
-  go :: NaryPiType SimpIR i -> [IExpr o]
-     -> SubstReaderT AtomSubstVal EnvReaderM i o ([SAtom o], Dest o)
-  go (NaryPiType bs effs resultTy) xs = case bs of
-    Nest (b:>argTy) rest -> do
-      argTy' <- substM argTy
-      (argTree, xsRest) <- listToTree argTy' xs
-      arg <- repValAtom $ RepVal argTy' argTree
-      (args, dest) <- extendSubst (b @> SubstVal arg) $ go (NaryPiType rest effs resultTy) xsRest
-      return (arg:args, dest)
-    Empty -> do
-      resultTy' <- substM resultTy
-      (destTree, xsRest) <- listToTree resultTy' xs
-      case xsRest of
-        [] -> return ()
-        _  -> error "Shouldn't have any Imp arguments left"
-      return ([], Dest resultTy' destTree)
+interpretImpArgsWithDest :: EnvReader m
+  => NaryPiType SimpIR n -> [IExpr n] -> m n ([SAtom n], Dest n)
+interpretImpArgsWithDest t xs = do
+  (NaryPiType bs _ resultTy) <- return t
+  (args, xsLeft) <- _interpretImpArgs (EmptyAbs bs) xs
+  resultTy' <- applySubst (bs @@> (SubstVal <$> args)) resultTy
+  (destTree, xsRest) <- listToTree resultTy' xsLeft
+  case xsRest of
+    [] -> return ()
+    _  -> error "Shouldn't have any Imp arguments left"
+  return (args, Dest resultTy' destTree)
+
+interpretImpArgs :: EnvReader m
+  => EmptyAbs (Nest SBinder) n -> [IExpr n] -> m n [SAtom n]
+interpretImpArgs t args = do
+  (args', xsLeft) <- _interpretImpArgs t args
+  case xsLeft of
+    [] -> return args'
+    _  -> error "Shouldn't have any Imp arguments left"
+
+_interpretImpArgs :: EnvReader m
+  => EmptyAbs (Nest SBinder) n -> [IExpr n] -> m n ([SAtom n], [IExpr n])
+_interpretImpArgs t args =
+  liftEnvReaderM $ runSubstReaderT idSubst $ go t args where
+    go :: EmptyAbs (Nest SBinder) i -> [IExpr o]
+       -> SubstReaderT AtomSubstVal EnvReaderM i o ([SAtom o], [IExpr o])
+    go (Abs bs UnitE) xs = case bs of
+      Nest (b:>argTy) rest -> do
+        argTy' <- substM argTy
+        (argTree, xsRest) <- listToTree argTy' xs
+        arg <- repValAtom $ RepVal argTy' argTree
+        (args', xsLeft) <- extendSubst (b @> SubstVal arg) $ go (EmptyAbs rest) xsRest
+        return (arg:args', xsLeft)
+      Empty -> return ([], xs)
 
 -- === ImpM monad ===
 
@@ -238,19 +265,8 @@ liftImpM cont = do
 
 -- === the actual pass ===
 
--- We don't emit any results when a destination is provided, since they are already
--- going to be available through the dest.
-translateTopLevel :: CallingConvention -> DestBlock SimpIR i -> SubstImpM i o (ImpFunction o)
-translateTopLevel cc (DestBlock (destb:>destTy) body) = buildNullaryImpFunction cc do
-  dest <- case destTy of
-    RefTy _ ansTy -> allocDestUnmanaged =<< substM ansTy
-    _ -> error "Expected a reference type for body destination"
-  extendSubst (destb @> SubstVal (destToAtom dest)) $ void $ translateBlock Nothing body
-  resultAtom <- loadAtom dest
-  repValToList <$> atomToRepVal resultAtom
-
 translateBlock :: forall i o. Emits o
-               => MaybeDest o -> SBlock i -> SubstImpM i o (SAtom o)
+  => MaybeDest o -> SBlock i -> SubstImpM i o (SAtom o)
 translateBlock dest (Block _ decls result) = translateDeclNest decls $ translateExpr dest $ Atom result
 
 translateDeclNestSubst
@@ -262,14 +278,16 @@ translateDeclNestSubst !s = \case
     x <- withSubst s $ translateExpr Nothing expr
     translateDeclNestSubst (s <>> (b@>SubstVal x)) rest
 
-translateDeclNest :: Emits o => Nest SDecl i i' -> SubstImpM i' o a -> SubstImpM i o a
+translateDeclNest :: Emits o
+  => Nest SDecl i i' -> SubstImpM i' o a -> SubstImpM i o a
 translateDeclNest decls cont = do
   s  <- getSubst
   s' <- translateDeclNestSubst s decls
   withSubst s' cont
 {-# INLINE translateDeclNest #-}
 
-translateExpr :: forall i o. Emits o => MaybeDest o -> SExpr i -> SubstImpM i o (SAtom o)
+translateExpr :: forall i o. Emits o
+  => MaybeDest o -> SExpr i -> SubstImpM i o (SAtom o)
 translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
   Hof hof -> toImpHof maybeDest hof
   TopApp f' xs' -> do
@@ -351,7 +369,8 @@ translateExpr maybeDest expr = confuseGHC >>= \_ -> case expr of
       Nothing   -> return atom
       Just dest -> storeAtom dest atom >> return atom
 
-toImpRefOp :: Emits o => MaybeDest o -> SAtom i -> RefOp SimpIR i -> SubstImpM i o (SAtom o)
+toImpRefOp :: Emits o
+  => MaybeDest o -> SAtom i -> RefOp SimpIR i -> SubstImpM i o (SAtom o)
 toImpRefOp maybeDest refDest' m = do
   refDest <- atomToDest =<< substM refDest'
   substM m >>= \case
@@ -1196,12 +1215,6 @@ emitCall maybeDest (NaryPiType bs _ resultTy) f xs = do
   let impArgs = concat argsImp ++ destImp
   _ <- impCall f impArgs
   loadAtom dest
-
-buildNullaryImpFunction
-  :: CallingConvention
-  -> (forall l. (Emits l, DExt n l) => SubstImpM i l [IExpr l])
-  -> SubstImpM i n (ImpFunction n)
-buildNullaryImpFunction cc cont = buildImpFunction cc [] $ const cont
 
 buildImpFunction
   :: CallingConvention

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -488,7 +488,7 @@ instance Pretty (Binding c n) where
     InstanceBinding instanceDef -> pretty instanceDef
     MethodBinding className idx _ -> "Method" <+> pretty idx <+> "of" <+> pretty className
     TopFunBinding f -> pretty f
-    FunObjCodeBinding _ _ -> "<object file>"
+    FunObjCodeBinding _ -> "<object file>"
     ModuleBinding  _ -> "<module>"
     PtrBinding   _ _ -> "<ptr>"
     -- TODO(alex): do something actually useful here

--- a/src/lib/RawName.hs
+++ b/src/lib/RawName.hs
@@ -103,7 +103,7 @@ firstSilentName = zeroBits
 lastSilentName :: NameRep
 lastSilentName = complement zeroBits `clearBit` nameKindBit
 
-newtype NameHint = NameHint Int
+newtype NameHint = NameHint Int deriving (Store)
 newtype RawName  = RawName  Int deriving (Eq, Ord, Generic, Hashable, Store)
 
 freshRawName :: NameHint -> RawNameMap a -> RawName

--- a/src/lib/Runtime.hs
+++ b/src/lib/Runtime.hs
@@ -149,6 +149,8 @@ storeLitVal ptr val = liftIO case val of
   Int64Lit   x -> poke (castPtr ptr) x
   Int32Lit   x -> poke (castPtr ptr) x
   Word8Lit   x -> poke (castPtr ptr) x
+  Word32Lit  x -> poke (castPtr ptr) x
+  Word64Lit  x -> poke (castPtr ptr) x
   Float64Lit x -> poke (castPtr ptr) x
   Float32Lit x -> poke (castPtr ptr) x
   PtrLit _ (PtrLitVal x) -> poke (castPtr ptr) x

--- a/src/lib/Runtime.hs
+++ b/src/lib/Runtime.hs
@@ -62,7 +62,7 @@ data LLVMCallable = LLVMCallable
 
 -- The NativeFunction needs to have been compiled with EntryFunCC.
 callEntryFun :: LLVMCallable -> [LitVal] -> IO [LitVal]
-callEntryFun LLVMCallable{..} args = do
+callEntryFun LLVMCallable{nativeFun, benchRequired, logger, resultTypes} args = do
   withPipeToLogger logger \fd ->
     allocaCells (length args) \argsPtr ->
       allocaCells (length resultTypes) \resultPtr -> do

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -655,7 +655,7 @@ loadObject fname =
       return f
 
 loadObjectContent :: (Topper m, Mut n) => CFunction n -> m n NativeFunction
-loadObjectContent CFunction{..} = do
+loadObjectContent CFunction{objectCode, linkerNames} = do
   (LinktimeNames funNames ptrNames) <- return linkerNames
   funVals <- forM funNames \name -> nativeFunPtr <$> loadObject name
   ptrVals <- forM ptrNames \name -> snd <$> lookupPtrName name

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -579,7 +579,7 @@ data Binding (c::C) (n::S) where
   HandlerBinding    :: HandlerDef n                   -> Binding HandlerNameC    n
   EffectOpBinding   :: EffectOpDef n                  -> Binding EffectOpNameC   n
   TopFunBinding     :: TopFun n                       -> Binding TopFunNameC     n
-  FunObjCodeBinding :: FunObjCode -> LinktimeNames n  -> Binding FunObjCodeNameC n
+  FunObjCodeBinding :: CFunction n                    -> Binding FunObjCodeNameC n
   ModuleBinding     :: Module n                       -> Binding ModuleNameC     n
   -- TODO: add a case for abstracted pointers, as used in `ClosedImpFunction`
   PtrBinding        :: PtrType -> PtrLitVal           -> Binding PtrNameC        n
@@ -2173,7 +2173,7 @@ instance GenericE (Binding c) where
           (WhenC MethodNameC   c (ClassName `PairE` LiftE Int `PairE` CAtom)))
       (EitherE7
           (WhenC TopFunNameC     c (TopFun))
-          (WhenC FunObjCodeNameC c (LiftE FunObjCode `PairE` LinktimeNames))
+          (WhenC FunObjCodeNameC c (CFunction))
           (WhenC ModuleNameC     c (Module))
           (WhenC PtrNameC        c (LiftE (PtrType, PtrLitVal)))
           (WhenC EffectNameC     c (EffectDef))
@@ -2192,7 +2192,7 @@ instance GenericE (Binding c) where
     InstanceBinding   instanceDef       -> Case0 $ Case5 $ WhenC $ instanceDef
     MethodBinding     className idx f   -> Case0 $ Case6 $ WhenC $ className `PairE` LiftE idx `PairE` f
     TopFunBinding     fun               -> Case1 $ Case0 $ WhenC $ fun
-    FunObjCodeBinding x y               -> Case1 $ Case1 $ WhenC $ LiftE x `PairE` y
+    FunObjCodeBinding cFun              -> Case1 $ Case1 $ WhenC $ cFun
     ModuleBinding m                     -> Case1 $ Case2 $ WhenC $ m
     PtrBinding ty p                     -> Case1 $ Case3 $ WhenC $ LiftE (ty,p)
     EffectBinding   effDef              -> Case1 $ Case4 $ WhenC $ effDef
@@ -2211,7 +2211,7 @@ instance GenericE (Binding c) where
     Case0 (Case5 (WhenC (instanceDef)))                   -> InstanceBinding   instanceDef
     Case0 (Case6 (WhenC ((n `PairE` LiftE i `PairE` f)))) -> MethodBinding     n i f
     Case1 (Case0 (WhenC (fun)))                           -> TopFunBinding     fun
-    Case1 (Case1 (WhenC ((LiftE x `PairE` y))))           -> FunObjCodeBinding x y
+    Case1 (Case1 (WhenC (cFun)))                          -> FunObjCodeBinding cFun
     Case1 (Case2 (WhenC (m)))                             -> ModuleBinding     m
     Case1 (Case3 (WhenC ((LiftE (ty,p)))))                -> PtrBinding        ty p
     Case1 (Case4 (WhenC (effDef)))                        -> EffectBinding     effDef

--- a/src/lib/Types/Imp.hs
+++ b/src/lib/Types/Imp.hs
@@ -69,7 +69,8 @@ data CallingConvention =
    --   Python without XLA.
    -- - Used for generating calls to standalone functions.
    StandardCC
-   -- - Args and dests are each packed into a buffer and passed as one pointer.
+   -- - Args and dests are each packed into a buffer and passed as one pointer,
+   --   dests first.
    -- - Used for generating functions called from within an XLA computation.
  | XLACC
    -- - Args are packed by the caller into a buffer and passed as a pointer

--- a/tests/unit/ConstantCastingSpec.hs
+++ b/tests/unit/ConstantCastingSpec.hs
@@ -16,7 +16,7 @@ import Test.QuickCheck
 
 import Builder
 import Core
-import Imp (repValFromFlatList)
+import Imp (toImpFunction, repValFromFlatList)
 import Lower
 import Name
 import Optimize
@@ -41,7 +41,7 @@ exprToBlock expr = do
 evalBlock :: (Topper m, Mut n) => SBlock n -> m n (SRepVal n)
 evalBlock block = do
   NullaryDestLamExpr lowered <- lowerFullySequential $ NullaryLamExpr block
-  imp <- asImpFunction lowered
+  imp <- toImpFunction (EntryFunCC CUDANotRequired) (NullaryDestLamExpr lowered)
   llvm <- packageLLVMCallable imp
   resultVals <- liftIO $ callEntryFun llvm []
   resultTy <- getDestBlockType lowered

--- a/tests/unit/ConstantCastingSpec.hs
+++ b/tests/unit/ConstantCastingSpec.hs
@@ -9,6 +9,7 @@
 module ConstantCastingSpec (spec) where
 
 import Control.Monad
+import Control.Monad.IO.Class
 import Test.Hspec
 import Test.Hspec.QuickCheck
 import Test.QuickCheck
@@ -20,6 +21,7 @@ import Lower
 import Name
 import Optimize
 import QueryType (getDestBlockType)
+import Runtime
 import TopLevel
 import Types.Core
 import Types.Imp
@@ -40,7 +42,8 @@ evalBlock :: (Topper m, Mut n) => SBlock n -> m n (SRepVal n)
 evalBlock block = do
   NullaryDestLamExpr lowered <- lowerFullySequential $ NullaryLamExpr block
   imp <- asImpFunction lowered
-  resultVals <- evalLLVM imp
+  llvm <- packageLLVMCallable imp
+  resultVals <- liftIO $ callEntryFun llvm []
   resultTy <- getDestBlockType lowered
   repValFromFlatList resultTy resultVals
 


### PR DESCRIPTION
Goal: Be able to unit-test an upcoming experimental jax->dex pipeline from Haskell.

Side-benefit: Speed up our Haskell unit test suite (and improve coverage) by not recompiling the trivial casting function with LLVM for every input value on which we might test its behavior.

This occasioned a rework of TopLevel.hs, to make the actual compilation pipeline clearer and more uniform.