### PR TITLE
Separate types and atoms into two ADTs

### DIFF
--- a/src/lib/Builder.hs
+++ b/src/lib/Builder.hs
@@ -937,7 +937,7 @@ symbolicTangentTy :: (EnvReader m, Fallible1 m) => CType n -> m n (CType n)
 symbolicTangentTy elTy = lookupSourceMap "SymbolicTangent" >>= \case
   Just (UTyConVar symTanName) -> do
     return $ TypeCon "SymbolicTangent" symTanName $
-      TyConParams [Explicit] [elTy]
+      TyConParams [Explicit] [Type elTy]
   Nothing -> throw UnboundVarErr $
     "Can't define a custom linearization with symbolic zeros: " ++
     "the SymbolicTangent type is not in scope."
@@ -946,7 +946,7 @@ symbolicTangentTy elTy = lookupSourceMap "SymbolicTangent" >>= \case
 symbolicTangentZero :: EnvReader m => SType n -> m n (SAtom n)
 symbolicTangentZero argTy = return $ SumVal [UnitTy, argTy] 0 UnitVal
 
-symbolicTangentNonZero :: EnvReader m => SAtom n -> m n (SType n)
+symbolicTangentNonZero :: EnvReader m => SAtom n -> m n (SAtom n)
 symbolicTangentNonZero val = do
   ty <- getType val
   return $ SumVal [UnitTy, ty] 1 val

--- a/src/lib/Generalize.hs
+++ b/src/lib/Generalize.hs
@@ -39,7 +39,9 @@ generalizeArgs fTy argsTop = liftGeneralizerM $ runSubstReaderT idSubst do
     go (Nest (WithExpl expl b) bs) (arg:args) = do
       ty' <- substM $ binderType b
       arg' <- case (ty', expl) of
-        (TyKind, _) -> liftSubstReaderT $ generalizeType arg
+        (TyKind, _) -> liftSubstReaderT case arg of
+          Type t -> Type <$> generalizeType t
+          _ -> error "not a type"
         (DictTy _, Inferred Nothing (Synth _)) -> generalizeDict ty' arg
         _ -> isData ty' >>= \case
           True -> liftM Var $ liftSubstReaderT $ emitGeneralizationParameter ty' arg
@@ -104,7 +106,9 @@ emitGeneralizationParameter ty val = GeneralizerM do
 -- Given a type (an Atom of type `Type`), abstracts over all data components
 generalizeType :: Type CoreIR n -> GeneralizerM n (Type CoreIR n)
 generalizeType ty = traverseTyParams ty \paramRole paramReqTy param -> case paramRole of
-  TypeParam -> generalizeType param
+  TypeParam -> Type <$> case param of
+    Type t -> generalizeType t
+    _ -> error "not a type"
   DictParam -> generalizeDict paramReqTy param
   DataParam -> Var <$> emitGeneralizationParameter paramReqTy param
 
@@ -115,29 +119,29 @@ generalizeType ty = traverseTyParams ty \paramRole paramReqTy param -> case para
 -- for other operations on types, like newtype stripping.
 
 traverseTyParams
-  :: (EnvReader m, EnvExtender m)
-  => Atom CoreIR n
-  -> (forall l . DExt n l => ParamRole -> Type CoreIR l -> Atom CoreIR l -> m l (Atom CoreIR l))
-  -> m n (Atom CoreIR n)
+  :: forall m n. (EnvReader m, EnvExtender m)
+  => CType n
+  -> (forall l . DExt n l => ParamRole -> CType l -> CAtom l -> m l (CAtom l))
+  -> m n (CType n)
 traverseTyParams ty f = getDistinct >>= \Distinct -> case ty of
   DictTy (DictType sn name params) -> do
     Abs paramRoles UnitE <- getClassRoleBinders name
     params' <- traverseRoleBinders f paramRoles params
     return $ DictTy $ DictType sn name params'
   TabPi (TabPiType (b:>(IxType iTy (IxDictAtom d))) resultTy) -> do
-    iTy' <- f TypeParam TyKind iTy
+    iTy' <- f' TypeParam TyKind iTy
     dictTy <- liftM ignoreExcept $ runFallibleT1 $ DictTy <$> ixDictType iTy'
     d'   <- f DictParam dictTy d
     withFreshBinder (getNameHint b) iTy' \(b':>_) -> do
-      resultTy' <- applyRename (b@>binderName b') resultTy >>= f TypeParam TyKind
+      resultTy' <- applyRename (b@>binderName b') resultTy >>= (f' TypeParam TyKind)
       return $ TabTy (b':>IxType iTy' (IxDictAtom d')) resultTy'
   -- shouldn't need this once we can exclude IxDictFin and IxDictSpecialized from CoreI
   TabPi t -> return $ TabPi t
   TC tc -> TC <$> case tc of
     BaseType b -> return $ BaseType b
-    ProdType tys -> ProdType <$> forM tys \t -> f TypeParam TyKind t
+    ProdType tys -> ProdType <$> forM tys \t -> f' TypeParam TyKind t
     RefType _ _ -> error "not implemented" -- how should we handle the ParamRole for the heap parameter?
-    SumType  tys -> SumType  <$> forM tys \t -> f TypeParam TyKind t
+    SumType  tys -> SumType  <$> forM tys \t -> f' TypeParam TyKind t
     TypeKind     -> return TypeKind
     HeapType     -> return HeapType
   NewtypeTyCon con -> NewtypeTyCon <$> case con of
@@ -149,6 +153,13 @@ traverseTyParams ty f = getDistinct >>= \Distinct -> case ty of
       params' <- traverseRoleBinders f roleBinders params
       return $ UserADTType sn def $ TyConParams infs params'
   _ -> error $ "Not implemented: " ++ pprint ty
+  where
+    f' :: forall l . DExt n l => ParamRole -> CType l -> CType l -> m l (CType l)
+    f' r t x = fromType <$> f r t (Type x)
+
+    fromType :: CAtom l -> CType l
+    fromType (Type t) = t
+    fromType x = error $ "not a type: " ++ pprint x
 {-# INLINE traverseTyParams #-}
 
 traverseRoleBinders

--- a/src/lib/Imp.hs
+++ b/src/lib/Imp.hs
@@ -879,7 +879,6 @@ atomToRepVal x = RepVal <$> getType x <*> go x where
             ProjectProduct idx    -> case t' of
               Branch ts -> return $ ts !! idx
               _ -> error "should only be projecting a branch"
-    _ -> error $ "not implemented: " ++ show atom
 
 -- XXX: We used to have a function called `destToAtom` which loaded the value
 -- from the dest. This version is not that. It just lifts a dest into an atom of

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -310,6 +310,8 @@ instance Inlinable SAtomName where
 instance Inlinable SAtom where
   inline ctx a = inlineAtom (EmitToAtomCtx ctx) a
 
+instance Inlinable SType
+
 instance Inlinable SBlock where
   inline ctx (Block ann decls ans) = case (ann, decls) of
     (NoBlockAnn, Empty) ->
@@ -441,7 +443,7 @@ instance ( Inlinable e1, Inlinable e2, Inlinable e3, Inlinable e4
     Case7 x -> (Case7 <$> inline Stop x) >>= reconstruct ctx
   {-# INLINE inline #-}
 
-instance (RenameB b, BindsEnv b) => Inlinable (Abs b (Atom SimpIR)) where
+instance (RenameB b, BindsEnv b) => Inlinable (Abs b (Type SimpIR)) where
   inline ctx (Abs b body) = do
     s <- getSubst
     babs <- runSubstReaderT (asRenameSubst s) $ renameM (Abs b (idSubstFrag b))

--- a/src/lib/Linearize.hs
+++ b/src/lib/Linearize.hs
@@ -332,9 +332,6 @@ linearizeAtom atom = case atom of
       Just idx -> return $ WithTangent (Var v') $ getTangentArg idx
   Con con -> linearizePrimCon con
   DepPair _ _ _     -> notImplemented
-  TabPi _         -> emitZeroT
-  DepPairTy _     -> emitZeroT
-  TC _            -> emitZeroT
   PtrVar _        -> emitZeroT
   ProjectElt i x -> do
     WithTangent x' tx <- linearizeAtom x

--- a/src/lib/OccAnalysis.hs
+++ b/src/lib/OccAnalysis.hs
@@ -233,7 +233,7 @@ instance HasOCC SBlock where
 -- TODO What, actually, is the right thing to do for type annotations?  Do we
 -- want a rule like "we never inline into type annotations", or such?  For
 -- now, traversing with the main analysis seems safe.
-occTy :: SAtom n -> OCCM n (SAtom n)
+occTy :: SType n -> OCCM n (SType n)
 occTy ty = occ accessOnce ty
 
 -- TODO(optimization) Could reuse the free variable caching from dce here too.
@@ -476,6 +476,7 @@ instance HasOCC (EffectRow SimpIR)
 instance HasOCC (EffectRowTail SimpIR)
 instance HasOCC (Effect SimpIR)
 instance HasOCC (IxDict SimpIR)
+instance HasOCC (Type SimpIR)
 instance HasOCC (GenericOpRep const SimpIR) where
 
 instance HasOCC (RepVal SimpIR) where

--- a/src/lib/Optimize.hs
+++ b/src/lib/Optimize.hs
@@ -496,6 +496,7 @@ instance HasDCE (RefOp SimpIR)
 instance HasDCE (BaseMonoid SimpIR)
 instance HasDCE (Hof SimpIR)
 instance HasDCE SAtom
+instance HasDCE SType
 instance HasDCE (LamExpr     SimpIR)
 instance HasDCE (TabPiType   SimpIR)
 instance HasDCE (DepPairType SimpIR)

--- a/src/lib/Transpose.hs
+++ b/src/lib/Transpose.hs
@@ -310,9 +310,6 @@ transposeAtom atom ct = case atom of
       LinTrivial -> return ()
   Con con         -> transposeCon con ct
   DepPair _ _ _   -> notImplemented
-  TabPi _         -> notTangent
-  DepPairTy _     -> notTangent
-  TC _            -> notTangent
   PtrVar _        -> notTangent
   ProjectElt i' x' -> do
     let (idxs, v) = asNaryProj i' x'


### PR DESCRIPTION
Types can still appear in atoms but only the CoreIR. This makes SimpIR a bit more precise, but the main reason for the change is to allow us to relax the ANF constraint on types so that we can do things like indexing within types.