### PR TITLE
Reorganize primitive ops

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -92,6 +92,7 @@ library
                      , Types.Imp
                      , Types.Misc
                      , Types.Primitives
+                     , Types.OpNames
                      , Types.Source
                      , QueryType
                      , Util

--- a/src/lib/AbstractSyntax.hs
+++ b/src/lib/AbstractSyntax.hs
@@ -62,6 +62,7 @@ import Name
 import PPrint ()
 import Types.Primitives
 import Types.Source
+import qualified Types.OpNames as P
 import Util
 
 -- === Converting concrete syntax to abstract syntax ===
@@ -515,10 +516,10 @@ expr = propagateSrcE expr' where
       _ -> error "n-ary dependent pairs not implemented"
 
 charExpr :: Char -> (UExpr' VoidS)
-charExpr c = UPrim (UPrimCon $ Lit $ Word8Lit $ fromIntegral $ fromEnum c) []
+charExpr c = ULit $ Word8Lit $ fromIntegral $ fromEnum c
 
 unitExpr :: UExpr' VoidS
-unitExpr = UPrim (UPrimCon $ ProdCon []) []
+unitExpr = UPrim (UCon $ P.ProdCon) []
 
 -- === Builders ===
 

--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -25,7 +25,6 @@ import Data.Functor.Identity
 import Data.Functor ((<&>))
 import qualified Data.List.NonEmpty    as NE
 import qualified Data.Map.Strict as M
-import GHC.Exts (inline)
 
 import Subst
 import Core
@@ -193,7 +192,7 @@ instance IRRep r => CheaplyReducibleE r (Atom r) (Atom r) where
         return $ TabPi $ TabPiType b' resultTy'
     -- We traverse the Atom constructors that might contain lambda expressions
     -- explicitly, to make sure that we can skip normalizing free vars inside those.
-    Con con -> Con <$> (inline traversePrimCon) cheapReduceE con
+    Con con -> Con <$> traverseOp con cheapReduceE (error "unexpected lambda")
     DictCon d -> cheapReduceE d
     SimpInCore (LiftSimp t x) -> do
       t' <- cheapReduceE t
@@ -524,9 +523,16 @@ instance IRRep r => SubstE AtomSubstVal (BaseMonoid r)
 instance SubstE AtomSubstVal UserEffectOp
 instance IRRep r => SubstE AtomSubstVal (DAMOp r)
 instance IRRep r => SubstE AtomSubstVal (Hof r)
+instance IRRep r => SubstE AtomSubstVal (TC r)
+instance IRRep r => SubstE AtomSubstVal (Con r)
+instance IRRep r => SubstE AtomSubstVal (MiscOp r)
+instance IRRep r => SubstE AtomSubstVal (VectorOp r)
+instance IRRep r => SubstE AtomSubstVal (MemOp r)
+instance IRRep r => SubstE AtomSubstVal (PrimOp r)
 instance IRRep r => SubstE AtomSubstVal (RefOp r)
 instance IRRep r => SubstE AtomSubstVal (Expr r)
 instance IRRep r => SubstE AtomSubstVal (Block r)
+instance IRRep r => SubstE AtomSubstVal (GenericOpRep const r)
 instance SubstE AtomSubstVal InstanceBody
 instance SubstE AtomSubstVal DictType
 instance SubstE AtomSubstVal DictExpr

--- a/src/lib/ConcreteSyntax.hs
+++ b/src/lib/ConcreteSyntax.hs
@@ -33,6 +33,7 @@ import Name
 import Types.Core
 import Types.Source
 import Types.Primitives
+import qualified Types.OpNames as P
 import Util
 
 -- TODO: implement this more efficiently rather than just parsing the whole
@@ -826,7 +827,7 @@ primNames = M.fromList
   , ("floor", unary  Floor), ("ceil"  , unary Ceil), ("round", unary Round)
   , ("log1p", unary  Log1p), ("lgamma", unary LGamma)
   , ("erf"  , unary Erf),    ("erfc"  , unary Erfc)
-  , ("TyKind"    , UPrimTC $ TypeKind)
+  , ("TyKind"    , UPrimTC $ P.TypeKind)
   , ("Float64"   , baseTy $ Scalar Float64Type)
   , ("Float32"   , baseTy $ Scalar Float32Type)
   , ("Int64"     , baseTy $ Scalar Int64Type)
@@ -844,38 +845,37 @@ primNames = M.fromList
   , ("Fin"           , UFin)
   , ("EffKind"       , UEffectRowKind)
   , ("NatCon"        , UNatCon)
-  , ("Ref"       , UPrimTC $ RefType () ())
-  , ("HeapType"  , UPrimTC $ HeapType)
+  , ("Ref"       , UPrimTC $ P.RefType)
+  , ("HeapType"  , UPrimTC $ P.HeapType)
   , ("indexRef"   , UIndexRef)
-  , ("alloc"    , memOp $ IOAlloc (Scalar Word8Type) ())
-  , ("free"     , memOp $ IOFree ())
-  , ("ptrOffset", memOp $ PtrOffset () ())
-  , ("ptrLoad"  , memOp $ PtrLoad ())
-  , ("ptrStore" , memOp $ PtrStore () ())
-  , ("throwError"    , miscOp $ ThrowError ())
-  , ("throwException", miscOp $ ThrowException ())
-  , ("dataConTag"    , miscOp $ SumTag ())
-  , ("toEnum"        , miscOp $ ToEnum () ())
-  , ("outputStream"  , miscOp $ OutputStream)
-  , ("cast"          , miscOp $ CastOp () ())
-  , ("bitcast"       , miscOp $ BitcastOp () ())
-  , ("unsafeCoerce"  , miscOp $ UnsafeCoerce () ())
-  , ("garbageVal"    , miscOp $ GarbageVal ())
-  , ("select"        , miscOp $ Select () () ())
-  , ("showAny"       , miscOp $ ShowAny ())
-  , ("showScalar"    , miscOp $ ShowScalar ())
+  , ("alloc"    , memOp $ P.IOAlloc)
+  , ("free"     , memOp $ P.IOFree)
+  , ("ptrOffset", memOp $ P.PtrOffset)
+  , ("ptrLoad"  , memOp $ P.PtrLoad)
+  , ("ptrStore" , memOp $ P.PtrStore)
+  , ("throwError"    , miscOp $ P.ThrowError)
+  , ("throwException", miscOp $ P.ThrowException)
+  , ("dataConTag"    , miscOp $ P.SumTag)
+  , ("toEnum"        , miscOp $ P.ToEnum)
+  , ("outputStream"  , miscOp $ P.OutputStream)
+  , ("cast"          , miscOp $ P.CastOp)
+  , ("bitcast"       , miscOp $ P.BitcastOp)
+  , ("unsafeCoerce"  , miscOp $ P.UnsafeCoerce)
+  , ("garbageVal"    , miscOp $ P.GarbageVal)
+  , ("select"        , miscOp $ P.Select)
+  , ("showAny"       , miscOp $ P.ShowAny)
+  , ("showScalar"    , miscOp $ P.ShowScalar)
   , ("projNewtype" , UProjNewtype)
   , ("applyMethod0" , UApplyMethod 0)
   , ("applyMethod1" , UApplyMethod 1)
   , ("applyMethod2" , UApplyMethod 2)
-  , ("pair"         , UPrimCon $ ProdCon [(), ()])
   , ("explicitApply", UExplicitApply)
   , ("monoLit", UMonoLiteral)
   ]
   where
-    binary op = UPrimOp $ BinOp op () ()
-    baseTy b = UPrimTC $ BaseType b
-    memOp op = UPrimOp $ MemOp op
-    unary  op = UPrimOp $ UnOp  op ()
+    binary op = UBinOp op
+    baseTy b  = UBaseType b
+    memOp op  = UMemOp op
+    unary  op = UUnOp  op
     ptrTy  ty = PtrType (CPU, ty)
-    miscOp op = UPrimOp $ MiscOp op
+    miscOp op = UMiscOp op

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -504,7 +504,7 @@ fromNaryTabLamExact exactDepth lam = do
 fromNaryForExpr :: IRRep r => Int -> Expr r n -> Maybe (Int, LamExpr r n)
 fromNaryForExpr maxDepth | maxDepth <= 0 = error "expected non-negative number of args"
 fromNaryForExpr maxDepth = \case
-  Hof (For _ _ (UnaryLamExpr b body)) ->
+  PrimOp (Hof (For _ _ (UnaryLamExpr b body))) ->
     extend <|> (Just $ (1, LamExpr (Nest b Empty) body))
     where
       extend = do

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -216,7 +216,7 @@ inlineDeclsSubst = \case
     -- since their main purpose is to force inlining in the simplifier, and if
     -- one just stuck like this it has become equivalent to a `for` anyway.
     ixDepthExpr :: Expr SimpIR n -> Int
-    ixDepthExpr (Hof (For _ _ (UnaryLamExpr _ body))) = 1 + ixDepthBlock body
+    ixDepthExpr (PrimOp (Hof (For _ _ (UnaryLamExpr _ body)))) = 1 + ixDepthBlock body
     ixDepthExpr _ = 0
     ixDepthBlock :: Block SimpIR n -> Int
     ixDepthBlock (exprBlock -> (Just expr)) = ixDepthExpr expr
@@ -398,20 +398,13 @@ instance Inlinable (Name SpecializedDictNameC) where
   inline ctx n = substM n >>= reconstruct ctx
 instance Inlinable (Name TopFunNameC) where
   inline ctx n = substM n >>= reconstruct ctx
-
-instance Inlinable e => Inlinable (ComposeE PrimOp e) where
-  inline ctx (ComposeE op) =
-    (ComposeE <$> traverse (inline Stop) op) >>= reconstruct ctx
-  {-# INLINE inline #-}
-instance Inlinable e => Inlinable (ComposeE (PrimCon SimpIR) e) where
-  inline ctx (ComposeE con) =
-    (ComposeE <$> traverse (inline Stop) con) >>= reconstruct ctx
-  {-# INLINE inline #-}
-instance Inlinable e => Inlinable (ComposeE (PrimTC SimpIR) e) where
-  inline ctx (ComposeE tc) =
-    (ComposeE <$> traverse (inline Stop) tc) >>= reconstruct ctx
-  {-# INLINE inline #-}
-
+instance Inlinable (GenericOpRep const SimpIR)
+instance Inlinable (PrimOp SimpIR)
+instance Inlinable (MemOp SimpIR)
+instance Inlinable (VectorOp SimpIR)
+instance Inlinable (MiscOp SimpIR)
+instance Inlinable (Con SimpIR)
+instance Inlinable (TC SimpIR)
 instance Inlinable (LamExpr SimpIR)
 instance Inlinable (TabPiType SimpIR)
 instance Inlinable (DepPairType SimpIR)

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -40,7 +40,7 @@ simplifyJaxpr (Jaxpr invars constvars eqns outvars) = do
       body <- buildBlock do
         simplifyEqns eqns do
           outs <- (map fst) <$> mapM simplifyAtom outvars
-          return $ Con $ P.ProdCon $ outs
+          return $ Con $ ProdCon $ outs
       return $ LamExpr (invarsB >>> constvarsB) body
 
 simplifyJBinders
@@ -104,7 +104,7 @@ simplifyAtom = \case
         Rename nm' -> return (Var nm', ty)
   -- TODO In Jax, literals can presumably include (large) arrays.  How should we
   -- represent them here?
-  JLiteral (JLit {..}) -> return (Con (P.Lit (P.Float32Lit 0.0)), ty)
+  JLiteral (JLit {..}) -> return (Con (Lit (P.Float32Lit 0.0)), ty)
 
 simplifyPrim :: Emits o
   => [(SAtom o, JVarType)] -> Primitive -> JaxSimpM i o [SAtom o]
@@ -119,7 +119,7 @@ unaryExpandRank :: forall i o. Emits o
 unaryExpandRank op arg JArrayName{shape} = go arg shape where
   go :: Emits l => SAtom l -> [DimSizeName] -> JaxSimpM i l (SAtom l)
   go arg' = \case
-    [] -> emitExprToAtom $ PrimOp (P.UnOp op arg')
+    [] -> emitExprToAtom $ PrimOp (UnOp op arg')
     (DimSize sz:rest) -> buildFor noHint P.Fwd (finIxTy sz) \i -> do
       ixed <- emitExprToAtom $ TabApp (sink arg') [Var i]
       go ixed rest

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -178,6 +178,7 @@ instance SourceRenamableB (UAnnBinder req) where
 instance SourceRenamableE UExpr' where
   sourceRenameE expr = setMayShadow True case expr of
     UVar v -> UVar <$> sourceRenameE v
+    ULit l -> return $ ULit l
     ULam lam -> ULam <$> sourceRenameE lam
     UPi (UPiExpr pats appExpl eff body) ->
       sourceRenameB pats \pats' ->

--- a/src/lib/Types/OpNames.hs
+++ b/src/lib/Types/OpNames.hs
@@ -1,0 +1,119 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+-- This module contains payload-free versions of the ops defined in Types.Core.
+-- It uses the same constructor names so it should be imported qualified.
+
+module Types.OpNames where
+
+import IRVariants
+import Data.Hashable
+import GHC.Generics (Generic (..))
+import Data.Store (Store (..))
+
+data TC = ProdType | SumType | RefType | TypeKind | HeapType
+data Con = ProdCon | SumCon Int | HeapVal
+
+data BinOp =
+   IAdd | ISub | IMul | IDiv | ICmp CmpOp | FAdd | FSub | FMul
+ | FDiv | FCmp CmpOp | FPow | BAnd | BOr | BShL | BShR | IRem | BXor
+
+data UnOp =
+   Exp | Exp2 | Log | Log2 | Log10 | Log1p | Sin | Cos | Tan | Sqrt | Floor
+ | Ceil | Round | LGamma | Erf | Erfc | FNeg | BNot
+
+data CmpOp = Less | Greater | Equal | LessEqual | GreaterEqual
+
+data MemOp = IOAlloc | IOFree | PtrOffset | PtrLoad | PtrStore
+
+data MiscOp =
+   Select | CastOp | BitcastOp | UnsafeCoerce | GarbageVal | Effects
+ | ThrowError | ThrowException | Tag | SumTag | Create | ToEnum
+ | OutputStream | ShowAny | ShowScalar
+
+data VectorOp  = VectorBroadcast | VectorIota | VectorSubref
+
+data Hof  (r::IR) =
+   While | RunReader | RunWriter | RunState | RunIO | RunInit
+ | CatchException | Linearize | Transpose
+
+data DAMOp = Seq | RememberDest | AllocDest | Place | Freeze
+
+data RefOp = MAsk | MExtend | MGet | MPut | IndexRef | ProjRef Projection
+
+data Projection =
+   UnwrapNewtype -- TODO: add `HasCore r` constraint
+ | ProjectProduct Int
+   deriving (Show, Eq, Generic)
+
+data UserEffectOp = Handle | Resume | Perform
+
+deriving instance Generic BinOp
+deriving instance Generic UnOp
+deriving instance Generic CmpOp
+deriving instance Generic TC
+deriving instance Generic Con
+deriving instance Generic MemOp
+deriving instance Generic MiscOp
+deriving instance Generic VectorOp
+deriving instance Generic (Hof r)
+deriving instance Generic DAMOp
+deriving instance Generic RefOp
+deriving instance Generic UserEffectOp
+
+instance Hashable BinOp
+instance Hashable UnOp
+instance Hashable CmpOp
+instance Hashable TC
+instance Hashable Con
+instance Hashable MemOp
+instance Hashable MiscOp
+instance Hashable VectorOp
+instance Hashable (Hof r)
+instance Hashable DAMOp
+instance Hashable RefOp
+instance Hashable UserEffectOp
+instance Hashable Projection
+
+instance Store BinOp
+instance Store UnOp
+instance Store CmpOp
+instance Store TC
+instance Store Con
+instance Store MemOp
+instance Store MiscOp
+instance Store VectorOp
+instance IRRep r => Store (Hof r)
+instance Store DAMOp
+instance Store RefOp
+instance Store UserEffectOp
+instance Store Projection
+
+deriving instance Show BinOp
+deriving instance Show UnOp
+deriving instance Show CmpOp
+deriving instance Show TC
+deriving instance Show Con
+deriving instance Show MemOp
+deriving instance Show MiscOp
+deriving instance Show VectorOp
+deriving instance Show (Hof r)
+deriving instance Show DAMOp
+deriving instance Show RefOp
+deriving instance Show UserEffectOp
+
+deriving instance Eq BinOp
+deriving instance Eq UnOp
+deriving instance Eq CmpOp
+deriving instance Eq TC
+deriving instance Eq Con
+deriving instance Eq MemOp
+deriving instance Eq MiscOp
+deriving instance Eq VectorOp
+deriving instance Eq (Hof r)
+deriving instance Eq DAMOp
+deriving instance Eq RefOp
+deriving instance Eq UserEffectOp

--- a/src/lib/Types/Primitives.hs
+++ b/src/lib/Types/Primitives.hs
@@ -18,7 +18,9 @@
 {-# LANGUAGE DerivingVia #-}
 {-# LANGUAGE DefaultSignatures #-}
 
-module Types.Primitives where
+module Types.Primitives (
+  module Types.Primitives, UnOp (..), BinOp (..),
+  CmpOp (..), Projection (..)) where
 
 import Name
 import qualified Data.ByteString       as BS
@@ -29,111 +31,19 @@ import Data.Hashable
 import Data.Store (Store (..))
 import qualified Data.Store.Internal as SI
 import Foreign.Ptr
-import GHC.Exts (inline)
 
 import GHC.Generics (Generic (..))
 
 import Occurrence
-import IRVariants
 import Util (zipErr)
+import Types.OpNames (UnOp (..), BinOp (..), CmpOp (..), Projection (..))
 
 type SourceName = String
-
-data PrimTC (r::IR) (e:: *) where
-  BaseType         :: BaseType       -> PrimTC r e
-  ProdType         :: [e]            -> PrimTC r e
-  SumType          :: [e]            -> PrimTC r e
-  RefType          :: e -> e         -> PrimTC r e
-  -- TODO: `HasCore r` constraint
-  TypeKind         ::                   PrimTC r e
-  HeapType         ::                   PrimTC r e
-  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-
-traversePrimTC :: Applicative f => (e -> f e') -> PrimTC r e -> f (PrimTC r e')
-traversePrimTC = inline traverse
-{-# INLINABLE traversePrimTC #-}
-
-data PrimCon (r::IR) (e:: *) where
-  Lit          :: LitVal            -> PrimCon r e
-  ProdCon      :: [e]               -> PrimCon r e
-  SumCon       :: [e] -> Int -> e   -> PrimCon r e -- type, tag, payload
-  HeapVal      ::                      PrimCon r e
-  deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-
-data MemOp e =
-   IOAlloc BaseType e
- | IOFree e
- | PtrOffset e e
- | PtrLoad e
- | PtrStore e e
-   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-
-data PrimOp e =
-   UnOp     UnOp  e
- | BinOp    BinOp e e
- | MemOp    (MemOp e)
- | VectorOp (VectorOp e)
- | MiscOp   (MiscOp e)
-   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-
-traversePrimOp :: Applicative f => (e -> f e') -> PrimOp e -> f (PrimOp e')
-traversePrimOp = inline traverse
-{-# INLINABLE traversePrimOp #-}
-
-data MiscOp e =
-   Select e e e                 -- (3) predicate, val-if-true, val-if-false
- | CastOp e e                   -- (2) Type, then value. See CheckType.hs for valid coercions.
- | BitcastOp e e                -- (2) Type, then value. See CheckType.hs for valid coercions.
- | UnsafeCoerce e e             -- type, then value. Assumes runtime representation is the same.
- | GarbageVal e                 -- type of value (assume `Data` constraint)
- -- Effects
- | ThrowError e                 -- (1) Hard error (parameterized by result type)
- | ThrowException e             -- (1) Catchable exceptions (unlike `ThrowError`)
- -- Tag of a sum type
- | SumTag e
- -- Create an enum (payload-free ADT) from a Word8
- | ToEnum e e
- -- printing
- | OutputStream
- | ShowAny e    -- implemented in Simplify
- | ShowScalar e -- Implemented in Imp. Result is a pair of an `IdxRepValTy`
-                -- giving the logical size of the result and a fixed-size table,
-                -- `Fin showStringBufferSize => Char`, assumed to have sufficient space.
-   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
-
-showStringBufferSize :: Word32
-showStringBufferSize = 32
-
-data VectorOp e =
-   VectorBroadcast e e  -- value, vector type
- | VectorIota e  -- vector type
- | VectorSubref e e e -- ref, base ix, vector type
-   deriving (Show, Eq, Generic, Functor, Foldable, Traversable)
 
 newtype AlwaysEqual a = AlwaysEqual a
         deriving (Show, Generic, Functor, Foldable, Traversable, Hashable, Store)
 instance Eq (AlwaysEqual a) where
   _ == _ = True
-
-traversePrimCon :: Applicative f => (e -> f e') -> PrimCon r e -> f (PrimCon r e')
-traversePrimCon = inline traverse
-{-# INLINABLE traversePrimCon #-}
-
-data BinOp = IAdd | ISub | IMul | IDiv | ICmp CmpOp
-           | FAdd | FSub | FMul | FDiv | FCmp CmpOp | FPow
-           | BAnd | BOr | BShL | BShR | IRem | BXor
-             deriving (Show, Eq, Generic)
-
-data UnOp = Exp | Exp2
-          | Log | Log2 | Log10 | Log1p
-          | Sin | Cos | Tan | Sqrt
-          | Floor | Ceil | Round
-          | LGamma | Erf | Erfc
-          | FNeg | BNot
-            deriving (Show, Eq, Generic)
-
-data CmpOp = Less | Greater | Equal | LessEqual | GreaterEqual
-             deriving (Show, Eq, Generic)
 
 data Direction = Fwd | Rev  deriving (Show, Eq, Generic)
 type ForAnn = Direction
@@ -292,9 +202,6 @@ instance Store RequiredMethodAccess
 instance Store LetAnn
 instance Store RWS
 instance Store Direction
-instance Store UnOp
-instance Store BinOp
-instance Store CmpOp
 instance Store BaseType
 instance Store LitVal
 instance Store ScalarBaseType
@@ -304,18 +211,8 @@ instance Store AppExplicitness
 instance Store DepPairExplicitness
 instance Store InferenceMechanism
 
-instance Store a => Store (PrimCon r a)
-instance Store a => Store (PrimTC  r a)
-instance Store a => Store (PrimOp    a)
-instance Store a => Store (MemOp     a)
-instance Store a => Store (VectorOp  a)
-instance Store a => Store (MiscOp    a)
-
 instance Hashable RWS
 instance Hashable Direction
-instance Hashable UnOp
-instance Hashable BinOp
-instance Hashable CmpOp
 instance Hashable BaseType
 instance Hashable PtrLitVal
 instance Hashable PtrSnapshot
@@ -329,12 +226,6 @@ instance Hashable DepPairExplicitness
 instance Hashable InferenceMechanism
 instance Hashable RequiredMethodAccess
 
-instance Hashable a => Hashable (PrimCon r a)
-instance Hashable a => Hashable (PrimTC  r a)
-instance Hashable a => Hashable (PrimOp    a)
-instance Hashable a => Hashable (MemOp     a)
-instance Hashable a => Hashable (VectorOp  a)
-instance Hashable a => Hashable (MiscOp    a)
 instance Store (b n l) => Store (WithExpl b n l)
 
 instance (Color c, BindsOneName b c) => BindsOneName (WithExpl b) c where

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -33,6 +33,7 @@ import GHC.Generics (Generic (..))
 import Data.Store (Store (..))
 
 import Name
+import qualified Types.OpNames as P
 import IRVariants
 import Err
 import Util (File (..))
@@ -235,6 +236,7 @@ data UDecl' (n::S) (l::S) where
 type UExpr = WithSrcE UExpr'
 data UExpr' (n::S) =
    UVar (SourceNameOr UVar n)
+ | ULit LitVal
  | ULam (ULamExpr n)
  | UPi  (UPiExpr n)
  | UApp (UExpr n) [UExpr n] [UNamedArg n]
@@ -541,18 +543,22 @@ data EnvQuery =
 -- === Primitive names ===
 
 data PrimName =
-    UPrimTC  (PrimTC CoreIR ())
-  | UPrimCon (PrimCon CoreIR ())
-  | UPrimOp  (PrimOp ())
-  | UMAsk | UMExtend | UMGet | UMPut
-  | UWhile | ULinearize | UTranspose
-  | URunReader | URunWriter | URunState | URunIO | UCatchException
-  | UProjNewtype | UExplicitApply | UMonoLiteral
-  | UIndexRef | UApplyMethod Int
-  | UNat | UNatCon | UFin
-  | UEffectRowKind
-  | UTuple -- overloaded for type constructor and data constructor, resolved in inference
-    deriving (Show, Eq)
+   UBaseType BaseType
+ | UPrimTC   P.TC
+ | UCon      P.Con
+ | UMemOp    P.MemOp
+ | UVectorOp P.VectorOp
+ | UMiscOp   P.MiscOp
+ | UUnOp     UnOp
+ | UBinOp    BinOp
+ | UMAsk | UMExtend | UMGet | UMPut
+ | UWhile | ULinearize | UTranspose
+ | URunReader | URunWriter | URunState | URunIO | UCatchException
+ | UProjNewtype | UExplicitApply | UMonoLiteral
+ | UIndexRef | UApplyMethod Int
+ | UNat | UNatCon | UFin | UEffectRowKind
+ | UTuple -- overloaded for type constructor and data constructor, resolved in inference
+   deriving (Show, Eq)
 
 -- === instances ===
 

--- a/tests/unit/ConstantCastingSpec.hs
+++ b/tests/unit/ConstantCastingSpec.hs
@@ -18,13 +18,14 @@ import Core
 import Name
 import Optimize
 import Runtime
+import IRVariants
 import TopLevel
 import Types.Core
 import Types.Imp
 import Types.Primitives
 import Types.Source
 
-castOp :: ScalarBaseType -> (SAtom n) -> PrimOp (SAtom n)
+castOp :: ScalarBaseType -> (SAtom n) -> PrimOp SimpIR n
 castOp ty x = MiscOp $ CastOp (BaseTy (Scalar ty)) x
 
 castLam :: EnvExtender m => ScalarBaseType -> ScalarBaseType -> m n (SLam n)

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -50,7 +50,7 @@ uExprToBlock expr = do
 findRunIOAnnotation :: SBlock n -> LetAnn
 findRunIOAnnotation (Block _ decls _) = go decls where
   go :: Nest SDecl n l -> LetAnn
-  go (Nest (Let _ (DeclBinding ann _ (Hof (RunIO _)))) _) = ann
+  go (Nest (Let _ (DeclBinding ann _ (PrimOp (Hof (RunIO _))))) _) = ann
   go (Nest _ rest) = go rest
   go Empty = error "RunIO not found"
 


### PR DESCRIPTION
This is in preparation for treating types as distinct from atoms in SimpIR and then allowing expressions in types. I switched over the remaining generic "functor" primitives to ADTs that explicitly contain atoms.

The challenge is that we can no longer derive instances for generic traversals like `Traversable` and we can't use the unit-leaf (e.g. `MiscOp ()`) versions to represent op "names". So this change also introduces some new machinery for generically handling primitive ops.

Our main representation of primitive operations constrains their arity and the sorts of arguments they take, with constructors like `RunReader (Atom r n) (LamExpr r n)` which is convenient when we're pattern-matching on a particular primitive. But in other places we want a more generic representation - when we're parsing, printing and generically traversing for substitution or whatever.

This patch introduces a class `GenericOp` which lets you describe an isomorphism between and op and an `(opConstant, [LamExpr], [Atom])` triple (soon to be extended with type args too). The `opConstant` field is an associated type and it should have instances for printing and parsing.