### PR TITLE
Add blocks to UExpr IR

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -466,8 +466,8 @@ instance VSpace(n=>a) given (a|VSpace, n|Ix)
 
 instance VSpace((a, b)) given (a|VSpace, b|VSpace)
   def (.*)(s, pair) =
-    (a, b) = pair
-    (s .* a, s .* b)
+    (x, y) = pair
+    (s .* x, s .* y)
 
 instance VSpace((i:n) => (..i) => a) given (n|Ix, a|VSpace)
   def (.*)(s, xs) = for i. s .* xs[i]
@@ -1552,19 +1552,19 @@ instance Show(())
   def show(_) = "()"
 
 instance Show((a, b)) given (a|Show, b|Show)
-  def show(x) =
-    (a, b) = x
-    "(" <> show a <> ", " <> show b <> ")"
+  def show(tup) =
+    (x, y) = tup
+    "(" <> show x <> ", " <> show y <> ")"
 
 instance Show((a, b, c)) given (a|Show, b|Show, c|Show)
-  def show(x) =
-    (a, b, c) = x
-    "(" <> show a <> ", " <> show b <> ", " <> show c <> ")"
+  def show(tup) =
+    (x, y, z) = tup
+    "(" <> show x <> ", " <> show y <> ", " <> show z <> ")"
 
 instance Show((a, b, c, d)) given (a|Show, b|Show, c|Show, d|Show)
-  def show(x) =
-    (a, b, c, d) = x
-    "(" <> show a <> ", " <> show b <> ", " <> show c <> ", " <> show d <> ")"
+  def show(tup) =
+    (x, y, z, w) = tup
+    "(" <> show x <> ", " <> show y <> ", " <> show z <> ", " <> show w <> ")"
 
 '### Parse interface
 For types that can be parsed from a `String`.

--- a/src/lib/Lexing.hs
+++ b/src/lib/Lexing.hs
@@ -294,7 +294,7 @@ withIndent p = do
   nextLine
   indent <- T.length <$> takeWhileP (Just "space") (==' ')
   when (indent <= 0) empty
-  pLocal (\ctx -> ctx { curIndent = curIndent ctx + indent }) $ p
+  pLocal (\ctx -> ctx { curIndent = curIndent ctx + indent }) $ mayNotBreak p
 {-# INLINE withIndent #-}
 
 pLocal :: (ParseCtx -> ParseCtx) -> Parser a -> Parser a

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -247,7 +247,7 @@ evalSourceBlock'
 evalSourceBlock' mname block = case sbContents block of
   TopDecl decl -> parseDecl decl >>= execUDecl mname
   Command cmd expr' -> do
-   expr <- parseBlock expr'
+   expr <- parseExpr expr'
    case cmd of
     -- TODO: we should filter the top-level emissions we produce in this path
     -- we want cache entries but we don't want dead names.
@@ -597,7 +597,7 @@ evalSpecializations fs = do
     updateTopEnv $ UpdateTopFunEvalStatus f (Finished $ TopFunLowerings objName)
 
 execUDecl
-  :: (Topper m, Mut n) => ModuleSourceName -> UDecl VoidS VoidS -> m n ()
+  :: (Topper m, Mut n) => ModuleSourceName -> UTopDecl VoidS VoidS -> m n ()
 execUDecl mname decl = do
   logTop $ PassInfo Parse $ pprint decl
   Abs renamedDecl sourceMap <-

--- a/tests/instance-interface-syntax-tests.dx
+++ b/tests/instance-interface-syntax-tests.dx
@@ -31,7 +31,3 @@ instance Inhabited(Word32)
   witness = 0
    pass
 -- CHECK: Parse error
--- CHECK: unexpected
--- CHECK: pass
--- CHECK: expecting
--- CHECK: name, or symbol name

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -12,7 +12,7 @@ import Data.Text
 import Test.Hspec
 
 import ConcreteSyntax (parseUModule)
-import AbstractSyntax (parseBlock)
+import AbstractSyntax (parseExpr)
 import Err
 import Inference (inferTopUExpr, synthTopE)
 import Name
@@ -35,7 +35,7 @@ sourceTextToBlocks source = do
 sourceBlockToBlock :: (Topper m, Mut n) => SourceBlock -> m n (Maybe (SBlock n))
 sourceBlockToBlock block = case sbContents block of
   Misc (ImportModule moduleName)  -> importModule moduleName >> return Nothing
-  Command (EvalExpr (Printed _)) expr -> Just <$> (parseBlock expr >>= uExprToBlock)
+  Command (EvalExpr (Printed _)) expr -> Just <$> (parseExpr expr >>= uExprToBlock)
   UnParseable _ s -> throw ParseErr s
   _ -> error $ "Unexpected SourceBlock " ++ pprint block ++ " in unit tests"
 


### PR DESCRIPTION
Previously we had blocks in the concrete syntax and in Core but we turned them into nested let expressions during abstract syntax parsing and back again during inference. It wasn't a major problem but it led to some unexpected errors to do with escaping type variables when we tried to implement automatic dependent pair unpacking.

This change might also improve the quality of source location information since it makes UExpr closer to the actual source text.