### PR TITLE
Start implementing dependent pairs that pack and unpack themselves automatically

### DIFF
--- a/misc/dex.el
+++ b/misc/dex.el
@@ -5,12 +5,18 @@
 ;; https://developers.google.com/open-source/licenses/bsd
 
 (setq dex-highlights
-  '(("--\\([^o].*$\\|$\\)"   . font-lock-comment-face)
+  `(("--\\([^o].*$\\|$\\)"   . font-lock-comment-face)
     ("^> .*$"                . font-lock-comment-face)
     ("^'\\(.\\|\n.\\)*\n\n"  . font-lock-comment-face)
     ("\\w+:"                 . font-lock-comment-face)
     ("^:\\w*"                . font-lock-preprocessor-face)
-    ("\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|\\bstruct\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|\\binstance\\b\\|\\bgiven\\b\\|\\bdo\\b\\|\\bview\\b\\|\\bimport\\b\\|\\bforeign\\b\\|\\bsatisfying\\b\\|\\bself\\b" .
+    (,(concat
+       "\\bdef\\b\\|\\bfor\\b\\|\\brof\\b\\|\\bcase\\b\\|"
+       "\\bstruct\\b\\|\\bdata\\b\\|\\bwhere\\b\\|\\bof\\b\\|"
+       "\\bif\\b\\|\\bthen\\b\\|\\belse\\b\\|\\binterface\\b\\|"
+       "\\binstance\\b\\|\\bgiven\\b\\|\\bdo\\b\\|\\bview\\b\\|"
+       "\\bwith\\b\\|\\bself\\b\\|"
+       "\\bimport\\b\\|\\bforeign\\b\\|\\bsatisfying\\b") .
            font-lock-keyword-face)
     ("--o"                               . font-lock-variable-name-face)
     ("[-.,!;$^&*:~+/=<>|?\\\\]"           . font-lock-variable-name-face)

--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1397,14 +1397,14 @@ buildTelescopeVal xsTop tyTop = fst <$> go tyTop xsTop where
       (x1, ~(xDep : rest')) <- go ty1 rest
       ty2' <- applySubst (b@>SubstVal xDep) ty2
       (x2, rest'') <- go ty2' rest'
-      let depPairTy = DepPairType b (telescopeTypeType ty2)
+      let depPairTy = DepPairType ExplicitDepPair b (telescopeTypeType ty2)
       return (PairVal x1 (DepPair xDep x2 depPairTy), rest'')
 
 telescopeTypeType :: TelescopeType (AtomNameC r) (Type r) n -> Type r n
 telescopeTypeType (ProdTelescope tys) = ProdTy tys
 telescopeTypeType (DepTelescope lhs (Abs b rhs)) = do
   let lhs' = telescopeTypeType lhs
-  let rhs' = DepPairTy (DepPairType b (telescopeTypeType rhs))
+  let rhs' = DepPairTy (DepPairType ExplicitDepPair b (telescopeTypeType rhs))
   PairTy lhs' rhs'
 
 unpackTelescope

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -386,7 +386,7 @@ liftSimpAtom ty simpAtom = case simpAtom of
       (BaseTy _  , Con (Lit v))      -> return $ Con $ Lit v
       (ProdTy tys, Con (ProdCon xs))   -> Con . ProdCon <$> zipWithM rec tys xs
       (SumTy  tys, Con (SumCon _ i x)) -> Con . SumCon tys i <$> rec (tys!!i) x
-      (DepPairTy dpt@(DepPairType (b:>t1) t2), DepPair x1 x2 _) -> do
+      (DepPairTy dpt@(DepPairType _ (b:>t1) t2), DepPair x1 x2 _) -> do
         x1' <- rec t1 x1
         t2' <- applySubst (b@>SubstVal x1') t2
         x2' <- rec t2' x2
@@ -414,7 +414,7 @@ confuseGHC = getDistinct
 -- CheapReduction and QueryType import?
 
 depPairLeftTy :: DepPairType r n -> Type r n
-depPairLeftTy (DepPairType (_:>ty) _) = ty
+depPairLeftTy (DepPairType _ (_:>ty) _) = ty
 {-# INLINE depPairLeftTy #-}
 
 unwrapNewtypeType :: EnvReader m => NewtypeTyCon n -> m n (NewtypeCon n, Type CoreIR n)
@@ -467,7 +467,7 @@ makeStructRepVal tyConName args = do
     _ -> return $ ProdVal args
 
 instantiateDepPairTy :: (IRRep r, EnvReader m) => DepPairType r n -> Atom r n -> m n (Type r n)
-instantiateDepPairTy (DepPairType b rhsTy) x = applyAbs (Abs b rhsTy) (SubstVal x)
+instantiateDepPairTy (DepPairType _ b rhsTy) x = applyAbs (Abs b rhsTy) (SubstVal x)
 {-# INLINE instantiateDepPairTy #-}
 
 projType :: (IRRep r, EnvReader m) => Int -> Type r n -> Atom r n -> m n (Type r n)

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -339,7 +339,7 @@ instance HasType CoreIR DictExpr where
   getTypeE e = dictExprType e
 
 instance IRRep r => HasType r (DepPairType r) where
-  getTypeE (DepPairType b ty) = do
+  getTypeE (DepPairType _ b ty) = do
     checkB b \_ -> ty |: TyKind
     return TyKind
 
@@ -1074,7 +1074,7 @@ checkDataLike ty = case ty of
   TabPi (TabPiType b eltTy) -> do
     renameBinders b \_ ->
       checkDataLike eltTy
-  DepPairTy (DepPairType b@(_:>l) r) -> do
+  DepPairTy (DepPairType _ b@(_:>l) r) -> do
     recur l
     renameBinders b \_ -> checkDataLike r
   NewtypeTyCon LabelType -> notData

--- a/src/lib/GenericTraversal.hs
+++ b/src/lib/GenericTraversal.hs
@@ -170,10 +170,10 @@ instance GenericallyTraversableE CoreIR TyConParams where
     TyConParams infs <$> mapM tge params
 
 instance IRRep r => GenericallyTraversableE r (DepPairType r) where
-  traverseGenericE (DepPairType (b:>lty) rty) = do
+  traverseGenericE (DepPairType expl (b:>lty) rty) = do
     lty' <- tge lty
     withFreshBinder (getNameHint b) lty' \b' -> do
-      extendRenamer (b@>binderName b') $ DepPairType b' <$> tge rty
+      extendRenamer (b@>binderName b') $ DepPairType expl b' <$> tge rty
 
 instance IRRep r => GenericallyTraversableE r (BaseMonoid r) where
   traverseGenericE (BaseMonoid x f) = BaseMonoid <$> tge x <*> tge f

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -710,7 +710,7 @@ typeToTree tyTop = return $ go REmpty tyTop
     BaseTy b -> Leaf $ LeafType (unRNest ctx) b
     TabTy b bodyTy -> go (RNest ctx (TabCtx b)) bodyTy
     RefTy _ t -> go (RNest ctx RefCtx) t
-    DepPairTy (DepPairType (b:>t1) (t2)) -> do
+    DepPairTy (DepPairType _ (b:>t1) (t2)) -> do
       let tree1 = rec t1
       let tree2 = go (RNest ctx (DepPairCtx (JustB (b:>t1)))) t2
       Branch [tree1, tree2]
@@ -746,7 +746,7 @@ valueToTree (RepVal tyTop valTop) = do
     BaseTy b -> return $ Leaf $ LeafType (unRNest ctx) b
     TabTy b bodyTy -> go (RNest ctx (TabCtx b)) bodyTy val
     RefTy _ t -> go (RNest ctx RefCtx) t val
-    DepPairTy (DepPairType (b:>t1) (t2)) -> case val of
+    DepPairTy (DepPairType _ (b:>t1) (t2)) -> case val of
       Branch [v1, v2] -> do
         case ctx of
           REmpty -> do

--- a/src/lib/Lexing.hs
+++ b/src/lib/Lexing.hs
@@ -80,7 +80,7 @@ checkNotKeyword p = try $ do
 
 data KeyWord = DefKW | ForKW | For_KW | RofKW | Rof_KW | CaseKW | OfKW
              | DataKW | StructKW | InterfaceKW
-             | InstanceKW | GivenKW | SatisfyingKW
+             | InstanceKW | GivenKW | WithKW | SatisfyingKW
              | IfKW | ThenKW | ElseKW | DoKW
              | ImportKW | ForeignKW | NamedInstanceKW
              | EffectKW | HandlerKW | JmpKW | CtlKW | ReturnKW | ResumeKW
@@ -105,6 +105,7 @@ keyWordToken = \case
   InstanceKW      -> "instance"
   NamedInstanceKW -> "named-instance"
   GivenKW         -> "given"
+  WithKW          -> "with"
   SatisfyingKW    -> "satisfying"
   DoKW            -> "do"
   ImportKW        -> "import"

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -259,7 +259,7 @@ instance Pretty (DictType n) where
 
 instance IRRep r => Pretty (DepPairType r n) where pretty = prettyFromPrettyPrec
 instance IRRep r => PrettyPrec (DepPairType r n) where
-  prettyPrec (DepPairType b rhs) =
+  prettyPrec (DepPairType _ b rhs) =
     atPrec ArgPrec $ align $ group $ parens $ p b <+> "&>" <+> p rhs
 
 instance Pretty (EffectOpType n) where
@@ -656,7 +656,8 @@ instance PrettyPrec (UTabPiExpr n) where
 
 instance Pretty (UDepPairType n) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (UDepPairType n) where
-  prettyPrec (UDepPairType pat ty) = atPrec LowestPrec $ align $
+  -- TODO: print explicitness info
+  prettyPrec (UDepPairType _ pat ty) = atPrec LowestPrec $ align $
     p pat <+> "&>" <+> pLowest ty
 
 instance Pretty (UBlock' n) where

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -755,7 +755,7 @@ rawStrType :: IRRep r => EnvReader m => m n (Type r n)
 rawStrType = liftEnvReaderM do
   withFreshBinder "n" IdxRepTy \b -> do
     tabTy <- rawFinTabType (Var $ binderName b) CharRepTy
-    return $ DepPairTy $ DepPairType b tabTy
+    return $ DepPairTy $ DepPairType ExplicitDepPair b tabTy
 
 -- `n` argument is IdxRepVal, not Nat
 rawFinTabType :: IRRep r => EnvReader m => Atom r n -> Atom r n -> m n (Type r n)

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -143,12 +143,12 @@ getRepType ty = go ty where
       RefType h a -> RefType  <$> toDataAtomIgnoreReconAssumeNoDecls h <*> go a
       TypeKind    -> error $ notDataType
       HeapType    -> return $ HeapType
-    DepPairTy (DepPairType b@(_:>l) r) -> do
+    DepPairTy (DepPairType expl b@(_:>l) r) -> do
       l' <- go l
       withFreshBinder (getNameHint b) l' \b' -> do
         x <- liftSimpAtom (sink l) (Var $ binderName b')
         r' <- go =<< applySubst (b@>SubstVal x) r
-        return $ DepPairTy $ DepPairType b' r'
+        return $ DepPairTy $ DepPairType expl b' r'
     TabPi (TabPiType (b:>ixTy) bodyTy) -> do
       ixTy' <- simplifyIxType ixTy
       withFreshBinder (getNameHint b) ixTy' \b' -> do

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -188,9 +188,9 @@ instance SourceRenamableE UExpr' where
     UTabPi (UTabPiExpr pat body) ->
       sourceRenameB pat \pat' ->
         UTabPi <$> (UTabPiExpr pat' <$> sourceRenameE body)
-    UDepPairTy (UDepPairType pat body) ->
+    UDepPairTy (UDepPairType expl pat body) ->
       sourceRenameB pat \pat' ->
-        UDepPairTy <$> (UDepPairType pat' <$> sourceRenameE body)
+        UDepPairTy <$> (UDepPairType expl pat' <$> sourceRenameE body)
     UDepPair lhs rhs ->
       UDepPair <$> sourceRenameE lhs <*> sourceRenameE rhs
     UTabApp f x -> UTabApp <$> sourceRenameE f <*> mapM sourceRenameE x

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -243,7 +243,7 @@ data CorePiType (n::S) where
   CorePiType :: AppExplicitness -> CoreBinders n l -> EffectRow CoreIR l -> Type CoreIR l -> CorePiType n
 
 data DepPairType (r::IR) (n::S) where
-  DepPairType :: Binder r n l -> Type r l -> DepPairType r n
+  DepPairType :: DepPairExplicitness -> Binder r n l -> Type r l -> DepPairType r n
 
 data Projection =
    UnwrapNewtype -- TODO: add `HasCore r` constraint
@@ -2009,10 +2009,10 @@ deriving via WrapE (PiType r) n instance IRRep r => Generic (PiType r n)
 instance IRRep r => Store (PiType r n)
 
 instance GenericE (DepPairType r) where
-  type RepE (DepPairType r) = Abs (Binder r) (Type r)
-  fromE (DepPairType b resultTy) = Abs b resultTy
+  type RepE (DepPairType r) = PairE (LiftE DepPairExplicitness) (Abs (Binder r) (Type r))
+  fromE (DepPairType expl b resultTy) = LiftE expl `PairE` Abs b resultTy
   {-# INLINE fromE #-}
-  toE   (Abs b resultTy) = DepPairType b resultTy
+  toE   (LiftE expl `PairE` Abs b resultTy) = DepPairType expl b resultTy
   {-# INLINE toE #-}
 
 instance IRRep r => SinkableE      (DepPairType r)

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -158,6 +158,7 @@ data Explicitness =
     Explicit
   | Inferred (Maybe SourceName) InferenceMechanism  deriving (Show, Eq, Ord, Generic)
 data AppExplicitness = ExplicitApp | ImplicitApp  deriving (Show, Generic, Eq)
+data DepPairExplicitness = ExplicitDepPair | ImplicitDepPair  deriving (Show, Generic, Eq)
 
 data WithExpl (b::B) (n::S) (l::S) =
   WithExpl { getExpl :: Explicitness , withoutExpl :: b n l }
@@ -312,6 +313,7 @@ instance Store ScalarBaseType
 instance Store Device
 instance Store Explicitness
 instance Store AppExplicitness
+instance Store DepPairExplicitness
 instance Store InferenceMechanism
 
 instance Store a => Store (PrimCon r a)
@@ -336,6 +338,7 @@ instance Hashable Device
 instance Hashable LetAnn
 instance Hashable Explicitness
 instance Hashable AppExplicitness
+instance Hashable DepPairExplicitness
 instance Hashable InferenceMechanism
 instance Hashable RequiredMethodAccess
 

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -64,7 +64,8 @@ pattern SIInternalName n a = SourceOrInternalName (InternalName n a)
 
 -- optional arrow, effects, result type
 type ExplicitParams = [Group]
-type GivenClause = ([Group], Maybe [Group])
+type GivenClause = ([Group], Maybe [Group])  -- implicits, classes
+type WithClause  = [Group] -- no classes because we don't want to carry class dicts at runtime
 
 type CTopDecl = WithSrc CTopDecl'
 data CTopDecl'
@@ -149,6 +150,7 @@ data Group'
   | CDo CSBlock
   | CGivens GivenClause
   | CArrow Group (Maybe CEffs) Group
+  | CWith Group WithClause
     deriving (Show, Generic)
 
 type Bin = WithSrc Bin'
@@ -291,7 +293,7 @@ data UTabPiExpr (n::S) where
   UTabPiExpr :: UOptAnnBinder n l -> UType l -> UTabPiExpr n
 
 data UDepPairType (n::S) where
-  UDepPairType :: UOptAnnBinder n l -> UType l -> UDepPairType n
+  UDepPairType :: DepPairExplicitness -> UOptAnnBinder n l -> UType l -> UDepPairType n
 
 type UConDef (n::S) (l::S) = (SourceName, Nest UReqAnnBinder n l)
 

--- a/tests/struct-tests.dx
+++ b/tests/struct-tests.dx
@@ -20,7 +20,7 @@ my_struct = MyStruct 1 2 "abc"
 > 12 | :p my_struct.(1 + 1)
 >    |             ^^
 > unexpected ".("
-> expecting "->", "..", "<..", backquoted name, end of input, end of line, infix operator, name, or symbol name
+> expecting "->", "..", "<..", "with", backquoted name, end of input, end of line, infix operator, name, or symbol name
 :p my_struct
 > MyStruct(1, 2., "abc")
 

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -692,3 +692,11 @@ def my_id2(x:a) -> a given (a, b:Type) = x
 >
 > :p my_id2 1.0
 >    ^^^^^^^^^^
+
+def returns_dep_pair(n:Nat) -> (Fin new => Nat with (new:Nat)) =
+  n2 = n + n
+  for i:(Fin n2). ordinal i
+
+xs = returns_dep_pair 4
+:p sum xs
+> 28


### PR DESCRIPTION
Still to do:
  - [ ] Make sure unpacking happens after function application. It currently happens inside `instantiateSigma` which should be called after function application but currently isn't. Possibly a recent regression with the n-ary functions patch.
  - [ ] Allow more than one implicit argument to dependent pairs, distinguished by name.
  - [ ] Allow explicit packing and unpacking via named components.
  - [x] Fix the hack where we special-case `UDecl` in `checkSigma`.
  - [ ] Deprecate the old explicit dependent pair, and perhaps even rule out dependency in data constructors.
  - [ ] Possibly replace some uses of `List` in the standard library with implicit dependent pairs.
