### PR TITLE
Allow implicit args in type constructors.

### DIFF
--- a/lib/set.dx
+++ b/lib/set.dx
@@ -93,29 +93,29 @@ def set_intersect(
 
 -- TODO Implicit arguments to data definitions
 -- (Probably `a` should be implicit)
-struct Element(a|Ord, set:(Set a)) =
+struct Element(set:(Set a)) given (a|Ord) =
   val: Nat
 
 -- TODO The set argument could be implicit (inferred from the Element
 -- type), but maybe it's easier to read if it's explicit.
-def member(x:a, set:(Set a)) -> Maybe (Element a set) given (a|Ord) =
+def member(x:a, set:(Set a)) -> Maybe (Element set) given (a|Ord) =
   UnsafeAsSet(_, elts) = set
   case search_sorted elts x of
-    Just n -> Just $ Element.new (ordinal n)
+    Just n -> Just $ Element.new(ordinal n)
     Nothing -> Nothing
 
-def value(x:Element a set) -> a given (a|Ord, set:Set a) =
+def value(x:Element set) -> a given (a|Ord, set:Set a) =
   UnsafeAsSet(_, elts) = set
   elts[unsafe_from_ordinal x.val]
 
-instance Ix(Element a set) given (a|Ord, set:Set a)
+instance Ix(Element set) given (a|Ord, set:Set a)
   def size'() = set_size set
   def ordinal(n) = n.val
   def unsafe_from_ordinal(n) = Element.new(n)
 
-instance Eq(Element a set) given (a|Ord, set:Set a)
+instance Eq(Element set) given (a|Ord, set:Set a)
   def (==)(ix1, ix2) = ordinal ix1 == ordinal ix2
 
-instance Ord(Element a set) given (a|Ord, set:Set a)
+instance Ord(Element set) given (a|Ord, set:Set a)
   def (<)(ix1, ix2) = ordinal ix1 < ordinal ix2
   def (>)(ix1, ix2) = ordinal ix1 > ordinal ix2

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -2434,7 +2434,7 @@ instance Unifiable (IxType CoreIR) where
 
 instance Unifiable TyConParams where
   -- We ignore the dictionaries because we assume coherence
-  unifyZonked ps ps' = zipWithM_ unify (filterExplicitParams ps) (filterExplicitParams ps')
+  unifyZonked ps ps' = zipWithM_ unify (ignoreSynthParams ps) (ignoreSynthParams ps')
 
 instance Unifiable (EffectRow CoreIR) where
   unifyZonked x1 x2 =

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -977,7 +977,7 @@ instance PrettyPrec (NewtypeTyCon n) where
         | Just sym <- fromInfix (fromString name) ->
         atPrec ArgPrec $ align $ group $
           parens $ flatAlt " " "" <> pApp l <> line <> p sym <+> pApp r
-      _  -> atPrec LowestPrec $ pAppArg (p name) $ filterExplicitParams (TyConParams infs params)
+      _  -> atPrec LowestPrec $ pAppArg (p name) $ ignoreSynthParams (TyConParams infs params)
 
 instance (IRRep r, PrettyPrec e) => Pretty (PrimCon r e) where pretty = prettyFromPrettyPrec
 instance (IRRep r, PrettyPrec e) => PrettyPrec (PrimCon r e) where

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -1148,14 +1148,17 @@ instance GenericE TyConParams where
 -- We ignore the dictionary parameters because we assume coherence
 instance AlphaEqE TyConParams where
   alphaEqE params params' =
-    alphaEqE (ListE $ filterExplicitParams params) (ListE $ filterExplicitParams params')
+    alphaEqE (ListE $ ignoreSynthParams params) (ListE $ ignoreSynthParams params')
 
 instance AlphaHashableE TyConParams where
   hashWithSaltE env salt params =
-    hashWithSaltE env salt $ ListE $ filterExplicitParams params
+    hashWithSaltE env salt $ ListE $ ignoreSynthParams params
 
-filterExplicitParams :: TyConParams n -> [CAtom n]
-filterExplicitParams (TyConParams infs xs) = [x | (Explicit, x) <- zip infs xs]
+ignoreSynthParams :: TyConParams n -> [CAtom n]
+ignoreSynthParams (TyConParams infs xs) = [x | (inf, x) <- zip infs xs, notSynth inf]
+  where notSynth = \case
+          Inferred _ (Synth _) -> False
+          _ -> True
 
 instance SinkableE           TyConParams
 instance HoistableE          TyConParams

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -72,10 +72,12 @@ data CTopDecl'
   | CData
       SourceName      -- Type constructor name
       ExplicitParams
+      (Maybe GivenClause)
       [(SourceName, ExplicitParams)]   -- Constructor names and argument sets
   | CStruct
       SourceName      -- Type constructor name
       ExplicitParams
+      (Maybe GivenClause)
       [(SourceName, Group)] -- Field names and types
   | CInterface
       SourceName  -- Interface name

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -52,7 +52,7 @@ emptyset = to_set ([]::(Fin 0)=>String)
 
 names2 = to_set ["Bob", "Alice", "Charlie", "Alice"]
 
-Person = (Element String names2)
+Person = (Element names2)
 
 :p size Person
 > 3


### PR DESCRIPTION
Mostly a matter of adding the `given` clause, but I also had to tweak unification to be sensitive to inferred-by-unification type constructor parameters. Now we can write `Element myStrings` instead of `Element String myStrings`.