### PR TITLE
Revert tiled matmul implementation because it triggers a segfault when running benchmarks.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2570,8 +2570,7 @@ def tile(
     body (FullTileIx(n, tile_size, tile_ix'))
   body (CodaIx(n, coda_offset, coda_size))
 
--- matmul. Better symbol to use? `@`?
-def (**)(
+def tiled_matmul(
     x: l=>m=>Float,
     y: m=>n=>Float
     ) -> l=>n=>Float  given (l|Ix, m|Ix, n|Ix) =
@@ -2590,6 +2589,14 @@ def (**)(
               for_ m_offset:m_set.
                 m_ix = inject m_offset
                 result!l_ix!n_ix += x[l_ix,m_ix] * y[m_ix,n_ix]
+
+-- matmul. Better symbol to use? `@`?
+def (**)(
+    x: l=>m=>Float,
+    y: m=>n=>Float
+    ) -> l=>n=>Float  given (l|Ix, m|Ix, n|Ix) =
+  -- TODO(https://github.com/google-research/dex-lang/issues/1212) Replace with tiled_matmul.
+  naive_matmul(x, y)
 
 def (**.)(mat: n=>m=>Float, v: m=>Float) -> (n=>Float) given (n|Ix, m|Ix) =
   for i. vdot(mat[i], v)

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -3,7 +3,7 @@ import linalg
 -- Check that the optimized matmul gives the same answers as the naive one
 amat = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
 
-:p amat ** amat ~~ naive_matmul amat amat
+:p tiled_matmul(amat, amat) ~~ naive_matmul amat amat
 > True
 
 -- Check that the inverse of the inverse is identity.


### PR DESCRIPTION
We suspect #1212 as the cause.