### PR TITLE
Tweak the error message to say "positional arguments"

### DIFF
--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -1379,7 +1379,7 @@ checkArity bs args = do
   let arity = length [() | Explicit <- nestToList (\(WithExpl expl _) -> expl) bs]
   let numArgs = length args
   when (numArgs /= arity) do
-    throw TypeErr $ "Wrong number of arugments provided. Expected " ++
+    throw TypeErr $ "Wrong number of positional arguments provided. Expected " ++
       pprint arity ++ " but got " ++ pprint numArgs
 
 -- TODO: check that there are no extra named args provided

--- a/tests/instance-methods-tests.dx
+++ b/tests/instance-methods-tests.dx
@@ -28,7 +28,7 @@ instance FooBar1(Int)
   -- but the instance `FooBar1 Int` is currently still being defined and, at
   -- this point, can only grant access to method `foo1` (with index 0).
   bar1 = \x. bar1 x + 1
-> Type error:Wrong number of arugments provided. Expected 1 but got 0
+> Type error:Wrong number of positional arguments provided. Expected 1 but got 0
 >
 >   foo1 = \x. x + 1
 >   ^^^^^^^^^^^^^^^^

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -614,11 +614,11 @@ interface I(param:Type)
 
 instance I(A, extraneous) given (extraneous)
   m = todo
-> Type error:Wrong number of arugments provided. Expected 1 but got 2
+> Type error:Wrong number of positional arguments provided. Expected 1 but got 2
 
 instance I()
   m = todo
-> Type error:Wrong number of arugments provided. Expected 1 but got 0
+> Type error:Wrong number of positional arguments provided. Expected 1 but got 0
 
 -- This example shows that constraints that we learn from the body of a function
 -- can be used outside the function.


### PR DESCRIPTION
since that's what it's counting.

Fixes #1265.