### PR TITLE
Cache types in atoms and expressions.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -94,6 +94,7 @@ library
                      , Types.OpNames
                      , Types.Source
                      , QueryType
+                     , QueryTypePure
                      , Util
   if flag(live)
     exposed-modules:   Actor

--- a/lib/prelude.dx
+++ b/lib/prelude.dx
@@ -2365,7 +2365,7 @@ def dex_test_mode() -> Bool = unsafe_io \. check_env "DEX_TEST_MODE"
 '## Exception effect
 -- TODO: move `error` and `todo` to here.
 
-def catch(f:() -> {Except|eff} a) -> {|eff} Maybe a given (a, eff) =
+def catch(f:() -> {Except|eff} a) -> {|eff} Maybe a given (a, eff)=
   f' : (() -> {Except|eff} a) = \. f()
   %catchException(f')
 

--- a/src/Dex/Foreign/Context.hs
+++ b/src/Dex/Foreign/Context.hs
@@ -106,7 +106,7 @@ dexInsert ctxPtr namePtr atomPtr = do
   runTopperMFromContext ctxPtr do
     -- TODO: Check if atom is compatible with context! Use module name?
     name <- emitTopLet (getNameHint @String sourceName) PlainLet $ Atom $ unsafeCoerceE atom
-    emitSourceMap $ SourceMap $ M.singleton sourceName [ModuleVar Main $ Just $ UAtomVar name]
+    emitSourceMap $ SourceMap $ M.singleton sourceName [ModuleVar Main $ Just $ UAtomVar (atomVarName name)]
 
 dexLookup :: Ptr Context -> CString -> IO (Ptr AtomEx)
 dexLookup ctxPtr namePtr = do
@@ -114,7 +114,7 @@ dexLookup ctxPtr namePtr = do
   runTopperMFromContext ctxPtr do
     lookupSourceMap name >>= \case
       Just (UAtomVar v) -> lookupAtomName v >>= \case
-        LetBound (DeclBinding _ _ (Atom atom)) -> liftIO $ toStablePtr $ AtomEx atom
+        LetBound (DeclBinding _ (Atom atom)) -> liftIO $ toStablePtr $ AtomEx atom
         _ -> liftIO $ setError "Looking up an unevaluated atom?" $> nullPtr
       Just _  -> liftIO $ setError "Only Atom names can be looked up" $> nullPtr
       Nothing -> liftIO $ setError ("Unbound name: " ++ name) $> nullPtr

--- a/src/lib/Algebra.hs
+++ b/src/lib/Algebra.hs
@@ -59,7 +59,7 @@ sumUsingPolys lim (Abs i body) = do
         ++ "Trying to sum from 0 to " ++ pprint lim ++ " - 1, \\"
         ++ pprint i' ++ "." ++ pprint body'
   limName <- emit (Atom lim)
-  emitPolynomial $ sum (LeftE limName) sumAbs
+  emitPolynomial $ sum (LeftE (atomVarName limName)) sumAbs
 
 mul :: Polynomial n-> Polynomial n -> Polynomial n
 mul (Polynomial x) (Polynomial y) =
@@ -143,14 +143,14 @@ blockAsPoly (Block _ decls result) =
 blockAsPolyRec :: Nest (Decl SimpIR) i i' -> Atom SimpIR i' -> BlockTraverserM i o (Polynomial o)
 blockAsPolyRec decls result = case decls of
   Empty -> atomAsPoly result
-  Nest (Let b (DeclBinding _ _ expr)) restDecls -> do
+  Nest (Let b (DeclBinding _ expr)) restDecls -> do
     p <- optional (exprAsPoly expr)
     extendSubst (b@>PolySubstVal p) $ blockAsPolyRec restDecls result
 
   where
     atomAsPoly :: Atom SimpIR i -> BlockTraverserM i o (Polynomial o)
     atomAsPoly = \case
-      Var v       -> atomNameAsPoly v
+      Var v       -> atomVarAsPoly v
       RepValAtom (RepVal _ (Leaf (IVar v' _))) -> impNameAsPoly v'
       IdxRepVal i -> return $ poly [((fromIntegral i) % 1, mono [])]
       _ -> empty
@@ -159,12 +159,13 @@ blockAsPolyRec decls result = case decls of
     impNameAsPoly v = getSubst <&> (!v) >>= \case
       PolyRename v' -> return $ poly [(1, mono [(RightE v', 1)])]
 
-    atomNameAsPoly :: AtomName SimpIR i -> BlockTraverserM i o (Polynomial o)
-    atomNameAsPoly v = getSubst <&> (!v) >>= \case
+    atomVarAsPoly :: AtomVar SimpIR i -> BlockTraverserM i o (Polynomial o)
+    atomVarAsPoly v = getSubst <&> (! atomVarName v) >>= \case
       PolySubstVal Nothing   -> empty
       PolySubstVal (Just cp) -> return cp
-      PolyRename   v'        ->
-        getType v' >>= \case
+      PolyRename v' -> do
+        v'' <- toAtomVar v'
+        case getType v'' of
           IdxRepTy -> return $ poly [(1, mono [(LeftE v', 1)])]
           _ -> empty
 
@@ -208,7 +209,9 @@ emitPolynomial (Polynomial p) = do
 emitMonomial :: (Emits n, Builder SimpIR m) => Monomial n -> m n (Atom SimpIR n)
 emitMonomial (Monomial m) = do
   varAtoms <- forM (toList m) \(v, e) -> case v of
-    LeftE v' -> ipow (Var v') e
+    LeftE v' -> do
+      v'' <- Var <$> toAtomVar v'
+      ipow v'' e
     RightE v' -> do
       let atom = RepValAtom $ RepVal IdxRepTy (Leaf (IVar v' IIdxRepTy))
       ipow atom e

--- a/src/lib/CheckType.hs
+++ b/src/lib/CheckType.hs
@@ -29,7 +29,7 @@ import MTL1
 import Name
 import Subst
 import PPrint ()
-import QueryType hiding (HasType, getTypeE)
+import QueryType hiding (HasType)
 import Types.Core
 import Types.Imp
 import Types.Primitives
@@ -188,7 +188,7 @@ instance IRRep r => CheckableE r (Type r) where
 instance IRRep r => HasType r (AtomName r) where
   getTypeE name = do
     name' <- renameM name
-    atomBindingType <$> lookupAtomName name'
+    getType <$> lookupAtomName name'
   {-# INLINE getTypeE #-}
 
 instance IRRep r => CheckableE r (Block r) where
@@ -199,7 +199,7 @@ instance IRRep r => HasType r (Atom r) where
     Var name -> do
       ty <- getTypeE name
       case ty of
-        RawRefTy _ -> renameM name >>= affineUsed
+        RawRefTy _ -> renameM name >>= affineUsed . atomVarName
         _ -> return ()
       return ty
     Lam (CoreLamExpr piTy lam) -> do
@@ -214,17 +214,16 @@ instance IRRep r => HasType r (Atom r) where
       return $ DepPairTy ty'
     Con con  -> typeCheckPrimCon con
     Eff eff  -> checkE eff $> EffKind
-    PtrVar v -> renameM v >>= lookupEnv >>= \case
-      PtrBinding ty _ -> return $ PtrTy ty
-    DictCon dictExpr -> getTypeE dictExpr
+    PtrVar t _ -> return $ PtrTy t  -- TODO: check against env
+    DictCon _ dictExpr -> getTypeE dictExpr  -- TODO: check against cached type
     RepValAtom (RepVal ty _) -> renameM ty
     NewtypeCon con x -> NewtypeTyCon <$> typeCheckNewtypeCon con x
     SimpInCore x -> getTypeE x
     DictHole _ ty _ -> checkTypeE TyKind ty
-    ProjectElt UnwrapNewtype x -> do
+    ProjectElt _ UnwrapNewtype x -> do
       NewtypeTyCon con <- getTypeE x
       snd <$> unwrapNewtypeType con
-    ProjectElt (ProjectProduct i) x -> do
+    ProjectElt _ (ProjectProduct i) x -> do
       ty <- getTypeE x
       case ty of
         ProdTy tys -> return $ tys !! i
@@ -235,6 +234,14 @@ instance IRRep r => HasType r (Atom r) where
           instantiateDepPairTy t xFst
         _ -> throw TypeErr $ "Not a product type:" ++ pprint ty
     TypeAsAtom ty -> getTypeE ty
+
+instance IRRep r => HasType r (AtomVar r) where
+  getTypeE (AtomVar v t1) = do
+    t1' <- renameM t1
+    v' <- renameM v
+    t2 <- getType <$> lookupAtomName v'
+    checkTypesEq t1' t2
+    return t1'
 
 instance IRRep r => HasType r (Type r) where
   getTypeE atom = case atom of
@@ -249,10 +256,13 @@ instance IRRep r => HasType r (Type r) where
       checkArgTys paramBs params'
       return TyKind
     TyVar v -> getTypeE v
-    ProjectEltTy UnwrapNewtype x -> do
+    ProjectEltTy resultTy UnwrapNewtype x -> do
+      resultTy' <- renameM resultTy
       NewtypeTyCon con <- getTypeE x
-      snd <$> unwrapNewtypeType con
-    ProjectEltTy (ProjectProduct i) x -> do
+      ty <- snd <$> unwrapNewtypeType con
+      checkTypesEq resultTy' ty
+      return ty
+    ProjectEltTy _ (ProjectProduct i) x -> do
       ty <- getTypeE x
       case ty of
         ProdTy tys -> return $ tys !! i
@@ -283,17 +293,16 @@ instance (BindsNames b, CheckableB r b) => CheckableB r (WithExpl b) where
 
 typeCheckExpr :: (Typer m r, IRRep r) => EffectRow r o -> Expr r i -> m i o (Type r o)
 typeCheckExpr effs expr = case expr of
-  App f xs -> do
+  App (EffTy _ reqTy) f xs -> do
     fTy <- getTypeE f
-    checkApp effs fTy $ toList xs
-  TabApp f xs -> do
+    checkApp effs fTy xs >>= checkAgainstGiven reqTy
+  TabApp reqTy f xs -> do
     fTy <- getTypeE f
-    checkTabApp fTy xs
-  -- TODO: check!
-  TopApp f xs -> do
+    checkTabApp fTy xs >>= checkAgainstGiven reqTy
+  TopApp (EffTy _ reqTy) f xs -> do
     PiType bs _ resultTy <- getTypeTopFun =<< renameM f
     xs' <- mapM renameM xs
-    checkedApplyNaryAbs (Abs bs resultTy) xs'
+    checkedApplyNaryAbs (Abs bs resultTy) xs' >>= checkAgainstGiven reqTy
   Atom x   -> getTypeE x
   PrimOp op -> typeCheckPrimOp effs op
   Case e alts resultTy caseEffs -> do
@@ -302,15 +311,15 @@ typeCheckExpr effs expr = case expr of
     checkCase e alts resultTy' caseEffs'
     checkExtends effs caseEffs'
     return resultTy'
-  ApplyMethod dict i args -> do
+  ApplyMethod (EffTy _ reqTy) dict i args -> do
     DictTy (DictType _ className params) <- getTypeE dict
-    def@(ClassDef _ _ _ paramBs classBs methodTys) <- lookupClassDef className
+    ClassDef _ _ _ paramBs classBs methodTys <- lookupClassDef className
     let methodTy = methodTys !! i
-    superclassDicts <- getSuperclassDicts def <$> renameM dict
+    superclassDicts <- getSuperclassDicts =<< renameM dict
     let subst = (    paramBs @@> map SubstVal params
                  <.> classBs @@> map SubstVal superclassDicts)
     methodTy' <- applySubst subst methodTy
-    checkApp effs (Pi methodTy') args
+    checkApp effs (Pi methodTy') args >>= checkAgainstGiven reqTy
   TabCon _ ty xs -> do
     ty'@(TabPi (TabPiType b restTy)) <- checkTypeE TyKind ty
     case fromConstAbs (Abs b restTy) of
@@ -333,11 +342,8 @@ instance IRRep r => HasType r (Block r) where
    where
     go :: Typer m r => EffectRow r o -> Type r o -> Nest (Decl r) i i' -> Atom r i' -> m i o ()
     go _ reqTy Empty result = result |: reqTy
-    go effs reqTy (Nest (Let b rhs@(DeclBinding _ tyAnn expr)) decls) result = do
-      tyAnn |: TyKind
-      tyAnn' <- renameM tyAnn
-      tyExpr <- typeCheckExpr effs expr
-      checkTypesEq tyAnn' tyExpr
+    go effs reqTy (Nest (Let b rhs@(DeclBinding _ expr)) decls) result = do
+      void $ typeCheckExpr effs expr
       rhs' <- renameM rhs
       withFreshBinder (getNameHint b) rhs' \(b':>_) -> do
         extendRenamer (b@>binderName b') do
@@ -401,6 +407,12 @@ instance (BindsNames b, CheckableB r b) => CheckableB r (Nest b) where
           withExtEvidence (ext1 >>> ext2) $
             cont $ Nest b' rest'
 
+checkAgainstGiven :: (Typer m r, IRRep r) => Type r i -> Type r o -> m i o (Type r o)
+checkAgainstGiven givenTy computedTy = do
+  givenTy' <- renameM givenTy
+  checkTypesEq givenTy' computedTy
+  return givenTy'
+
 checkCoreLam :: Typer m CoreIR => CorePiType o -> LamExpr CoreIR i -> m i o ()
 checkCoreLam (CorePiType _ Empty effs resultTy) (LamExpr Empty body) = do
   resultTy' <- checkBlockWithEffs effs body
@@ -439,7 +451,7 @@ typeCheckNewtypeCon
 typeCheckNewtypeCon con x = case con of
   NatCon   -> x|:IdxRepTy          >> return Nat
   FinCon n -> n|:NatTy >> x|:NatTy >> renameM (Fin n)
-  UserADTData d params -> do
+  UserADTData _ d params -> do
     d' <- renameM d
     def@(TyConDef sn _ _) <- lookupTyCon d'
     params' <- renameM params
@@ -479,18 +491,20 @@ typeCheckPrimOp effs op = case op of
       MPut  x   -> x|:s   >> declareEff effs (RWSEffect State  h) $> UnitTy
       MAsk      ->           declareEff effs (RWSEffect Reader h) $> s
       MExtend _ x -> x|:s >> declareEff effs (RWSEffect Writer h) $> UnitTy
-      IndexRef i -> do
+      IndexRef givenTy i -> do
         TabTy (b:>IxType iTy _) eltTy <- return s
         i' <- checkTypeE iTy i
         eltTy' <- applyAbs (Abs b eltTy) (SubstVal i')
-        return $ TC $ RefType h eltTy'
-      ProjRef p -> TC . RefType h <$> case p of
-        ProjectProduct i -> do
-          ProdTy tys <- return s
-          return $ tys !! i
-        UnwrapNewtype -> do
-          NewtypeTyCon tc <- return s
-          snd <$> unwrapNewtypeType tc
+        checkAgainstGiven givenTy (TC $ RefType h eltTy')
+      ProjRef givenTy p -> do
+        resultEltTy <- case p of
+          ProjectProduct i -> do
+            ProdTy tys <- return s
+            return $ tys !! i
+          UnwrapNewtype -> do
+            NewtypeTyCon tc <- return s
+            snd <$> unwrapNewtypeType tc
+        checkAgainstGiven givenTy (TC $ RefType h resultEltTy)
 
 typeCheckMemOp :: forall r m i o. (Typer m r, IRRep r) => EffectRow r o -> MemOp r i -> m i o (Type r o)
 typeCheckMemOp effs = \case
@@ -553,10 +567,10 @@ typeCheckMiscOp effs = \case
     where hostPtrTy ty = PtrType (CPU, ty)
   ShowAny x ->
     -- TODO: constrain `ShowAny` to have `HasCore r`
-    checkE x >> rawStrType
+    checkE x >> return rawStrType
   ShowScalar x -> do
     BaseTy (Scalar _) <- getTypeE x
-    PairTy IdxRepTy <$> rawFinTabType (IdxRepVal showStringBufferSize) CharRepTy
+    return $ PairTy IdxRepTy $ rawFinTabType (IdxRepVal showStringBufferSize) CharRepTy
   ThrowError ty -> ty|:TyKind >> renameM ty
   ThrowException ty -> do
     declareEff effs ExceptionEffect
@@ -607,7 +621,7 @@ typeCheckUserEffect = \case
 typeCheckPrimHof :: forall r m i o. (Typer m r, IRRep r) => EffectRow r o -> Hof r i -> m i o (Type r o)
 typeCheckPrimHof effs hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
   For _ ixDict f -> do
-    ixTy <- ixTyFromDict =<< renameM ixDict
+    ixTy <- ixTyFromDict <$> renameM ixDict
     PiType (UnaryNest (b:>argTy)) _ eltTy <- checkLamExpr f
     checkTypesEq (ixTypeType ixTy) argTy
     return $ TabTy (b:>ixTy) eltTy
@@ -618,7 +632,7 @@ typeCheckPrimHof effs hof = addContext ("Checking HOF:\n" ++ pprint hof) case ho
   Linearize f x -> do
     PiType (UnaryNest (binder:>a)) Pure b <- checkLamExpr f
     b' <- liftHoistExcept $ hoist binder b
-    fLinTy <- Pi <$> nonDepPiType [a] Pure b'
+    fLinTy <- return $ Pi $ nonDepPiType [a] Pure b'
     x |: a
     return $ PairTy b' fLinTy
   Transpose f x -> do
@@ -655,14 +669,14 @@ typeCheckPrimHof effs hof = addContext ("Checking HOF:\n" ++ pprint hof) case ho
     return $ PairTy resultTy stateTy
   RunIO   body -> checkBlockWithEffs  (extendEffect IOEffect   effs) body
   RunInit body -> checkBlockWithEffs  (extendEffect InitEffect effs) body
-  CatchException body -> do
+  CatchException reqTy body -> do
     ty <- checkBlockWithEffs (extendEffect ExceptionEffect effs) body
-    makePreludeMaybeTy ty
+    makePreludeMaybeTy ty >>= checkAgainstGiven reqTy
 
 typeCheckDAMOp :: forall r m i o . (Typer m r, IRRep r) => EffectRow r o -> DAMOp r i -> m i o (Type r o)
 typeCheckDAMOp effs op = addContext ("Checking DAMOp:\n" ++ show op) case op of
   Seq _ ixDict carry f -> do
-    ixTy <- ixTyFromDict =<< renameM ixDict
+    ixTy <- ixTyFromDict <$> renameM ixDict
     carryTy' <- getTypeE carry
     let badCarry = throw TypeErr $ "Seq carry should be a product of raw references, got: " ++ pprint carryTy'
     case carryTy' of
@@ -674,7 +688,6 @@ typeCheckDAMOp effs op = addContext ("Checking DAMOp:\n" ++ show op) case op of
   RememberDest d body -> do
     dTy@(RawRefTy _) <- getTypeE d
     PiType (UnaryNest b) _ UnitTy <- checkLamExpr body
-
     checkTypesEq (binderType b) dTy
     return dTy
   AllocDest ty -> RawRefTy <$> checkTypeE TyKind ty
@@ -691,7 +704,7 @@ checkLamExpr :: (Typer m r, IRRep r) => LamExpr r i -> m i o (PiType r o)
 checkLamExpr (LamExpr bsTop body) = case bsTop of
   Empty -> do
     resultTy <- getTypeE body
-    effs <- renameM $ blockEffects body
+    effs <- renameM $ getEffects body
     return $ PiType Empty effs resultTy
   Nest (b:>ty) bs -> do
     ty' <- checkTypeE TyKind ty
@@ -710,7 +723,7 @@ checkLamExprWithEffs allowedEffs lam = do
 checkBlockWithEffs :: (Typer m r, IRRep r) => EffectRow r o -> Block r i -> m i o (Type r o)
 checkBlockWithEffs allowedEffs block = do
   ty <- getTypeE block
-  effs <- renameM $ blockEffects block
+  effs <- renameM $ getEffects block
   checkExtends allowedEffs effs
   return ty
 
@@ -718,7 +731,7 @@ checkRWSAction :: (Typer m r, IRRep r) => EffectRow r o -> RWS -> LamExpr r i ->
 checkRWSAction effs rws f = do
   BinaryLamExpr bH bR body <- return f
   renameBinders bH \bH' -> renameBinders bR \bR' -> do
-    h <- sinkM $ binderName bH'
+    h <- sinkM $ binderVar bH'
     let effs' = extendEffect (RWSEffect rws $ Var h) (sink effs)
     RefTy _ referentTy <- sinkM $ binderType bR'
     resultTy <- checkBlockWithEffs effs' body
@@ -924,8 +937,7 @@ checkedApplyNaryAbs (Abs bsTop e) xsTop = do
    go :: EmptyAbs (Nest b) o -> [Atom r o] -> m o ()
    go (Abs Empty UnitE) [] = return ()
    go (Abs (Nest b bs) UnitE) (x:xs) = do
-     xTy <- getType x
-     checkAlphaEq (binderType b) xTy
+     checkAlphaEq (binderType b) (getType x)
      bs' <- applySubst (b@>SubstVal x) (Abs bs UnitE)
      go bs' xs
    go _ _ = throw TypeErr "wrong number of arguments"
@@ -944,7 +956,7 @@ instance IRRep r => CheckableE r (EffectRow r) where
       NoTail -> return ()
       EffectRowTail v -> do
         v' <- renameM v
-        ty <- atomBindingType <$> lookupAtomName v'
+        ty <- getType <$> lookupAtomName (atomVarName v')
         checkTypesEq EffKind ty
 
 declareEff :: forall r m i o. (IRRep r, Typer m r) => EffectRow r o -> Effect r o -> m i o ()

--- a/src/lib/Generalize.hs
+++ b/src/lib/Generalize.hs
@@ -23,7 +23,7 @@ import Types.Primitives
 generalizeIxDict :: EnvReader m => Atom CoreIR n -> m n (Generalized CoreIR CAtom n)
 generalizeIxDict dict = liftGeneralizerM do
   dict' <- sinkM dict
-  dictTy <- getType dict'
+  dictTy <- return $ getType dict'
   dictTyGeneralized <- generalizeType dictTy
   dictGeneralized <- liftEnvReaderM $ generalizeDict dictTyGeneralized dict'
   return dictGeneralized
@@ -90,7 +90,7 @@ liftGeneralizerM cont = do
 {-# INLINE liftGeneralizerM #-}
 
 -- XXX: the supplied type may be more general than the type of the atom!
-emitGeneralizationParameter :: Type CoreIR n -> Atom CoreIR n -> GeneralizerM n (AtomName CoreIR n)
+emitGeneralizationParameter :: Type CoreIR n -> Atom CoreIR n -> GeneralizerM n (AtomVar CoreIR n)
 emitGeneralizationParameter ty val = GeneralizerM do
   Abs b v <- return $ newName noHint
   let emission = Abs (RNest REmpty (GeneralizationEmission (b:>ty) val)) v
@@ -99,7 +99,7 @@ emitGeneralizationParameter ty val = GeneralizerM do
     -- dependent pair binders). As long as those variables are only used in
     -- DataParam roles, this hoisting should succeed.
     Nothing -> error $ "expected atom to be hoistable " ++ pprint val
-    Just v' -> return v'
+    Just v' -> return $ AtomVar v' ty
 
 -- === actual generalization traversal ===
 

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -15,6 +15,7 @@ import IRVariants
 import Name
 import JAX.Concrete
 import Subst
+import QueryType
 import Types.Core
 import Types.Primitives qualified as P
 
@@ -61,7 +62,7 @@ simplifyJTy JArrayName{shape, dtype} = go shape $ simplifyDType dtype where
   go [] ty = return ty
   go ((DimSize sz):rest) ty = do
     rest' <- go rest ty
-    finIxTy sz ==> rest'
+    return $ finIxTy sz ==> rest'
 
 simplifyDType :: DType -> Type r n
 simplifyDType = \case
@@ -101,7 +102,9 @@ simplifyAtom = \case
       case env ! nm of
         -- TODO Assuming the subst is not type-changing
         SubstVal x -> return (x, ty)
-        Rename nm' -> return (Var nm', ty)
+        Rename nm' -> do
+          nm'' <- toAtomVar nm'
+          return (Var nm'', ty)
   -- TODO In Jax, literals can presumably include (large) arrays.  How should we
   -- represent them here?
   JLiteral (JLit {..}) -> return (Con (Lit (P.Float32Lit 0.0)), ty)
@@ -121,5 +124,5 @@ unaryExpandRank op arg JArrayName{shape} = go arg shape where
   go arg' = \case
     [] -> emitExprToAtom $ PrimOp (UnOp op arg')
     (DimSize sz:rest) -> buildFor noHint P.Fwd (finIxTy sz) \i -> do
-      ixed <- emitExprToAtom $ TabApp (sink arg') [Var i]
+      ixed <- mkTabApp (sink arg') [Var i] >>= emitExprToAtom
       go ixed rest

--- a/src/lib/Lower.hs
+++ b/src/lib/Lower.hs
@@ -74,10 +74,10 @@ lowerFullySequential (LamExpr bs body) = liftEnvReaderM $ do
 
 lowerFullySequentialBlock :: EnvReader m => SBlock n -> m n (DestBlock SimpIR n)
 lowerFullySequentialBlock b = liftAtomSubstBuilder do
-  resultDestTy <- RawRefTy <$> getTypeSubst b
+  resultDestTy <- RawRefTy <$> substM (getType b)
   withFreshBinder (getNameHint @String "ans") resultDestTy \destBinder -> do
     DestBlock destBinder <$> buildBlock do
-      let dest = Var $ sink $ binderName destBinder
+      let dest = Var $ sink $ binderVar destBinder
       lowerBlockWithDest dest b $> UnitVal
 {-# SCC lowerFullySequentialBlock #-}
 
@@ -121,7 +121,7 @@ lowerFor
   :: Emits o => Maybe (Dest SimpIR o) -> ForAnn -> IxDict SimpIR i -> LamExpr SimpIR i
   -> LowerM i o (SExpr o)
 lowerFor maybeDest dir ixDict lam@(UnaryLamExpr (ib:>ty) body) = do
-  ansTy <- getTypeSubst $ Hof $ For dir ixDict $ lam
+  ansTy <- substM $ getType $ For dir ixDict $ lam
   ixDict' <- substM ixDict
   ty' <- substM ty
   case isSingletonType ansTy of
@@ -135,14 +135,15 @@ lowerFor maybeDest dir ixDict lam@(UnaryLamExpr (ib:>ty) body) = do
       initDest <- ProdVal . (:[]) <$> case maybeDest of
         Just  d -> return d
         Nothing -> emitOp $ DAMOp $ AllocDest ansTy
-      destTy <- getType initDest
+      let destTy = getType initDest
       body' <- buildUnaryLamExpr noHint (PairTy ty' destTy) \b' -> do
         (i, destProd) <- fromPair $ Var b'
         dest <- normalizeProj (ProjectProduct 0) destProd
-        idest <- emitOp $ RefOp dest $ IndexRef i
+        idest <- emitOp =<< mkIndexRef dest i
         extendSubst (ib @> SubstVal i) $ lowerBlockWithDest idest body $> UnitVal
-      let seqHof = PrimOp $ DAMOp $ Seq dir ixDict' initDest body'
-      PrimOp . DAMOp . Freeze . ProjectElt (ProjectProduct 0) <$> (Var <$> emit seqHof)
+      let seqHof = DAMOp $ Seq dir ixDict' initDest body'
+      ans <- emitOp seqHof >>= getProj 0
+      return $ PrimOp $ DAMOp $ Freeze ans
 lowerFor _ _ _ _ = error "expected a unary lambda expression"
 
 lowerTabCon :: forall i o. Emits o
@@ -185,10 +186,10 @@ lowerCase maybeDest scrut alts resultTy = do
     alts' <- forM alts \(Abs (b:>ty) body) -> do
       ty' <- substM ty
       buildAbs (getNameHint b) ty' \b' ->
-        extendSubst (b @> Rename b') $
+        extendSubst (b @> Rename (atomVarName b')) $
           buildBlock do
             lowerBlockWithDest (Var $ sink $ local_dest) body $> UnitVal
-    eff' <- foldMapM getEffects alts'
+    eff' <- foldMapM (pure . getEffects) alts'
     void $ emitExpr $ Case (sink scrut') alts' UnitTy eff'
     return UnitVal
   return $ PrimOp $ DAMOp $ Freeze dest'
@@ -234,10 +235,10 @@ lookupDest = flip lookupNameMap
 -- XXX: When adding more cases, be careful about potentially repeated vars in the output!
 decomposeDest :: Emits o => Dest SimpIR o -> SAtom i' -> LowerM i o (Maybe (DestAssignment i' o))
 decomposeDest dest = \case
-  Var v -> return $ Just $ singletonNameMap v $ FullDest dest
-  ProjectElt p x -> do
+  Var v -> return $ Just $ singletonNameMap (atomVarName v) $ FullDest dest
+  ProjectElt _ p x -> do
     (ps, v) <- return $ asNaryProj p x
-    return $ Just $ singletonNameMap v $ ProjDest ps dest
+    return $ Just $ singletonNameMap (atomVarName v) $ ProjDest ps dest
   _ -> return Nothing
 
 lowerBlockWithDest :: Emits o => Dest SimpIR o -> SBlock i -> LowerM i o (SAtom o)
@@ -254,8 +255,11 @@ lowerBlockWithDest dest (Block _ decls ans) = do
         Just DistinctBetween -> do
           s' <- traverseDeclNestWithDestS destMap s decls
           -- But we have to emit explicit writes, for all the vars that are not defined in decls!
-          forM_ (toListNameMap $ hoistFilterNameMap decls destMap) \(n, d) ->
-            place d $ case s ! n of Rename v -> Var v; SubstVal a -> a
+          forM_ (toListNameMap $ hoistFilterNameMap decls destMap) \(n, d) -> do
+            x <- case s ! n of
+              Rename v -> Var <$> toAtomVar v
+              SubstVal a -> return a
+            place d x
           withSubst s' $ substM ans
 
 traverseDeclNestWithDestS
@@ -264,12 +268,12 @@ traverseDeclNestWithDestS
   -> LowerM i o (Subst AtomSubstVal i' o)
 traverseDeclNestWithDestS destMap s = \case
   Empty -> return s
-  Nest (Let b (DeclBinding ann _ expr)) rest -> do
+  Nest (Let b (DeclBinding ann expr)) rest -> do
     DistinctBetween <- return $ withExtEvidence rest $ shortenBetween @i' b
     let maybeDest = lookupDest destMap $ sinkBetween $ binderName b
     expr' <- withSubst s $ lowerExprWithDest maybeDest expr
     v <- emitDecl (getNameHint b) ann expr'
-    traverseDeclNestWithDestS destMap (s <>> (b @> Rename v)) rest
+    traverseDeclNestWithDestS destMap (s <>> (b @> Rename (atomVarName v))) rest
 
 lowerExprWithDest :: forall i o. Emits o => Maybe (ProjDest o) -> SExpr i -> LowerM i o (SExpr o)
 lowerExprWithDest dest expr = case expr of
@@ -313,7 +317,7 @@ lowerExprWithDest dest expr = case expr of
           ty' <- visitType $ ignoreHoistFailure $ hoist hb ty
           liftM (PrimOp . Hof) $ mkHof refDest =<<
             buildEffLam (getNameHint rb) ty' \hb' rb' ->
-              extendRenamer (hb@>hb' <.> rb@>rb') do
+              extendRenamer (hb@>atomVarName hb' <.> rb@>atomVarName rb') do
                 case bodyDest of
                   Nothing -> lowerBlock body
                   Just bd -> lowerBlockWithDest (sink bd) body
@@ -354,13 +358,17 @@ data Stability
 
 data VSubstValC (c::C) (n::S) where
   VVal :: Stability -> SAtom n -> VSubstValC (AtomNameC SimpIR) n
+  VRename :: SAtomName n -> VSubstValC (AtomNameC SimpIR) n
+
 type VAtom = VSubstValC (AtomNameC SimpIR)
 instance SinkableV VSubstValC
 instance SinkableE (VSubstValC c) where
   sinkingProofE fresh (VVal s x) = VVal s $ sinkingProofE fresh x
+  sinkingProofE fresh (VRename v) = VRename $ sinkingProofE fresh v
 
 instance PrettyPrec (VSubstValC c n) where
   prettyPrec (VVal s atom) = atPrec LowestPrec $ "@" <> viaShow s <+> pretty atom
+  prettyPrec (VRename v) = atPrec LowestPrec $ "rename" <> pretty v
 
 type TopVectorizeM = BuilderT SimpIR (ReaderT Word32 (StateT Errs FallibleM))
 
@@ -406,7 +414,7 @@ vectorizeLoopsRec :: (Ext i o, Emits o)
 vectorizeLoopsRec frag nest =
   case nest of
     Empty -> return frag
-    Nest (Let b (DeclBinding ann _ expr)) rest -> do
+    Nest (Let b (DeclBinding ann expr)) rest -> do
       vectorByteWidth <- ask
       expr' <- applyRename frag expr
       narrowestTypeByteWidth <- getNarrowestTypeByteWidth expr'
@@ -428,7 +436,7 @@ vectorizeLoopsRec frag nest =
                 body' <- applyRename frag body
                 emit $ PrimOp $ DAMOp $ Seq dir (IxDictRawFin (IdxRepVal n)) dest' body'
         _ -> emitDecl (getNameHint b) ann =<< applyRename frag expr
-      vectorizeLoopsRec (frag <.> b @> v) rest
+      vectorizeLoopsRec (frag <.> b @> atomVarName v) rest
 
 atMostInitEffect :: IRRep r => EffectRow r n -> Bool
 atMostInitEffect scrutinee = case scrutinee of
@@ -440,7 +448,7 @@ vectorizeSeq :: forall i i' o. (Distinct o, Ext i o)
              => Word32 -> SubstFrag Name i i' o -> LamExpr SimpIR i'
              -> TopVectorizeM o (LamExpr SimpIR o)
 vectorizeSeq loopWidth frag (UnaryLamExpr (b:>ty) body) = do
-  if atMostInitEffect (blockEffects body)
+  if atMostInitEffect (getEffects body)
     then do
       (_, ty') <- case ty of
         ProdTy [ixTy, ref] -> do
@@ -468,7 +476,7 @@ vectorizeSeq _ _ _ = error "expected a unary lambda expression"
 
 fromNameVAtom :: forall c n. Color c => Name c n -> VSubstValC c n
 fromNameVAtom v = case eqColorRep @c @(AtomNameC SimpIR) of
-  Just ColorsEqual -> VVal Uniform $ Var v
+  Just ColorsEqual -> VRename v
   _ -> error "Unexpected non-atom name"
 
 newtype VectorizeM i o a =
@@ -487,7 +495,7 @@ vectorizeBlock block@(Block _ decls (ans :: SAtom i')) =
       go :: Emits o => Nest SDecl i i' -> VectorizeM i o (VAtom o)
       go = \case
         Empty -> vectorizeAtom ans
-        Nest (Let b (DeclBinding _ _ expr)) rest -> do
+        Nest (Let b (DeclBinding _ expr)) rest -> do
           v <- vectorizeExpr expr
           extendSubst (b @> v) $ go rest
 
@@ -516,10 +524,10 @@ vectorizeDAMOp op =
 vectorizeRefOp :: Emits o => SAtom i -> RefOp SimpIR i -> VectorizeM i o (VAtom o)
 vectorizeRefOp ref' op =
   case op of
-    IndexRef i' -> do
+    IndexRef _ i' -> do
       VVal Uniform ref <- vectorizeAtom ref'
       VVal Contiguous i <- vectorizeAtom i'
-      getType ref >>= \case
+      case getType ref of
         TC (RefType _ (TabTy tb a)) -> do
           vty <- getVectorType =<< case hoist tb a of
             HoistSuccess a' -> return a'
@@ -561,7 +569,7 @@ vectorizePrimOp op = case op of
     VVal Contiguous <$> emitOp (MemOp $ PtrOffset ptr off)
   MemOp (PtrLoad arg) -> do
     VVal Contiguous ptr <- vectorizeAtom arg
-    BaseTy (PtrType (addrSpace, a)) <- getType ptr
+    BaseTy (PtrType (addrSpace, a)) <- return $ getType ptr
     BaseTy av <- getVectorType $ BaseTy a
     ptr' <- emitOp $ MiscOp $ CastOp (BaseTy $ PtrType (addrSpace, av)) ptr
     VVal Varying <$> emitOp (MemOp $ PtrLoad ptr')
@@ -585,16 +593,16 @@ vectorizeType t = do
 vectorizeAtom :: SAtom i -> VectorizeM i o (VAtom o)
 vectorizeAtom atom = addVectErrCtx "vectorizeAtom" ("Atom:\n" ++ pprint atom) do
   case atom of
-    Var v -> lookupSubstM v
+    Var v -> lookupSubstM $ atomVarName v
     -- Vectors of base newtypes are already newtype-stripped.
-    ProjectElt (ProjectProduct i) x -> do
+    ProjectElt _ (ProjectProduct i) x -> do
       VVal vv x' <- vectorizeAtom x
       ov <- case vv of
         ProdStability sbs -> return $ sbs !! i
         _ -> throwVectErr "Invalid projection"
       x'' <- normalizeProj (ProjectProduct i) x'
       return $ VVal ov x''
-    ProjectElt UnwrapNewtype _ -> error "Shouldn't have newtypes left" -- TODO: check statically
+    ProjectElt _ UnwrapNewtype _ -> error "Shouldn't have newtypes left" -- TODO: check statically
     Con (Lit l) -> return $ VVal Uniform $ Con $ Lit l
     _ -> do
       subst <- getSubst
@@ -619,11 +627,11 @@ ensureVarying :: Emits o => VAtom o -> VectorizeM i o (SAtom o)
 ensureVarying (VVal s val) = case s of
   Varying -> return val
   Uniform -> do
-    vty <- getVectorType =<< getType val
+    vty <- getVectorType $ getType val
     emitOp $ VectorOp $ VectorBroadcast val vty
   -- Note that the implementation of this case will depend on val's type.
   Contiguous -> do
-    ty <- getType val
+    let ty = getType val
     vty <- getVectorType ty
     case ty of
       BaseTy (Scalar sbt) -> do
@@ -632,6 +640,9 @@ ensureVarying (VVal s val) = case s of
         emitOp $ BinOp (if isIntegral sbt then IAdd else FAdd) bval iota
       _ -> throwVectErr "Not implemented"
   ProdStability _ -> throwVectErr "Not implemented"
+ensureVarying (VRename v) = do
+  x <- Var <$> toAtomVar v
+  ensureVarying (VVal Uniform x)
 
 -- === Extensions to the name system ===
 
@@ -676,7 +687,7 @@ instance ExprVisitorNoEmits (CalcWidthM i o) SimpIR i o where
     PrimOp (RefOp _ _) -> fallback
     PrimOp _ -> do
       expr' <- renameM expr
-      ty <- getType expr'
+      let ty = getType expr'
       modify (\(LiftE x) -> LiftE $ min (typeByteWidth ty) x)
       return expr'
     _ -> fallback

--- a/src/lib/QueryType.hs
+++ b/src/lib/QueryType.hs
@@ -4,12 +4,10 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module QueryType where
+module QueryType (module QueryType, module QueryTypePure, toAtomVar) where
 
 import Control.Category ((>>>))
 import Control.Monad
-import Data.Foldable (toList)
-import Data.Functor ((<&>))
 import Data.List (elemIndex)
 
 import Types.Primitives
@@ -18,96 +16,113 @@ import Types.Source
 import Types.Imp
 import IRVariants
 import Core
-import CheapReduction
 import Err
 import Name hiding (withFreshM)
 import Subst
 import Util
 import PPrint ()
-
--- === Main API for querying types ===
-
-getTypeSubst :: (SubstReader AtomSubstVal m, EnvReader2 m, HasType r e)
-             => e i -> m i o (Type r o)
-getTypeSubst e = do
-  subst <- getSubst
-  liftTypeQueryM subst $ getTypeE e
-{-# INLINE getTypeSubst #-}
-
-getType :: (EnvReader m, HasType r e) => e n -> m n (Type r n)
-getType e = liftTypeQueryM idSubst $ getTypeE e
-{-# INLINE getType #-}
-
-getLamExprType :: (IRRep r, EnvReader m) => LamExpr r n -> m n (PiType r n)
-getLamExprType lam = liftTypeQueryM idSubst $ getLamExprTypeE lam
-{-# INLINE getLamExprType #-}
-
--- TODO: Fold this into a real HasType instance
-getDestBlockType :: (IRRep r, EnvReader m) => DestBlock r n -> m n (Type r n)
-getDestBlockType (DestBlock (_:>RawRefTy ansTy) _) = return ansTy
-getDestBlockType _ = error "Expected a reference type for body destination"
-{-# INLINE getDestBlockType #-}
-
-getNaryDestLamExprType :: (IRRep r, EnvReader m) => DestLamExpr r n -> m n (PiType r n)
-getNaryDestLamExprType lam = liftTypeQueryM idSubst $ getDestLamExprType lam
-{-# INLINE getNaryDestLamExprType #-}
-
-getReferentTypeRWSAction :: (EnvReader m, IRRep r) => LamExpr r o -> m o (Type r o)
-getReferentTypeRWSAction f = liftTypeQueryM idSubst $ liftM snd $ getTypeRWSAction f
+import QueryTypePure
+import CheapReduction
 
 sourceNameType :: (EnvReader m, Fallible1 m) => SourceName -> m n (Type CoreIR n)
 sourceNameType v = do
   lookupSourceMap v >>= \case
     Nothing -> throw UnboundVarErr $ pprint v
-    Just uvar -> liftTypeQueryM idSubst $ getTypeE uvar
-
--- === Querying effects ===
-
-isPure :: (IRRep r, EnvReader m, HasEffectsE e r) => e n -> m n Bool
-isPure e = getEffects e <&> \case
-  Pure -> True
-  _    -> False
-
-getEffects :: (EnvReader m, HasEffectsE e r) => e n -> m n (EffectRow r n)
-getEffects e = liftTypeQueryM idSubst $ getEffectsImpl e
-{-# INLINE getEffects #-}
-
-getEffectsSubst :: (EnvReader2 m, SubstReader AtomSubstVal m, HasEffectsE e r)
-                => e i -> m i o (EffectRow r o)
-getEffectsSubst e = do
-  subst <- getSubst
-  liftTypeQueryM subst $ getEffectsImpl e
-{-# INLINE getEffectsSubst #-}
+    Just uvar -> getUVarType uvar
 
 -- === Exposed helpers for querying types and effects ===
 
-caseAltsBinderTys :: (IRRep r, Fallible1 m, EnvReader m)
-                  => Type r n -> m n [Type r n]
+caseAltsBinderTys :: (EnvReader m,  IRRep r) => Type r n -> m n [Type r n]
 caseAltsBinderTys ty = case ty of
   SumTy types -> return types
   NewtypeTyCon t -> case t of
     UserADTType _ defName params -> do
       def <- lookupTyCon defName
-      ADTCons cons <- instantiateTyConDef def params
+      ~(ADTCons cons) <- instantiateTyConDef def params
       return [repTy | DataConDef _ _ repTy _ <- cons]
-    _ -> fail msg
-  _ -> fail msg
+    _ -> error msg
+  _ -> error msg
   where msg = "Case analysis only supported on ADTs, not on " ++ pprint ty
 
 extendEffect :: IRRep r => Effect r n -> EffectRow r n -> EffectRow r n
 extendEffect eff (EffectRow effs t) = EffectRow (effs <> eSetSingleton eff) t
 
-getPartialAppType :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
-getPartialAppType f xs = liftTypeQueryM idSubst $ partialAppType f xs
-{-# INLINE getPartialAppType #-}
+typeOfApp  :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
+typeOfApp (Pi (CorePiType _ bs _ resultTy)) xs = do
+  let subst = bs @@> fmap SubstVal xs
+  applySubst subst resultTy
+typeOfApp _ _ = error "expected a pi type"
 
-getAppType :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
-getAppType f xs = liftTypeQueryM idSubst $ appType f xs
-{-# INLINE getAppType #-}
+typeOfTabApp :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
+typeOfTabApp t [] = return t
+typeOfTabApp (TabTy (b:>_) resultTy) (i:rest) = do
+  resultTy' <- applySubst (b@>SubstVal i) resultTy
+  typeOfTabApp resultTy' rest
+typeOfTabApp ty _ = error $ "expected a table type. Got: " ++ pprint ty
 
-getTabAppType :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
-getTabAppType f xs = liftTypeQueryM idSubst $ typeTabApp f xs
-{-# INLINE getTabAppType #-}
+typeOfApplyMethod :: EnvReader m => CAtom n -> Int -> [CAtom n] -> m n (EffTy CoreIR n)
+typeOfApplyMethod d i args = do
+  ty <- Pi <$> getMethodType d i
+  appEffTy ty args
+
+typeOfDictExpr :: EnvReader m => DictExpr n -> m n (CType n)
+typeOfDictExpr e = liftM ignoreExcept $ liftEnvReaderT $ case e of
+  InstanceDict instanceName args -> do
+    InstanceDef className bs params _ <- lookupInstanceDef instanceName
+    ClassDef sourceName _ _ _ _ _ <- lookupClassDef className
+    ListE params' <- applySubst (bs @@> map SubstVal args) $ ListE params
+    return $ DictTy $ DictType sourceName className params'
+  InstantiatedGiven given args -> typeOfApp (getType given) args
+  SuperclassProj d i -> do
+    DictTy (DictType _ className params) <- return $ getType d
+    ClassDef _ _ _ bs superclasses _ <- lookupClassDef className
+    applySubst (bs @@> map SubstVal params) $
+      getSuperclassType REmpty superclasses i
+  IxFin n -> liftM DictTy $ ixDictType $ NewtypeTyCon $ Fin n
+  DataData ty -> DictTy <$> dataDictType ty
+
+typeOfTopApp :: EnvReader m => TopFunName n -> [SAtom n] -> m n (EffTy SimpIR n)
+typeOfTopApp f xs = do
+  PiType bs eff resultTy <- getTypeTopFun f
+  applySubst (bs @@> map SubstVal xs) (EffTy eff resultTy)
+
+typeOfIndexRef :: (EnvReader m, Fallible1 m, IRRep r) => Type r n -> Atom r n -> m n (Type r n)
+typeOfIndexRef (TC (RefType h s)) i = do
+  TabTy (b:>_) eltTy <- return s
+  eltTy' <- applyAbs (Abs b eltTy) (SubstVal i)
+  return $ TC $ RefType h eltTy'
+typeOfIndexRef _ _ = error "expected a ref type"
+
+typeOfProjRef :: EnvReader m => Type r n -> Projection -> m n (Type r n)
+typeOfProjRef (TC (RefType h s)) p = do
+  TC . RefType h <$> case p of
+    ProjectProduct i -> do
+      ~(ProdTy tys) <- return s
+      return $ tys !! i
+    UnwrapNewtype -> do
+      case s of
+        NewtypeTyCon tc -> snd <$> unwrapNewtypeType tc
+        _ -> error "expected a newtype"
+typeOfProjRef _ _ = error "expected a reference"
+
+appEffTy  :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (EffTy r n)
+appEffTy (Pi (CorePiType _ bs eff resultTy)) xs = do
+  let subst = bs @@> fmap SubstVal xs
+  applySubst subst $ EffTy eff resultTy
+appEffTy t _ = error $ "expected a pi type, got: " ++ pprint t
+
+partialAppType  :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (Type r n)
+partialAppType (Pi (CorePiType expl bs effs resultTy)) xs = do
+  PairB bs1 bs2 <- return $ splitNestAt (length xs) bs
+  let subst = bs1 @@> fmap SubstVal xs
+  applySubst subst $ Pi $ CorePiType expl bs2 effs resultTy
+partialAppType _ _ = error "expected a pi type"
+
+appEffects :: (IRRep r, EnvReader m) => Type r n -> [Atom r n] -> m n (EffectRow r n)
+appEffects (Pi (CorePiType _ bs effs _)) xs = do
+  let subst = bs @@> fmap SubstVal xs
+  applySubst subst effs
+appEffects _ _ = error "expected a pi type"
 
 getReferentTy :: (IRRep r, MonadFail m) => EmptyAbs (PairB (Binder r) (Binder r)) n -> m (Type r n)
 getReferentTy (Abs (PairB hB refB) UnitE) = do
@@ -124,82 +139,70 @@ getMethodIndex className methodSourceName = do
     Just i -> return i
 {-# INLINE getMethodIndex #-}
 
-litType :: LitVal -> BaseType
-litType v = case v of
-  Int64Lit   _ -> Scalar Int64Type
-  Int32Lit   _ -> Scalar Int32Type
-  Word8Lit   _ -> Scalar Word8Type
-  Word32Lit  _ -> Scalar Word32Type
-  Word64Lit  _ -> Scalar Word64Type
-  Float64Lit _ -> Scalar Float64Type
-  Float32Lit _ -> Scalar Float32Type
-  PtrLit ty _  -> PtrType ty
-
-instance HasType CoreIR UVar where
-  getTypeE = \case
-    UAtomVar    v -> getTypeE $ Var v
-    UTyConVar   v -> getTypeE v
-    UDataConVar v -> getTypeE v
-    UPunVar     v -> getStructDataConType =<< substM v
-    UClassVar   v -> getTypeE v
-    UMethodVar  v -> getTypeE v
-    UEffectVar   _ -> error "not implemented"
-    UEffectOpVar _ -> error "not implemented"
-
-instance HasType CoreIR ClassName where
-  getTypeE v = do
-    ClassDef _ _ _ bs _ _ <- substM v >>= lookupClassDef
+getUVarType :: EnvReader m => UVar n -> m n (CType n)
+getUVarType = \case
+  UAtomVar v -> getType <$> toAtomVar v
+  UTyConVar   v -> getTyConNameType v
+  UDataConVar v -> getDataConNameType v
+  UPunVar     v -> getStructDataConType v
+  UClassVar v -> do
+    ClassDef _ _ _ bs _ _ <- lookupClassDef v
     let bs' = fmapNest (\(RolePiBinder _ b) -> b) bs
     return $ Pi $ CorePiType ExplicitApp bs' Pure TyKind
+  UMethodVar  v -> getMethodNameType v
+  UEffectVar   _ -> error "not implemented"
+  UEffectOpVar _ -> error "not implemented"
 
-instance HasType CoreIR MethodName where
-  getTypeE v = substM v >>= lookupEnv >>= \case
-    MethodBinding className i -> do
-      classDef@(ClassDef _ _ paramNames paramBs scBinders methodTys) <- lookupClassDef className
-      let paramBs' = zipWithNest paramBs paramNames \(RolePiBinder _ (WithExpl _ b)) paramName ->
-            WithExpl (Inferred paramName Unify) b
-      refreshAbs (Abs paramBs' $ Abs scBinders (methodTys !! i)) \paramBs'' (Abs scBinders' piTy) -> do
-        let params = nestToList (Var . sink . binderName) paramBs''
-        dictTy <- DictTy <$> dictType (sink className) params
-        withFreshBinder noHint dictTy \dictB -> do
-          let scDicts = getSuperclassDicts (sink classDef) (Var $ binderName dictB)
-          piTy' <- applySubst (scBinders'@@>(SubstVal<$>scDicts)) piTy
-          CorePiType appExpl methodBs effs resultTy <- return piTy'
-          let dictBs = UnaryNest $ WithExpl (Inferred Nothing (Synth $ Partial $ succ i)) dictB
-          return $ Pi $ CorePiType appExpl (paramBs'' >>> dictBs >>> methodBs) effs resultTy
+getMethodNameType :: EnvReader m => MethodName n -> m n (CType n)
+getMethodNameType v = liftEnvReaderM $ lookupEnv v >>= \case
+  MethodBinding className i -> do
+    ClassDef _ _ paramNames paramBs scBinders methodTys <- lookupClassDef className
+    let paramBs' = zipWithNest paramBs paramNames \(RolePiBinder _ (WithExpl _ b)) paramName ->
+          WithExpl (Inferred paramName Unify) b
+    refreshAbs (Abs paramBs' $ Abs scBinders (methodTys !! i)) \paramBs'' (Abs scBinders' piTy) -> do
+      let params = Var <$> nestToAtomVars (fmapNest withoutExpl paramBs'')
+      dictTy <- DictTy <$> dictType (sink className) params
+      withFreshBinder noHint dictTy \dictB -> do
+        scDicts <- getSuperclassDicts (Var $ binderVar dictB)
+        piTy' <- applySubst (scBinders'@@>(SubstVal<$>scDicts)) piTy
+        CorePiType appExpl methodBs effs resultTy <- return piTy'
+        let dictBs = UnaryNest $ WithExpl (Inferred Nothing (Synth $ Partial $ succ i)) dictB
+        return $ Pi $ CorePiType appExpl (paramBs'' >>> dictBs >>> methodBs) effs resultTy
 
 getMethodType :: EnvReader m => Dict n -> Int -> m n (CorePiType n)
 getMethodType dict i = do
-  ~(DictTy (DictType _ className params)) <- getType dict
-  def@(ClassDef _ _ _ paramBs classBs methodTys) <- lookupClassDef className
+  ~(DictTy (DictType _ className params)) <- return $ getType dict
+  ClassDef _ _ _ paramBs classBs methodTys <- lookupClassDef className
   let methodTy = methodTys !! i
-  let superclassDicts = getSuperclassDicts def dict
+  superclassDicts <- getSuperclassDicts dict
   let subst = (    paramBs @@> map SubstVal params
                <.> classBs @@> map SubstVal superclassDicts)
   applySubst subst methodTy
 {-# INLINE getMethodType #-}
 
-instance HasType CoreIR TyConName where
-  getTypeE v = do
-    TyConDef _ bs _ <- substM v >>= lookupTyCon
-    case bs of
-      Empty -> return TyKind
-      _ -> do
-        let bs' = fmapNest (\(RolePiBinder _ b) -> b) bs
-        return $ Pi $ CorePiType ExplicitApp bs' Pure TyKind
 
-instance HasType CoreIR DataConName where
-  getTypeE dataCon = do
-    (tyCon, i) <- lookupDataCon =<< substM dataCon
-    tyConDef@(TyConDef tcSn paramBs (ADTCons dataCons)) <- lookupTyCon tyCon
-    buildDataConType tyConDef \paramBs' paramVs params -> do
-      DataConDef _ ab _ _ <- applyRename (paramBs @@> paramVs) (dataCons !! i)
-      refreshAbs ab \dataBs UnitE -> do
-        let appExpl = case dataBs of Empty -> ImplicitApp
-                                     _     -> ExplicitApp
-        let resultTy = NewtypeTyCon $ UserADTType tcSn (sink tyCon) (sink params)
-        let dataBs' = fmapNest (WithExpl Explicit) dataBs
-        return $ Pi $ CorePiType appExpl (paramBs' >>> dataBs') Pure resultTy
+getTyConNameType :: EnvReader m => TyConName n -> m n (Type CoreIR n)
+getTyConNameType v = do
+  TyConDef _ bs _ <- lookupTyCon v
+  case bs of
+    Empty -> return TyKind
+    _ -> do
+      let bs' = fmapNest (\(RolePiBinder _ b) -> b) bs
+      return $ Pi $ CorePiType ExplicitApp bs' Pure TyKind
+
+getDataConNameType :: EnvReader m => DataConName n -> m n (Type CoreIR n)
+getDataConNameType dataCon = liftEnvReaderM do
+  (tyCon, i) <- lookupDataCon dataCon
+  lookupTyCon tyCon >>= \case
+    tyConDef@(TyConDef tcSn paramBs ~(ADTCons dataCons)) ->
+      buildDataConType tyConDef \paramBs' paramVs params -> do
+        DataConDef _ ab _ _ <- applyRename (paramBs @@> paramVs) (dataCons !! i)
+        refreshAbs ab \dataBs UnitE -> do
+          let appExpl = case dataBs of Empty -> ImplicitApp
+                                       _     -> ExplicitApp
+          let resultTy = NewtypeTyCon $ UserADTType tcSn (sink tyCon) (sink params)
+          let dataBs' = fmapNest (WithExpl Explicit) dataBs
+          return $ Pi $ CorePiType appExpl (paramBs' >>> dataBs') Pure resultTy
 
 getStructDataConType :: EnvReader m => TyConName n -> m n (CType n)
 getStructDataConType tyCon = liftEnvReaderM do
@@ -207,7 +210,7 @@ getStructDataConType tyCon = liftEnvReaderM do
   buildDataConType tyConDef \paramBs' paramVs params -> do
     fieldTys <- forM fields \(_, t) -> applyRename (paramBs @@> paramVs) t
     let resultTy = NewtypeTyCon $ UserADTType tcSn (sink tyCon) params
-    Abs dataBs resultTy' <- typesAsBinderNest fieldTys resultTy
+    Abs dataBs resultTy' <- return $ typesAsBinderNest fieldTys resultTy
     let dataBs' = fmapNest (WithExpl Explicit) dataBs
     return $ Pi $ CorePiType ExplicitApp (paramBs' >>> dataBs') Pure resultTy'
 
@@ -223,7 +226,8 @@ buildDataConType (TyConDef _ bs _) cont = do
   refreshAbs (Abs bs' UnitE) \bs'' UnitE -> do
     let expls = nestToList (\(RolePiBinder _ b) -> getExpl b) bs
     let vs = nestToNames bs''
-    cont bs'' vs $ TyConParams expls (Var <$> vs)
+    vs' <- mapM toAtomVar vs
+    cont bs'' vs $ TyConParams expls (Var <$> vs')
 
 makeTyConParams :: EnvReader m => TyConName n -> [CAtom n] -> m n (TyConParams n)
 makeTyConParams tc params = do
@@ -231,22 +235,37 @@ makeTyConParams tc params = do
   let expls = nestToList (\(RolePiBinder _ b) -> getExpl b) paramBs
   return $ TyConParams expls params
 
-typeBinOp :: BinOp -> BaseType -> BaseType
-typeBinOp binop xTy = case binop of
-  IAdd   -> xTy;  ISub   -> xTy
-  IMul   -> xTy;  IDiv   -> xTy
-  IRem   -> xTy;
-  ICmp _ -> Scalar Word8Type
-  FAdd   -> xTy;  FSub   -> xTy
-  FMul   -> xTy;  FDiv   -> xTy;
-  FPow   -> xTy
-  FCmp _ -> Scalar Word8Type
-  BAnd   -> xTy;  BOr    -> xTy
-  BXor   -> xTy
-  BShL   -> xTy;  BShR   -> xTy
+getDataClassName :: (Fallible1 m, EnvReader m) => m n (ClassName n)
+getDataClassName = lookupSourceMap "Data" >>= \case
+  Nothing -> throw CompilerErr $ "Data interface needed but not defined!"
+  Just (UClassVar v) -> return v
+  Just _ -> error "not a class var"
 
-typeUnOp :: UnOp -> BaseType -> BaseType
-typeUnOp = const id  -- All unary ops preserve the type of the input
+dataDictType :: (Fallible1 m, EnvReader m) => CType n -> m n (DictType n)
+dataDictType ty = do
+  dataClassName <- getDataClassName
+  dictType dataClassName [Type ty]
+
+getIxClassName :: (Fallible1 m, EnvReader m) => m n (ClassName n)
+getIxClassName = lookupSourceMap "Ix" >>= \case
+  Nothing -> throw CompilerErr $ "Ix interface needed but not defined!"
+  Just (UClassVar v) -> return v
+  Just _ -> error "not a class var"
+
+dictType :: EnvReader m => ClassName n -> [CAtom n] -> m n (DictType n)
+dictType className params = do
+  ClassDef sourceName _ _ _ _ _ <- lookupClassDef className
+  return $ DictType sourceName className params
+
+ixDictType :: (Fallible1 m, EnvReader m) => CType n -> m n (DictType n)
+ixDictType ty = do
+  ixClassName <- getIxClassName
+  dictType ixClassName [Type ty]
+
+makePreludeMaybeTy :: EnvReader m => CType n -> m n (CType n)
+makePreludeMaybeTy ty = do
+  ~(Just (UTyConVar tyConName)) <- lookupSourceMap "Maybe"
+  return $ TypeCon "Maybe" tyConName $ TyConParams [Explicit] [Type ty]
 
 -- === computing effects ===
 
@@ -265,342 +284,31 @@ declNestEffectsRec :: IRRep r => Nest (Decl r) n l -> EffectRow r l -> EnvReader
 declNestEffectsRec Empty !acc = return acc
 declNestEffectsRec n@(Nest decl rest) !acc = withExtEvidence n do
   expr <- sinkM $ declExpr decl
-  deff <- getEffects expr
-  acc' <- sinkM $ acc <> deff
+  acc' <- sinkM $ acc <> (getEffects expr)
   declNestEffectsRec rest acc'
   where
     declExpr :: Decl r n l -> Expr r n
-    declExpr (Let _ (DeclBinding _ _ expr)) = expr
-
--- === implementation of querying types ===
-
-newtype TypeQueryM (i::S) (o::S) (a :: *) = TypeQueryM {
-  runTypeQueryM :: SubstReaderT AtomSubstVal EnvReaderM i o a }
-  deriving ( Functor, Applicative, Monad
-           , EnvReader, EnvExtender, ScopeReader
-           , SubstReader AtomSubstVal)
-
-liftTypeQueryM :: (EnvReader m) => Subst AtomSubstVal i o
-               -> TypeQueryM i o a -> m o a
-liftTypeQueryM subst act =
-  liftEnvReaderM $
-    runSubstReaderT subst $
-      runTypeQueryM act
-{-# INLINE liftTypeQueryM #-}
-
-instance MonadFail (TypeQueryM i o) where
-  fail = error
-  {-# INLINE fail #-}
-
-instance Fallible (TypeQueryM i o) where
-  throwErrs err = error $ pprint err
-  {-# INLINE throwErrs #-}
-  addErrCtx = const id
-  {-# INLINE addErrCtx #-}
-
-class HasType (r::IR) (e::E) | e -> r where
-  getTypeE :: e i -> TypeQueryM i o (Type r o)
-
-instance IRRep r => HasType r (AtomName r) where
-  getTypeE name = do
-    substM (Var name) >>= \case
-      Var name' -> atomBindingType <$> lookupAtomName name'
-      atom -> getType atom
-  {-# INLINE getTypeE #-}
-
-instance IRRep r => HasType r (Atom r) where
-  getTypeE :: forall i o. Atom r i -> TypeQueryM i o (Type r o)
-  getTypeE atom = case atom of
-    Var name -> getTypeE name
-    Lam (CoreLamExpr piTy _) -> Pi <$> substM piTy
-    DepPair _ _ ty -> do
-      ty' <- substM ty
-      return $ DepPairTy ty'
-    Con con -> getTypePrimCon con
-    Eff _ -> return EffKind
-    PtrVar v -> substM v >>= lookupEnv >>= \case
-      PtrBinding ty _ -> return $ PtrTy ty
-    DictCon dictExpr -> getTypeE dictExpr
-    NewtypeCon con _ -> getNewtypeType con
-    RepValAtom repVal -> do RepVal ty _ <- substM repVal; return ty
-    ProjectElt (ProjectProduct i) x -> do
-      ty <- getTypeE x
-      x' <- substM x
-      projType i ty x'
-    ProjectElt UnwrapNewtype x -> do
-      getTypeE x >>= \case
-        NewtypeTyCon tc -> snd <$> unwrapNewtypeType tc
-        ty -> error $ "Not a newtype: " ++ pprint x ++ ":" ++ pprint ty
-    SimpInCore x -> getTypeE x
-    DictHole _ ty _ -> substM ty
-    TypeAsAtom ty -> getTypeE ty
-
-instance IRRep r => HasType r (Type r) where
-  getTypeE :: forall i o. Type r i -> TypeQueryM i o (Type r o)
-  getTypeE = \case
-    NewtypeTyCon con -> getTypeE con
-    Pi _        -> return TyKind
-    TabPi _     -> return TyKind
-    DepPairTy _ -> return TyKind
-    TC _        -> return TyKind
-    DictTy _    -> return TyKind
-    TyVar v     -> getTypeE v
-    ProjectEltTy (ProjectProduct i) x -> do
-      ty <- getTypeE x
-      x' <- substM x
-      projType i ty x'
-    ProjectEltTy UnwrapNewtype x -> do
-      getTypeE x >>= \case
-        NewtypeTyCon tc -> snd <$> unwrapNewtypeType tc
-        ty -> error $ "Not a newtype: " ++ pprint x ++ ":" ++ pprint ty
-
-instance HasType CoreIR SimpInCore where
-  getTypeE = \case
-    LiftSimp t _ -> substM t
-    LiftSimpFun piTy _ -> Pi <$> substM piTy
-    TabLam t _ -> TabPi <$> substM t
-    ACase _ _ t -> substM t
-
-instance HasType CoreIR NewtypeTyCon where
-  getTypeE = \case
-    Nat               -> return TyKind
-    Fin _             -> return TyKind
-    EffectRowKind     -> return TyKind
-    UserADTType _ _ _ -> return TyKind
-
-getNewtypeType :: NewtypeCon i -> TypeQueryM i o (CType o)
-getNewtypeType con = case con of
-  NatCon          -> return $ NewtypeTyCon Nat
-  FinCon n        -> NewtypeTyCon . Fin <$> substM n
-  UserADTData d params -> do
-    d' <- substM d
-    params' <- substM params
-    TyConDef sn _ _ <- lookupTyCon d'
-    return $ NewtypeTyCon $ UserADTType sn d' params'
-
-getTypePrimCon :: IRRep r => Con r i -> TypeQueryM i o (Type r o)
-getTypePrimCon con = case con of
-  Lit l -> return $ BaseTy $ litType l
-  ProdCon xs -> ProdTy <$> mapM getTypeE xs
-  SumCon tys _ _ -> SumTy <$> traverse substM tys
-  HeapVal       -> return $ TC HeapType
-
-getIxClassName :: (Fallible1 m, EnvReader m) => m n (ClassName n)
-getIxClassName = lookupSourceMap "Ix" >>= \case
-  Nothing -> throw CompilerErr $ "Ix interface needed but not defined!"
-  Just (UClassVar v) -> return v
-  Just _ -> error "not a class var"
-
-dictType :: (Fallible1 m, EnvReader m) => ClassName n -> [CAtom n] -> m n (DictType n)
-dictType className params = do
-  ClassDef sourceName _ _ _ _ _ <- lookupClassDef className
-  return $ DictType sourceName className params
-
-ixDictType :: (Fallible1 m, EnvReader m) => CType n -> m n (DictType n)
-ixDictType ty = do
-  ixClassName <- getIxClassName
-  dictType ixClassName [Type ty]
-
-getDataClassName :: (Fallible1 m, EnvReader m) => m n (ClassName n)
-getDataClassName = lookupSourceMap "Data" >>= \case
-  Nothing -> throw CompilerErr $ "Data interface needed but not defined!"
-  Just (UClassVar v) -> return v
-  Just _ -> error "not a class var"
-
-dataDictType :: (Fallible1 m, EnvReader m) => CType n -> m n (DictType n)
-dataDictType ty = do
-  dataClassName <- getDataClassName
-  dictType dataClassName [Type ty]
-
-makePreludeMaybeTy :: EnvReader m => CType n -> m n (CType n)
-makePreludeMaybeTy ty = do
-  ~(Just (UTyConVar tyConName)) <- lookupSourceMap "Maybe"
-  return $ TypeCon "Maybe" tyConName $ TyConParams [Explicit] [Type ty]
-
-appType  :: IRRep r => Type r o -> [Atom r i] -> TypeQueryM i o (Type r o)
-appType fTy xs = do
-  Pi (CorePiType _ bs _ resultTy) <- return fTy
-  xs' <- mapM substM xs
-  let subst = bs @@> fmap SubstVal xs'
-  applySubst subst resultTy
-
-partialAppType  :: IRRep r => Type r o -> [Atom r i] -> TypeQueryM i o (Type r o)
-partialAppType fTy xs = do
-  Pi (CorePiType expl bs effs resultTy) <- return fTy
-  xs' <- mapM substM xs
-  PairB bs1 bs2 <- return $ splitNestAt (length xs) bs
-  let subst = bs1 @@> fmap SubstVal xs'
-  applySubst subst $ Pi $ CorePiType expl bs2 effs resultTy
-
-appEffects  :: IRRep r => Type r o -> [Atom r i] -> TypeQueryM i o (EffectRow r o)
-appEffects fTy xs = do
-  Pi (CorePiType _ bs effs _) <- return fTy
-  xs' <- mapM substM xs
-  let subst = bs @@> fmap SubstVal xs'
-  applySubst subst effs
-
-typeTabApp :: IRRep r => Type r o -> [Atom r i] -> TypeQueryM i o (Type r o)
-typeTabApp ty [] = return ty
-typeTabApp ty (i:rest) = do
-  TabTy (b:>_) resultTy <- return ty
-  i' <- substM i
-  resultTy' <- applySubst (b@>SubstVal i') resultTy
-  typeTabApp resultTy' rest
-
-instance HasType CoreIR DictExpr where
-  getTypeE e =  case e of
-    InstanceDict instanceName args -> do
-      instanceName' <- substM instanceName
-      InstanceDef className bs params _ <- lookupInstanceDef instanceName'
-      ClassDef sourceName _ _ _ _ _ <- lookupClassDef className
-      args' <- mapM substM args
-      ListE params' <- applySubst (bs @@> map SubstVal args') $ ListE params
-      return $ DictTy $ DictType sourceName className params'
-    InstantiatedGiven given args -> do
-      givenTy <- getTypeE given
-      appType givenTy (toList args)
-    SuperclassProj d i -> do
-      DictTy (DictType _ className params) <- getTypeE d
-      ClassDef _ _ _ bs superclasses _ <- lookupClassDef className
-      applySubst (bs @@> map SubstVal params) $
-        getSuperclassType REmpty superclasses i
-    IxFin n -> do
-      n' <- substM n
-      liftM DictTy $ ixDictType $ NewtypeTyCon $ Fin n'
-    DataData ty -> DictTy <$> (dataDictType =<< substM ty)
-
-getSuperclassType :: RNest CBinder n l -> Nest CBinder l l' -> Int -> CType n
-getSuperclassType _ Empty = error "bad index"
-getSuperclassType bsAbove (Nest b bs) = \case
-  0 -> ignoreHoistFailure $ hoist bsAbove $ binderType b
-  i -> getSuperclassType (RNest bsAbove b) bs (i-1)
-
-instance IRRep r => HasType r (Expr r) where
-  getTypeE expr = case expr of
-    App f xs -> do
-      fTy <- getTypeE f
-      appType fTy $ toList xs
-    TopApp f xs -> do
-      PiType bs _ resultTy <- getTypeTopFun =<< substM f
-      xs' <- mapM substM xs
-      applySubst (bs @@> map SubstVal xs') resultTy
-    TabApp f xs -> do
-      fTy <- getTypeE f
-      typeTabApp fTy xs
-    Atom x   -> getTypeE x
-    TabCon _ ty _ -> substM ty
-    PrimOp          op -> getTypeE op
-    Case _ _ resultTy _ -> substM resultTy
-    ApplyMethod dict i args -> do
-      dict' <- substM dict
-      methodTy <- getMethodType dict' i
-      appType (Pi methodTy) args
-
-instance IRRep r => HasType r (DAMOp r) where
-  getTypeE = \case
-    AllocDest ty -> RawRefTy <$> substM ty
-    Place _ _ -> return UnitTy
-    Freeze ref -> getTypeE ref >>= \case
-      RawRefTy ty -> return ty
-      ty -> error $ "Not a reference type: " ++ pprint ty
-    Seq _ _ cinit _ -> getTypeE cinit
-    RememberDest d _ -> getTypeE d
-
-instance HasType CoreIR UserEffectOp where
-  getTypeE = \case
-    Handle hndName [] body -> do
-      hndName' <- substM hndName
-      r <- getTypeE body
-      instantiateHandlerType hndName' r []
-    Handle _ _ _  -> error "not implemented"
-    Perform eff i -> do
-      Eff (OneEffect (UserEffect effName)) <- return eff
-      EffectDef _ ops <- substM effName >>= lookupEffectDef
-      let (_, EffectOpType _pol lamTy) = ops !! i
-      return lamTy
-    Resume retTy _ -> substM retTy
-
-instance IRRep r => HasType r (PrimOp r) where
-  getTypeE primOp = case primOp of
-    BinOp op x _ -> do
-      xTy <- getTypeBaseType x
-      return $ TC $ BaseType $ typeBinOp op xTy
-    UnOp op x -> TC . BaseType . typeUnOp op <$> getTypeBaseType x
-    Hof  hof -> getTypeHof hof
-    MemOp op -> getTypeE op
-    MiscOp op -> getTypeE op
-    VectorOp op -> getTypeE op
-    DAMOp           op -> getTypeE op
-    UserEffectOp    op -> getTypeE op
-    RefOp ref m -> do
-      TC (RefType h s) <- getTypeE ref
-      case m of
-        MGet        -> return s
-        MPut _      -> return UnitTy
-        MAsk        -> return s
-        MExtend _ _ -> return UnitTy
-        IndexRef i -> do
-          TabTy (b:>_) eltTy <- return s
-          i' <- substM i
-          eltTy' <- applyAbs (Abs b eltTy) (SubstVal i')
-          return $ TC $ RefType h eltTy'
-        ProjRef p -> TC . RefType h <$> case p of
-          ProjectProduct i -> do
-            ProdTy tys <- return s
-            return $ tys !! i
-          UnwrapNewtype -> do
-            NewtypeTyCon tc <- return s
-            snd <$> unwrapNewtypeType tc
-
-instance IRRep r => HasType r (MemOp r) where
-  getTypeE = \case
-    IOAlloc _ -> return $ PtrTy (CPU, Scalar Word8Type)
-    IOFree _ -> return UnitTy
-    PtrOffset arr _ -> getTypeE arr
-    PtrLoad ptr -> do
-      PtrTy (_, t) <- getTypeE ptr
-      return $ BaseTy t
-    PtrStore _ _ -> return UnitTy
-
-instance IRRep r => HasType r (VectorOp r) where
-  getTypeE = \case
-    VectorBroadcast _ vty -> substM vty
-    VectorIota vty -> substM vty
-    VectorSubref ref _ vty -> getTypeE ref >>= \case
-      TC (RefType h _) -> TC . RefType h <$> substM vty
-      ty -> error $ "Not a reference type: " ++ pprint ty
-
-instance IRRep r => HasType r (MiscOp r) where
-  getTypeE = \case
-    Select _ x _ -> getTypeE x
-    ThrowError ty -> substM ty
-    ThrowException ty -> substM ty
-    CastOp t _ -> substM t
-    BitcastOp t _ -> substM t
-    UnsafeCoerce t _ -> substM t
-    GarbageVal t -> substM t
-    SumTag _ -> return TagRepTy
-    ToEnum t _ -> substM t
-    OutputStream ->
-      return $ BaseTy $ hostPtrTy $ Scalar Word8Type
-      where hostPtrTy ty = PtrType (CPU, ty)
-    ShowAny _ -> rawStrType -- TODO: constrain `ShowAny` to have `HasCore r`
-    ShowScalar _ -> PairTy IdxRepTy <$> rawFinTabType (IdxRepVal showStringBufferSize) CharRepTy
+    declExpr (Let _ (DeclBinding _ expr)) = expr
 
 instantiateHandlerType :: EnvReader m => HandlerName n -> CType n -> [CAtom n] -> m n (CType n)
 instantiateHandlerType hndName r args = do
   HandlerDef _ rb bs _effs retTy _ _ <- lookupHandlerDef hndName
   applySubst (rb @> (SubstVal (Type r)) <.> bs @@> (map SubstVal args)) retTy
 
-getSuperclassDicts :: ClassDef n -> CAtom n -> [CAtom n]
-getSuperclassDicts (ClassDef _ _ _ _ classBs _) dict =
-  for [0 .. nestLength classBs - 1] \i -> DictCon $ SuperclassProj dict i
+getSuperclassDicts :: EnvReader m => CAtom n -> m n ([CAtom n])
+getSuperclassDicts dict = do
+  case getType dict of
+    DictTy dTy -> do
+      ts <- getSuperclassTys dTy
+      forM (enumerate ts) \(i, t) -> return $ DictCon t $ SuperclassProj dict i
+    _ -> error "expected a dict type"
 
-getTypeBaseType :: (IRRep r, HasType r e) => e i -> TypeQueryM i o BaseType
-getTypeBaseType e =
-  getTypeE e >>= \case
-    TC (BaseType b) -> return b
-    ty -> throw TypeErr $ "Expected a base type. Got: " ++ pprint ty
+getSuperclassTys :: EnvReader m => DictType n -> m n [CType n]
+getSuperclassTys (DictType _ className params) = do
+  ClassDef _ _ _ bs superclasses _ <- lookupClassDef className
+  forM [0 .. nestLength superclasses - 1] \i -> do
+    applySubst (bs @@> map SubstVal params) $
+      getSuperclassType REmpty superclasses i
 
 getTypeTopFun :: EnvReader m => TopFunName n -> m n (PiType SimpIR n)
 getTypeTopFun f = lookupTopFun f >>= \case
@@ -620,217 +328,3 @@ liftIFunType (IFunType _ argTys resultTys) = liftEnvReaderM $ go argTys where
     t:ts -> withFreshBinder noHint (BaseTy t) \b -> do
       PiType bs effs resultTy <- go ts
       return $ PiType (Nest b bs) effs resultTy
-
-getTypeHof :: IRRep r => Hof r i -> TypeQueryM i o (Type r o)
-getTypeHof hof = addContext ("Checking HOF:\n" ++ pprint hof) case hof of
-  For _ dict f -> do
-    PiType (UnaryNest (b:>_)) _ eltTy <- getLamExprTypeE f
-    ixTy <- ixTyFromDict =<< substM dict
-    return $ TabTy (b:>ixTy) eltTy
-  While _ -> return UnitTy
-  Linearize f _ -> do
-    PiType (UnaryNest (binder:>a)) Pure b <- getLamExprTypeE f
-    let b' = ignoreHoistFailure $ hoist binder b
-    fLinTy <- Pi <$> nonDepPiType [a] Pure b'
-    return $ PairTy b' fLinTy
-  Transpose f _ -> do
-    PiType (UnaryNest (_:>a)) _ _ <- getLamExprTypeE f
-    return a
-  RunReader _ f -> do
-    (resultTy, _) <- getTypeRWSAction f
-    return resultTy
-  RunWriter _ _ f -> do
-    uncurry PairTy <$> getTypeRWSAction f
-  RunState _ _ f -> do
-    (resultTy, stateTy) <- getTypeRWSAction f
-    return $ PairTy resultTy stateTy
-  RunIO f -> getTypeE f
-  RunInit f -> getTypeE f
-  CatchException f -> getTypeE f >>= makePreludeMaybeTy
-
-getLamExprTypeE :: IRRep r => LamExpr r i -> TypeQueryM i o (PiType r o)
-getLamExprTypeE (LamExpr bs body) =
-  substBinders bs \bs' -> do
-    effs <- substM $ blockEffects body
-    resultTy <- getTypeE body
-    return $ PiType bs' effs resultTy
-
-getDestLamExprType :: IRRep r => DestLamExpr r i -> TypeQueryM i o (PiType r o)
-getDestLamExprType (DestLamExpr bs body) =
-  substBinders bs \bs' -> do
-    resultTy <- getDestBlockType =<< substM body
-    effs <- substM $ destBlockEffects body
-    return $ PiType bs' effs resultTy
-
-getTypeRWSAction :: IRRep r => LamExpr r i -> TypeQueryM i o (Type r o, Type r o)
-getTypeRWSAction f = do
-  PiType (BinaryNest regionBinder refBinder) _ resultTy <- getLamExprTypeE f
-  RefTy _ referentTy <- return $ binderType refBinder
-  let referentTy' = ignoreHoistFailure $ hoist regionBinder referentTy
-  let resultTy' = ignoreHoistFailure $ hoist (PairB regionBinder refBinder) resultTy
-  return (resultTy', referentTy')
-
-instance IRRep r => HasType r (Block r) where
-  getTypeE (Block NoBlockAnn Empty result) = getTypeE result
-  getTypeE (Block (BlockAnn ty _) _ _) = substM ty
-  getTypeE _ = error "impossible"
-
-ixTyFromDict :: IRRep r => EnvReader m => IxDict r n -> m n (IxType r n)
-ixTyFromDict ixDict = flip IxType ixDict <$> case ixDict of
-  IxDictAtom dict -> getType dict >>= \case
-    DictTy (DictType "Ix" _ [Type iTy]) -> return iTy
-    _ -> error $ "Not an Ix dict: " ++ pprint dict
-  IxDictRawFin _ -> return IdxRepTy
-  IxDictSpecialized n _ _ -> return n
-
-rawStrType :: IRRep r => EnvReader m => m n (Type r n)
-rawStrType = liftEnvReaderM do
-  withFreshBinder "n" IdxRepTy \b -> do
-    tabTy <- rawFinTabType (Var $ binderName b) CharRepTy
-    return $ DepPairTy $ DepPairType ExplicitDepPair b tabTy
-
--- `n` argument is IdxRepVal, not Nat
-rawFinTabType :: IRRep r => EnvReader m => Atom r n -> Type r n -> m n (Type r n)
-rawFinTabType n eltTy = IxType IdxRepTy (IxDictRawFin n) ==> eltTy
-
--- === querying effects implementation ===
-
-class HasEffectsE (e::E) (r::IR) | e -> r where
-  getEffectsImpl :: e i -> TypeQueryM i o (EffectRow r o)
-
-instance IRRep r => HasEffectsE (Expr r) r where
-  getEffectsImpl = exprEffects
-  {-# INLINE getEffectsImpl #-}
-
-instance IRRep r => HasEffectsE (DeclBinding r) r where
-  getEffectsImpl (DeclBinding _ _ expr) = getEffectsImpl expr
-  {-# INLINE getEffectsImpl #-}
-
-exprEffects :: IRRep r => Expr r i -> TypeQueryM i o (EffectRow r o)
-exprEffects expr = case expr of
-  Atom _  -> return Pure
-  App f xs -> do
-    fTy <- getTypeSubst f
-    appEffects fTy xs
-  TopApp f xs -> do
-    PiType bs effs _ <- getTypeTopFun =<< substM f
-    xs' <- mapM substM xs
-    applySubst (bs @@> fmap SubstVal xs') effs
-  TabApp _ _ -> return Pure
-  Case _ _ _ effs -> substM effs
-  TabCon _ _ _      -> return Pure
-  ApplyMethod dict i args -> do
-    dict' <- substM dict
-    methodTy <- getMethodType dict' i
-    appEffects (Pi methodTy) args
-  PrimOp primOp -> primOpEffects primOp
-
-primOpEffects ::IRRep r => PrimOp r i -> TypeQueryM i o (EffectRow r o)
-primOpEffects = \case
-  UnOp  _ _   -> return Pure
-  BinOp _ _ _ -> return Pure
-  VectorOp _  -> return Pure
-  MemOp op -> case op of
-    IOAlloc  _    -> return $ OneEffect IOEffect
-    IOFree   _    -> return $ OneEffect IOEffect
-    PtrLoad  _    -> return $ OneEffect IOEffect
-    PtrStore _ _  -> return $ OneEffect IOEffect
-    PtrOffset _ _ -> return Pure
-  MiscOp op -> case op of
-    ThrowException _ -> return $ OneEffect ExceptionEffect
-    Select _ _ _     -> return Pure
-    ThrowError _     -> return Pure
-    CastOp _ _       -> return Pure
-    UnsafeCoerce _ _ -> return Pure
-    GarbageVal _     -> return Pure
-    BitcastOp _ _    -> return Pure
-    SumTag _         -> return Pure
-    ToEnum _ _       -> return Pure
-    OutputStream     -> return Pure
-    ShowAny _        -> return Pure
-    ShowScalar _     -> return Pure
-  RefOp ref m -> do
-    TC (RefType h _) <- getTypeSubst ref
-    return case m of
-      MGet      -> OneEffect (RWSEffect State  h)
-      MPut    _ -> OneEffect (RWSEffect State  h)
-      MAsk      -> OneEffect (RWSEffect Reader h)
-      -- XXX: We don't verify the base monoid. See note about RunWriter.
-      MExtend _ _ -> OneEffect (RWSEffect Writer h)
-      IndexRef _ -> Pure
-      ProjRef _  -> Pure
-  UserEffectOp op -> case op of
-    Handle v _ body -> do
-      HandlerDef eff _ _ _ _ _ _ <- substM v >>= lookupHandlerDef
-      deleteEff (UserEffect eff) <$> getEffectsImpl body
-    Resume _ _  -> return Pure
-    Perform effVal _ -> do
-      Eff eff <- return effVal
-      substM eff
-  DAMOp op -> case op of
-    Place    _ _  -> return $ OneEffect InitEffect
-    Seq _ _ _ f      -> functionEffs f
-    RememberDest _ f -> functionEffs f
-    AllocDest _ -> return Pure -- is this correct?
-    Freeze _    -> return Pure -- is this correct?
-  Hof hof -> case hof of
-    For _ _ f     -> functionEffs f
-    While body    -> getEffectsImpl body
-    Linearize _ _ -> return Pure  -- Body has to be a pure function
-    Transpose _ _ -> return Pure  -- Body has to be a pure function
-    RunReader _ f -> rwsFunEffects Reader f
-    RunWriter d _ f -> rwsFunEffects Writer f <&> maybeInit d
-    RunState  d _ f -> rwsFunEffects State  f <&> maybeInit d
-    RunIO          f -> deleteEff IOEffect        <$> getEffectsImpl f
-    RunInit        f -> deleteEff InitEffect      <$> getEffectsImpl f
-    CatchException f -> deleteEff ExceptionEffect <$> getEffectsImpl f
-    where maybeInit :: IRRep r => Maybe (Atom r i) -> (EffectRow r o -> EffectRow r o)
-          maybeInit d = case d of Just _ -> (<>OneEffect InitEffect); Nothing -> id
-
-instance IRRep r => HasEffectsE (Block r) r where
-  getEffectsImpl (Block (BlockAnn _ effs) _ _) = substM effs
-  getEffectsImpl (Block NoBlockAnn _ _) = return Pure
-  {-# INLINE getEffectsImpl #-}
-
-instance IRRep r => HasEffectsE (DestBlock r) r where
-  getEffectsImpl (DestBlock b (Block ann _ _)) = case ann of
-    BlockAnn _ effs -> substM $ ignoreHoistFailure $ hoist b effs
-    NoBlockAnn -> return Pure
-  {-# INLINE getEffectsImpl #-}
-
-instance IRRep r => HasEffectsE (Alt r) r where
-  getEffectsImpl (Abs bs body) =
-    substBinders bs \bs' ->
-      ignoreHoistFailure . hoist bs' <$> getEffectsImpl body
-  {-# INLINE getEffectsImpl #-}
-
--- wrapper to allow checking the effects of an applied nullary lambda
-data NullaryLamApp r n = NullaryLamApp (LamExpr r n)
--- XXX: this should only be used for nullary lambdas
-instance IRRep r => HasEffectsE (NullaryLamApp r) r where
-  getEffectsImpl (NullaryLamApp (NullaryLamExpr block)) = getEffectsImpl block
-  getEffectsImpl _ = error "not a nullary lambda"
-  {-# INLINE getEffectsImpl #-}
-
--- wrapper to allow checking the effects of an applied nullary dest lambda
-data NullaryDestLamApp r n = NullaryDestLamApp (DestLamExpr r n)
--- XXX: this should only be used for nullary lambdas
-instance IRRep r => HasEffectsE (NullaryDestLamApp r) r where
-  getEffectsImpl (NullaryDestLamApp (NullaryDestLamExpr block)) = getEffectsImpl block
-  getEffectsImpl _ = error "not a nullary lambda"
-  {-# INLINE getEffectsImpl #-}
-
-functionEffs :: IRRep r => LamExpr r i -> TypeQueryM i o (EffectRow r o)
-functionEffs f = getLamExprTypeE f >>= \case
-  PiType b effs _ -> return $ ignoreHoistFailure $ hoist b effs
-
-rwsFunEffects :: IRRep r => RWS -> LamExpr r i -> TypeQueryM i o (EffectRow r o)
-rwsFunEffects rws f = getLamExprTypeE f >>= \case
-   PiType (BinaryNest h ref) effs _ -> do
-     let effs' = ignoreHoistFailure $ hoist ref effs
-     let effs'' = deleteEff (RWSEffect rws (Var $ binderName h)) effs'
-     return $ ignoreHoistFailure $ hoist h effs''
-   _ -> error "Expected a binary function type"
-
-deleteEff :: IRRep r => Effect r n -> EffectRow r n -> EffectRow r n
-deleteEff eff (EffectRow effs t) = EffectRow (effs `eSetDifference` eSetSingleton eff) t

--- a/src/lib/QueryTypePure.hs
+++ b/src/lib/QueryTypePure.hs
@@ -1,0 +1,422 @@
+-- Copyright 2023 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+module QueryTypePure where
+
+import Types.Primitives
+import Types.Core
+import IRVariants
+import Name
+
+class HasType (r::IR) (e::E) | e -> r where
+  getType :: e n -> Type r n
+
+class HasEffects (e::E) (r::IR) | e -> r where
+  getEffects :: e n -> EffectRow r n
+
+isPure :: (IRRep r, HasEffects e r) => e n -> Bool
+isPure e = case getEffects e of
+  Pure -> True
+  _    -> False
+
+-- === querying types implementation ===
+
+instance IRRep r => HasType r (AtomBinding r) where
+  getType = \case
+    LetBound    (DeclBinding _ e)  -> getType e
+    MiscBound   ty                 -> ty
+    SolverBound (InfVarBound ty _) -> ty
+    SolverBound (SkolemBound ty)   -> ty
+    NoinlineFun ty _               -> ty
+    TopDataBound (RepVal ty _)     -> ty
+    FFIFunBound piTy _ -> Pi piTy
+
+litType :: LitVal -> BaseType
+litType v = case v of
+  Int64Lit   _ -> Scalar Int64Type
+  Int32Lit   _ -> Scalar Int32Type
+  Word8Lit   _ -> Scalar Word8Type
+  Word32Lit  _ -> Scalar Word32Type
+  Word64Lit  _ -> Scalar Word64Type
+  Float64Lit _ -> Scalar Float64Type
+  Float32Lit _ -> Scalar Float32Type
+  PtrLit ty _  -> PtrType ty
+
+typeBinOp :: BinOp -> BaseType -> BaseType
+typeBinOp binop xTy = case binop of
+  IAdd   -> xTy;  ISub   -> xTy
+  IMul   -> xTy;  IDiv   -> xTy
+  IRem   -> xTy;
+  ICmp _ -> Scalar Word8Type
+  FAdd   -> xTy;  FSub   -> xTy
+  FMul   -> xTy;  FDiv   -> xTy;
+  FPow   -> xTy
+  FCmp _ -> Scalar Word8Type
+  BAnd   -> xTy;  BOr    -> xTy
+  BXor   -> xTy
+  BShL   -> xTy;  BShR   -> xTy
+
+typeUnOp :: UnOp -> BaseType -> BaseType
+typeUnOp = const id  -- All unary ops preserve the type of the input
+
+
+instance IRRep r => HasType r (AtomVar r) where
+  getType (AtomVar _ ty) = ty
+  {-# INLINE getType #-}
+
+instance IRRep r => HasType r (Atom r) where
+  getType atom = case atom of
+    Var name -> getType name
+    Lam (CoreLamExpr piTy _) -> Pi piTy
+    DepPair _ _ ty -> DepPairTy ty
+    Con con -> getType con
+    Eff _ -> EffKind
+    PtrVar t _ -> PtrTy t
+    DictCon ty _ -> ty
+    NewtypeCon con _ -> getNewtypeType con
+    RepValAtom (RepVal ty _) -> ty
+    ProjectElt t _ _ -> t
+    SimpInCore x -> getType x
+    DictHole _ ty _ -> ty
+    TypeAsAtom ty -> getType ty
+
+instance IRRep r => HasType r (Type r) where
+  getType = \case
+    NewtypeTyCon con -> getType con
+    Pi _        -> TyKind
+    TabPi _     -> TyKind
+    DepPairTy _ -> TyKind
+    TC _        -> TyKind
+    DictTy _    -> TyKind
+    TyVar v     -> getType v
+    ProjectEltTy t _ _ -> t
+
+instance HasType CoreIR SimpInCore where
+  getType = \case
+    LiftSimp t _       -> t
+    LiftSimpFun piTy _ -> Pi $ piTy
+    TabLam t _         -> TabPi $ t
+    ACase _ _ t        -> t
+
+instance HasType CoreIR NewtypeTyCon where
+  getType _ = TyKind
+
+getNewtypeType :: NewtypeCon n -> CType n
+getNewtypeType con = case con of
+  NatCon          -> NewtypeTyCon Nat
+  FinCon n        -> NewtypeTyCon $ Fin n
+  UserADTData sn d params -> NewtypeTyCon $ UserADTType sn d params
+
+instance IRRep r => HasType r (Con r) where
+  getType = \case
+    Lit l          -> BaseTy $ litType l
+    ProdCon xs     -> ProdTy $ map getType xs
+    SumCon tys _ _ -> SumTy tys
+    HeapVal        -> TC HeapType
+
+getSuperclassType :: RNest CBinder n l -> Nest CBinder l l' -> Int -> CType n
+getSuperclassType _ Empty = error "bad index"
+getSuperclassType bsAbove (Nest b bs) = \case
+  0 -> ignoreHoistFailure $ hoist bsAbove $ binderType b
+  i -> getSuperclassType (RNest bsAbove b) bs (i-1)
+
+instance IRRep r => HasType r (Expr r) where
+  getType expr = case expr of
+    App (EffTy _ ty) _ _ -> ty
+    TopApp (EffTy _ ty) _ _ -> ty
+    TabApp t _ _ -> t
+    Atom x   -> getType x
+    TabCon _ ty _ -> ty
+    PrimOp op -> getType op
+    Case _ _ resultTy _ -> resultTy
+    ApplyMethod (EffTy _ t) _ _ _ -> t
+
+instance IRRep r => HasType r (DAMOp r) where
+  getType = \case
+    AllocDest ty -> RawRefTy ty
+    Place _ _ -> UnitTy
+    Freeze ref -> case getType ref of
+      RawRefTy ty -> ty
+      ty -> error $ "Not a reference type: " ++ show ty
+    Seq _ _ cinit _ -> getType cinit
+    RememberDest d _ -> getType d
+
+instance HasType CoreIR UserEffectOp where
+  getType = \case
+    Handle _ _ _ -> undefined
+    Perform _ _ -> undefined
+    Resume retTy _ -> retTy
+
+instance IRRep r => HasType r (PrimOp r) where
+  getType primOp = case primOp of
+    BinOp op x _ -> TC $ BaseType $ typeBinOp op $ getTypeBaseType x
+    UnOp  op x   -> TC $ BaseType $ typeUnOp  op $ getTypeBaseType x
+    Hof  hof -> getType hof
+    MemOp op -> getType op
+    MiscOp op -> getType op
+    VectorOp op -> getType op
+    DAMOp           op -> getType op
+    UserEffectOp    op -> getType op
+    RefOp ref m -> case getType ref of
+      TC (RefType _ s) -> case m of
+        MGet        -> s
+        MPut _      -> UnitTy
+        MAsk        -> s
+        MExtend _ _ -> UnitTy
+        IndexRef t _ -> t
+        ProjRef t _ -> t
+      _ -> error "not a reference type"
+
+getTypeBaseType :: (IRRep r, HasType r e) => e n -> BaseType
+getTypeBaseType e = case getType e of
+  TC (BaseType b) -> b
+  ty -> error $ "Expected a base type. Got: " ++ show ty
+
+instance IRRep r => HasType r (MemOp r) where
+  getType = \case
+    IOAlloc _ -> PtrTy (CPU, Scalar Word8Type)
+    IOFree _ -> UnitTy
+    PtrOffset arr _ -> getType arr
+    PtrLoad ptr -> do
+      let PtrTy (_, t) = getType ptr
+      BaseTy t
+    PtrStore _ _ -> UnitTy
+
+instance IRRep r => HasType r (VectorOp r) where
+  getType = \case
+    VectorBroadcast _ vty -> vty
+    VectorIota vty -> vty
+    VectorSubref ref _ vty -> case getType ref of
+      TC (RefType h _) -> TC $ RefType h vty
+      ty -> error $ "Not a reference type: " ++ show ty
+
+instance IRRep r => HasType r (MiscOp r) where
+  getType = \case
+    Select _ x _ -> getType x
+    ThrowError t     -> t
+    ThrowException t -> t
+    CastOp t _       -> t
+    BitcastOp t _    -> t
+    UnsafeCoerce t _ -> t
+    GarbageVal t -> t
+    SumTag _     -> TagRepTy
+    ToEnum t _   -> t
+    OutputStream -> BaseTy $ hostPtrTy $ Scalar Word8Type
+      where hostPtrTy ty = PtrType (CPU, ty)
+    ShowAny _ -> rawStrType -- TODO: constrain `ShowAny` to have `HasCore r`
+    ShowScalar _ -> PairTy IdxRepTy $ rawFinTabType (IdxRepVal showStringBufferSize) CharRepTy
+
+instance IRRep r => HasType r (Hof r) where
+  getType = \case
+    For _ dict f -> case getLamExprType f of
+      PiType (UnaryNest (b:>_)) _ eltTy ->
+        TabTy (b:>ixTyFromDict dict) eltTy
+      _ -> error "expected a unary pi type"
+    While _ -> UnitTy
+    Linearize f _ -> case getLamExprType f of
+      PiType (UnaryNest (binder:>a)) Pure b -> do
+        let b' = ignoreHoistFailure $ hoist binder b
+        let fLinTy = Pi $ nonDepPiType [a] Pure b'
+        PairTy b' fLinTy
+      _ -> error "expected a unary pi type"
+    Transpose f _ -> case getLamExprType f of
+      PiType (UnaryNest (_:>a)) _ _ -> a
+      _ -> error "expected a unary pi type"
+    RunReader _ f -> resultTy
+      where (resultTy, _) = getTypeRWSAction f
+    RunWriter _ _ f -> uncurry PairTy $ getTypeRWSAction f
+    RunState _ _ f -> PairTy resultTy stateTy
+      where (resultTy, stateTy) = getTypeRWSAction f
+    RunIO f -> getType f
+    RunInit f -> getType f
+    CatchException ty _ -> ty
+
+rawStrType :: IRRep r => Type r n
+rawStrType = case newName "n" of
+  Abs b v -> do
+    let tabTy = rawFinTabType (Var $ AtomVar v IdxRepTy) CharRepTy
+    DepPairTy $ DepPairType ExplicitDepPair (b:>IdxRepTy) tabTy
+
+-- `n` argument is IdxRepVal, not Nat
+rawFinTabType :: IRRep r => Atom r n -> Type r n -> Type r n
+rawFinTabType n eltTy = IxType IdxRepTy (IxDictRawFin n) ==> eltTy
+
+typesAsBinderNest
+  :: (SinkableE e, HoistableE e, IRRep r)
+  => [Type r n] -> e n -> Abs (Nest (Binder r)) e n
+typesAsBinderNest types body = toConstBinderNest types body
+
+nonDepPiType :: [CType n] -> EffectRow CoreIR n -> CType n -> CorePiType n
+nonDepPiType argTys eff resultTy = case typesAsBinderNest argTys (PairE eff resultTy) of
+  Abs bs (PairE eff' resultTy') -> do
+    let bs' = fmapNest (WithExpl Explicit) bs
+    CorePiType ExplicitApp bs' eff' resultTy'
+
+nonDepTabPiType :: IRRep r => IxType r n -> Type r n -> TabPiType r n
+nonDepTabPiType argTy resultTy =
+  case toConstAbsPure resultTy of
+    Abs b resultTy' -> TabPiType (b:>argTy) resultTy'
+
+(==>) :: IRRep r => IxType r n -> Type r n -> Type r n
+a ==> b = TabPi $ nonDepTabPiType a b
+
+finIxTy :: Int -> IxType r n
+finIxTy n = IxType IdxRepTy (IxDictRawFin (IdxRepVal $ fromIntegral n))
+
+ixTyFromDict :: IRRep r => IxDict r n -> IxType r n
+ixTyFromDict ixDict = flip IxType ixDict $ case ixDict of
+  IxDictAtom dict -> case getType dict of
+    DictTy (DictType "Ix" _ [Type iTy]) -> iTy
+    _ -> error $ "Not an Ix dict: " ++ show dict
+  IxDictRawFin _ -> IdxRepTy
+  IxDictSpecialized n _ _ -> n
+
+getLamExprType :: IRRep r => LamExpr r n -> PiType r n
+getLamExprType (LamExpr bs body) = PiType bs (getEffects body) (getType body)
+
+getDestLamExprType :: IRRep r => DestLamExpr r n -> PiType r n
+getDestLamExprType (DestLamExpr bs body) = PiType bs (getEffects body) (getType body)
+
+getTypeRWSAction :: IRRep r => LamExpr r n -> (Type r n, Type r n)
+getTypeRWSAction f = case getLamExprType f of
+  PiType (BinaryNest regionBinder refBinder) _ resultTy -> do
+    case binderType refBinder of
+      RefTy _ referentTy -> do
+        let referentTy' = ignoreHoistFailure $ hoist regionBinder referentTy
+        let resultTy' = ignoreHoistFailure $ hoist (PairB regionBinder refBinder) resultTy
+        (resultTy', referentTy')
+      _ -> error "expected a ref"
+  _ -> error "expected a pi type"
+
+instance IRRep r => HasType r (Block r) where
+  getType (Block NoBlockAnn Empty result) = getType result
+  getType (Block (BlockAnn ty _) _ _) = ty
+  getType _ = error "impossible"
+
+instance IRRep r => HasType r (DestBlock r) where
+  getType (DestBlock (_:>RawRefTy ansTy) _) = ansTy
+  getType _ = error "not a valid dest block"
+
+-- === querying effects implementation ===
+
+instance IRRep r => HasEffects (Expr r) r where
+  getEffects = \case
+    Atom _ -> Pure
+    App (EffTy eff _) _ _ -> eff
+    TopApp (EffTy eff _) _ _ -> eff
+    TabApp _ _ _ -> Pure
+    Case _ _ _ effs -> effs
+    TabCon _ _ _      -> Pure
+    ApplyMethod (EffTy eff _) _ _ _ -> eff
+    PrimOp primOp -> getEffects primOp
+
+instance IRRep r => HasEffects (DeclBinding r) r where
+  getEffects (DeclBinding _ expr) = getEffects expr
+  {-# INLINE getEffects #-}
+
+instance IRRep r => HasEffects (PrimOp r) r where
+  getEffects = \case
+    UnOp  _ _   -> Pure
+    BinOp _ _ _ -> Pure
+    VectorOp _  -> Pure
+    MemOp op -> case op of
+      IOAlloc  _    -> OneEffect IOEffect
+      IOFree   _    -> OneEffect IOEffect
+      PtrLoad  _    -> OneEffect IOEffect
+      PtrStore _ _  -> OneEffect IOEffect
+      PtrOffset _ _ -> Pure
+    MiscOp op -> case op of
+      ThrowException _ -> OneEffect ExceptionEffect
+      Select _ _ _     -> Pure
+      ThrowError _     -> Pure
+      CastOp _ _       -> Pure
+      UnsafeCoerce _ _ -> Pure
+      GarbageVal _     -> Pure
+      BitcastOp _ _    -> Pure
+      SumTag _         -> Pure
+      ToEnum _ _       -> Pure
+      OutputStream     -> Pure
+      ShowAny _        -> Pure
+      ShowScalar _     -> Pure
+    RefOp ref m -> case getType ref of
+      TC (RefType h _) -> case m of
+        MGet      -> OneEffect (RWSEffect State  h)
+        MPut    _ -> OneEffect (RWSEffect State  h)
+        MAsk      -> OneEffect (RWSEffect Reader h)
+        -- XXX: We don't verify the base monoid. See note about RunWriter.
+        MExtend _ _ -> OneEffect (RWSEffect Writer h)
+        IndexRef _ _ -> Pure
+        ProjRef _ _  -> Pure
+      _ -> error "not a ref"
+    UserEffectOp _ -> undefined
+    DAMOp op -> case op of
+      Place    _ _  -> OneEffect InitEffect
+      Seq _ _ _ f      -> functionEffs f
+      RememberDest _ f -> functionEffs f
+      AllocDest _ -> Pure -- is this correct?
+      Freeze _    -> Pure -- is this correct?
+    Hof hof -> case hof of
+      For _ _ f     -> functionEffs f
+      While body    -> getEffects body
+      Linearize _ _ -> Pure  -- Body has to be a pure function
+      Transpose _ _ -> Pure  -- Body has to be a pure function
+      RunReader _ f -> rwsFunEffects Reader f
+      RunWriter d _ f -> maybeInit d $ rwsFunEffects Writer f
+      RunState  d _ f -> maybeInit d $ rwsFunEffects State  f
+      RunIO          f -> deleteEff IOEffect        $ getEffects f
+      RunInit        f -> deleteEff InitEffect      $ getEffects f
+      CatchException _ f -> deleteEff ExceptionEffect $ getEffects f
+      where maybeInit :: IRRep r => Maybe (Atom r i) -> (EffectRow r o -> EffectRow r o)
+            maybeInit d = case d of Just _ -> (<>OneEffect InitEffect); Nothing -> id
+  {-# INLINE getEffects #-}
+
+
+instance IRRep r => HasEffects (Block r) r where
+  getEffects (Block (BlockAnn _ effs) _ _) = effs
+  getEffects (Block NoBlockAnn _ _) = Pure
+  {-# INLINE getEffects #-}
+
+instance IRRep r => HasEffects (DestBlock r) r where
+  getEffects (DestBlock b (Block ann _ _)) = case ann of
+    BlockAnn _ effs -> ignoreHoistFailure $ hoist b effs
+    NoBlockAnn -> Pure
+  {-# INLINE getEffects #-}
+
+instance IRRep r => HasEffects (Alt r) r where
+  getEffects (Abs bs body) = ignoreHoistFailure $ hoist bs (getEffects body)
+  {-# INLINE getEffects #-}
+
+-- wrapper to allow checking the effects of an applied nullary lambda
+data NullaryLamApp r n = NullaryLamApp (LamExpr r n)
+-- XXX: this should only be used for nullary lambdas
+instance IRRep r => HasEffects (NullaryLamApp r) r where
+  getEffects (NullaryLamApp (NullaryLamExpr block)) = getEffects block
+  getEffects _ = error "not a nullary lambda"
+  {-# INLINE getEffects #-}
+
+-- wrapper to allow checking the effects of an applied nullary dest lambda
+data NullaryDestLamApp r n = NullaryDestLamApp (DestLamExpr r n)
+-- XXX: this should only be used for nullary lambdas
+instance IRRep r => HasEffects (NullaryDestLamApp r) r where
+  getEffects (NullaryDestLamApp (NullaryDestLamExpr block)) = getEffects block
+  getEffects _ = error "not a nullary lambda"
+  {-# INLINE getEffects #-}
+
+functionEffs :: IRRep r => LamExpr r n -> EffectRow r n
+functionEffs f = case getLamExprType f of
+  PiType b effs _ -> ignoreHoistFailure $ hoist b effs
+
+rwsFunEffects :: IRRep r => RWS -> LamExpr r n -> EffectRow r n
+rwsFunEffects rws f = case getLamExprType f of
+   PiType (BinaryNest h ref) effs _ -> do
+     let effs' = ignoreHoistFailure $ hoist ref effs
+     let hVal = Var $ AtomVar (binderName h) (TC HeapType)
+     let effs'' = deleteEff (RWSEffect rws hVal) effs'
+     ignoreHoistFailure $ hoist h effs''
+   _ -> error "Expected a binary function type"
+
+deleteEff :: IRRep r => Effect r n -> EffectRow r n -> EffectRow r n
+deleteEff eff (EffectRow effs t) = EffectRow (effs `eSetDifference` eSetSingleton eff) t

--- a/src/lib/RuntimePrint.hs
+++ b/src/lib/RuntimePrint.hs
@@ -57,7 +57,7 @@ emitCharLit :: Emits n => Char -> Print n
 emitCharLit c = emitChar $ charRepVal c
 
 showAnyRec :: forall n. Emits n => CAtom n -> Print n
-showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
+showAnyRec atom = case getType atom of
   -- hack to print chars nicely. TODO: make `Char` a newtype
   TC t -> case t of
     BaseType bt -> case bt of
@@ -78,16 +78,16 @@ showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
       parens $ sepBy ", " $ map rec xs
     -- TODO: traverse the type and print out data components
     TypeKind -> printAsConstant
-  ProjectEltTy _ _ -> error "not implemented"
+  ProjectEltTy _ _ _ -> error "not implemented"
   Pi _ -> printTypeOnly "function"
   TabPi _ -> brackets $ forEachTabElt atom \iOrd x -> do
     isFirst <- ieq iOrd (NatVal 0)
     void $ emitIf isFirst UnitTy (return UnitVal) (emitLit ", " >> return UnitVal)
     rec x
   NewtypeTyCon tc -> case tc of
-    Fin _ -> rec $ unwrapNewtype atom
+    Fin _ -> rec =<< unwrapNewtype atom
     Nat -> do
-      let n = unwrapNewtype atom
+      n <- unwrapNewtype atom
       -- Cast to Int so that it prints in decimal instead of hex
       let intTy = TC (BaseType (Scalar Int64Type))
       emitExpr (PrimOp $ MiscOp $ CastOp intTy n) >>= rec
@@ -102,7 +102,7 @@ showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
       def <- lookupTyCon defName
       conDefs <- instantiateTyConDef def params
       case conDefs of
-        ADTCons [con] -> showDataCon con $ unwrapNewtype atom
+        ADTCons [con] -> showDataCon con =<< unwrapNewtype atom
         ADTCons cons -> void $ buildCase atom UnitTy \i arg -> do
           showDataCon (sink $ cons !! i) arg
           return UnitVal
@@ -128,14 +128,14 @@ showAnyRec atom = getType atom >>= \atomTy -> case atomTy of
   -- Done well, this could let you inspect the results of dictionary synthesis
   -- and maybe even debug synthesis failures.
   DictTy _ -> printAsConstant
-  TyVar _ -> error $ "unexpected type variable: " ++ pprint atomTy
+  TyVar v -> error $ "unexpected type variable: " ++ pprint v
   where
     rec :: Emits n' => CAtom n' -> Print n'
     rec = showAnyRec
 
     printTypeOnly :: String -> Print n
     printTypeOnly thingName = do
-      ty <- getType atom
+      ty <- return $ getType atom
       emitLit $ "<" <> thingName <> " of type " <> pprint ty <> ">"
 
     printAsConstant :: Print n
@@ -163,11 +163,11 @@ withBuffer
   -> BuilderM CoreIR n (CAtom n)
 withBuffer cont = do
   lam <- withFreshBinder "h" (TC HeapType) \h -> do
-    bufTy <- bufferTy (Var $ binderName h)
+    bufTy <- bufferTy (Var $ binderVar h)
     withFreshBinder "buf" bufTy \b -> do
-      let eff = OneEffect (RWSEffect State (Var $ sink $ binderName h))
+      let eff = OneEffect (RWSEffect State (Var $ sink $ binderVar h))
       body <- buildBlock do
-        cont $ sink $ Var $ binderName b
+        cont $ sink $ Var $ binderVar b
         return UnitVal
       let piBinders = BinaryNest (WithExpl (Inferred Nothing Unify) h) (WithExpl Explicit b)
       let piTy = CorePiType ExplicitApp piBinders eff UnitTy
@@ -183,15 +183,15 @@ bufferTy h = do
 -- argument has type `Fin n => Word8`
 extendBuffer :: (Emits n, CBuilder m) => CAtom n -> CAtom n -> m n ()
 extendBuffer buf tab = do
-  RefTy h _ <- getType buf
-  TabTy (_:>ixTy) _ <- getType tab
+  RefTy h _ <- return $ getType buf
+  TabTy (_:>ixTy) _ <- return $ getType tab
   n <- applyIxMethodCore Size ixTy []
   void $ applyPreludeFunction "stack_extend_internal" [n, h, buf, tab]
 
 -- argument has type `Word8`
 pushBuffer :: (Emits n, CBuilder m) => CAtom n -> CAtom n -> m n ()
 pushBuffer buf x = do
-  RefTy h _ <- getType buf
+  RefTy h _ <- return $ getType buf
   void $ applyPreludeFunction "stack_push_internal" [h, buf, x]
 
 stringLitAsCharTab :: (Emits n, CBuilder m) => String -> m n (CAtom n)
@@ -199,11 +199,16 @@ stringLitAsCharTab s = do
   t <- finTabTyCore (NatVal $ fromIntegral $ length s) CharRepTy
   emitExpr $ TabCon Nothing t (map charRepVal s)
 
+finTabTyCore :: (Fallible1 m, EnvReader m) => CAtom n -> CType n -> m n (CType n)
+finTabTyCore n eltTy = do
+  d <- mkDictAtom $ IxFin n
+  return $ IxType (FinTy n) (IxDictAtom d) ==> eltTy
+
 getPreludeFunction :: EnvReader m => String -> m n (CAtom n)
 getPreludeFunction sourceName = do
   lookupSourceMap sourceName >>= \case
     Just uvar -> case uvar of
-      UAtomVar v -> return $ Var v
+      UAtomVar v -> Var <$> toAtomVar v
       _ -> notfound
     Nothing -> notfound
  where notfound = error $ "Function not defined: " ++ sourceName
@@ -231,7 +236,7 @@ forEachTabElt
   -> (forall l. (Emits l, DExt n l) => CAtom l -> CAtom l -> m l ())
   -> m n ()
 forEachTabElt tab cont = do
-  TabTy (_:>ixTy) _ <- getType tab
+  TabTy (_:>ixTy) _ <- return $ getType tab
   void $ buildFor "i" Fwd ixTy \i -> do
     x <- tabApp (sink tab) (Var i)
     i' <- applyIxMethodCore Ordinal (sink ixTy) [Var i]

--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -33,7 +33,7 @@ import Transpose
 import Types.Core
 import Types.Source
 import Types.Primitives
-import Util (enumerate, foldMapM)
+import Util (enumerate)
 
 -- === Simplification ===
 
@@ -63,7 +63,7 @@ import Util (enumerate, foldMapM)
 
 tryAsDataAtom :: Emits n => CAtom n -> SimplifyM i n (Maybe (SAtom n, Type CoreIR n))
 tryAsDataAtom atom = do
-  ty <- getType atom
+  let ty = getType atom
   isData ty >>= \case
     False -> return Nothing
     True -> Just <$> do
@@ -72,22 +72,22 @@ tryAsDataAtom atom = do
  where
   go :: Emits n => CAtom n -> SimplifyM i n (SAtom n)
   go = \case
-    Var v -> lookupAtomName v >>= \case
-      LetBound (DeclBinding _ _ (Atom x)) -> go x
+    Var v -> lookupAtomName (atomVarName v) >>= \case
+      LetBound (DeclBinding _ (Atom x)) -> go x
       _ -> error "Shouldn't have irreducible top names left"
     Con con -> Con <$> case con of
       Lit v -> return $ Lit v
       ProdCon xs -> ProdCon <$> mapM go xs
       SumCon  tys tag x -> SumCon <$> mapM getRepType tys <*> pure tag <*> go x
       HeapVal       -> return HeapVal
-    PtrVar v        -> return $ PtrVar v
+    PtrVar t v      -> return $ PtrVar t v
     DepPair x y ty -> do
       DepPairTy ty' <- getRepType $ DepPairTy ty
       DepPair <$> go x <*> go y <*> pure ty'
-    ProjectElt UnwrapNewtype x -> go x
+    ProjectElt _ UnwrapNewtype x -> go x
     -- TODO: do we need to think about a case like `fst (1, \x.x)`, where
     -- the projection is data but the argument isn't?
-    ProjectElt (ProjectProduct i) x -> normalizeProj (ProjectProduct i) =<< go x
+    ProjectElt _ (ProjectProduct i) x -> normalizeProj (ProjectProduct i) =<< go x
     NewtypeCon _ x  -> go x
     SimpInCore x    -> case x of
       LiftSimp _ x' -> return x'
@@ -95,7 +95,7 @@ tryAsDataAtom atom = do
       TabLam _ tabLam -> forceTabLam tabLam
       ACase scrut alts resultTy -> forceACase scrut alts resultTy
     Lam _           -> notData
-    DictCon _       -> notData
+    DictCon _ _     -> notData
     Eff _           -> notData
     DictHole _ _ _  -> notData
     TypeAsAtom _    -> notData
@@ -105,7 +105,7 @@ tryAsDataAtom atom = do
 forceTabLam :: Emits n => TabLamExpr n -> SimplifyM i n (SAtom n)
 forceTabLam (Abs (b:>ixTy) ab) =
   buildFor (getNameHint b) Fwd ixTy \v -> do
-    Abs decls result <- applyRename (b@>v) ab
+    Abs decls result <- applyRename (b@>(atomVarName v)) ab
     result' <- emitDecls decls result
     toDataAtomIgnoreRecon result'
 
@@ -135,13 +135,13 @@ getRepType ty = go ty where
     DepPairTy (DepPairType expl b@(_:>l) r) -> do
       l' <- go l
       withFreshBinder (getNameHint b) l' \b' -> do
-        x <- liftSimpAtom (sink l) (Var $ binderName b')
+        x <- liftSimpAtom (sink l) (Var $ binderVar b')
         r' <- go =<< applySubst (b@>SubstVal x) r
         return $ DepPairTy $ DepPairType expl b' r'
     TabPi (TabPiType (b:>ixTy) bodyTy) -> do
       ixTy' <- simplifyIxType ixTy
       withFreshBinder (getNameHint b) ixTy' \b' -> do
-        x <- liftSimpAtom (sink $ ixTypeType ixTy) (Var $ binderName b')
+        x <- liftSimpAtom (sink $ ixTypeType ixTy) (Var $ binderVar b')
         bodyTy' <- go =<< applySubst (b@>SubstVal x) bodyTy
         return $ TabPi $ TabPiType b' bodyTy'
     NewtypeTyCon con -> do
@@ -150,7 +150,7 @@ getRepType ty = go ty where
     Pi _           -> error notDataType
     DictTy _       -> error notDataType
     TyVar _ -> error "Shouldn't have type variables in CoreIR IR with SimpIR builder names"
-    ProjectEltTy _ _ -> error "Shouldn't have this left"
+    ProjectEltTy _ _ _ -> error "Shouldn't have this left"
     where notDataType = "Not a type of runtime-representable data: " ++ pprint ty
 
 toDataAtom :: Emits n => CAtom n -> SimplifyM i n (SAtom n, Type CoreIR n)
@@ -179,7 +179,7 @@ withSimplifiedBinders Empty cont = getDistinct >>= \Distinct -> cont Empty []
 withSimplifiedBinders (Nest (bCore:>ty) bsCore) cont = do
   simpTy <- getRepType ty
   withFreshBinder (getNameHint bCore) simpTy \bSimp -> do
-    x <- liftSimpAtom (sink ty) (Var $ binderName bSimp)
+    x <- liftSimpAtom (sink ty) (Var $ binderVar bSimp)
     -- TODO: carry a substitution instead of doing N^2 work like this
     Abs bsCore' UnitE <- applySubst (bCore@>SubstVal x) (EmptyAbs bsCore)
     withSimplifiedBinders bsCore' \bsSimp xs ->
@@ -279,26 +279,28 @@ simpDeclsSubst
   -> SimplifyM i o (Subst AtomSubstVal i' o)
 simpDeclsSubst !s = \case
   Empty -> return s
-  Nest (Let b (DeclBinding _ _ expr)) rest -> do
+  Nest (Let b (DeclBinding _ expr)) rest -> do
     let hint = (getNameHint b)
     x <- withSubst s $ simplifyExpr hint expr
     simpDeclsSubst (s <>> (b@>SubstVal x)) rest
 
 simplifyExpr :: Emits o => NameHint -> Expr CoreIR i -> SimplifyM i o (CAtom o)
 simplifyExpr hint expr = confuseGHC >>= \_ -> case expr of
-  App f xs -> do
+  App (EffTy _ ty) f xs -> do
+    ty' <- substM ty
     xs' <- mapM simplifyAtom xs
-    simplifyApp hint f xs'
-  TabApp f xs -> do
+    simplifyApp hint ty' f xs'
+  TabApp _ f xs -> do
     xs' <- mapM simplifyAtom xs
     f'  <- simplifyAtom f
     simplifyTabApp f' xs'
   Atom x -> simplifyAtom x
   PrimOp  op  -> simplifyOp hint op
-  ApplyMethod dict i xs -> do
+  ApplyMethod (EffTy _ ty) dict i xs -> do
+    ty' <- substM ty
     xs' <- mapM simplifyAtom xs
     dict' <- simplifyAtom dict
-    applyDictMethod dict' i xs'
+    applyDictMethod ty' dict' i xs'
   TabCon _ ty xs -> do
     ty' <- substM ty
     tySimp <- getRepType ty'
@@ -323,18 +325,18 @@ simplifyRefOp op ref = case op of
     x' <- simplifyDataAtom x
     emitRefOp $ MPut x'
   MAsk   -> emitRefOp MAsk
-  IndexRef x -> do
+  IndexRef _ x -> do
     x' <- simplifyDataAtom x
-    emitRefOp $ IndexRef x'
-  ProjRef (ProjectProduct i) -> emitRefOp $ ProjRef (ProjectProduct i)
-  ProjRef UnwrapNewtype -> return ref
+    emitOp =<< mkIndexRef ref x'
+  ProjRef _ (ProjectProduct i) -> emitOp =<< mkProjRef ref (ProjectProduct i)
+  ProjRef _ UnwrapNewtype -> return ref
   where emitRefOp op' = emitOp $ RefOp ref op'
 
 caseComputingEffs
   :: forall m n r. (MonadFail1 m, EnvReader m, IRRep r)
   => Atom r n -> [Alt r n] -> Type r n -> m n (Expr r n)
 caseComputingEffs scrut alts resultTy = do
-  Case scrut alts resultTy <$> foldMapM getEffects alts
+  return $ Case scrut alts resultTy $ foldMap getEffects alts
 {-# INLINE caseComputingEffs #-}
 
 defuncCaseCore :: Emits o
@@ -344,7 +346,7 @@ defuncCaseCore :: Emits o
 defuncCaseCore scrut resultTy cont = do
   tryAsDataAtom scrut >>= \case
     Just (scrutSimp, _) -> do
-      altBinderTys <- caseAltsBinderTys =<< getType scrut
+      altBinderTys <- caseAltsBinderTys $ getType scrut
       defuncCase scrutSimp resultTy \i x -> do
         let xCoreTy = altBinderTys !! i
         x' <- liftSimpAtom (sink xCoreTy) x
@@ -370,7 +372,7 @@ defuncCase scrut resultTy cont = do
   case trySelectBranch scrut of
     Just (i, arg) -> getDistinct >>= \Distinct -> cont i arg
     Nothing -> do
-      scrutTy <- getType scrut
+      scrutTy <- return $ getType scrut
       altBinderTys <- caseAltsBinderTys scrutTy
       tryGetRepType resultTy >>= \case
         Just resultTyData -> do
@@ -403,7 +405,7 @@ simplifyAlt
   -> SimplifyM i o (Alt SimpIR o, ReconstructAtom o)
 simplifyAlt split ty cont = fromPairE <$> do
   withFreshBinder noHint ty \b -> do
-    ab <- buildScoped $ cont $ sink $ Var $ binderName b
+    ab <- buildScoped $ cont $ sink $ Var $ binderVar b
     (resultWithDecls, recon) <- refreshAbs ab \decls result -> do
       let locals = toScopeFrag b >>> toScopeFrag decls
       -- TODO: this might be too cautious. The type only needs to
@@ -417,15 +419,15 @@ simplifyAlt split ty cont = fromPairE <$> do
     return $ PairE (Abs b block) recon
 
 getAltNonDataTy :: EnvReader m => Alt SimpIR n -> m n (SType n)
-getAltNonDataTy (Abs bs body) = liftSubstEnvReaderM do
+getAltNonDataTy (Abs bs body) = liftSubstEnvReaderM @AtomSubstVal do
   substBinders bs \bs' -> do
-    ~(PairTy _ ty) <- getTypeSubst body
+    ~(PairTy _ ty) <- substM $ getType body
     -- Result types of simplified abs should be hoistable past binder
     return $ ignoreHoistFailure $ hoist bs' ty
 
 simplifyApp :: forall i o. Emits o
-  => NameHint -> CAtom i -> [CAtom o] -> SimplifyM i o (CAtom o)
-simplifyApp hint f xs =  case f of
+  => NameHint -> CType o -> CAtom i -> [CAtom o] -> SimplifyM i o (CAtom o)
+simplifyApp hint resultTy f xs =  case f of
   Lam (CoreLamExpr _ lam) -> fast lam
   _ -> slow =<< simplifyAtomAndInline f
   where
@@ -435,24 +437,20 @@ simplifyApp hint f xs =  case f of
     slow :: CAtom o -> SimplifyM i o (CAtom o)
     slow = \case
       Lam (CoreLamExpr _ lam) -> dropSubst $ fast lam
-      SimpInCore (ACase e alts ty) -> dropSubst do
-        resultTy <- getAppType ty xs
+      SimpInCore (ACase e alts _) -> dropSubst do
         defuncCase e resultTy \i x -> do
           Abs b body <- return $ alts !! i
           extendSubst (b@>SubstVal x) do
             xs' <- mapM sinkM xs
-            simplifyApp hint body xs'
-      SimpInCore (LiftSimpFun (CorePiType _ bs _ resultTy) (LamExpr bs' body)) -> do
-        let resultTy' = ignoreHoistFailure $ hoist bs resultTy
+            simplifyApp hint (sink resultTy) body xs'
+      SimpInCore (LiftSimpFun _ (LamExpr bs body)) -> do
         xs' <- mapM toDataAtomIgnoreRecon xs
-        body' <- applySubst (bs'@@>map SubstVal xs') body
-        liftSimpAtom resultTy' =<< emitBlock body'
+        body' <- applySubst (bs@@>map SubstVal xs') body
+        liftSimpAtom resultTy =<< emitBlock body'
       Var v -> do
-        lookupAtomName v >>= \case
+        lookupAtomName (atomVarName v) >>= \case
           NoinlineFun _ _ -> simplifyTopFunApp v xs
           FFIFunBound _ f' -> do
-            fTy <- getType $ Var v
-            resultTy <- getAppType fTy xs
             xs' <- mapM toDataAtomIgnoreRecon xs
             liftSimpAtom resultTy =<< naryTopApp f' xs'
           b -> error $ "Should only have noinline functions left " ++ pprint b
@@ -466,14 +464,14 @@ simplifyAtomAndInline :: CAtom i -> SimplifyM i o (CAtom o)
 simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
   Var v -> do
     env <- getSubst
-    case env ! v of
-      Rename v' -> doInline v'
+    case env ! atomVarName v of
+      Rename v' -> doInline =<< toAtomVar v'
       SubstVal (Var v') -> doInline v'
       SubstVal x -> return x
   -- This is a hack because we weren't normalize the unwrapping of
   -- `unit_type_scale` in `plot.dx`. We need a better system for deciding how to
   -- normalize and inline.
-  ProjectElt i x -> do
+  ProjectElt _ i x -> do
     x' <- simplifyAtom x >>= normalizeProj i
     dropSubst $ simplifyAtomAndInline x'
   _ -> simplifyAtom atom >>= \case
@@ -481,14 +479,14 @@ simplifyAtomAndInline atom = confuseGHC >>= \_ -> case atom of
     ans -> return ans
   where
     doInline v = do
-      lookupAtomName v >>= \case
-        LetBound (DeclBinding _ _ (Atom x)) -> dropSubst $ simplifyAtomAndInline x
+      lookupAtomName (atomVarName v) >>= \case
+        LetBound (DeclBinding _ (Atom x)) -> dropSubst $ simplifyAtomAndInline x
         _ -> return $ Var v
 
-simplifyTopFunApp :: Emits n => CAtomName n -> [CAtom n] -> SimplifyM i n (CAtom n)
+simplifyTopFunApp :: Emits n => CAtomVar n -> [CAtom n] -> SimplifyM i n (CAtom n)
 simplifyTopFunApp fName xs = do
-  fTy@(Pi piTy) <- getType $ Var fName
-  resultTy <- getAppType fTy xs
+  fTy@(Pi piTy) <- return $ getType fName
+  resultTy <- typeOfApp fTy xs
   isData resultTy >>= \case
     True -> do
       (xsGeneralized, runtimeArgs) <- generalizeArgs piTy xs
@@ -522,8 +520,8 @@ specializedFunCoreDefinition (AppSpecialization f (Abs bs staticArgs)) = do
     -- This avoids an infinite loop. Otherwise, in simplifyTopFunction,
     -- where we eta-expand and try to simplify `App f args`, we would see `f` as a
     -- "noinline" function and defer its simplification.
-    NoinlineFun _ f' <- lookupAtomName (sink f)
-    ListE staticArgs' <- applyRename (bs@@>runtimeArgs) staticArgs
+    NoinlineFun _ f' <- lookupAtomName (atomVarName (sink f))
+    ListE staticArgs' <- applyRename (bs@@>(atomVarName <$> runtimeArgs)) staticArgs
     naryApp f' staticArgs'
 
 simplifyTabApp :: forall i o. Emits o
@@ -540,7 +538,7 @@ simplifyTabApp f@(SimpInCore sic) xs = case sic of
         simplifyTabApp atom' xsRest
       Nothing -> error "should never happen"
   ACase e alts ty -> dropSubst do
-    resultTy <- getTabAppType ty xs
+    resultTy <- typeOfTabApp ty xs
     defuncCase e resultTy \i x -> do
       Abs b body <- return $ alts !! i
       extendSubst (b@>SubstVal x) do
@@ -548,8 +546,8 @@ simplifyTabApp f@(SimpInCore sic) xs = case sic of
         body' <- substM body
         simplifyTabApp body' xs'
   LiftSimp _ f' -> do
-    fTy <- getType f
-    resultTy <- getTabAppType fTy xs
+    fTy <- return $ getType f
+    resultTy <- typeOfTabApp fTy xs
     xs' <- mapM toDataAtomIgnoreRecon xs
     liftSimpAtom resultTy =<< naryTabApp f' xs'
   LiftSimpFun _ _ -> error "not implemented"
@@ -559,7 +557,7 @@ simplifyIxType :: IxType CoreIR o -> SimplifyM i o (IxType SimpIR o)
 simplifyIxType (IxType t ixDict) = do
   t' <- getRepType t
   IxType t' <$> case ixDict of
-    IxDictAtom (DictCon (IxFin n)) -> do
+    IxDictAtom (DictCon _ (IxFin n)) -> do
       n' <- toDataAtomIgnoreReconAssumeNoDecls n
       return $ IxDictRawFin n'
     IxDictAtom d -> do
@@ -594,8 +592,8 @@ simplifyDictMethod absDict@(Abs bs dict) method = do
   ty <- liftEnvReaderM $ ixMethodType method absDict
   lamExpr <- liftBuilder $ buildLamExprFromPi ty \allArgs -> do
     let (extraArgs, methodArgs) = splitAt (nestLength bs) allArgs
-    dict' <- applyRename (bs @@> extraArgs) dict
-    emitExpr $ ApplyMethod dict' (fromEnum method) (Var <$> methodArgs)
+    dict' <- applyRename (bs @@> (atomVarName <$> extraArgs)) dict
+    emitExpr =<< mkApplyMethod dict' (fromEnum method) (Var <$> methodArgs)
   simplifyTopFunction lamExpr
 
 ixMethodType :: IxMethod -> AbsDict n -> EnvReaderM n (PiType CoreIR n)
@@ -613,26 +611,28 @@ simplifyAtom atom = confuseGHC >>= \_ -> case atom of
   DepPair x y ty -> DepPair <$> simplifyAtom x <*> simplifyAtom y <*> substM ty
   Con con -> Con <$> traverseOp con substM simplifyAtom (error "unexpected lambda")
   Eff eff -> Eff <$> substM eff
-  PtrVar v -> PtrVar <$> substM v
-  DictCon d -> (DictCon <$> substM d) >>= cheapNormalize
+  PtrVar t v -> PtrVar t <$> substM v
+  DictCon t d -> (DictCon <$> substM t <*> substM d) >>= cheapNormalize
   DictHole _ _ _ -> error "shouldn't have dict holes past inference"
   NewtypeCon _ _ -> substM atom
-  ProjectElt i x -> normalizeProj i =<< simplifyAtom x
+  ProjectElt _ i x -> normalizeProj i =<< simplifyAtom x
   SimpInCore _ -> substM atom
   TypeAsAtom _ -> substM atom
 
-simplifyVar :: AtomName CoreIR i -> SimplifyM i o (CAtom o)
+simplifyVar :: AtomVar CoreIR i -> SimplifyM i o (CAtom o)
 simplifyVar v = do
   env <- getSubst
-  case env ! v of
+  case env ! atomVarName v of
     SubstVal x -> return x
     Rename v' -> do
       AtomNameBinding bindingInfo <- lookupEnv v'
+      let ty = getType bindingInfo
       case bindingInfo of
         -- Functions get inlined only at application sites
-        LetBound (DeclBinding _ (Pi _) _) -> return $ Var v'
-        LetBound (DeclBinding _ _ (Atom x)) -> dropSubst $ simplifyAtom x
-        _ -> return $ Var v'
+        LetBound (DeclBinding _  _) | isFun -> return $ Var $ AtomVar v' ty
+          where isFun = case ty of Pi _ -> True; _ -> False
+        LetBound (DeclBinding _ (Atom x)) -> dropSubst $ simplifyAtom x
+        _ -> return $ Var $ AtomVar v' ty
 
 -- Assumes first order (args/results are "data", allowing newtypes), monormophic
 simplifyLam
@@ -642,8 +642,8 @@ simplifyLam (LamExpr bsTop body) = case bsTop of
   Nest (b:>ty) bs -> do
     ty' <- substM ty
     tySimp <- getRepType ty'
-    withFreshBinder (getNameHint b) tySimp \(b':>_) -> do
-      x <- liftSimpAtom (sink ty') (Var $ binderName b')
+    withFreshBinder (getNameHint b) tySimp \b''@(b':>_) -> do
+      x <- liftSimpAtom (sink ty') (Var $ binderVar b'')
       extendSubst (b@>SubstVal x) do
         (LamExpr bs' body', Abs bsRecon recon) <- simplifyLam $ LamExpr bs body
         return (LamExpr (Nest (b':>tySimp) bs') body', Abs (Nest b' bsRecon) recon)
@@ -695,7 +695,7 @@ buildSimplifiedBlock cont = do
     tryAsDataAtom ans >>= \case
       Nothing -> return $ LeftE ans
       Just (dataResult, _) -> do
-        ansTy <- getType ans
+        ansTy <- return $ getType ans
         return $ RightE (dataResult `PairE` ansTy)
   case eitherResult of
     LeftE ans -> do
@@ -744,7 +744,7 @@ simplifyOp hint op = case op of
     _ -> simplifyGenericOp op'
   where
     liftResult x = do
-      ty <- getTypeSubst op
+      ty <- substM $ getType op
       liftSimpAtom ty x
 
 simplifyGenericOp
@@ -753,7 +753,7 @@ simplifyGenericOp
   => op CoreIR i
   -> SimplifyM i o (CAtom o)
 simplifyGenericOp op = do
-  ty <- getTypeSubst op
+  ty <- substM $ getType op
   op' <- traverseOp op
            (substM >=> getRepType)
            (simplifyAtom >=> toDataAtomIgnoreRecon)
@@ -765,24 +765,24 @@ simplifyGenericOp op = do
 pattern CoerceReconAbs :: Abs (Nest b) ReconstructAtom n
 pattern CoerceReconAbs <- Abs _ (CoerceRecon _)
 
-applyDictMethod :: Emits o => CAtom o -> Int -> [CAtom o] -> SimplifyM i o (CAtom o)
-applyDictMethod d i methodArgs = do
+applyDictMethod :: Emits o => CType o -> CAtom o -> Int -> [CAtom o] -> SimplifyM i o (CAtom o)
+applyDictMethod resultTy d i methodArgs = do
   cheapNormalize d >>= \case
-    DictCon (InstanceDict instanceName instanceArgs) -> dropSubst do
+    DictCon _ (InstanceDict instanceName instanceArgs) -> dropSubst do
       instanceArgs' <- mapM simplifyAtom instanceArgs
       InstanceDef _ bsInstance _ body <- lookupInstanceDef instanceName
       let InstanceBody _ methods = body
       let method = methods !! i
       extendSubst (bsInstance @@> (SubstVal <$> instanceArgs')) do
-        simplifyApp noHint method methodArgs
-    DictCon (IxFin n) -> applyIxFinMethod (toEnum i) n methodArgs
+        simplifyApp noHint resultTy method methodArgs
+    DictCon _ (IxFin n) -> applyIxFinMethod (toEnum i) n methodArgs
     d' -> error $ "Not a simplified dict: " ++ pprint d'
   where
     applyIxFinMethod :: EnvReader m => IxMethod -> CAtom n -> [CAtom n] -> m n (CAtom n)
     applyIxFinMethod method n args = do
       case (method, args) of
         (Size, []) -> return n  -- result : Nat
-        (Ordinal, [ix]) -> return $ unwrapNewtype ix -- result : Nat
+        (Ordinal, [ix]) -> unwrapNewtype ix -- result : Nat
         (UnsafeFromOrdinal, [ix]) -> return $ NewtypeCon (FinCon n) ix
         _ -> error "bad ix args"
 
@@ -790,20 +790,20 @@ simplifyHof :: Emits o => NameHint -> Hof CoreIR i -> SimplifyM i o (CAtom o)
 simplifyHof _hint hof = case hof of
   For d ixDict lam -> do
     (lam', Abs (UnaryNest bIx) recon) <- simplifyLam lam
-    ixTypeCore <- ixTyFromDict =<< substM ixDict
+    ixTypeCore <- ixTyFromDict <$> substM ixDict
     ixTypeSimp@(IxType _ ixDict') <- simplifyIxType ixTypeCore
     ans <- emitExpr $ PrimOp $ Hof $ For d ixDict' lam'
     case recon of
       CoerceRecon _ -> do
-        resultTy <- getTypeSubst $ Hof hof
+        resultTy <- substM $ getType $ Hof hof
         liftSimpAtom resultTy ans
       LamRecon (Abs bsClosure reconResult) -> do
-        TabPi resultTy <- getTypeSubst $ Hof hof
+        TabPi resultTy <- substM $ getType $ Hof hof
         liftM (SimpInCore . TabLam resultTy) $
           buildAbs noHint ixTypeSimp \i -> buildScoped do
             i' <- sinkM i
             xs <- unpackTelescope bsClosure =<< tabApp (sink ans) (Var i')
-            applySubst (bIx@>Rename i' <.> bsClosure @@> map SubstVal xs) reconResult
+            applySubst (bIx@>Rename (atomVarName i') <.> bsClosure @@> map SubstVal xs) reconResult
   While body -> do
     SimplifiedBlock body' (CoerceRecon resultTy) <- buildSimplifiedBlock $ simplifyBlock body
     result <- emitOp (Hof $ While body')
@@ -852,7 +852,7 @@ simplifyHof _hint hof = case hof of
     (lam', recon) <- simplifyLam lam
     CoerceReconAbs <- return recon
     (result, linFun) <- liftDoubleBuilderToSimplifyM $ linearize lam' x'
-    PairTy resultTy linFunTy <- getTypeSubst $ Hof hof
+    PairTy resultTy linFunTy <- substM $ getType $ Hof hof
     result' <- liftSimpAtom resultTy result
     linFun' <- liftSimpFun linFunTy linFun
     return $ PairVal result' linFun'
@@ -860,9 +860,9 @@ simplifyHof _hint hof = case hof of
     (lam', CoerceReconAbs) <- simplifyLam lam
     x' <- simplifyDataAtom x
     result <- transpose lam' x'
-    resultTy <- getTypeSubst $ Hof hof
+    resultTy <- substM $ getType $ Hof hof
     liftSimpAtom resultTy result
-  CatchException body-> do
+  CatchException _ body-> do
     SimplifiedBlock body' recon <- buildSimplifiedBlock $ simplifyBlock body
     block <- liftBuilder $ runSubstReaderT idSubst $ buildBlock $ exceptToMaybeBlock body'
     result <- emitBlock block
@@ -878,10 +878,10 @@ fmapMaybe
   => SAtom n -> (forall l. DExt n l => SAtom l -> m l (CAtom l))
   -> m n (CAtom n)
 fmapMaybe scrut f = do
-  ~(MaybeTy justTy) <- getType scrut
+  ~(MaybeTy justTy) <- return $ getType scrut
   (justAlt, resultJustTy) <- withFreshBinder noHint justTy \b -> do
-    result <- f (Var $ binderName b)
-    resultTy <- ignoreHoistFailure . hoist b <$> getType result
+    result <- f (Var $ binderVar b)
+    resultTy <- return $ ignoreHoistFailure $ hoist b (getType result)
     result' <- preludeJustVal result
     return (Abs b result', resultTy)
   nothingAlt <- buildAbs noHint UnitTy \_ -> preludeNothingVal $ sink resultJustTy
@@ -905,8 +905,9 @@ preludeNothingVal ty = do
 preludeMaybeNewtypeCon :: EnvReader m => CType n -> m n (NewtypeCon n)
 preludeMaybeNewtypeCon ty = do
   ~(Just (UTyConVar tyConName)) <- lookupSourceMap "Maybe"
+  TyConDef sn _ _ <- lookupTyCon tyConName
   let params = TyConParams [Explicit] [Type ty]
-  return $ UserADTData tyConName params
+  return $ UserADTData sn tyConName params
 
 simplifyBlock :: Emits o => Block CoreIR i -> SimplifyM i o (CAtom o)
 simplifyBlock (Block _ decls result) = simplifyDecls decls $ simplifyAtom result
@@ -942,7 +943,7 @@ tryGetCustomRule f' = do
   case f of
     DexTopFun def _ _ _ -> case def of
       Specialization (AppSpecialization fCore absParams) ->
-        fmap (absParams,) <$> lookupCustomRules fCore
+        fmap (absParams,) <$> lookupCustomRules (atomVarName fCore)
       _ -> return Nothing
     _ -> return Nothing
 
@@ -960,12 +961,13 @@ simplifyCustomLinearization (Abs runtimeBs staticArgs) actives rule = do
       Abs runtimeBs' <$> buildScoped do
         ListE staticArgs' <- applySubst (runtimeBs @@> (SubstVal . sink <$> runtimeArgs)) staticArgs
         fCustom' <- sinkM fCustom
-        pairResult <- dropSubst $ simplifyApp noHint fCustom' staticArgs'
+        resultTy <- typeOfApp (getType fCustom') staticArgs'
+        pairResult <- dropSubst $ simplifyApp noHint resultTy fCustom' staticArgs'
         (primalResult, fLin) <- fromPair pairResult
         primalResult' <- toDataAtomIgnoreRecon primalResult
         let explicitPrimalArgs = drop nImplicit staticArgs'
         allTangentTys <- forM explicitPrimalArgs \primalArg -> do
-          tangentType =<< getRepType =<< getType primalArg
+          tangentType =<< getRepType (getType primalArg)
         let actives' = drop (length actives - nExplicit) actives
         activeTangentTys <- catMaybes <$> forM (zip allTangentTys actives')
           \(t, active) -> return case active of True  -> Just t; False -> Nothing
@@ -979,10 +981,11 @@ simplifyCustomLinearization (Abs runtimeBs staticArgs) actives rule = do
           -- a custom linearization defined for a function on ADTs will
           -- not work.
           fLin' <- sinkM fLin
-          Pi (CorePiType _ bs _ _) <- getType fLin'
+          Pi (CorePiType _ bs _ _) <- return $ getType fLin'
           let tangentCoreTys = fromNonDepNest bs
           tangentArgs' <- zipWithM liftSimpAtom tangentCoreTys tangentArgs
-          tangentResult <- dropSubst $ simplifyApp noHint fLin' tangentArgs'
+          resultTyTangent <- typeOfApp (getType fLin') tangentArgs'
+          tangentResult <- dropSubst $ simplifyApp noHint resultTyTangent fLin' tangentArgs'
           toDataAtomIgnoreRecon tangentResult
         return $ PairE primalResult' fLin'
   where
@@ -1013,7 +1016,7 @@ defuncLinearized ab = liftBuilder $ refreshAbs ab \bs ab' -> do
   (declsAndResult, reconAbs, residualsTangentsBs) <-
     refreshAbs ab' \decls (PairE primalResult fLin) -> do
       (residuals, reconAbs) <- telescopicCapture (toScopeFrag decls) fLin
-      rTy <- getType residuals
+      let rTy = getType residuals
       LamExpr tBs _ <- return fLin
       residualsTangentsBs <- withFreshBinder "residual" rTy \rB -> do
         Abs tBs' UnitE <- sinkM $ Abs tBs UnitE
@@ -1023,7 +1026,7 @@ defuncLinearized ab = liftBuilder $ refreshAbs ab \bs ab' -> do
   primalFun <- LamExpr bs <$> makeBlockFromDecls declsAndResult
   LamExpr residualAndTangentBs tangentBody <- buildLamExpr residualsTangentsBs \(residuals:tangents) -> do
     LamExpr tangentBs' body <- applyReconAbs (sink reconAbs) (Var residuals)
-    applyRename (tangentBs' @@> tangents) body >>= emitBlock
+    applyRename (tangentBs' @@> (atomVarName <$> tangents)) body >>= emitBlock
   let tangentFun = LamExpr (bs >>> residualAndTangentBs) tangentBody
   return $ PairE primalFun tangentFun
 
@@ -1040,7 +1043,7 @@ exceptToMaybeBlock _ = error "impossible"
 
 exceptToMaybeDecls :: Emits o => SType o -> Nest SDecl i i' -> SExpr i' -> HandlerM i o (SAtom o)
 exceptToMaybeDecls _ Empty result = exceptToMaybeExpr result
-exceptToMaybeDecls resultTy (Nest (Let b (DeclBinding _ _ rhs)) decls) finalResult = do
+exceptToMaybeDecls resultTy (Nest (Let b (DeclBinding _ rhs)) decls) finalResult = do
   maybeResult <- exceptToMaybeExpr rhs
   case maybeResult of
     -- This case is just an optimization (but an important one!)
@@ -1061,24 +1064,24 @@ exceptToMaybeExpr expr = case expr of
       extendSubst (b @> SubstVal v) $ exceptToMaybeBlock body
   Atom x -> do
     x' <- substM x
-    ty <- getType x'
+    let ty = getType x'
     return $ JustAtom ty x'
   PrimOp (Hof (For ann d (UnaryLamExpr b body))) -> do
-    ixTy <- ixTyFromDict =<< substM d
+    ixTy <- ixTyFromDict <$> substM d
     maybes <- buildForAnn (getNameHint b) ann ixTy \i ->
-      extendSubst (b@>Rename i) $ exceptToMaybeBlock body
+      extendSubst (b@>Rename (atomVarName i)) $ exceptToMaybeBlock body
     catMaybesE maybes
   PrimOp (MiscOp (ThrowException _)) -> do
-    ty <- getTypeSubst expr
+    ty <- substM $ getType expr
     return $ NothingAtom ty
   PrimOp (Hof (RunState Nothing s lam)) -> do
     s' <- substM s
     BinaryLamExpr h ref body <- return lam
     result  <- emitRunState noHint s' \h' ref' ->
-      extendSubst (h @> Rename h' <.> ref @> Rename ref') do
+      extendSubst (h @> Rename (atomVarName h') <.> ref @> Rename (atomVarName ref')) do
         exceptToMaybeBlock body
     (maybeAns, newState) <- fromPair result
-    a <- getTypeSubst expr
+    a <- substM $ getType expr
     emitMaybeCase maybeAns (MaybeTy a)
        (return $ NothingAtom $ sink a)
        (\ans -> return $ JustAtom (sink a) $ PairVal ans (sink newState))
@@ -1086,26 +1089,26 @@ exceptToMaybeExpr expr = case expr of
     monoid' <- substM monoid
     accumTy <- substM =<< (getReferentTy $ EmptyAbs $ PairB h ref)
     result <- emitRunWriter noHint accumTy monoid' \h' ref' ->
-      extendSubst (h @> Rename h' <.> ref @> Rename ref') $
+      extendSubst (h @> Rename (atomVarName h') <.> ref @> Rename (atomVarName ref')) $
         exceptToMaybeBlock body
     (maybeAns, accumResult) <- fromPair result
-    a <- getTypeSubst expr
+    a <- substM $ getType expr
     emitMaybeCase maybeAns (MaybeTy a)
       (return $ NothingAtom $ sink a)
       (\ans -> return $ JustAtom (sink a) $ PairVal ans (sink accumResult))
   PrimOp (Hof (While body)) -> runMaybeWhile $ exceptToMaybeBlock body
   _ -> do
     expr' <- substM expr
-    hasExceptions expr' >>= \case
+    case hasExceptions expr' of
       True -> error $ "Unexpected exception-throwing expression: " ++ pprint expr
       False -> do
         v <- emit expr'
-        ty <- getType v
+        let ty = getType v
         return $ JustAtom ty (Var v)
 
-hasExceptions :: EnvReader m => SExpr n -> m n Bool
-hasExceptions expr = getEffects expr >>= \case
-  EffectRow effs NoTail -> return $ ExceptionEffect `eSetMember` effs
+hasExceptions :: SExpr n -> Bool
+hasExceptions expr = case getEffects expr of
+  EffectRow effs NoTail -> ExceptionEffect `eSetMember` effs
 
 -- === instances ===
 

--- a/src/lib/Subst.hs
+++ b/src/lib/Subst.hs
@@ -355,7 +355,7 @@ instance (SinkableV v, ScopeReader m, EnvExtender m)
 type SubstEnvReaderM v = SubstReaderT v EnvReaderM :: MonadKind2
 
 liftSubstEnvReaderM
-  :: (EnvReader m, FromName v)
+  :: forall v m n a. (EnvReader m, FromName v)
   => SubstEnvReaderM v n n a
   -> m n a
 liftSubstEnvReaderM cont = liftEnvReaderM $ runSubstReaderT idSubst $ cont

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -48,15 +48,15 @@ import Types.Imp
 -- === core IR ===
 
 data Atom (r::IR) (n::S) where
- Var        :: AtomName r n    -> Atom r n
+ Var        :: AtomVar r n    -> Atom r n
  Con        :: Con r n         -> Atom r n
- PtrVar     :: PtrName n       -> Atom r n
- ProjectElt :: Projection -> Atom r n                   -> Atom r n
+ PtrVar     :: PtrType -> PtrName n -> Atom r n
+ ProjectElt :: Type r n -> Projection -> Atom r n                   -> Atom r n
  DepPair    :: Atom r n -> Atom r n -> DepPairType r n  -> Atom r n
  -- === CoreIR only ===
  Lam          :: CoreLamExpr n                 -> Atom CoreIR n
  Eff          :: EffectRow CoreIR n            -> Atom CoreIR n
- DictCon      :: DictExpr n                    -> Atom CoreIR n
+ DictCon      :: Type CoreIR n -> DictExpr n   -> Atom CoreIR n
  NewtypeCon   :: NewtypeCon n -> Atom CoreIR n -> Atom CoreIR n
  DictHole     :: AlwaysEqual SrcPosCtx -> Type CoreIR n -> RequiredMethodAccess
               -> Atom CoreIR n
@@ -69,14 +69,19 @@ data Type (r::IR) (n::S) where
  TC           :: TC  r n         -> Type r n
  TabPi        :: TabPiType r n   -> Type r n
  DepPairTy    :: DepPairType r n -> Type r n
- TyVar        :: AtomName CoreIR n -> Type CoreIR n
+ TyVar        :: AtomVar CoreIR n -> Type CoreIR n
  DictTy       :: DictType n      -> Type CoreIR n
  Pi           :: CorePiType  n   -> Type CoreIR n
  NewtypeTyCon :: NewtypeTyCon n  -> Type CoreIR n
  -- It was bad enough having this in `Atom`, but it's even worse now that it's
  -- replicated in `Type` too. We should be able to remove both once
  -- we represent types as normalized blocks.
- ProjectEltTy :: Projection -> CAtom n -> Type CoreIR n
+ ProjectEltTy :: CType n -> Projection -> CAtom n -> Type CoreIR n
+
+data AtomVar (r::IR) (n::S) = AtomVar
+  { atomVarName :: AtomName r n
+  , atomVarType :: Type r n }
+     deriving (Show, Generic)
 
 type TabLamExpr = Abs (IxBinder SimpIR) (Abs (Nest SDecl) CAtom)
 data SimpInCore (n::S) =
@@ -92,14 +97,14 @@ deriving via WrapE (Atom r) n instance IRRep r => Generic (Atom r n)
 deriving via WrapE (Type r) n instance IRRep r => Generic (Type r n)
 
 data Expr r n where
- TopApp :: TopFunName n -> [SAtom n]         -> Expr SimpIR n
- TabApp :: Atom r n -> [Atom r n]            -> Expr r n
+ TopApp :: EffTy SimpIR n -> TopFunName n -> [SAtom n]         -> Expr SimpIR n
+ TabApp :: Type r n -> Atom r n -> [Atom r n] -> Expr r n
  Case   :: Atom r n -> [Alt r n] -> Type r n -> EffectRow r n -> Expr r n
  Atom   :: Atom r n                          -> Expr r n
  TabCon :: Maybe (WhenCore r Dict n) -> Type r n -> [Atom r n] -> Expr r n
  PrimOp :: PrimOp r n                           -> Expr r n
- App             :: CAtom n -> [CAtom n]        -> Expr CoreIR n
- ApplyMethod     :: CAtom n -> Int -> [CAtom n] -> Expr CoreIR n
+ App             :: EffTy CoreIR n -> CAtom n -> [CAtom n]        -> Expr CoreIR n
+ ApplyMethod     :: EffTy CoreIR n -> CAtom n -> Int -> [CAtom n] -> Expr CoreIR n
 
 deriving instance IRRep r => Show (Expr r n)
 deriving via WrapE (Expr r) n instance IRRep r => Generic (Expr r n)
@@ -111,7 +116,7 @@ data BaseMonoid r n =
 
 type EffAbs = Abs (Binder CoreIR) (EffectRow CoreIR)
 
-data DeclBinding r n = DeclBinding LetAnn (Type r n) (Expr r n)
+data DeclBinding r n = DeclBinding LetAnn (Expr r n)
      deriving (Show, Generic)
 data Decl (r::IR) (n::S) (l::S) = Let (AtomNameBinder r n l) (DeclBinding r n)
      deriving (Show, Generic)
@@ -379,7 +384,7 @@ data Hof r n where
  RunState  :: Maybe (Atom r n) -> Atom r n -> LamExpr r n -> Hof r n  -- dest, initial value, body lambda
  RunIO     :: Block r n -> Hof r n
  RunInit   :: Block r n -> Hof r n
- CatchException :: Block   CoreIR n -> Hof CoreIR n
+ CatchException :: CType n -> Block   CoreIR n -> Hof CoreIR n
  Linearize      :: LamExpr CoreIR n -> Atom CoreIR n -> Hof CoreIR n
  Transpose      :: LamExpr CoreIR n -> Atom CoreIR n -> Hof CoreIR n
 
@@ -400,8 +405,8 @@ data RefOp r n =
  | MExtend (BaseMonoid r n) (Atom r n)
  | MGet
  | MPut (Atom r n)
- | IndexRef (Atom r n)
- | ProjRef Projection
+ | IndexRef (Type r n) (Atom r n)
+ | ProjRef (Type r n) Projection
   deriving (Show, Generic)
 
 data UserEffectOp n =
@@ -420,6 +425,7 @@ type CBlock = Block CoreIR
 type CDecl  = Decl  CoreIR
 type CDecls = Decls CoreIR
 type CAtomName  = AtomName CoreIR
+type CAtomVar   = AtomVar CoreIR
 
 type SAtom  = Atom SimpIR
 type SType  = Type SimpIR
@@ -429,6 +435,7 @@ type SAlt   = Alt   SimpIR
 type SDecl  = Decl  SimpIR
 type SDecls = Decls SimpIR
 type SAtomName  = AtomName SimpIR
+type SAtomVar   = AtomVar SimpIR
 type SBinder = Binder SimpIR
 type SRepVal = RepVal SimpIR
 type SLam    = LamExpr SimpIR
@@ -437,7 +444,7 @@ type SLam    = LamExpr SimpIR
 
 -- Describes how to lift the "shallow" representation type to the newtype.
 data NewtypeCon (n::S) =
-   UserADTData (TyConName n) (TyConParams n)
+   UserADTData SourceName (TyConName n) (TyConParams n) -- source name is for the type
  | NatCon
  | FinCon (Atom CoreIR n)
    deriving (Show, Generic)
@@ -454,7 +461,7 @@ pattern TypeCon s d xs = NewtypeTyCon (UserADTType s d xs)
 
 isSumCon :: NewtypeCon n -> Bool
 isSumCon = \case
- UserADTData _ _ -> True
+ UserADTData _ _ _ -> True
  _ -> False
 
 -- === type classes ===
@@ -808,16 +815,6 @@ data AtomBinding (r::IR) (n::S) where
 deriving instance IRRep r => Show (AtomBinding r n)
 deriving via WrapE (AtomBinding r) n instance IRRep r => Generic (AtomBinding r n)
 
-atomBindingType :: AtomBinding r n -> Type r n
-atomBindingType b = case b of
-  LetBound    (DeclBinding _ ty _) -> ty
-  MiscBound   ty                   -> ty
-  SolverBound (InfVarBound ty _)   -> ty
-  SolverBound (SkolemBound ty)     -> ty
-  NoinlineFun ty _                 -> ty
-  TopDataBound (RepVal ty _) -> ty
-  FFIFunBound piTy _ -> Pi piTy
-
 -- name of function, name of arg
 type InferenceArgDesc = (String, String)
 data InfVarDesc =
@@ -888,13 +885,13 @@ data EffectRow (r::IR) (n::S) =
   deriving (Generic)
 
 data EffectRowTail (r::IR) (n::S) where
-  EffectRowTail :: AtomName CoreIR n -> EffectRowTail CoreIR n
+  EffectRowTail :: AtomVar CoreIR n -> EffectRowTail CoreIR n
   NoTail        ::                      EffectRowTail r n
 deriving instance IRRep r => Show (EffectRowTail r n)
 deriving instance IRRep r => Eq   (EffectRowTail r n)
 deriving via WrapE (EffectRowTail r) n instance IRRep r => Generic (EffectRowTail r n)
 
-data EffectAndType (r::IR) (n::S) = EffectAndType (EffectRow r n) (Type r n)
+data EffTy (r::IR) (n::S) = EffTy (EffectRow r n) (Type r n)
      deriving (Generic, Show)
 
 deriving instance IRRep r => Show (EffectRow r n)
@@ -945,7 +942,7 @@ data SpecializedDictDef n =
 
 -- TODO: extend with AD-oriented specializations, backend-specific specializations etc.
 data SpecializationSpec (n::S) =
-   AppSpecialization (AtomName CoreIR n) (Abstracted CoreIR (ListE CAtom) n)
+   AppSpecialization (AtomVar CoreIR n) (Abstracted CoreIR (ListE CAtom) n)
    deriving (Show, Generic)
 
 type Active = Bool
@@ -957,7 +954,7 @@ data LinearizationSpec (n::S) =
 
 class BindsOneName b (AtomNameC r) => BindsOneAtomName (r::IR) (b::B) | b -> r where
   binderType :: b n l -> Type r n
-  -- binderAtomName :: b n l -> AtomName r l
+  binderVar  :: DExt n l => b n l -> AtomVar r l
 
 bindersTypes :: (IRRep r, Distinct l, ProvesExt b, BindsNames b, BindsOneAtomName r b)
              => Nest b n l -> [Type r l]
@@ -965,14 +962,24 @@ bindersTypes Empty = []
 bindersTypes n@(Nest b bs) = ty : bindersTypes bs
   where ty = withExtEvidence n $ sink (binderType b)
 
+nestToAtomVars :: (Distinct l, Ext n l, IRRep r)
+               => Nest (Binder r) n l -> [AtomVar r l]
+nestToAtomVars = \case
+  Empty -> []
+  Nest b bs -> withExtEvidence b $ withSubscopeDistinct bs $
+    sink (binderVar b) : nestToAtomVars bs
+
 instance IRRep r => BindsOneAtomName r (BinderP (AtomNameC r) (Type r)) where
   binderType (_ :> ty) = ty
+  binderVar (b:>t) = AtomVar (binderName b) (sink t)
 
 instance IRRep r => BindsOneAtomName r (IxBinder r) where
   binderType (_ :> IxType ty _) = ty
+  binderVar  (b :> IxType ty _) = AtomVar (binderName b) (sink ty)
 
 instance BindsOneAtomName CoreIR b => BindsOneAtomName CoreIR (WithExpl b) where
   binderType (WithExpl _ b) = binderType b
+  binderVar  (WithExpl _ b) = binderVar b
 
 toBinderNest :: BindsOneAtomName r b => Nest b n l -> Nest (Binder r) n l
 toBinderNest Empty = Empty
@@ -1025,11 +1032,11 @@ instance HasArgType (TabPiType r) r where
 -- a Var, it doesn't check whether it's a type.
 pattern Type :: CType n -> CAtom n
 pattern Type t <- ((\case Var v          -> Just (TyVar v)
-                          ProjectElt i x -> Just $ ProjectEltTy i x
+                          ProjectElt t i x -> Just $ ProjectEltTy t i x
                           TypeAsAtom t   -> Just t
                           _            -> Nothing) -> Just t)
   where Type (TyVar v) = Var v
-        Type (ProjectEltTy i x) = ProjectElt i x
+        Type (ProjectEltTy t i x) = ProjectElt t i x
         Type t         = TypeAsAtom t
 
 pattern IdxRepScalarBaseTy :: ScalarBaseType
@@ -1138,7 +1145,7 @@ pattern AtomicBlock atom <- Block _ Empty atom
   where AtomicBlock atom = Block NoBlockAnn Empty atom
 
 exprBlock :: IRRep r => Block r n -> Maybe (Expr r n)
-exprBlock (Block _ (Nest (Let b (DeclBinding _ _ expr)) Empty) (Var n))
+exprBlock (Block _ (Nest (Let b (DeclBinding _ expr)) Empty) (Var (AtomVar n _)))
   | n == binderName b = Just expr
 exprBlock _ = Nothing
 {-# INLINE exprBlock #-}
@@ -1271,16 +1278,16 @@ instance HasNameHint (DataConDef n) where
 
 instance GenericE NewtypeCon where
   type RepE NewtypeCon = EitherE3
-   {- UserADTData -}  (TyConName `PairE` TyConParams)
+   {- UserADTData -}  (LiftE SourceName `PairE` TyConName `PairE` TyConParams)
    {- NatCon -}       UnitE
    {- FinCon -}       CAtom
   fromE = \case
-    UserADTData d p -> Case0 $ d `PairE` p
+    UserADTData sn d p -> Case0 $ LiftE sn `PairE` d `PairE` p
     NatCon          -> Case1 UnitE
     FinCon n        -> Case2 n
   {-# INLINE fromE #-}
   toE = \case
-    Case0 (d `PairE` p) -> UserADTData d p
+    Case0 (LiftE sn `PairE` d `PairE` p) -> UserADTData sn d p
     Case1 UnitE         -> NatCon
     Case2 n             -> FinCon n
     _ -> error "impossible"
@@ -1396,7 +1403,7 @@ instance IRRep r => GenericE (Hof r) where
   {- RunIO -}     (Block r)
     ) (EitherE4
   {- RunInit -}        (Block r)
-  {- CatchException -} (WhenCore r (Block r))
+  {- CatchException -} (WhenCore r (Type r `PairE` Block r))
   {- Linearize -}      (WhenCore r (LamExpr r `PairE` Atom r))
   {- Transpose -}      (WhenCore r (LamExpr r `PairE` Atom r)))
 
@@ -1408,7 +1415,7 @@ instance IRRep r => GenericE (Hof r) where
     RunState  d x body  -> Case0 (Case4 (toMaybeE d `PairE` x `PairE` body))
     RunIO body          -> Case0 (Case5 body)
     RunInit body        -> Case1 (Case0 body)
-    CatchException body -> Case1 (Case1 (WhenIRE body))
+    CatchException ty body -> Case1 (Case1 (WhenIRE (ty `PairE` body)))
     Linearize body x    -> Case1 (Case2 (WhenIRE (PairE body x)))
     Transpose body x    -> Case1 (Case3 (WhenIRE (PairE body x)))
   {-# INLINE fromE #-}
@@ -1423,7 +1430,7 @@ instance IRRep r => GenericE (Hof r) where
       _ -> error "impossible"
     Case1 hof -> case hof of
       Case0 body -> RunInit body
-      Case1 (WhenIRE body) -> CatchException body
+      Case1 (WhenIRE (ty `PairE` body)) -> CatchException ty body
       Case2 (WhenIRE (PairE body x)) -> Linearize body x
       Case3 (WhenIRE (PairE body x)) -> Transpose body x
       _ -> error "impossible"
@@ -1443,16 +1450,16 @@ instance GenericOp RefOp where
     MExtend (BaseMonoid z f) x -> GenericOpRep P.MExtend     [] [z, x] [f]
     MGet                       -> GenericOpRep P.MGet        [] []  []
     MPut x                     -> GenericOpRep P.MPut        [] [x] []
-    IndexRef x                 -> GenericOpRep P.IndexRef    [] [x] []
-    ProjRef p                  -> GenericOpRep (P.ProjRef p) [] []  []
+    IndexRef t x               -> GenericOpRep P.IndexRef    [t] [x] []
+    ProjRef t p                -> GenericOpRep (P.ProjRef p) [t] []  []
   {-# INLINE fromOp #-}
   toOp = \case
     GenericOpRep P.MAsk        [] []     []  -> Just $ MAsk
     GenericOpRep P.MExtend     [] [z, x] [f] -> Just $ MExtend (BaseMonoid z f) x
     GenericOpRep P.MGet        [] []     []  -> Just $ MGet
     GenericOpRep P.MPut        [] [x]    []  -> Just $ MPut x
-    GenericOpRep P.IndexRef    [] [x]    []  -> Just $ IndexRef x
-    GenericOpRep (P.ProjRef p) [] []     []  -> Just $ ProjRef p
+    GenericOpRep P.IndexRef    [t] [x]   []  -> Just $ IndexRef t x
+    GenericOpRep (P.ProjRef p) [t] []    []  -> Just $ ProjRef t p
     _ -> Nothing
   {-# INLINE toOp #-}
 
@@ -1501,12 +1508,12 @@ instance IRRep r => GenericE (Atom r) where
   -- GHC Core dump to make sure you haven't regressed this optimization.
   type RepE (Atom r) = EitherE3
          (EitherE4
-  {- Var -}        (AtomName r)
-  {- ProjectElt -} (LiftE Projection `PairE` Atom r)
+  {- Var -}        (AtomVar r)
+  {- ProjectElt -} (Type r `PairE` LiftE Projection `PairE` Atom r)
   {- Lam -}        (WhenCore r CoreLamExpr)
-  {- DepPair -}    ( Atom r `PairE` Atom r `PairE` DepPairType r)
+  {- DepPair -}    (Atom r `PairE` Atom r `PairE` DepPairType r)
          ) (EitherE4
-  {- DictCon  -}   (WhenCore r DictExpr)
+  {- DictCon  -}   (WhenCore r (CType `PairE` DictExpr))
   {- NewtypeCon -}     (WhenCore r (NewtypeCon `PairE` Atom r))
   {- DictHole -}       (WhenCore r (LiftE (AlwaysEqual SrcPosCtx) `PairE`
                                     (Type CoreIR) `PairE`
@@ -1514,7 +1521,7 @@ instance IRRep r => GenericE (Atom r) where
   {- Con -}        (Con r)
          ) (EitherE5
   {- Eff -}        ( WhenCore r (EffectRow r))
-  {- PtrVar -}     PtrName
+  {- PtrVar -}     (LiftE PtrType `PairE` PtrName)
   {- RepValAtom -} ( WhenSimp r (RepVal r))
   {- SimpInCore -} ( WhenCore r SimpInCore)
   {- TypeAsAtom -} ( WhenCore r (Type CoreIR))
@@ -1522,15 +1529,15 @@ instance IRRep r => GenericE (Atom r) where
 
   fromE atom = case atom of
     Var v             -> Case0 (Case0 v)
-    ProjectElt idxs x -> Case0 (Case1 (PairE (LiftE idxs) x))
+    ProjectElt t idxs x -> Case0 (Case1 (t `PairE` LiftE idxs `PairE` x))
     Lam lamExpr       -> Case0 (Case2 (WhenIRE lamExpr))
     DepPair l r ty    -> Case0 (Case3 $ l `PairE` r `PairE` ty)
-    DictCon d           -> Case1 $ Case0 $ WhenIRE d
+    DictCon t d         -> Case1 $ Case0 $ WhenIRE $ t `PairE` d
     NewtypeCon c x      -> Case1 $ Case1 $ WhenIRE (c `PairE` x)
     DictHole s t access -> Case1 $ Case2 $ WhenIRE (LiftE s `PairE` t `PairE` LiftE access)
     Con con             -> Case1 $ Case3 con
     Eff effs      -> Case2 $ Case0 $ WhenIRE effs
-    PtrVar v      -> Case2 $ Case1 $ v
+    PtrVar t v    -> Case2 $ Case1 $ LiftE t `PairE` v
     RepValAtom rv -> Case2 $ Case2 $ WhenIRE $ rv
     SimpInCore x  -> Case2 $ Case3 $ WhenIRE x
     TypeAsAtom t  -> Case2 $ Case4 $ WhenIRE t
@@ -1539,19 +1546,19 @@ instance IRRep r => GenericE (Atom r) where
   toE atom = case atom of
     Case0 val -> case val of
       Case0 v -> Var v
-      Case1 (PairE (LiftE idxs) x) -> ProjectElt idxs x
+      Case1 (t `PairE` LiftE idxs `PairE` x) -> ProjectElt t idxs x
       Case2 (WhenIRE (lamExpr)) -> Lam lamExpr
       Case3 (l `PairE` r `PairE` ty) -> DepPair l r ty
       _ -> error "impossible"
     Case1 val -> case val of
-      Case0 (WhenIRE d) -> DictCon d
+      Case0 (WhenIRE (t `PairE` d)) -> DictCon t d
       Case1 (WhenIRE (c `PairE` x)) -> NewtypeCon c x
       Case2 (WhenIRE (LiftE s `PairE` t `PairE` LiftE access)) -> DictHole s t access
       Case3 con -> Con con
       _ -> error "impossible"
     Case2 val -> case val of
       Case0 (WhenIRE effs) -> Eff effs
-      Case1 v -> PtrVar v
+      Case1 (LiftE t `PairE` v) -> PtrVar t v
       Case2 (WhenIRE rv) -> RepValAtom rv
       Case3 (WhenIRE x)  -> SimpInCore x
       Case4 (WhenIRE t)  -> TypeAsAtom t
@@ -1565,16 +1572,43 @@ instance IRRep r => AlphaEqE       (Atom r)
 instance IRRep r => AlphaHashableE (Atom r)
 instance IRRep r => RenameE        (Atom r)
 
+instance IRRep r => GenericE (AtomVar r) where
+  type RepE (AtomVar r) = PairE (AtomName r) (Type r)
+  fromE (AtomVar v t) = PairE v t
+  {-# INLINE fromE #-}
+  toE   (PairE v t) = AtomVar v t
+  {-# INLINE toE #-}
+
+instance HasNameHint (AtomVar r n) where
+  getNameHint (AtomVar v _) = getNameHint v
+
+instance Eq (AtomVar r n) where
+  AtomVar v1 _ == AtomVar v2 _ = v1 == v2
+
+instance IRRep r => SinkableE      (AtomVar r)
+instance IRRep r => HoistableE     (AtomVar r)
+
+
+-- We ignore the type annotation because it should be determined by the var
+instance IRRep r => AlphaEqE (AtomVar r) where
+  alphaEqE (AtomVar v _) (AtomVar v' _) = alphaEqE v v'
+
+-- We ignore the type annotation because it should be determined by the var
+instance IRRep r => AlphaHashableE (AtomVar r) where
+  hashWithSaltE env salt (AtomVar v _) = hashWithSaltE env salt v
+
+instance IRRep r => RenameE        (AtomVar r)
+
 instance IRRep r => GenericE (Type r) where
   type RepE (Type r) = EitherE8
-  {- TyVar -}        (WhenCore r CAtomName)
+  {- TyVar -}        (WhenCore r CAtomVar)
   {- Pi -}           (WhenCore r CorePiType)
   {- TabPi -}        (TabPiType r)
   {- DepPairTy -}    (DepPairType r)
   {- DictTy  -}      (WhenCore r DictType)
   {- NewtypeTyCon -} (WhenCore r NewtypeTyCon)
   {- TC -}           (TC  r)
-  {- ProjectEltTy -} (WhenCore r (LiftE Projection `PairE` Atom r))
+  {- ProjectEltTy -} (WhenCore r (Type r `PairE` LiftE Projection `PairE` Atom r))
 
   fromE = \case
     TyVar v        -> Case0 $ WhenIRE v
@@ -1584,7 +1618,7 @@ instance IRRep r => GenericE (Type r) where
     DictTy  d      -> Case4 $ WhenIRE d
     NewtypeTyCon t -> Case5 $ WhenIRE t
     TC  con        -> Case6 $ con
-    ProjectEltTy idxs x -> Case7 (WhenIRE (PairE (LiftE idxs) x))
+    ProjectEltTy t idxs x -> Case7 (WhenIRE (t `PairE` LiftE idxs `PairE` x))
   {-# INLINE fromE #-}
 
   toE = \case
@@ -1595,7 +1629,7 @@ instance IRRep r => GenericE (Type r) where
     Case4 (WhenIRE d) -> DictTy d
     Case5 (WhenIRE t) -> NewtypeTyCon t
     Case6 con         -> TC con
-    Case7 (WhenIRE (PairE (LiftE idxs) x)) -> ProjectEltTy idxs x
+    Case7 (WhenIRE (t `PairE` LiftE idxs `PairE` x)) -> ProjectEltTy t idxs x
   {-# INLINE toE #-}
 
 instance IRRep r => SinkableE      (Type r)
@@ -1607,39 +1641,39 @@ instance IRRep r => RenameE        (Type r)
 instance IRRep r => GenericE (Expr r) where
   type RepE (Expr r) = EitherE2
     ( EitherE5
- {- App -}    (WhenCore r (Atom r `PairE` ListE (Atom r)))
- {- TabApp -} (Atom r `PairE` ListE (Atom r))
+ {- App -}    (WhenCore r (EffTy r `PairE` Atom r `PairE` ListE (Atom r)))
+ {- TabApp -} (Type r `PairE` Atom r `PairE` ListE (Atom r))
  {- Case -}   (Atom r `PairE` ListE (Alt r) `PairE` Type r `PairE` EffectRow r)
  {- Atom -}   (Atom r)
- {- TopApp -} (WhenSimp r (TopFunName `PairE` ListE (Atom r)))
+ {- TopApp -} (WhenSimp r (EffTy r `PairE` TopFunName `PairE` ListE (Atom r)))
     )
     ( EitherE3
  {- TabCon -}          (MaybeE (WhenCore r Dict) `PairE` Type r `PairE` ListE (Atom r))
  {- PrimOp -}          (PrimOp r)
- {- ApplyMethod -}     (WhenCore r (Atom r `PairE` LiftE Int `PairE` ListE (Atom r))))
+ {- ApplyMethod -}     (WhenCore r (EffTy r `PairE` Atom r `PairE` LiftE Int `PairE` ListE (Atom r))))
 
   fromE = \case
-    App    f xs        -> Case0 $ Case0 (WhenIRE (f `PairE` ListE xs))
-    TabApp f xs        -> Case0 $ Case1 (f `PairE` ListE xs)
+    App    et f xs        -> Case0 $ Case0 (WhenIRE (et `PairE` f `PairE` ListE xs))
+    TabApp  t f xs        -> Case0 $ Case1 (t `PairE` f `PairE` ListE xs)
     Case e alts ty eff -> Case0 $ Case2 (e `PairE` ListE alts `PairE` ty `PairE` eff)
     Atom x             -> Case0 $ Case3 (x)
-    TopApp f xs        -> Case0 $ Case4 (WhenIRE (f `PairE` ListE xs))
+    TopApp et f xs        -> Case0 $ Case4 (WhenIRE (et `PairE` f `PairE` ListE xs))
     TabCon d ty xs     -> Case1 $ Case0 (toMaybeE d `PairE` ty `PairE` ListE xs)
     PrimOp op          -> Case1 $ Case1 op
-    ApplyMethod d i xs -> Case1 $ Case2 (WhenIRE (d `PairE` LiftE i `PairE` ListE xs))
+    ApplyMethod et d i xs -> Case1 $ Case2 (WhenIRE (et `PairE` d `PairE` LiftE i `PairE` ListE xs))
   {-# INLINE fromE #-}
   toE = \case
     Case0 case0 -> case case0 of
-      Case0 (WhenIRE (f `PairE` ListE xs))                -> App    f xs
-      Case1 (f `PairE` ListE xs)                          -> TabApp f xs
+      Case0 (WhenIRE (et `PairE` f `PairE` ListE xs))     -> App    et f xs
+      Case1 (t `PairE` f `PairE` ListE xs)                -> TabApp t f xs
       Case2 (e `PairE` ListE alts `PairE` ty `PairE` eff) -> Case e alts ty eff
       Case3 (x)                                           -> Atom x
-      Case4 (WhenIRE (f `PairE` ListE xs))                -> TopApp f xs
+      Case4 (WhenIRE (et `PairE` f `PairE` ListE xs))     -> TopApp et f xs
       _ -> error "impossible"
     Case1 case1 -> case case1 of
       Case0 (d `PairE` ty `PairE` ListE xs) -> TabCon (fromMaybeE d) ty xs
       Case1 op -> PrimOp op
-      Case2 (WhenIRE (d `PairE` LiftE i `PairE` ListE xs)) -> ApplyMethod d i xs
+      Case2 (WhenIRE (et `PairE` d `PairE` LiftE i `PairE` ListE xs)) -> ApplyMethod et d i xs
       _ -> error "impossible"
     _ -> error "impossible"
   {-# INLINE toE #-}
@@ -1906,6 +1940,7 @@ instance BindsOneName RolePiBinder (AtomNameC CoreIR) where
 
 instance BindsOneAtomName CoreIR RolePiBinder where
   binderType (RolePiBinder _ b) = binderType b
+  binderVar  (RolePiBinder _ b) = binderVar  b
 
 instance ProvesExt   RolePiBinder
 instance BindsNames  RolePiBinder
@@ -2302,7 +2337,7 @@ instance AlphaHashableE TopFun
 
 instance GenericE SpecializationSpec where
   type RepE SpecializationSpec =
-         PairE (AtomName CoreIR) (Abs (Nest (Binder CoreIR)) (ListE CAtom))
+         PairE (AtomVar CoreIR) (Abs (Nest (Binder CoreIR)) (ListE CAtom))
   fromE (AppSpecialization fname (Abs bs args)) = PairE fname (Abs bs args)
   {-# INLINE fromE #-}
   toE   (PairE fname (Abs bs args)) = AppSpecialization fname (Abs bs args)
@@ -2432,10 +2467,10 @@ instance AlphaEqE       DotMethods
 instance AlphaHashableE DotMethods
 
 instance IRRep r => GenericE (DeclBinding r) where
-  type RepE (DeclBinding r) = LiftE LetAnn `PairE` Type r `PairE` Expr r
-  fromE (DeclBinding ann ty expr) = LiftE ann `PairE` ty `PairE` expr
+  type RepE (DeclBinding r) = LiftE LetAnn `PairE` Expr r
+  fromE (DeclBinding ann expr) = LiftE ann `PairE` expr
   {-# INLINE fromE #-}
-  toE   (LiftE ann `PairE` ty `PairE` expr) = DeclBinding ann ty expr
+  toE   (LiftE ann `PairE` expr) = DeclBinding ann expr
   {-# INLINE toE #-}
 
 instance IRRep r => SinkableE      (DeclBinding r)
@@ -2501,7 +2536,7 @@ instance IRRep r => AlphaEqE       (EffectRow r)
 instance IRRep r => AlphaHashableE (EffectRow r)
 
 instance IRRep r => GenericE (EffectRowTail r) where
-  type RepE (EffectRowTail r) = EitherE (WhenCore r (AtomName CoreIR)) UnitE
+  type RepE (EffectRowTail r) = EitherE (WhenCore r (AtomVar CoreIR)) UnitE
   fromE = \case
     EffectRowTail v -> LeftE (WhenIRE v)
     NoTail          -> RightE UnitE
@@ -2517,18 +2552,18 @@ instance IRRep r => RenameE        (EffectRowTail r)
 instance IRRep r => AlphaEqE       (EffectRowTail r)
 instance IRRep r => AlphaHashableE (EffectRowTail r)
 
-instance IRRep r => GenericE (EffectAndType r) where
-  type RepE (EffectAndType r) = PairE (EffectRow r) (Type r)
-  fromE (EffectAndType eff ty) = eff `PairE` ty
+instance IRRep r => GenericE (EffTy r) where
+  type RepE (EffTy r) = PairE (EffectRow r) (Type r)
+  fromE (EffTy eff ty) = eff `PairE` ty
   {-# INLINE fromE #-}
-  toE   (eff `PairE` ty) = EffectAndType eff ty
+  toE   (eff `PairE` ty) = EffTy eff ty
   {-# INLINE toE #-}
 
-instance IRRep r => SinkableE      (EffectAndType r)
-instance IRRep r => HoistableE     (EffectAndType r)
-instance IRRep r => RenameE        (EffectAndType r)
-instance IRRep r => AlphaEqE       (EffectAndType r)
-instance IRRep r => AlphaHashableE (EffectAndType r)
+instance IRRep r => SinkableE      (EffTy r)
+instance IRRep r => HoistableE     (EffTy r)
+instance IRRep r => RenameE        (EffTy r)
+instance IRRep r => AlphaEqE       (EffTy r)
+instance IRRep r => AlphaHashableE (EffTy r)
 
 instance IRRep r => BindsAtMostOneName (Decl r) (AtomNameC r) where
   Let b _ @> x = b @> x
@@ -2817,7 +2852,9 @@ instance IRRep r => Store (Con r n)
 instance IRRep r => Store (PrimOp r n)
 instance IRRep r => Store (RepVal r n)
 instance IRRep r => Store (Type r n)
+instance IRRep r => Store (EffTy r n)
 instance IRRep r => Store (Atom r n)
+instance IRRep r => Store (AtomVar r n)
 instance IRRep r => Store (Expr r n)
 instance Store (SimpInCore n)
 instance Store (SolverBinding n)

--- a/tests/unit/ConstantCastingSpec.hs
+++ b/tests/unit/ConstantCastingSpec.hs
@@ -31,7 +31,7 @@ castOp ty x = MiscOp $ CastOp (BaseTy (Scalar ty)) x
 castLam :: EnvExtender m => ScalarBaseType -> ScalarBaseType -> m n (SLam n)
 castLam fromTy toTy = do
   withFreshBinder noHint (BaseTy (Scalar fromTy)) \x -> do
-    body <- exprToBlock $ PrimOp $ castOp toTy $ Var $ binderName x
+    body <- exprToBlock $ PrimOp $ castOp toTy $ Var $ binderVar x
     return $ LamExpr (Nest x Empty) body
 
 exprToBlock :: EnvReader m => SExpr n -> m n (SBlock n)

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -50,7 +50,7 @@ uExprToBlock expr = do
 findRunIOAnnotation :: SBlock n -> LetAnn
 findRunIOAnnotation (Block _ decls _) = go decls where
   go :: Nest SDecl n l -> LetAnn
-  go (Nest (Let _ (DeclBinding ann _ (PrimOp (Hof (RunIO _))))) _) = ann
+  go (Nest (Let _ (DeclBinding ann (PrimOp (Hof (RunIO _))))) _) = ann
   go (Nest _ rest) = go rest
   go Empty = error "RunIO not found"
 


### PR DESCRIPTION
This lets us query types without an environment. The reason to do this now is that we're about to allow decls on the rhs of pi types, which means that evaluating the type of `f(x, y)` will require emitting decls. We don't want to have to emit decls every time we query the type of an expression so we need to have the type cached. And if we're doing that, we may as well go all the way and require that the type be queryable even without an environment. That also lets us take away the type annotation from decls, which reduces redundancy a bit. As a bonus, we can now query the types of terms in i-space, so we don't need `getTypeSubst` and similar.