### PR TITLE
Coalesce dependent pair contexts in Imp representation.

### DIFF
--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2605,7 +2605,7 @@ def (**)(
     y: m=>n=>Float
     ) -> l=>n=>Float  given (l|Ix, m|Ix, n|Ix) =
   -- TODO(https://github.com/google-research/dex-lang/issues/1212) Replace with tiled_matmul.
-  naive_matmul(x, y)
+  tiled_matmul(x, y)
 
 def (**.)(mat: n=>m=>Float, v: m=>Float) -> (n=>Float) given (n|Ix, m|Ix) =
   for i. vdot(mat[i], v)

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -1118,6 +1118,20 @@ case frob of
 > 4.
 
 
+-- regression tests for #1212
+data Rectangle(a) = AsRectangle(n:Nat, m:Nat, elts:(Fin n => Fin m => a))
+data Brick(a) = AsBrick(n:Nat, m:Nat, l:Nat, elts:(Fin n => Fin m => Fin l => a))
 
+def mk_rect(n:Nat) -> Rectangle Nat =
+  AsRectangle _ _ $ for i:(Fin n) j:(Fin n). ordinal i
 
+def mk_brick(n:Nat) -> Brick Nat =
+  AsBrick _ _ _ $ for i:(Fin n) j:(Fin n) k:(Fin n). ordinal i
 
+rect = mk_rect(3)
+rect
+> (AsRectangle 3 3 [[0, 0, 0], [1, 1, 1], [2, 2, 2]])
+
+brick = mk_brick(3)
+brick
+> (AsBrick 3 3 3 [[[0, 0, 0], [0, 0, 0], [0, 0, 0]], [[1, 1, 1], [1, 1, 1], [1, 1, 1]], [[2, 2, 2], [2, 2, 2], [2, 2, 2]]])


### PR DESCRIPTION
Fixes #1212.