### PR TITLE
Implement traversals over the type/atom/lambda/pi components of CoreIR/SimpIR terms

### DIFF
--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -1345,7 +1345,6 @@ instance GenericE UserEffectOp where
     _ -> error "impossible"
   {-# INLINE toE #-}
 
-
 instance SinkableE      UserEffectOp
 instance HoistableE     UserEffectOp
 instance RenameE        UserEffectOp


### PR DESCRIPTION
The current `GenericTraversal` machinery goes under binders generically so it has to make assumptions about the name environment and how to extend it. This makes it less applicable than I'd initially hoped. For example, the DCE and Occ passes can't use it because they're bottom-up instead of top-down.

This patch adds a name-agnostic system that lets you traverse the components of a term in an aribtrary (e.g. non-name-carrying) monad. The term's components are a mixture of non-atom names, atoms, types, lambda terms and pi terms. The caller-supplied functions for handling lambda and pi presumably go under their binders, but this only needs to work in the caller's specific monad.

This machinery is somewhere between `GenericE` and `GenericTraversal` in terms of how much is assumes about the IR structure and the monad you're working in.