### PR TITLE
Add a prototype translation from Jax to Dex in Haskell

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -269,10 +269,12 @@ foreign-library Dex
   type:                native-shared
   other-modules:       Dex.Foreign.API
                      , Dex.Foreign.Context
+                     , Dex.Foreign.JAX
                      , Dex.Foreign.JIT
                      , Dex.Foreign.Serialize
                      , Dex.Foreign.Util
   build-depends:       dex
+                     , aeson
                      , base
                      , bytestring
                      , containers

--- a/dex.cabal
+++ b/dex.cabal
@@ -297,6 +297,7 @@ foreign-library Dex
                      , FlexibleInstances
                      , GADTs
                      , LambdaCase
+                     , NamedFieldPuns
                      , OverloadedStrings
                      , RecordWildCards
                      , ScopedTypeVariables

--- a/dex.cabal
+++ b/dex.cabal
@@ -63,6 +63,7 @@ library
                      , Inline
                      , IRVariants
                      , JAX.Concrete
+                     , JAX.ToSimp
                      , LLVM.Link
                      , LLVM.Compile
                      , LLVM.CUDA

--- a/dex.cabal
+++ b/dex.cabal
@@ -62,6 +62,7 @@ library
                      , Inference
                      , Inline
                      , IRVariants
+                     , JAX.Concrete
                      , LLVM.Link
                      , LLVM.Compile
                      , LLVM.CUDA
@@ -314,8 +315,12 @@ test-suite spec
                      , mtl
                      , QuickCheck
                      , text
+                     , aeson
+                     , aeson-pretty
+                     , bytestring
                      , dex
   other-modules:       ConstantCastingSpec
+                     , JaxADTSpec
                      , OccAnalysisSpec
                      , OccurrenceSpec
                      , RawNameSpec

--- a/dex.cabal
+++ b/dex.cabal
@@ -63,6 +63,7 @@ library
                      , Inline
                      , IRVariants
                      , JAX.Concrete
+                     , JAX.Rename
                      , JAX.ToSimp
                      , LLVM.Link
                      , LLVM.Compile

--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -95,6 +95,7 @@ getFunctionSignature  = dex_func('dexGetFunctionSignature', HsContextPtr, Native
 freeFunctionSignature = dex_func('dexFreeFunctionSignature', NativeFunctionSignaturePtr, None)
 
 roundtripJaxprJson = dex_func('dexRoundtripJaxprJson', ctypes.c_char_p, ctypes.c_char_p)
+compileJaxpr = dex_func('dexCompileJaxpr', HsContextPtr, ExportCC, ctypes.c_char_p, NativeFunction)
 
 xlaCpuTrampoline = lib.dexXLACPUTrampoline
 

--- a/python/dex/api.py
+++ b/python/dex/api.py
@@ -94,6 +94,8 @@ unload     = dex_func('dexUnload',  HsContextPtr, NativeFunction, None)
 getFunctionSignature  = dex_func('dexGetFunctionSignature', HsContextPtr, NativeFunction, NativeFunctionSignaturePtr)
 freeFunctionSignature = dex_func('dexFreeFunctionSignature', NativeFunctionSignaturePtr, None)
 
+roundtripJaxprJson = dex_func('dexRoundtripJaxprJson', ctypes.c_char_p, ctypes.c_char_p)
+
 xlaCpuTrampoline = lib.dexXLACPUTrampoline
 
 init()

--- a/python/dex/interop/jax/jaxpr_json.py
+++ b/python/dex/interop/jax/jaxpr_json.py
@@ -1,0 +1,97 @@
+# Copyright 2023 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import json
+import numpy as np
+import jax
+from jax._src import core
+from jax._src.lax import lax
+
+def dump_jaxpr(jaxpr: core.ClosedJaxpr) -> dict:
+  # TODO Serialize effects
+  assert jaxpr.effects == core.no_effects
+  # Ignoring debug info
+  return dict(invars=[dump_var(v) for v in jaxpr.jaxpr.invars],
+              outvars=[dump_atom(x) for x in jaxpr.jaxpr.outvars],
+              eqns=[dump_eqn(e) for e in jaxpr.jaxpr.eqns],
+              constvars=[dump_var(v) for v in jaxpr.jaxpr.constvars],
+              consts=jaxpr.consts
+              )
+
+
+def dump_atom(x):
+  # TODO tag
+  if type(x) is core.Var:
+    return dump_var(x)
+  else:
+    raise NotImplementedError
+
+def dump_var(v):
+  # Option: remove count and suffix to shrink the size of the generated json.
+  return dict(name=id(v), count=v.count, suffix=v.suffix, ty=dump_aval(v.aval))
+
+def dump_aval(a):
+  # TODO Support other needful members of the AbstractValue hierarchy,
+  # not just ShapedArray.
+  # TODO Support weak_type, named_shape
+  return dict(shape=a.shape, dtype=core._short_dtype_name(a.dtype))
+
+def dump_eqn(e):
+  # TODO Support effects
+  # TODO Support source info
+  return dict(primitive=e.primitive.name,
+              params=e.params,
+              invars=[dump_atom(x) for x in e.invars],
+              outvars=[dump_var(v) for v in e.outvars])
+
+def load_jaxpr(d) -> core.ClosedJaxpr:
+  return load_jaxpr_local({}, d)
+
+def load_jaxpr_local(var_map, d):
+  invars = [load_var(var_map, v) for v in d['invars']]
+  outvars = [load_atom(var_map, v) for v in d['outvars']]
+  eqns = [load_eqn(var_map, v) for v in d['eqns']]
+  constvars = [load_var(var_map, v) for v in d['constvars']]
+  jaxpr = core.Jaxpr(constvars, invars, outvars, eqns)
+  return core.ClosedJaxpr(jaxpr, d['consts'])
+
+def load_atom(var_map, d):
+  # TODO literals
+  return load_var(var_map, d)
+
+def load_var(var_map, d):
+  if d['name'] not in var_map:
+    aval = load_aval(d['ty'])
+    var = core.Var(d['count'], d['suffix'], aval)
+    var_map[d['name']] = var
+  return var_map[d['name']]
+
+# TODO Support the full range of JAX dtypes
+short_dtype_names = dict(
+    f32 = np.float32,
+    f64 = np.float64,
+    i32 = np.int32,
+    i64 = np.int64)
+
+# TODO Collect the complete set of JAX primitives properly
+def jax_primitives():
+  result = {}
+  for name in dir(lax):
+    obj = getattr(lax, name)
+    if isinstance(obj, core.Primitive):
+      result[obj.name] = obj
+  return result
+
+primitives = jax_primitives()
+
+def load_aval(d):
+  return core.ShapedArray(d['shape'], short_dtype_names[d['dtype']])
+
+def load_eqn(var_map, d):
+  prim = primitives[d['primitive']]
+  invars = [load_atom(var_map, x) for x in d['invars']]
+  outvars = [load_var(var_map, v) for v in d['outvars']]
+  return core.JaxprEqn(invars, outvars, prim, d['params'], core.no_effects, None)

--- a/python/dex/interop/jax/jaxpr_json.py
+++ b/python/dex/interop/jax/jaxpr_json.py
@@ -63,6 +63,7 @@ def dump_params(name, params):
   result = params.copy()
   if name == 'scan':
     result['jaxpr'] = dump_jaxpr(params['jaxpr'])
+    result['linear'] = list(params['linear'])
   if name == 'convert_element_type':
     result['new_dtype'] = dump_dtype(params['new_dtype'])
   return result
@@ -99,7 +100,8 @@ def load_var(var_map, d):
 def load_lit(d):
   return core.Literal(d['val'], load_aval(d['ty']))
 
-# TODO Support the full range of JAX dtypes
+# TODO Support the full range of JAX dtypes:
+# numpy dtypes, bint, bfloat16
 short_dtype_names = dict(
     f32 = np.dtype('float32'),
     f64 = np.dtype('float64'),

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -10,16 +10,22 @@ import unittest
 import jax
 import dex.interop.jax.jaxpr_json as jj
 
+def check_round_trip(jaxpr):
+  dump_str = json.dumps(jj.dump_jaxpr(jaxpr), indent=2)
+  reconstituted = json.loads(dump_str)
+  jaxpr_recon = jj.load_jaxpr(reconstituted)
+  assert str(jaxpr) == str(jaxpr_recon)
+
 class JaxprJsonTest(unittest.TestCase):
 
-  def test_dump(self):
+  def test_one_prim(self):
     jaxpr = jax.make_jaxpr(jax.numpy.sin)(3.)
-    dump_str = json.dumps(jj.dump_jaxpr(jaxpr), indent=2)
-    reconstituted = json.loads(dump_str)
-    jaxpr_recon = jj.load_jaxpr(reconstituted)
-    assert str(jaxpr) == str(jaxpr_recon)
+    check_round_trip(jaxpr)
+
+  def test_literal(self):
+    f = lambda x: jax.numpy.sin(x + 1) + 3
+    check_round_trip(jax.make_jaxpr(f)(3.))
 
   # TODO Test non-scalar shapes
   # TODO Test dependent shapes (that have variables in them)
-  # TODO Test literals
   # TODO Test funny primitives like scan

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -1,0 +1,25 @@
+# Copyright 2023 Google LLC
+#
+# Use of this source code is governed by a BSD-style
+# license that can be found in the LICENSE file or at
+# https://developers.google.com/open-source/licenses/bsd
+
+import json
+import unittest
+
+import jax
+import dex.interop.jax.jaxpr_json as jj
+
+class JaxprJsonTest(unittest.TestCase):
+
+  def test_dump(self):
+    jaxpr = jax.make_jaxpr(jax.numpy.sin)(3.)
+    dump_str = json.dumps(jj.dump_jaxpr(jaxpr), indent=2)
+    reconstituted = json.loads(dump_str)
+    jaxpr_recon = jj.load_jaxpr(reconstituted)
+    assert str(jaxpr) == str(jaxpr_recon)
+
+  # TODO Test non-scalar shapes
+  # TODO Test dependent shapes (that have variables in them)
+  # TODO Test literals
+  # TODO Test funny primitives like scan

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -40,7 +40,7 @@ class JaxprJsonTest(unittest.TestCase):
 
   def test_json_scan(self):
     def f(xs):
-      return jax.lax.scan(lambda tot, z: (tot + z, tot), 0., xs)
+      return jax.lax.scan(lambda tot, z: (tot + z, tot), 0.25, xs)
     check_json_round_trip(jax.make_jaxpr(f)(jnp.array([1., 2., 3.])))
 
   def test_haskell_one_prim(self):
@@ -51,6 +51,12 @@ class JaxprJsonTest(unittest.TestCase):
     f = lambda x: jax.numpy.sin(x + 1) + 3
     check_haskell_round_trip(jax.make_jaxpr(f)(3.))
 
+  def test_haskell_scan(self):
+    def f(xs):
+      return jax.lax.scan(lambda tot, z: (tot + z, tot), 0.25, xs)
+    check_haskell_round_trip(jax.make_jaxpr(f)(jnp.array([1., 2., 3.])))
+
   # TODO Test bigger shapes (matrices?)
   # TODO Test dependent shapes (that have variables in them)
+  # - How do I make a jaxpr with such a thing in it?
   # TODO Test more funny primitives like scan (scan itself works)

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -5,11 +5,13 @@
 # https://developers.google.com/open-source/licenses/bsd
 
 import json
+import math
 import unittest
 
 import jax
 import jax.numpy as jnp
 from dex import api
+from dex import native_function as nf
 from dex import prelude
 import dex.interop.jax.jaxpr_json as jj
 
@@ -64,8 +66,8 @@ class JaxprJsonTest(unittest.TestCase):
     module = prelude
     cc = api.FlatCC
     compiled = api.compileJaxpr(module, cc, api.as_cstr(jaxpr_dump))
-    func = nf.NativeFunction(module, cc, compiled)
-    assert func(3.) == sin(3.)
+    func = nf.NativeFunction(module, compiled, cc)
+    self.assertAlmostEqual(func(3.), math.sin(3.))
 
   # TODO Test bigger shapes (matrices?)
   # TODO Test dependent shapes (that have variables in them)

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -9,6 +9,7 @@ import unittest
 
 import jax
 import jax.numpy as jnp
+from dex import api
 import dex.interop.jax.jaxpr_json as jj
 
 def check_round_trip(jaxpr):
@@ -32,6 +33,13 @@ class JaxprJsonTest(unittest.TestCase):
     def f(xs):
       return jax.lax.scan(lambda tot, z: (tot + z, tot), 0., xs)
     check_round_trip(jax.make_jaxpr(f)(jnp.array([1., 2., 3.])))
+
+  def test_haskell_roundtrip(self):
+    jaxpr = jax.make_jaxpr(jax.numpy.sin)(3.)
+    dictified = jj.dump_jaxpr(jaxpr)
+    dump_str = json.dumps(dictified, indent=2)
+    returned = api.from_cstr(api.roundtripJaxprJson(api.as_cstr(dump_str)))
+    assert dump_str == returned
 
   # TODO Test bigger shapes (matrices?)
   # TODO Test dependent shapes (that have variables in them)

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -8,10 +8,12 @@ import json
 import unittest
 
 import jax
+import jax.numpy as jnp
 import dex.interop.jax.jaxpr_json as jj
 
 def check_round_trip(jaxpr):
-  dump_str = json.dumps(jj.dump_jaxpr(jaxpr), indent=2)
+  dictified = jj.dump_jaxpr(jaxpr)
+  dump_str = json.dumps(dictified, indent=2)
   reconstituted = json.loads(dump_str)
   jaxpr_recon = jj.load_jaxpr(reconstituted)
   assert str(jaxpr) == str(jaxpr_recon)
@@ -26,6 +28,11 @@ class JaxprJsonTest(unittest.TestCase):
     f = lambda x: jax.numpy.sin(x + 1) + 3
     check_round_trip(jax.make_jaxpr(f)(3.))
 
-  # TODO Test non-scalar shapes
+  def test_scan(self):
+    def f(xs):
+      return jax.lax.scan(lambda tot, z: (tot + z, tot), 0., xs)
+    check_round_trip(jax.make_jaxpr(f)(jnp.array([1., 2., 3.])))
+
+  # TODO Test bigger shapes (matrices?)
   # TODO Test dependent shapes (that have variables in them)
-  # TODO Test funny primitives like scan
+  # TODO Test more funny primitives like scan (scan itself works)

--- a/python/tests/jaxpr_json_test.py
+++ b/python/tests/jaxpr_json_test.py
@@ -39,7 +39,10 @@ class JaxprJsonTest(unittest.TestCase):
     dictified = jj.dump_jaxpr(jaxpr)
     dump_str = json.dumps(dictified, indent=2)
     returned = api.from_cstr(api.roundtripJaxprJson(api.as_cstr(dump_str)))
-    assert dump_str == returned
+    try:
+      assert dictified == json.loads(returned)
+    except json.decoder.JSONDecodeError:
+      assert False, returned
 
   # TODO Test bigger shapes (matrices?)
   # TODO Test dependent shapes (that have variables in them)

--- a/src/Dex/Foreign/API.hs
+++ b/src/Dex/Foreign/API.hs
@@ -11,6 +11,7 @@ import Foreign.C
 
 import Dex.Foreign.Context
 import Dex.Foreign.Serialize
+import Dex.Foreign.JAX
 import Dex.Foreign.JIT
 
 -- Public API (commented out exports are defined in rts.c)
@@ -39,3 +40,6 @@ foreign export ccall "dexCompile"    dexCompile    :: Ptr Context -> CInt -> Ptr
 foreign export ccall "dexUnload"     dexUnload     :: Ptr Context -> ExportNativeFunctionAddr -> IO ()
 foreign export ccall "dexGetFunctionSignature"  dexGetFunctionSignature  :: Ptr Context -> ExportNativeFunctionAddr -> IO (Ptr ClosedExportedSignature)
 foreign export ccall "dexFreeFunctionSignature" dexFreeFunctionSignature :: Ptr ClosedExportedSignature -> IO ()
+
+-- JAX serialization
+foreign export ccall "dexRoundtripJaxprJson" dexRoundtripJaxprJson :: CString -> IO CString

--- a/src/Dex/Foreign/API.hs
+++ b/src/Dex/Foreign/API.hs
@@ -43,3 +43,4 @@ foreign export ccall "dexFreeFunctionSignature" dexFreeFunctionSignature :: Ptr 
 
 -- JAX serialization
 foreign export ccall "dexRoundtripJaxprJson" dexRoundtripJaxprJson :: CString -> IO CString
+foreign export ccall "dexCompileJaxpr" dexCompileJaxpr :: Ptr Context -> CInt -> CString -> IO ExportNativeFunctionAddr

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -47,9 +47,6 @@ import Dex.Foreign.Util
 data Context = Context EvalConfig (MVar TopStateEx) (MVar NativeFunctionTable)
 
 type ClosedExportedSignature = ExportedSignature 'VoidS
-data ExportNativeFunction =
-  ExportNativeFunction { nativeFunction  :: NativeFunction
-                       , nativeSignature :: ExportedSignature 'VoidS }
 
 type ExportNativeFunctionAddr = FunPtr () -- points to executable code
 type NativeFunctionTable = M.Map ExportNativeFunctionAddr ExportNativeFunction

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -12,7 +12,8 @@ module Dex.Foreign.Context (
   setError, runTopperMFromContext,
   dexCreateContext, dexDestroyContext, dexForkContext,
   dexInsert, dexLookup,
-  dexEval, dexFreshName, insertIntoNativeFunctionTable, popFromNativeFunctionTable
+  dexEval, dexFreshName, insertIntoNativeFunctionTable, popFromNativeFunctionTable,
+  intAsCC, emitExport
   ) where
 
 import Foreign.C
@@ -147,3 +148,14 @@ popFromNativeFunctionTable ctxPtr funcPtr = do
   addrTable <- takeMVar ptrTabMVar
   putMVar ptrTabMVar $  M.delete funcPtr addrTable
   return $ addrTable M.! funcPtr
+
+intAsCC :: CInt -> CallingConvention
+intAsCC 0 = StandardCC
+intAsCC 1 = XLACC
+intAsCC _ = error "Unrecognized calling convention"
+
+emitExport :: Ptr Context -> ExportNativeFunction -> IO ExportNativeFunctionAddr
+emitExport ctxPtr func = do
+  let funcPtr = nativeFunPtr $ nativeFunction func
+  insertIntoNativeFunctionTable ctxPtr funcPtr func
+  return funcPtr

--- a/src/Dex/Foreign/JAX.hs
+++ b/src/Dex/Foreign/JAX.hs
@@ -1,0 +1,23 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module Dex.Foreign.JAX where
+
+import Data.Aeson (encode, eitherDecode')
+import qualified Data.ByteString.Lazy.Char8 as B
+import Foreign.C
+
+import JAX.Concrete
+
+dexRoundtripJaxprJson :: CString -> IO CString
+dexRoundtripJaxprJson jsonPtr = do
+  json <- B.pack <$> peekCString jsonPtr
+  let maybeJaxpr :: Either String Jaxpr = eitherDecode' json
+  case maybeJaxpr of
+    Right jaxpr -> do
+      let redumped = encode jaxpr
+      newCString $ B.unpack redumped
+    Left err -> newCString err

--- a/src/Dex/Foreign/JAX.hs
+++ b/src/Dex/Foreign/JAX.hs
@@ -15,6 +15,7 @@ import Foreign.Ptr
 import Dex.Foreign.Context
 import Export
 import JAX.Concrete
+import JAX.Rename
 import JAX.ToSimp
 import Name
 
@@ -36,7 +37,9 @@ dexCompileJaxpr ctxPtr ccInt jsonPtr = do
   let maybeJaxpr :: Either String (ClosedJaxpr VoidS) = eitherDecode' json
   case maybeJaxpr of
     Right jaxpr -> runTopperMFromContext ctxPtr do
-      sLam <- liftJaxSimpM $ simplifyClosedJaxpr $ unsafeCoerceE jaxpr
+      Distinct <- getDistinct
+      jRename <- liftRenameM $ renameClosedJaxpr (unsafeCoerceE jaxpr)
+      sLam <- liftJaxSimpM $ simplifyClosedJaxpr jRename
       func <- prepareSLamForExport (intAsCC ccInt) sLam
       liftIO $ emitExport ctxPtr func
     Left err -> error err

--- a/src/Dex/Foreign/JAX.hs
+++ b/src/Dex/Foreign/JAX.hs
@@ -15,7 +15,7 @@ import JAX.Concrete
 dexRoundtripJaxprJson :: CString -> IO CString
 dexRoundtripJaxprJson jsonPtr = do
   json <- B.pack <$> peekCString jsonPtr
-  let maybeJaxpr :: Either String Jaxpr = eitherDecode' json
+  let maybeJaxpr :: Either String ClosedJaxpr = eitherDecode' json
   case maybeJaxpr of
     Right jaxpr -> do
       let redumped = encode jaxpr

--- a/src/Dex/Foreign/JAX.hs
+++ b/src/Dex/Foreign/JAX.hs
@@ -12,6 +12,8 @@ import Foreign.C
 
 import JAX.Concrete
 
+-- TODO newCString just mallocs the string; we have to
+-- arrange for the caller to free it.
 dexRoundtripJaxprJson :: CString -> IO CString
 dexRoundtripJaxprJson jsonPtr = do
   json <- B.pack <$> peekCString jsonPtr

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -44,11 +44,14 @@ dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
   let cc = intAsCC ccInt
   runTopperMFromContext ctxPtr do
     -- TODO: Check if atom is compatible with context! Use module name?
-    (nativeFun, nativeSig) <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
-    let funcPtr = nativeFunPtr $ nativeFun
-    let exportNativeFun = ExportNativeFunction nativeFun nativeSig
-    liftIO $ insertIntoNativeFunctionTable ctxPtr funcPtr exportNativeFun
-    return funcPtr
+    func <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
+    liftIO $ emitExport ctxPtr func
+
+emitExport :: Ptr Context -> ExportNativeFunction -> IO ExportNativeFunctionAddr
+emitExport ctxPtr func = do
+  let funcPtr = nativeFunPtr $ nativeFunction func
+  insertIntoNativeFunctionTable ctxPtr funcPtr func
+  return funcPtr
 
 dexGetFunctionSignature :: Ptr Context -> ExportNativeFunctionAddr -> IO (Ptr (ExportedSignature 'VoidS))
 dexGetFunctionSignature ctxPtr funcPtr = do

--- a/src/Dex/Foreign/JIT.hs
+++ b/src/Dex/Foreign/JIT.hs
@@ -28,15 +28,9 @@ import qualified Data.Map.Strict as M
 import Export
 import Name
 import Types.Core
-import Types.Imp
 
 import Dex.Foreign.Util
 import Dex.Foreign.Context
-
-intAsCC :: CInt -> CallingConvention
-intAsCC 0 = StandardCC
-intAsCC 1 = XLACC
-intAsCC _ = error "Unrecognized calling convention"
 
 dexCompile :: Ptr Context -> CInt -> Ptr AtomEx -> IO ExportNativeFunctionAddr
 dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
@@ -46,12 +40,6 @@ dexCompile ctxPtr ccInt funcAtomPtr = catchErrors do
     -- TODO: Check if atom is compatible with context! Use module name?
     func <- prepareFunctionForExport cc (unsafeCoerceE funcAtom)
     liftIO $ emitExport ctxPtr func
-
-emitExport :: Ptr Context -> ExportNativeFunction -> IO ExportNativeFunctionAddr
-emitExport ctxPtr func = do
-  let funcPtr = nativeFunPtr $ nativeFunction func
-  insertIntoNativeFunctionTable ctxPtr funcPtr func
-  return funcPtr
 
 dexGetFunctionSignature :: Ptr Context -> ExportNativeFunctionAddr -> IO (Ptr (ExportedSignature 'VoidS))
 dexGetFunctionSignature ctxPtr funcPtr = do

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -451,6 +451,12 @@ a --@ b = Pi <$> nonDepPiType LinArrow a Pure b
 (==>) :: (IRRep r, ScopeReader m) => IxType r n -> Type r n -> m n (Type r n)
 a ==> b = TabPi <$> nonDepTabPiType a b
 
+finTabTyCore :: EnvReader m => CAtom n -> CType n -> m n (CType n)
+finTabTyCore n eltTy = IxType (FinTy n) (IxDictAtom (DictCon (IxFin n))) ==> eltTy
+
+finIxTy :: Int -> IxType r n
+finIxTy n = IxType IdxRepTy (IxDictRawFin (IdxRepVal $ fromIntegral n))
+
 -- These `fromNary` functions traverse a chain of unary structures (LamExpr,
 -- TabLamExpr, PiType, respectively) up to the given maxDepth, and return the
 -- discovered binders packed as the nary structure (NaryLamExpr or NaryPiType),

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -12,6 +12,8 @@ module Export (
     ExportedSignature (..), ExportNativeFunction (..)
   ) where
 
+import Control.Category ((>>>))
+import Control.Monad.IO.Class
 import Data.List (intercalate)
 import Foreign.Storable
 import Foreign.C.String
@@ -25,6 +27,7 @@ import IRVariants
 import Name
 import QueryType
 import Simplify
+import Subst hiding (Rename)
 import TopLevel
 import Types.Core
 import Types.Imp
@@ -63,84 +66,123 @@ prepareSLamForExport :: (Mut n, Topper m)
   => CallingConvention -> SLam n -> m n ExportNativeFunction
 prepareSLamForExport cc f = do
   naryPi <- getNaryLamExprType f
-  undefined
+  closedNaryPi@(NaryPiType bs _ _) <- case hoistToTop naryPi of
+    HoistFailure _ ->
+      throw TypeErr $ "Types of exported functions have to be closed terms. Got: " ++ pprint naryPi
+    HoistSuccess npi -> return npi
+  let arrs = take (nestLength bs) $ repeat PlainArrow
+  sig <- liftExportSigM $ naryPiToExportSig cc arrs closedNaryPi
+  fImp <- compileTopLevelFun cc f
+  nativeFun <- toCFunction "userFunc" fImp >>= emitObjFile >>= loadObject
+  return $ ExportNativeFunction nativeFun sig
+{-# INLINE prepareSLamForExport #-}
+{-# SCC prepareSLamForExport #-}
 
 -- === Exported function signature ===
 
-type ExportSigM (n::S) = EnvReaderT FallibleM n
+data Rename (r::IR) (c::C) (n::S) where
+  Rename :: (Name (AtomNameC CoreIR) n) -> Rename r (AtomNameC r) n
+  JustRefer :: Name c n -> Rename r c n
 
-liftExportSigM :: Fallible m => ExportSigM VoidS a -> m a
+instance SinkableE (Rename r c) where
+  sinkingProofE = todoSinkableProof
+instance SinkableV (Rename r)
+instance FromName (Rename r) where
+  fromName = JustRefer
+
+newtype ExportSigM (r::IR) (i::S) (o::S) (a:: *) = ExportSigM {
+  runExportSigM :: SubstReaderT (Rename r) (EnvReaderT FallibleM) i o a }
+  deriving ( Functor, Applicative, Monad, ScopeReader, EnvExtender, Fallible
+           , EnvReader, SubstReader (Rename r), MonadFail)
+
+liftExportSigM :: Fallible m => ExportSigM r VoidS VoidS a -> m a
 liftExportSigM = liftExcept . runFallibleM . runEnvReaderT emptyOutMap
+  . runSubstReaderT idSubst . runExportSigM
 
-naryPiToExportSig :: CallingConvention
-  -> [Arrow] -> NaryPiType CoreIR n -> ExportSigM n (ExportedSignature n)
+naryPiToExportSig :: (IRRep r) => CallingConvention
+  -> [Arrow] -> NaryPiType r i -> ExportSigM r i o (ExportedSignature o)
 naryPiToExportSig cc arrs (NaryPiType tbs effs resultTy) = do
     case effs of
       Pure -> return ()
       _    -> throw TypeErr "Only pure functions can be exported"
-    goArgs Empty [] arrs tbs resultTy
-  where
-    goArgs :: Nest ExportArg n l' -> [CAtomName l'] -> [Arrow] -> Nest (Binder CoreIR) l' l
-           -> CType l -> ExportSigM l' (ExportedSignature n)
-    goArgs argSig argVs argArrs piBs piRes = case (argArrs, piBs) of
-      ([], Empty) -> goResult piRes \resSig ->
-        return $ ExportedSignature argSig resSig $ case cc of
-          StandardCC -> (fromListE $ sink $ ListE argVs) ++ nestToList (sink . binderName) resSig
-          XLACC      -> []
-          _ -> error $ "calling convention not supported: " ++ show cc
-      (arrow:arrows, Nest b bs) -> do
-        refreshAbs (Abs b (Abs bs piRes)) \(v:>ty) (Abs bs' piRes') -> do
-          let invalidArrow = throw TypeErr
-                               "Exported functions can only have regular and implicit arrow types"
-          vis <- case arrow of
-            PlainArrow    -> return ExplicitArg
-            ImplicitArrow -> return ImplicitArg
-            ClassArrow _  -> invalidArrow
-            LinArrow      -> invalidArrow
-          ety <- toExportType ty
-          goArgs (argSig `joinNest` Nest (ExportArg vis (v:>ety)) Empty)
-                 ((fromListE $ sink $ ListE argVs) ++ [binderName v]) arrows bs' piRes'
-      _ -> error "zip error"
+    goArgs cc Empty [] arrs tbs resultTy
 
-    goResult :: CType l
-             -> (forall q. DExt l q => Nest ExportResult l q -> ExportSigM q a)
-             -> ExportSigM l a
-    goResult ty cont = case ty of
-      ProdTy [lty, rty] ->
-        goResult lty \lres ->
-          goResult (sink rty) \rres ->
-            cont $ joinNest lres rres
-      _ -> withFreshBinder noHint ty \(b:>_) -> do
-        ety <- toExportType ty
-        cont $ Nest (ExportResult (b:>ety)) Empty
+goArgs :: (IRRep r)
+  => CallingConvention
+  -> Nest ExportArg o o'
+  -> [CAtomName o']
+  -> [Arrow]
+  -> Nest (Binder r) i i'
+  -> Type r i'
+  -> ExportSigM r i o' (ExportedSignature o)
+goArgs cc argSig argVs argArrs piBs piRes = case (argArrs, piBs) of
+  ([], Empty) -> goResult piRes \resSig ->
+    return $ ExportedSignature argSig resSig $ case cc of
+      StandardCC -> (fromListE $ sink $ ListE argVs) ++ nestToList (sink . binderName) resSig
+      XLACC      -> []
+      _ -> error $ "calling convention not supported: " ++ show cc
+  (arrow:arrows, Nest (b:>ty) bs) -> do
+    ety <- toExportType ty
+    withFreshBinder (getNameHint b) ety \(v:>_) ->
+      extendSubst (b @> Rename (binderName v)) $ do
+        let invalidArrow = throw TypeErr
+              "Exported functions can only have regular and implicit arrow types"
+        vis <- case arrow of
+          PlainArrow    -> return ExplicitArg
+          ImplicitArrow -> return ImplicitArg
+          ClassArrow _  -> invalidArrow
+          LinArrow      -> invalidArrow
+        goArgs cc (argSig >>> Nest (ExportArg vis (v:>ety)) Empty)
+               ((fromListE $ sink $ ListE argVs) ++ [binderName v]) arrows bs piRes
+  _ -> error "zip error"
 
-toExportType :: Fallible m => CType n -> m (ExportType n)
+goResult :: IRRep r => Type r i
+         -> (forall o'. DExt o o' =>
+             Nest ExportResult o o' -> ExportSigM r i o' a)
+         -> ExportSigM r i o a
+goResult ty cont = case ty of
+  ProdTy [lty, rty] ->
+    goResult lty \lres ->
+      goResult rty \rres ->
+        cont $ lres >>> rres
+  _ -> do
+    ety <- toExportType ty
+    withFreshBinder noHint ety \(b:>_) -> do
+      cont $ Nest (ExportResult (b:>ety)) Empty
+
+toExportType :: IRRep r => Type r i -> ExportSigM r i o (ExportType o)
 toExportType ty = case ty of
   BaseTy (Scalar sbt) -> return $ ScalarType sbt
-  NatTy               -> return $ ScalarType IdxRepScalarBaseTy
-  TabTy  _ _          -> case parseTabTy ty of
+  NewtypeTyCon Nat    -> return $ ScalarType IdxRepScalarBaseTy
+  TabTy  _ _          -> parseTabTy ty >>= \case
     Nothing  -> unsupported
     Just ety -> return ety
   _ -> unsupported
   where unsupported = throw TypeErr $ "Unsupported type of argument in exported function: " ++ pprint ty
 {-# INLINE toExportType #-}
 
-parseTabTy :: CType n -> Maybe (ExportType n)
+parseTabTy :: Type r i -> ExportSigM r i o (Maybe (ExportType o))
 parseTabTy = go []
   where
-    go :: [ExportDim n] -> CType n -> Maybe (ExportType n)
+    go :: forall r i o. [ExportDim o] -> Type r i
+      -> ExportSigM r i o (Maybe (ExportType o))
     go shape = \case
-      BaseTy (Scalar sbt) -> Just $ RectContArrayPtr sbt shape
-      NatTy               -> Just $ RectContArrayPtr IdxRepScalarBaseTy shape
+      BaseTy (Scalar sbt) -> return $ Just $ RectContArrayPtr sbt shape
+      NewtypeTyCon Nat    -> return $ Just $ RectContArrayPtr IdxRepScalarBaseTy shape
       TabTy  (b:>(IxType (NewtypeTyCon (Fin n)) _)) a -> do
-        dim <- case n of
-          Var v    -> Just (ExportDimVar v)
-          NatVal s -> Just (ExportDimLit $ fromIntegral s)
-          _        -> Nothing
-        case hoist b a of
-          HoistSuccess a' -> go (shape ++ [dim]) a'
-          HoistFailure _  -> Nothing
-      _ -> Nothing
+        maybeDim <- case n of
+          Var v    -> do
+            s <- getSubst
+            let (Rename v') = s ! v
+            return $ Just (ExportDimVar v')
+          NatVal s -> return $ Just (ExportDimLit $ fromIntegral s)
+          _        -> return Nothing
+        case maybeDim of
+          Just dim -> case hoist b a of
+            HoistSuccess a' -> go (shape ++ [dim]) a'
+            HoistFailure _  -> return Nothing
+          Nothing -> return Nothing
+      _ -> return Nothing
 
 data ArgVisibility = ImplicitArg | ExplicitArg
 
@@ -153,6 +195,7 @@ data ExportType n = RectContArrayPtr ScalarBaseType [ExportDim n]
 
 data    ExportArg    n l = ExportArg    ArgVisibility (BinderP ExportAtomNameC ExportType n l)
 newtype ExportResult n l = ExportResult               (BinderP ExportAtomNameC ExportType n l)
+  deriving (SinkableB)
 data ExportedSignature n = forall l l'.
   ExportedSignature { exportedArgSig   :: Nest ExportArg n l
                     , exportedResSig   :: Nest ExportResult l l'

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -8,6 +8,7 @@
 
 module Export (
     exportFunctions, prepareFunctionForExport, exportedSignatureDesc,
+    prepareSLamForExport,
     ExportedSignature (..), ExportNativeFunction (..)
   ) where
 
@@ -57,6 +58,12 @@ prepareFunctionForExport cc f = do
   return $ ExportNativeFunction nativeFun sig
 {-# INLINE prepareFunctionForExport #-}
 {-# SCC prepareFunctionForExport #-}
+
+prepareSLamForExport :: (Mut n, Topper m)
+  => CallingConvention -> SLam n -> m n ExportNativeFunction
+prepareSLamForExport cc f = do
+  naryPi <- getNaryLamExprType f
+  undefined
 
 -- === Exported function signature ===
 

--- a/src/lib/Export.hs
+++ b/src/lib/Export.hs
@@ -13,7 +13,6 @@ module Export (
   ) where
 
 import Control.Category ((>>>))
-import Control.Monad.IO.Class
 import Data.List (intercalate)
 import Foreign.Storable
 import Foreign.C.String

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -119,6 +119,7 @@ instance ToJSON JEqn where
 
 dumpPrimitive :: Primitive -> (String, A.Value)
 dumpPrimitive = \case
+  Add -> ("add", object [])
   Sin -> ("sin", object [])
 
 instance FromJSON JEqn where
@@ -134,6 +135,7 @@ instance FromJSON JEqn where
 
 parsePrimitive :: String -> A.Value -> A.Parser Primitive
 parsePrimitive name params = case name of
+  "add" -> return Add
   "sin" -> return Sin
   _ -> fail $ "Unknown primitive " ++ name
 

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -1,0 +1,99 @@
+module JAX.Concrete where
+
+import GHC.Generics (Generic (..))
+
+import Data.Aeson (ToJSON)
+
+type NumConsts = Int
+type NumCarry = Int
+type Unroll = Int -- how many copies of the body to replicate
+
+data Primitive =
+    Sin | Cos | Add | Mul
+  | Scan Bool -- reverse
+         Int  -- length
+         Jaxpr -- body
+         NumConsts
+         NumCarry
+         [Bool] -- which arguments are we linear wrt?
+         Unroll
+  -- | others!
+  deriving (Generic)
+
+data EltType = F64 | F32 -- others
+  deriving (Generic)
+
+data DimSizeDeBrujin = LitDimSize Int
+  | RefDimSizeInput Int  -- "de Brujin" index but counted from the left of the list
+  | RefDimSizeOutput Int -- same
+  deriving (Generic)
+data JArgType = JArrayDeBrujin EltType [DimSizeDeBrujin]
+-- On the output, can refer to input binders and preceding things in the output
+  deriving (Generic)
+data JFuncType = JFunc [JArgType] JEffects [JArgType]
+-- The ints just count from the beginning of the list of inputs of the jaxpr
+-- being typed by this JEffects datum
+  deriving (Generic)
+
+data DimSizeName = DimSizeName JAtom -- | polynomials? indexing operations?
+  deriving (Generic)
+data JVarType = JArrayName
+  { shape :: [DimSizeName]
+  , dtype :: EltType
+  }
+  deriving (Generic)
+data JEffects = IO | Read Int | Write Int | Append Int
+  deriving (Generic)
+
+data JAtom = JVar JVar
+           | JLitInt Int
+           -- | others
+  deriving (Generic)
+
+data JVar = JVariable
+  { name :: String
+  , ty :: JVarType
+  }
+  deriving (Generic)
+
+data Binder = Binder String JVarType
+  deriving (Generic)
+
+data JDecl = JDecl
+  { outVars :: [Binder]
+  , primitive :: Primitive
+  , inAtoms :: [JAtom]
+  }
+  deriving (Generic)
+
+-- examples of primitive parameters
+--  * broadcast - data describing axes
+--  * conv -- strides
+--  * contraction dimensions etc in matmul-ish things
+--  * scan -- direction, "unroll", num_carry, num_consts
+--  * transpose -- permutation
+
+-- other things
+--  * effects
+--  * dynamic shapes
+
+data Jaxpr = Jaxpr
+  { invars  :: [Binder]
+  , outvars :: [JAtom]
+  , eqns    :: [JDecl]
+  }
+  deriving (Generic)
+
+instance ToJSON JAtom
+instance ToJSON JVar
+instance ToJSON Binder
+instance ToJSON JVarType
+instance ToJSON JEffects
+instance ToJSON DimSizeName
+instance ToJSON JFuncType
+instance ToJSON Primitive
+instance ToJSON EltType
+instance ToJSON DimSizeDeBrujin
+instance ToJSON JArgType
+instance ToJSON Jaxpr
+instance ToJSON JDecl

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -26,7 +26,7 @@ data Primitive =
 data ScanParams = ScanParams
   { reverse :: Bool
   , length :: Int
-  , jaxpr :: ClosedJaxpr -- The scan body
+  , jaxpr :: (ClosedJaxpr VoidS) -- The scan body
   , num_consts :: Int
   , num_carry :: Int
   , linear :: [Bool] -- which arguments are we linear wrt?
@@ -143,8 +143,8 @@ data Jaxpr (n::S) where
     -> [JAtom o] -- outvars
     -> Jaxpr n
 
-data ClosedJaxpr = ClosedJaxpr
-  { jaxpr :: Jaxpr VoidS
+data ClosedJaxpr (n::S) = ClosedJaxpr
+  { jaxpr :: Jaxpr n
   , consts :: [A.Value]
   }
   deriving (Generic)
@@ -279,7 +279,7 @@ instance ToJSON JFuncType
 instance ToJSON Primitive
 instance ToJSON DimSizeDeBrujin
 instance ToJSON JArgType
-instance ToJSON ClosedJaxpr
+instance ToJSON (ClosedJaxpr n)
 instance ToJSON ScanParams
 instance ToJSON ConvertElementTypeParams
 
@@ -291,6 +291,6 @@ instance FromJSON JFuncType
 instance FromJSON Primitive
 instance FromJSON DimSizeDeBrujin
 instance FromJSON JArgType
-instance FromJSON ClosedJaxpr
+instance FromJSON (ClosedJaxpr VoidS)
 instance FromJSON ScanParams
 instance FromJSON ConvertElementTypeParams

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -81,6 +81,10 @@ data JSourceName = JSourceName
   , count :: Int
   , suffix :: String
   }
+  deriving (Eq, Ord, Show)
+
+instance HasNameHint JSourceName where
+  getNameHint JSourceName{suffix=suffix} = getNameHint suffix
 
 data JSourceNameOr (a::E) (n::S) where
   SourceName :: JSourceName -> JSourceNameOr a 'VoidS

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -8,7 +8,7 @@ module JAX.Concrete where
 
 import GHC.Generics (Generic (..))
 
-import Data.Aeson (ToJSON)
+import Data.Aeson (ToJSON, FromJSON)
 
 type NumConsts = Int
 type NumCarry = Int
@@ -103,3 +103,17 @@ instance ToJSON DimSizeDeBrujin
 instance ToJSON JArgType
 instance ToJSON Jaxpr
 instance ToJSON JDecl
+
+instance FromJSON JAtom
+instance FromJSON JVar
+instance FromJSON Binder
+instance FromJSON JVarType
+instance FromJSON JEffects
+instance FromJSON DimSizeName
+instance FromJSON JFuncType
+instance FromJSON Primitive
+instance FromJSON EltType
+instance FromJSON DimSizeDeBrujin
+instance FromJSON JArgType
+instance FromJSON Jaxpr
+instance FromJSON JDecl

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -17,7 +17,7 @@ import IRVariants
 import Name
 
 data Primitive =
-    Sin | Cos | Add | Mul
+    Sin | Add
   | Scan ScanParams
   | ConvertElementType ConvertElementTypeParams
   -- others!
@@ -101,6 +101,12 @@ data JLit = JLit
 data JBinder (n::S) (l::S) where
   JBindSource :: JSourceName -> JVarType -> JBinder n n
   JBind :: JSourceName -> JVarType -> NameBinder (AtomNameC SimpIR) n l -> JBinder n l
+
+instance BindsAtMostOneName JBinder (AtomNameC SimpIR) where
+  b @> x = case b of
+    JBindSource _ _ -> error "Unexpected source binder after parsing"
+    JBind _ _ b' -> singletonSubst b' x
+  {-# INLINE (@>) #-}
 
 jBinderVar :: JBinder n l -> JVar 'VoidS
 jBinderVar = \case

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -1,3 +1,9 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
 module JAX.Concrete where
 
 import GHC.Generics (Generic (..))

--- a/src/lib/JAX/Concrete.hs
+++ b/src/lib/JAX/Concrete.hs
@@ -150,12 +150,12 @@ data ClosedJaxpr (n::S) = ClosedJaxpr
   deriving (Generic)
 
 instance ToJSON (JVar n) where
-  toJSON JVar {..} = object
+  toJSON JVar {sourceName, ty} = object
     [ "name" .= name
     , "count" .= count
     , "suffix" .= suffix
     , "ty" .= ty
-    ] where JSourceName {..} = case sourceName of
+    ] where JSourceName {name, count, suffix} = case sourceName of
               SourceName nm -> nm
               InternalName nm _ -> nm
 
@@ -205,7 +205,7 @@ varsAsBinders :: [JVar 'VoidS] -> Nest JBinder 'VoidS 'VoidS
 varsAsBinders = voidNest . map varAsBinder
 
 varAsBinder :: JVar 'VoidS -> JBinder 'VoidS 'VoidS
-varAsBinder JVar{..} = case sourceName of
+varAsBinder JVar{sourceName, ty} = case sourceName of
   SourceName srcName -> JBindSource srcName ty
   InternalName _ _ -> error "Unexpected internal name during parsing"
 

--- a/src/lib/JAX/Rename.hs
+++ b/src/lib/JAX/Rename.hs
@@ -1,0 +1,108 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module JAX.Rename (liftRenameM, renameJaxpr) where
+
+import Data.Map qualified as M
+
+import Core
+import IRVariants
+import JAX.Concrete
+import Name
+
+newtype RenamerM (n::S) (a:: *) =
+  RenamerM { runRenamerM :: OutReaderT SourceMap (ScopeReaderM) n a }
+  deriving ( Functor, Applicative, Monad
+           , ScopeReader, ScopeExtender)
+
+newtype SourceMap (n::S) = SourceMap
+  (M.Map JSourceName (Name (AtomNameC SimpIR) n))
+  deriving (Semigroup, Monoid)
+
+instance SinkableE SourceMap where
+  sinkingProofE = undefined
+
+askSourceMap :: RenamerM n (SourceMap n)
+askSourceMap = RenamerM askOutReader
+
+extendSourceMap :: JSourceName -> (Name (AtomNameC SimpIR)) n
+  -> RenamerM n a -> RenamerM n a
+extendSourceMap sname name (RenamerM cont) = RenamerM do
+  sm <- askOutReader
+  let ext = SourceMap $ M.singleton sname name
+  localOutReader (sm <> ext) cont
+
+liftRenameM :: EnvReader m => RenamerM n (e n) -> m n (e n)
+liftRenameM act = liftScopeReaderM $ runOutReaderT mempty $ runRenamerM act
+
+renameJaxpr :: Distinct o => Jaxpr i -> RenamerM o (Jaxpr o)
+renameJaxpr (Jaxpr invars constvars eqns outvars) =
+  renameJBinders invars \invars' ->
+    renameJBinders constvars \constvars' ->
+      renameJEqns eqns \eqns' -> do
+        outvars' <- mapM renameJAtom outvars
+        return $ Jaxpr invars' constvars' eqns' outvars'
+
+renameJBinder :: Distinct o
+  => JBinder i i'
+  -> (forall o'. DExt o o' => JBinder o o' -> RenamerM o' a)
+  -> RenamerM o a
+renameJBinder binder cont = case binder of
+  JBindSource sname ty -> do
+    withFreshM (getNameHint sname) \freshName -> do
+      Distinct <- getDistinct
+      extendSourceMap sname (binderName freshName) $
+        cont $ JBind sname ty freshName
+  JBind _ _ _ -> error "Shouldn't be source-renaming internal names"
+
+renameJBinders :: Distinct o
+  => Nest JBinder i i'
+  -> (forall o'. DExt o o' => Nest JBinder o o' -> RenamerM o' a)
+  -> RenamerM o a
+renameJBinders Empty cont = cont Empty
+renameJBinders (Nest b bs) cont =
+  renameJBinder b \b' ->
+    renameJBinders bs \bs' ->
+      cont $ Nest b' bs'
+
+renameJAtom :: JAtom i -> RenamerM o (JAtom o)
+renameJAtom = \case
+  JVariable jvar -> JVariable <$> renameJVar jvar
+  JLiteral jlit -> return $ JLiteral jlit
+
+renameJVar :: JVar i -> RenamerM o (JVar o)
+renameJVar JVar{..} = do
+  sourceName' <- renameJSourceNameOr sourceName
+  return $ JVar sourceName' ty
+
+renameJSourceNameOr :: JSourceNameOr (Name (AtomNameC SimpIR)) i
+  -> RenamerM o (JSourceNameOr (Name (AtomNameC SimpIR)) o)
+renameJSourceNameOr = \case
+  SourceName sname -> do
+    SourceMap sm <- askSourceMap
+    case M.lookup sname sm of
+      (Just name) -> return $ InternalName sname name
+      Nothing -> error $ "Unbound variable " ++ show sname
+  InternalName _ _ -> error "Shouldn't be source-renaming internal names"
+
+renameJEqn :: Distinct o
+  => JEqn i i'
+  -> (forall o'. DExt o o' => JEqn o o' -> RenamerM o' a)
+  -> RenamerM o a
+renameJEqn JEqn{..} cont = do
+  invars' <- mapM renameJAtom invars
+  renameJBinders outvars \outvars' -> cont $ JEqn outvars' primitive invars'
+
+renameJEqns :: Distinct o
+  => Nest JEqn i i'
+  -> (forall o'. DExt o o' => Nest JEqn o o' -> RenamerM o' a)
+  -> RenamerM o a
+renameJEqns Empty cont = cont Empty
+renameJEqns (Nest b bs) cont =
+  renameJEqn b \b' ->
+    renameJEqns bs \bs' ->
+      cont $ Nest b' bs'
+

--- a/src/lib/JAX/Rename.hs
+++ b/src/lib/JAX/Rename.hs
@@ -4,7 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module JAX.Rename (liftRenameM, renameJaxpr) where
+module JAX.Rename (liftRenameM, renameClosedJaxpr, renameJaxpr) where
 
 import Data.Map qualified as M
 
@@ -37,6 +37,11 @@ extendSourceMap sname name (RenamerM cont) = RenamerM do
 
 liftRenameM :: EnvReader m => RenamerM n (e n) -> m n (e n)
 liftRenameM act = liftScopeReaderM $ runOutReaderT mempty $ runRenamerM act
+
+renameClosedJaxpr :: Distinct o => ClosedJaxpr i -> RenamerM o (ClosedJaxpr o)
+renameClosedJaxpr ClosedJaxpr{jaxpr, consts} = do
+  jaxpr' <- renameJaxpr jaxpr
+  return ClosedJaxpr{jaxpr=jaxpr', consts}
 
 renameJaxpr :: Distinct o => Jaxpr i -> RenamerM o (Jaxpr o)
 renameJaxpr (Jaxpr invars constvars eqns outvars) =

--- a/src/lib/JAX/Rename.hs
+++ b/src/lib/JAX/Rename.hs
@@ -79,7 +79,7 @@ renameJAtom = \case
   JLiteral jlit -> return $ JLiteral jlit
 
 renameJVar :: JVar i -> RenamerM o (JVar o)
-renameJVar JVar{..} = do
+renameJVar JVar{sourceName, ty} = do
   sourceName' <- renameJSourceNameOr sourceName
   return $ JVar sourceName' ty
 
@@ -97,7 +97,7 @@ renameJEqn :: Distinct o
   => JEqn i i'
   -> (forall o'. DExt o o' => JEqn o o' -> RenamerM o' a)
   -> RenamerM o a
-renameJEqn JEqn{..} cont = do
+renameJEqn JEqn{outvars, primitive, invars} cont = do
   invars' <- mapM renameJAtom invars
   renameJBinders outvars \outvars' -> cont $ JEqn outvars' primitive invars'
 

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -4,7 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module JAX.ToSimp where
+module JAX.ToSimp (liftJaxSimpM, simplifyJaxpr) where
 
 import Control.Category ((>>>))
 import GHC.Base (NonEmpty(..))
@@ -107,13 +107,13 @@ simplifyPrim :: Emits o
   => [(SAtom o, JVarType)] -> Primitive -> JaxSimpM i o [SAtom o]
 simplifyPrim args prim = case (prim, args) of
   (Sin, [(arg, ty)]) -> do
-    res <- unary_expand_rank P.Sin arg ty
+    res <- unaryExpandRank P.Sin arg ty
     return [res]
   _ -> undefined
 
-unary_expand_rank :: forall i o. Emits o
+unaryExpandRank :: forall i o. Emits o
   => P.UnOp -> SAtom o -> JVarType -> JaxSimpM i o (SAtom o)
-unary_expand_rank op arg JArrayName {..} = go arg shape where
+unaryExpandRank op arg JArrayName {..} = go arg shape where
   go :: Emits l => SAtom l -> [DimSizeName] -> JaxSimpM i l (SAtom l)
   go arg' = \case
     [] -> emitExprToAtom $ PrimOp (P.UnOp op arg')

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -4,7 +4,7 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module JAX.ToSimp (liftJaxSimpM, simplifyJaxpr) where
+module JAX.ToSimp (liftJaxSimpM, simplifyJaxpr, simplifyClosedJaxpr) where
 
 import Control.Category ((>>>))
 import GHC.Base (NonEmpty(..))
@@ -29,6 +29,10 @@ newtype JaxSimpM (i::S) (o::S) a = JaxSimpM
 liftJaxSimpM :: (EnvReader m) => JaxSimpM n n (e n) -> m n (e n)
 liftJaxSimpM act = liftBuilder $ runSubstReaderT idSubst $ runJaxSimpM act
 {-# INLINE liftJaxSimpM #-}
+
+simplifyClosedJaxpr :: ClosedJaxpr i -> JaxSimpM i o (LamExpr SimpIR o)
+simplifyClosedJaxpr ClosedJaxpr{jaxpr, consts=[]} = simplifyJaxpr jaxpr
+simplifyClosedJaxpr _ = error "TODO Support consts"
 
 simplifyJaxpr :: Jaxpr i -> JaxSimpM i o (LamExpr SimpIR o)
 simplifyJaxpr (Jaxpr invars constvars eqns outvars) = do

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -1,0 +1,75 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module JAX.ToSimp where
+
+import GHC.Base (NonEmpty(..))
+
+import Builder
+import Core
+import Err
+import IRVariants
+import Name
+import JAX.Concrete
+import Subst
+import Types.Core
+import Types.Primitives qualified as P
+
+newtype JaxSimpM (i::S) (o::S) a = JaxSimpM
+  { runJaxSimpM :: SubstReaderT AtomSubstVal (BuilderM SimpIR) i o a }
+  deriving ( Functor, Applicative, Monad, MonadFail
+           , ScopeReader, EnvReader, EnvExtender
+           , SubstReader AtomSubstVal, Fallible
+           , Builder SimpIR, ScopableBuilder SimpIR)
+
+simplifyEqn :: Emits o => JEqn i i' -> JaxSimpM i' o a -> JaxSimpM i o a
+simplifyEqn eqn cont = do
+  s  <- getSubst
+  s' <- simplifyEqnSubst s eqn
+  withSubst s' cont
+{-# INLINE simplifyEqn #-}
+
+simplifyEqnSubst :: Emits o
+  => Subst AtomSubstVal l o -> JEqn l i' -> JaxSimpM i o (Subst AtomSubstVal i' o)
+simplifyEqnSubst !s JEqn{..} = do
+  simpIn <- withSubst s $ mapM simplifyAtom invars
+  simpOut <- simplifyPrim simpIn primitive
+  return $ s <>> (outvars @@> (map SubstVal simpOut))
+
+simplifyAtom :: JAtom i -> JaxSimpM i o (SAtom o, JVarType)
+simplifyAtom = \case
+  JVariable (JVar {..}) -> case sourceName of
+    SourceName _ -> error "Unexpected source name during compilation"
+    InternalName _ nm -> do
+      env <- getSubst
+      case env ! nm of
+        -- TODO Assuming the subst is not type-changing
+        SubstVal x -> return (x, ty)
+        Rename nm' -> return (Var nm', ty)
+  -- TODO In Jax, literals can presumably include (large) arrays.  How should we
+  -- represent them here?
+  JLiteral (JLit {..}) -> return (Con (P.Lit (P.Float32Lit 0.0)), ty)
+
+simplifyPrim :: Emits o
+  => [(SAtom o, JVarType)] -> Primitive -> JaxSimpM i o [SAtom o]
+simplifyPrim args prim = case (prim, args) of
+  (Sin, [(arg, ty)]) -> do
+    res <- unary_expand_rank P.Sin arg ty
+    return [res]
+  _ -> undefined
+
+unary_expand_rank :: forall i o. Emits o
+  => P.UnOp -> SAtom o -> JVarType -> JaxSimpM i o (SAtom o)
+unary_expand_rank op arg JArrayName {..} = go arg shape where
+  go :: Emits l => SAtom l -> [DimSizeName] -> JaxSimpM i l (SAtom l)
+  go arg' = \case
+    [] -> emitExprToAtom $ PrimOp (P.UnOp op arg')
+    (DimSize sz:rest) -> buildFor noHint P.Fwd (finIxTy sz) \i -> do
+      ixed <- emitExprToAtom $ TabApp (sink arg') (Var i :| [])
+      go ixed rest
+
+finIxTy :: Int -> IxType r n
+finIxTy n = IxType IdxRepTy (IxDictRawFin (IdxRepVal $ fromIntegral n))

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -58,7 +58,7 @@ simplifyJBinders (Nest jb jbs) cont = case jb of
         simplifyJBinders jbs \bs' -> cont (Nest b' bs')
 
 simplifyJTy :: JVarType -> JaxSimpM i o (SType o)
-simplifyJTy JArrayName{..} = go shape $ simplifyDType dtype where
+simplifyJTy JArrayName{shape, dtype} = go shape $ simplifyDType dtype where
   go [] ty = return ty
   go ((DimSize sz):rest) ty = do
     rest' <- go rest ty
@@ -117,7 +117,7 @@ simplifyPrim args prim = case (prim, args) of
 
 unaryExpandRank :: forall i o. Emits o
   => P.UnOp -> SAtom o -> JVarType -> JaxSimpM i o (SAtom o)
-unaryExpandRank op arg JArrayName {..} = go arg shape where
+unaryExpandRank op arg JArrayName{shape} = go arg shape where
   go :: Emits l => SAtom l -> [DimSizeName] -> JaxSimpM i l (SAtom l)
   go arg' = \case
     [] -> emitExprToAtom $ PrimOp (P.UnOp op arg')

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -26,7 +26,11 @@ newtype JaxSimpM (i::S) (o::S) a = JaxSimpM
            , SubstReader AtomSubstVal, Fallible
            , Builder SimpIR, ScopableBuilder SimpIR)
 
-simplifyJaxpr :: Jaxpr -> JaxSimpM VoidS o (LamExpr SimpIR o)
+liftJaxSimpM :: (EnvReader m) => JaxSimpM n n (e n) -> m n (e n)
+liftJaxSimpM act = liftBuilder $ runSubstReaderT idSubst $ runJaxSimpM act
+{-# INLINE liftJaxSimpM #-}
+
+simplifyJaxpr :: Jaxpr i -> JaxSimpM i o (LamExpr SimpIR o)
 simplifyJaxpr (Jaxpr invars constvars eqns outvars) = do
   simplifyJBinders invars \invarsB -> do
     simplifyJBinders constvars \constvarsB -> do

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -686,6 +686,10 @@ nestToNames :: (Distinct l, Ext n l, BindsOneName b c, BindsNames b)
             => Nest b n l -> [Name c l]
 nestToNames bs = nestToList (sink . binderName) bs
 
+nestToList' :: (forall n' l'. b n' l' -> a) -> Nest b n l -> [a]
+nestToList' _ Empty = []
+nestToList' f (Nest b rest) = f b : nestToList' f rest
+
 splitNestAt :: Int -> Nest b n l -> PairB (Nest b) (Nest b) n l
 splitNestAt 0 bs = PairB Empty bs
 splitNestAt _  Empty = error "split index too high"

--- a/src/lib/RuntimePrint.hs
+++ b/src/lib/RuntimePrint.hs
@@ -68,7 +68,7 @@ showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
       PtrType _  -> printTypeOnly "pointer"
       Scalar _ -> do
         (n, tab) <- fromPair =<< emitExpr (PrimOp $ MiscOp $ ShowScalar atom)
-        logicalTabTy <- finTabTy (NewtypeCon NatCon n) CharRepTy
+        logicalTabTy <- finTabTyCore (NewtypeCon NatCon n) CharRepTy
         tab' <- emitExpr $ PrimOp $ MiscOp $ UnsafeCoerce logicalTabTy tab
         emitCharTab tab'
     -- TODO: we could do better than this but it's not urgent because raw sum types
@@ -228,7 +228,7 @@ pushBuffer buf x = do
 
 stringLitAsCharTab :: (Emits n, CBuilder m) => String -> m n (CAtom n)
 stringLitAsCharTab s = do
-  t <- finTabTy (NatVal $ fromIntegral $ length s) CharRepTy
+  t <- finTabTyCore (NatVal $ fromIntegral $ length s) CharRepTy
   emitExpr $ TabCon Nothing t (map charRepVal s)
 
 getPreludeFunction :: EnvReader m => String -> m n (CAtom n)
@@ -247,9 +247,6 @@ applyPreludeFunction name args = do
 
 strType :: EnvReader m => m n (CType n)
 strType = constructPreludeType "List" $ DataDefParams [(PlainArrow, CharRepTy)]
-
-finTabTy :: EnvReader m => CAtom n -> CType n -> m n (CType n)
-finTabTy n eltTy = IxType (FinTy n) (IxDictAtom (DictCon (IxFin n))) ==> eltTy
 
 constructPreludeType :: EnvReader m => String -> DataDefParams n -> m n (CType n)
 constructPreludeType sourceName params = do

--- a/tests/unit/JaxADTSpec.hs
+++ b/tests/unit/JaxADTSpec.hs
@@ -13,6 +13,7 @@ import Test.Hspec
 
 import Name
 import JAX.Concrete
+import JAX.Rename
 import JAX.ToSimp
 import Runtime
 import TopLevel
@@ -47,7 +48,9 @@ compile jaxpr = do
   fst <$> runTopperM cfg env do
     -- TODO Implement GenericE for jaxprs, derive SinkableE, and properly sink
     -- the jaxpr instead of just coercing it.
-    jSimp <- liftJaxSimpM $ simplifyJaxpr (unsafeCoerceE jaxpr)
+    Distinct <- getDistinct
+    jRename <- liftRenameM $ renameJaxpr (unsafeCoerceE jaxpr)
+    jSimp <- liftJaxSimpM $ simplifyJaxpr jRename
     compileTopLevelFun (EntryFunCC CUDANotRequired) jSimp >>= packageLLVMCallable
 
 spec :: Spec

--- a/tests/unit/JaxADTSpec.hs
+++ b/tests/unit/JaxADTSpec.hs
@@ -1,0 +1,23 @@
+module JaxADTSpec (spec) where
+
+import qualified Data.ByteString.Lazy.Char8 as B
+import Data.Aeson (encode)
+import Data.Aeson.Encode.Pretty (encodePretty)
+import Test.Hspec
+
+import JAX.Concrete
+
+a_jaxpr = Jaxpr
+  [Binder "x" (JArrayName [DimSizeName $ JLitInt 10] F32)]
+  [JVar $ JVariable "x" (JArrayName [DimSizeName $ JLitInt 10] F32)]
+  [JDecl
+    [Binder "y" (JArrayName [DimSizeName $ JLitInt 10] F32)]
+    Sin
+    [JVar $ JVariable "x" (JArrayName [DimSizeName $ JLitInt 10] F32)]]
+
+spec :: Spec
+spec = do
+  describe "JaxADT" do
+    it "jsonifies" do
+      putStrLn $ B.unpack $ encodePretty a_jaxpr
+      encode a_jaxpr `shouldBe` "foo"

--- a/tests/unit/JaxADTSpec.hs
+++ b/tests/unit/JaxADTSpec.hs
@@ -1,3 +1,9 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
 module JaxADTSpec (spec) where
 
 import qualified Data.ByteString.Lazy.Char8 as B


### PR DESCRIPTION
To wit, serialize jaxprs from Python as JSON; parse them in Haskell into a new ADT modeling JAX IR; and compile to Dex SimpIR from there.

What works:
- Making the "compute the sine of an angle" jaxpr, shipping it to Dex, compiling it, and running the compiled function from Python.
- Round-tripping some more complex jaxprs (like cumsum implemented with scan) through the JSON encoding to Haskell and back.
- Unit-testing compile-and-run of some hand-constructed jaxpr ADTs from Haskell unit tests.

What doesn't work:
- Everything else!
- JAX literals currently compile to Dex scalar zeros.
- JAX->Dex compilation can't handle binary primitives (to say nothing of scan).
- Haven't tested compiling jaxprs that accept or return arrays.