### PR TITLE
Teach CheckType to check that `Dest`s are actually used linearly

### DIFF
--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -1504,7 +1504,7 @@ impInstrTypes instr = case instr of
   IShowScalar _ _  -> return [Scalar Word32Type]
   where hostPtrTy ty = PtrType (CPU, ty)
 
-instance CheckableE ImpFunction where
+instance CheckableE SimpIR ImpFunction where
   checkE _ = return () -- TODO
 
 -- TODO: Don't use Core Envs for Imp!

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -1942,7 +1942,6 @@ checkUEff eff = case eff of
   UExceptionEffect -> return ExceptionEffect
   UIOEffect        -> return IOEffect
   UUserEffect ~(SIInternalName _ name) -> UserEffect <$> renameM name
-  UInitEffect -> return InitEffect
 
 constrainVarTy :: EmitsInf o => CAtomName o -> CType o -> InfererM i o ()
 constrainVarTy v tyReq = do

--- a/src/lib/Inference.hs
+++ b/src/lib/Inference.hs
@@ -3077,7 +3077,7 @@ instance PrettyE e => Pretty (UDeclInferenceResult e l) where
 instance SinkableE e => SinkableE (UDeclInferenceResult e) where
   sinkingProofE = todoSinkableProof
 
-instance (RenameE e, CheckableE e) => CheckableE (UDeclInferenceResult e) where
+instance (RenameE e, CheckableE CoreIR e) => CheckableE CoreIR (UDeclInferenceResult e) where
   checkE = \case
     UDeclResultDone _ -> return ()
     UDeclResultBindName _ block _ -> checkE block

--- a/src/lib/MTL1.hs
+++ b/src/lib/MTL1.hs
@@ -221,6 +221,10 @@ instance HoistableState UnitE where
   hoistState _ _ UnitE = UnitE
   {-# INLINE hoistState #-}
 
+instance HoistableState (NameMap c a) where
+  hoistState _ b m = hoistFilterNameMap b m
+  {-# INLINE hoistState #-}
+
 -------------------- ScopedT1 --------------------
 
 newtype ScopedT1 (s :: E) (m :: MonadKind1) (n :: S) (a :: *) =

--- a/src/lib/Name.hs
+++ b/src/lib/Name.hs
@@ -3179,6 +3179,12 @@ instance Monad HoistExcept where
 
 -- === extra data structures ===
 
+-- A map from names in some scope to values that do not contain names.  This is
+-- not trying to enforce completeness -- a name in the scope can fail to be in
+-- the map.
+
+-- Hoisting the map removes entries that are no longer in scope.
+
 newtype NameMap (c::C) (a:: *) (n::S) = UnsafeNameMap (RawNameMap a)
                                  deriving (Eq, Semigroup, Monoid, Store)
 
@@ -3217,6 +3223,9 @@ traverseNameMap f (UnsafeNameMap raw) = UnsafeNameMap <$> traverse f raw
 mapNameMap :: (a -> b) -> NameMap c a n -> (NameMap c b n)
 mapNameMap f (UnsafeNameMap raw) = UnsafeNameMap $ fmap f raw
 {-# INLINE mapNameMap #-}
+
+instance SinkableE (NameMap c a) where
+  sinkingProofE = undefined
 
 newtype NameMapE (c::C) (e:: E) (n::S) = NameMapE (NameMap c (e n) n)
   deriving (Eq, Semigroup, Monoid, Store)

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -401,7 +401,6 @@ instance Pretty (UEffect n) where
     UExceptionEffect -> "Except"
     UIOEffect        -> "IO"
     UUserEffect name -> p name
-    UInitEffect      -> "Init"
 
 instance PrettyPrec (Name s n) where prettyPrec = atPrec ArgPrec . pretty
 

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -275,7 +275,7 @@ instance GenericE SimplifiedBlock where
 instance SinkableE SimplifiedBlock
 instance RenameE SimplifiedBlock
 instance HoistableE SimplifiedBlock
-instance CheckableE SimplifiedBlock where
+instance CheckableE SimpIR SimplifiedBlock where
   checkE (SimplifiedBlock block _) =
     -- TODO: CheckableE instance for the recon too
     checkE block

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -224,7 +224,6 @@ instance SourceRenamableE UEffect where
   sourceRenameE UExceptionEffect = return UExceptionEffect
   sourceRenameE UIOEffect = return UIOEffect
   sourceRenameE (UUserEffect name) = UUserEffect <$> sourceRenameE name
-  sourceRenameE UInitEffect = return UInitEffect
 
 instance SourceRenamableE a => SourceRenamableE (WithSrcE a) where
   sourceRenameE (WithSrcE pos e) = addSrcContext pos $

--- a/src/lib/TopLevel.hs
+++ b/src/lib/TopLevel.hs
@@ -738,7 +738,7 @@ withCompileTime m = do
   (Result outs err, t) <- measureSeconds m
   return $ Result (outs ++ [TotalTime t]) err
 
-checkPass :: (Topper m, Pretty (e n), CheckableE e)
+checkPass :: (Topper m, Pretty (e n), CheckableE r e)
           => PassName -> m n (e n) -> m n (e n)
 checkPass name cont = do
   result <- logPass name do

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -761,7 +761,7 @@ data Effect (r::IR) (n::S) =
  | ExceptionEffect
  | IOEffect
  | UserEffect (Name EffectNameC n)
- | InitEffect
+ | InitEffect  -- Internal effect modeling writing to a destination.
  deriving (Generic, Show)
 
 data EffectRow (r::IR) (n::S) =

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -191,7 +191,6 @@ data UEffect (n::S) =
  | UExceptionEffect
  | UIOEffect
  | UUserEffect (SourceOrInternalName EffectNameC n)
- | UInitEffect
 
 data UEffectRow (n::S) =
   UEffectRow (S.Set (UEffect n)) (Maybe (SourceOrInternalName (AtomNameC CoreIR) n))


### PR DESCRIPTION
This is self-check in the compiler, confirming that destination-passing isn't generating code that violates its intended invariants.

As written, there are two problems:
    
- I don't know what the rules should be for destinations appearing inside loop bodies.  Current tweak permits a loop to just close over a destination and use it (once).
    
- Each arm of a `case` should be able to use a destination independently, but the current draft gets this wrong.  However, it seems that we don't destination-pass through `case` anyway, so the test suite still passes.