### PR TITLE
Actually lower all `for` loops to `seq` loops before the Imp pass

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -1149,13 +1149,13 @@ unsafePtrLoad x = do
 
 applyIxMethod :: (SBuilder m, Emits n) => IxDict SimpIR n -> IxMethod -> [SAtom n] -> m n (SAtom n)
 applyIxMethod dict method args = case dict of
-  -- These cases are use in SimpIR and they work with IdxRepVal
+  -- These cases are used in SimpIR and they work with IdxRepVal
   IxDictRawFin n -> case method of
     Size              -> do []  <- return args; return n
     Ordinal           -> do [i] <- return args; return i
     UnsafeFromOrdinal -> do [i] <- return args; return i
   IxDictSpecialized _ d params -> do
-    SpecializedDictBinding (SpecializedDict _ maybeFs) <- lookupEnv d
+    SpecializedDict _ maybeFs <- lookupSpecDict d
     Just fs <- return maybeFs
     LamExpr bs body <- return $ fs !! fromEnum method
     emitBlock =<< applySubst (bs @@> fmap SubstVal (params ++ args)) body

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -317,6 +317,11 @@ lookupModule :: EnvReader m => ModuleName n -> m n (Module n)
 lookupModule name = lookupEnv name >>= \case ModuleBinding m -> return m
 {-# INLINE lookupModule #-}
 
+lookupSpecDict :: EnvReader m => SpecDictName n -> m n (SpecializedDictDef n)
+lookupSpecDict name = lookupEnv name >>=
+  \case SpecializedDictBinding m -> return m
+{-# INLINE lookupSpecDict #-}
+
 lookupFunObjCode :: EnvReader m => FunObjCodeName n -> m n (CFunction n)
 lookupFunObjCode name = lookupEnv name >>= \case FunObjCodeBinding cFun -> return cFun
 {-# INLINE lookupFunObjCode #-}

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1394,7 +1394,7 @@ ordinalImp :: Emits n => IxType SimpIR n -> SAtom n -> SubstImpM i n (IExpr n)
 ordinalImp (IxType _ dict) i = fromScalarAtom =<< case dict of
   IxDictRawFin _ -> return i
   IxDictSpecialized _ d params -> do
-    SpecializedDictBinding (SpecializedDict _ (Just fs)) <- lookupEnv d
+    SpecializedDict _ (Just fs) <- lookupSpecDict d
     appSpecializedIxMethod (fs !! fromEnum Ordinal) (params ++ [i])
 
 unsafeFromOrdinalImp :: Emits n => IxType SimpIR n -> IExpr n -> SubstImpM i n (SAtom n)
@@ -1403,7 +1403,7 @@ unsafeFromOrdinalImp (IxType _ dict) i = do
   case dict of
     IxDictRawFin _ -> return i'
     IxDictSpecialized _ d params -> do
-      SpecializedDictBinding (SpecializedDict _ (Just fs)) <- lookupEnv d
+      SpecializedDict _ (Just fs) <- lookupSpecDict d
       appSpecializedIxMethod (fs !! fromEnum UnsafeFromOrdinal) (params ++ [i'])
 
 indexSetSizeImp :: Emits n => IxType SimpIR n -> SubstImpM i n (IExpr n)
@@ -1411,7 +1411,7 @@ indexSetSizeImp (IxType _ dict) = do
   ans <- case dict of
     IxDictRawFin n -> return n
     IxDictSpecialized _ d params -> do
-      SpecializedDictBinding (SpecializedDict _ (Just fs)) <- lookupEnv d
+      SpecializedDict _ (Just fs) <- lookupSpecDict d
       appSpecializedIxMethod (fs !! fromEnum Size) (params ++ [])
   fromScalarAtom ans
 

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -18,6 +18,7 @@ import GHC.Stack
 import Builder
 import Core
 import CheapReduction
+import Imp
 import IRVariants
 import MTL1
 import Name

--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -25,6 +25,7 @@ import GHC.Exts (inline)
 import Builder
 import Core
 import Err
+import Imp
 import GenericTraversal
 import CheapReduction
 import IRVariants

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -17,6 +17,7 @@ import Builder
 import Core
 import CheapReduction
 import Err
+import Imp
 import IRVariants
 import MTL1
 import Name

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -503,6 +503,7 @@ data TopEnvUpdate n =
  | UpdateLoadedModules      ModuleSourceName (ModuleName n)
  | UpdateLoadedObjects      (FunObjCodeName n) NativeFunction
  | FinishDictSpecialization (SpecDictName n) [LamExpr SimpIR n]
+ | LowerDictSpecialization  (SpecDictName n) [LamExpr SimpIR n]
  | UpdateTopFunEvalStatus   (TopFunName n) (TopFunEvalStatus n)
  | UpdateInstanceDef        (InstanceName n) (InstanceDef n)
  | UpdateTyConDef           (TyConName n) (TyConDef n)
@@ -2370,8 +2371,9 @@ instance GenericE TopEnvUpdate where
     {- AddCustomRule -}            (CAtomName `PairE` AtomRules)
     {- UpdateLoadedModules -}      (LiftE ModuleSourceName `PairE` ModuleName)
     {- UpdateLoadedObjects -}      (FunObjCodeName `PairE` LiftE NativeFunction)
-      ) ( EitherE5
+      ) ( EitherE6
     {- FinishDictSpecialization -} (SpecDictName `PairE` ListE (LamExpr SimpIR))
+    {- LowerDictSpecialization -}  (SpecDictName `PairE` ListE (LamExpr SimpIR))
     {- UpdateTopFunEvalStatus -}   (TopFunName `PairE` ComposeE EvalStatus TopFunLowerings)
     {- UpdateInstanceDef -}        (InstanceName `PairE` InstanceDef)
     {- UpdateTyConDef -}           (TyConName `PairE` TyConDef)
@@ -2383,10 +2385,11 @@ instance GenericE TopEnvUpdate where
     UpdateLoadedModules x y      -> Case0 $ Case2 (LiftE x `PairE` y)
     UpdateLoadedObjects x y      -> Case0 $ Case3 (x `PairE` LiftE y)
     FinishDictSpecialization x y -> Case1 $ Case0 (x `PairE` ListE y)
-    UpdateTopFunEvalStatus x y   -> Case1 $ Case1 (x `PairE` ComposeE y)
-    UpdateInstanceDef x y        -> Case1 $ Case2 (x `PairE` y)
-    UpdateTyConDef x y           -> Case1 $ Case3 (x `PairE` y)
-    UpdateFieldDef x y z         -> Case1 $ Case4 (x `PairE` LiftE y `PairE` z)
+    LowerDictSpecialization x y  -> Case1 $ Case1 (x `PairE` ListE y)
+    UpdateTopFunEvalStatus x y   -> Case1 $ Case2 (x `PairE` ComposeE y)
+    UpdateInstanceDef x y        -> Case1 $ Case3 (x `PairE` y)
+    UpdateTyConDef x y           -> Case1 $ Case4 (x `PairE` y)
+    UpdateFieldDef x y z         -> Case1 $ Case5 (x `PairE` LiftE y `PairE` z)
 
   toE = \case
     Case0 e -> case e of
@@ -2397,10 +2400,11 @@ instance GenericE TopEnvUpdate where
       _ -> error "impossible"
     Case1 e -> case e of
       Case0 (x `PairE` ListE y)           -> FinishDictSpecialization x y
-      Case1 (x `PairE` ComposeE y)        -> UpdateTopFunEvalStatus x y
-      Case2 (x `PairE` y)                 -> UpdateInstanceDef x y
-      Case3 (x `PairE` y)                 -> UpdateTyConDef x y
-      Case4 (x `PairE` LiftE y `PairE` z) -> UpdateFieldDef x y z
+      Case1 (x `PairE` ListE y)           -> LowerDictSpecialization x y
+      Case2 (x `PairE` ComposeE y)        -> UpdateTopFunEvalStatus x y
+      Case3 (x `PairE` y)                 -> UpdateInstanceDef x y
+      Case4 (x `PairE` y)                 -> UpdateTyConDef x y
+      Case5 (x `PairE` LiftE y `PairE` z) -> UpdateFieldDef x y z
       _ -> error "impossible"
     _ -> error "impossible"
 
@@ -2473,6 +2477,10 @@ applyUpdate e = \case
         let newBinding = SpecializedDictBinding $ SpecializedDict dAbs (Just methods)
         updateEnv dName newBinding e
       Just _ -> error "shouldn't be adding methods if we already have them"
+  LowerDictSpecialization dName methods -> do
+    let SpecializedDictBinding (SpecializedDict dAbs _) = lookupEnvPure e dName
+    let newBinding = SpecializedDictBinding $ SpecializedDict dAbs (Just methods)
+    updateEnv dName newBinding e
   UpdateTopFunEvalStatus f s -> do
     case lookupEnvPure e f of
       TopFunBinding (DexTopFun def ty simp _) ->


### PR DESCRIPTION
Turns out there were a few sneaky hidden ones:
- Constructing a value of a singleton array type used to produce a `for` loop, but now just constructs the contentless `RepVal` instead;
- Ix methods used to be able to sneak `for` loops past `lowerFullySequential`, but now they are lowered (and also optimized) like all other user code; and
- The Imp pass used to construct `for` loops itself (and recursively lower them) when implementing a writer effect with an array-typed accumulator, but now directly emits Imp loops instead.