### PR TITLE
Add BFGS optimizer example and benchmark vs. Jaxopt.

### DIFF
--- a/benchmarks/bfgs.py
+++ b/benchmarks/bfgs.py
@@ -56,7 +56,7 @@ def multiclass_logreg_jaxopt(X, y):
     params, state = update(params, state)
   run_time = time.time()
 
-  return compile_time - start_time, run_time - compile_time, state.error, state.iter_num
+  return compile_time - start_time, run_time - compile_time, state.error, state.iter_num, state.value
 
 
 def main(argv):
@@ -71,11 +71,12 @@ def main(argv):
   with open('examples/bfgs.dx', 'r') as f:
     m = dex.Module(f.read())
     # TODO pass max iter, etc.
-    dex_bfgs = djax.primitive(m.multiclass_logreg)
+    dex_bfgs = djax.primitive(m.multiclass_fin)
 
     # time_s, loops = bench_python(lambda : dex_bfgs(X, y))
     # print(f"> Run time: {time_s} s \t(based on {loops} runs)")
-    dex_bfgs(jnp.array(X), jnp.array(y), FLAGS.n_classes)
+    out = dex_bfgs(jnp.array(X), jnp.array(y), FLAGS.n_classes)
+    print(f"> Dex results: {out}")
     
     # # This runs
     # dex_run_bfgs = djax.primitive(m.run_logreg)

--- a/benchmarks/bfgs.py
+++ b/benchmarks/bfgs.py
@@ -43,6 +43,7 @@ def multiclass_logreg_jaxopt(X, y):
 
 
 def main(argv):
+  # Compare performance of Jaxopt and Dex BFGS on a multiclass logistic regression problem.
   X, y = datasets.make_classification(n_samples=FLAGS.n_samples,
                                       n_features=FLAGS.n_features,
                                       n_classes=FLAGS.n_classes,
@@ -54,7 +55,7 @@ def main(argv):
 
   with open('examples/bfgs.dx', 'r') as f:
     m = dex.Module(f.read())
-    dex_bfgs = djax.primitive(m.multiclass_fin)
+    dex_bfgs = djax.primitive(m.multiclass_logreg_int)
 
     start_time = time.time()
     dex_value = dex_bfgs(

--- a/benchmarks/bfgs.py
+++ b/benchmarks/bfgs.py
@@ -1,0 +1,86 @@
+
+from absl import app
+from absl import flags
+
+import jax
+from jax import numpy as jnp
+import jaxopt
+import dex
+from dex.interop import jax as djax
+import numpy as onp
+from sklearn import datasets
+
+import time
+import timeit
+
+FLAGS = flags.FLAGS
+
+flags.DEFINE_integer("maxiter", default=30, help="Max # of iterations.")
+flags.DEFINE_integer("n_samples", default=10000, help="Number of samples.")
+flags.DEFINE_integer("n_features", default=200, help="Number of features.")
+flags.DEFINE_integer("n_classes", default=5, help="Number of classes.")
+flags.DEFINE_string("task", "binary_logreg", "Task to benchmark.")
+
+
+def bench_python(f, loops=None):
+  """Return average runtime of `f` in seconds and number of iterations used."""
+  if loops is None:
+    f()
+    s = time.perf_counter()
+    f()
+    e = time.perf_counter()
+    duration = e - s
+    loops = max(4, int(2 / duration)) # aim for 2s
+  return (timeit.timeit(f, number=loops, globals=globals()) / loops, loops)
+
+def multiclass_logreg_jaxopt(X, y):
+  data = (X, y)
+  fun = jaxopt.objective.multiclass_logreg
+  init = jnp.zeros((X.shape[1], FLAGS.n_classes))
+  bfgs = jaxopt.BFGS(fun=fun, linesearch='zoom')
+  state = bfgs.init_state(init, data=data)
+  params = init
+
+  def cond_fn(state):
+    return (state.error > bfgs.tol) & (state.iter_num < bfgs.maxiter)
+
+  @jax.jit
+  def update(params, state):
+    return bfgs.update(params, state, data=data)
+
+  start_time = time.time()
+  params, state = update(params, state)
+  compile_time = time.time()
+
+  while cond_fn(state):
+    params, state = update(params, state)
+  run_time = time.time()
+
+  return compile_time - start_time, run_time - compile_time, state.error, state.iter_num
+
+
+def main(argv):
+  X, y = datasets.make_classification(n_samples=FLAGS.n_samples,
+                                      n_features=FLAGS.n_features,
+                                      n_classes=FLAGS.n_classes,
+                                      n_informative=FLAGS.n_classes,
+                                      random_state=0)
+  jaxopt_results = multiclass_logreg_jaxopt(X, y)
+  print(f"> Jaxopt results: {jaxopt_results}")
+
+  with open('examples/bfgs.dx', 'r') as f:
+    m = dex.Module(f.read())
+    # TODO pass max iter, etc.
+    dex_bfgs = djax.primitive(m.multiclass_logreg)
+
+    # time_s, loops = bench_python(lambda : dex_bfgs(X, y))
+    # print(f"> Run time: {time_s} s \t(based on {loops} runs)")
+    dex_bfgs(jnp.array(X), jnp.array(y), FLAGS.n_classes)
+    
+    # # This runs
+    # dex_run_bfgs = djax.primitive(m.run_logreg)
+    # dex_run_bfgs(0)
+
+
+if __name__ == '__main__':
+  app.run(main)

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -185,7 +185,9 @@ def multiclass_logreg(
   res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search maxls f) tol maxiter 
   res.fval
 
-def multiclass_fin(
+-- Define a version of `multiclass_logreg` with Int instead of Nat labels, callable from Python 
+-- (see benchmarks/bfgs.py).
+def multiclass_logreg_int(
   xs:(Fin n)=>(Fin d)=>Float,
   ys:(Fin n)=>Int,
   num_classes:Int,

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -162,26 +162,29 @@ def rosenbrock(coord:(Fin 2)=>Float) -> Float =
   y = coord[1@_]
   pow (1 - x) 2 + 100 * pow (y - x * x) 2
 
--- %bench "rosenbrock"
+%bench "rosenbrock"
 bfgs_minimize rosenbrock [10., 10.] eye (\f. backtracking_line_search 15 f) 0.001 100
+> BFGSresults(8.668621e-13, [0.9999993, 0.9999985], 2.538457e-05, 41)
+>
+> rosenbrock
+> Compile time: 618.962 ms
+> Run time:     57.489 us 	(based on 1 run)
 
-def multiclass_logistic_loss(xs: n=>d=>Float, ys: n=>Nat, w: (d, m)=>Float) -> Float given (n|Ix, d|Ix, m|Ix) =
+def multiclass_logistic_loss(xs: n=>d=>Float, ys: n=>m, w: (d, m)=>Float) -> Float given (n|Ix, d|Ix, m|Ix) =
   w_arr = for i:d. for j:m. w[(i, j)]
   logits = xs ** w_arr
-  logit_at_label = for i. logits[i, ys[i]@_]
+  logit_at_label = for i. logits[i, ys[i]]
   per_example_loss = for i. logsumexp logits[i] - logit_at_label[i]
   mean(per_example_loss)
 
 def multiclass_logreg(
   xs:n=>d=>Float,
-  ys:n=>Nat,
-  num_classes:Nat,
+  ys:n=>m,
   maxiter:Nat,
   maxls:Nat,
-  tol:Float) -> Float given (n|Ix, d|Ix)=
-  m = Fin num_classes
-  w0 = for i:(d, m). 0.
+  tol:Float) -> Float given (n|Ix, d|Ix, m|Ix)=
   ob_fun = \v. multiclass_logistic_loss xs ys v
+  w0 = zero
   res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search maxls f) tol maxiter 
   res.fval
 
@@ -194,15 +197,5 @@ def multiclass_logreg_int(
   maxiter:Int,
   maxls:Int,
   tol:Float) -> Float given (n, d) =
-  multiclass_logreg xs (for i. i32_to_n ys[i]) (i32_to_n num_classes) (i32_to_n maxiter) (i32_to_n maxls) tol
-
-N = Fin 10
-D = Fin 5
-
-def run_logreg(x:Int) -> Float =
-  xs:N=>D=>Float = for i:N. for j:D. rand (ixkey (new_key 0) (i, j))
-  ys:N=>Nat = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
-  multiclass_logreg xs ys 3 100 15 0.001
-
-%bench "log reg"
-run_logreg 0
+  y_ind = Fin (i32_to_n num_classes)
+  multiclass_logreg xs (for i. i32_to_n ys[i] @ y_ind) (i32_to_n maxiter) (i32_to_n maxls) tol

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -169,8 +169,8 @@ def multiclass_logistic_loss(xs: n=>d=>Float, ys: n=>Nat, w: (d, m)=>Float) -> F
   w_arr = for i:d. for j:m. w[(i, j)]
   logits = xs ** w_arr
   logit_at_label = for i. logits[i, ys[i]@_]
-  logits = for i. for j. logits[i, j] - logit_at_label[i]
-  logsumexp $ for i. logsumexp logits[i]
+  per_example_loss = for i. logsumexp logits[i] - logit_at_label[i]
+  sum(per_example_loss)
 
 def multiclass_logreg(
   xs:n=>d=>Float,
@@ -179,7 +179,7 @@ def multiclass_logreg(
   m = Fin num_classes
   w0 = for i:(d, m). 0.
   ob_fun = \v. multiclass_logistic_loss xs ys v
-  res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search 500 f) 0.001 100
+  res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search 500 f) 0.001 1
   res.fval
 
 def multiclass_fin(

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -170,23 +170,29 @@ def multiclass_logistic_loss(xs: n=>d=>Float, ys: n=>Nat, w: (d, m)=>Float) -> F
   logits = xs ** w_arr
   logit_at_label = for i. logits[i, ys[i]@_]
   per_example_loss = for i. logsumexp logits[i] - logit_at_label[i]
-  sum(per_example_loss)
+  mean(per_example_loss)
 
 def multiclass_logreg(
   xs:n=>d=>Float,
   ys:n=>Nat,
-  num_classes:Nat) -> Float given (n|Ix, d|Ix)=
+  num_classes:Nat,
+  maxiter:Nat,
+  maxls:Nat,
+  tol:Float) -> Float given (n|Ix, d|Ix)=
   m = Fin num_classes
   w0 = for i:(d, m). 0.
   ob_fun = \v. multiclass_logistic_loss xs ys v
-  res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search 500 f) 0.001 1
+  res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search maxls f) tol maxiter 
   res.fval
 
 def multiclass_fin(
   xs:(Fin n)=>(Fin d)=>Float,
   ys:(Fin n)=>Int,
-  num_classes:Int) -> Float given (n, d) =
-  multiclass_logreg xs (for i. i32_to_n ys[i]) (i32_to_n num_classes)
+  num_classes:Int,
+  maxiter:Int,
+  maxls:Int,
+  tol:Float) -> Float given (n, d) =
+  multiclass_logreg xs (for i. i32_to_n ys[i]) (i32_to_n num_classes) (i32_to_n maxiter) (i32_to_n maxls) tol
 
 N = Fin 10
 D = Fin 5
@@ -194,7 +200,7 @@ D = Fin 5
 def run_logreg(x:Int) -> Float =
   xs:N=>D=>Float = for i:N. for j:D. rand (ixkey (new_key 0) (i, j))
   ys:N=>Nat = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
-  multiclass_logreg xs ys 3
+  multiclass_logreg xs ys 3 100 15 0.001
 
 %bench "log reg"
 run_logreg 0

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -11,16 +11,16 @@ Optimization (2nd ed).
 statically unknown number of iterations. See `benchmarks/bfgs.py` for a 
 comparison with Jaxopt BFGS on a multiclass logistic regression problem.
 
-def outer_product {n m} (x:n=>Float) (y:m=>Float) : (n=>m=>Float) =
-  for i:n. for j:m. x.i * y.j
+def outer_product(x:n=>Float, y:m=>Float) -> (n=>m=>Float) given (n|Ix, m|Ix) =
+  for i:n. for j:m. x[i]* y[j]
 
-def zoom 
-    (f_line:Float->Float) 
-    (a_lo_init:Float) 
-    (a_hi_init:Float)
-    (c1:Float)
-    (c2:Float)
-    : Float =
+def zoom(
+  f_line: (Float)->Float,
+  a_lo_init:Float, 
+  a_hi_init:Float,
+  c1:Float,
+  c2:Float
+) -> Float =
   -- Zoom line search helper; Algorithm 3.6 from Nocedal and Wright (2006).
 
   f0 = f_line 0.
@@ -53,7 +53,10 @@ def zoom
                 a_lo_ref := a_i
                 Continue
 
-def zoom_line_search (maxiter:Nat) (f:Float->Float): Float =
+def zoom_line_search(
+  maxiter:Nat,
+  f: (Float)->Float
+  ) -> Float =
   --Algorithm 3.5 from Nocedal and Wright (2006).
   c1 = 0.0001
   c2 = 0.9
@@ -83,7 +86,10 @@ def zoom_line_search (maxiter:Nat) (f:Float->Float): Float =
                 a_ref := 0.5 * (a_i + a_max)
                 Continue
 
-def backtracking_line_search (maxiter:Nat) (f:Float->Float) : Float =
+def backtracking_line_search(
+  maxiter:Nat,
+  f: (Float)->Float
+  ) -> Float =
   -- Algorithm 3.1 in Nocedal and Wright (2006).
   a_init = 1. 
   f_0 = f 0.
@@ -100,20 +106,20 @@ def backtracking_line_search (maxiter:Nat) (f:Float->Float) : Float =
         a_ref := a_i * rho
         Continue
 
-def BFGSresults (n:Type) [Ix n] = {
-  fval : Float & 
-  x_opt: (n=>Float) &
-  error: Float &
-  num_iter: Nat}
+struct BFGSresults(n|Ix) = 
+  fval : Float
+  x_opt: (n=>Float)
+  error: Float 
+  num_iter: Nat
   
-def bfgs_minimize {n} 
-    (f:n=>Float->Float)                 --Objective function.
-    (x0:n=>Float)                       --Initial point.
-    (H0:n=>n=>Float)                    --Initial inverse Hessian approximation.
-    (linesearch:(Float->Float)->Float)  --Line search that returns a step size.
-    (tol:Float)                         --Convergence tolerance (of the gradient L2 norm).
-    (maxiter:Nat)                       --Maximum number of BFGS iterations.
-    :BFGSresults n =             
+def bfgs_minimize(
+  f: (n=>Float)->Float,                 --Objective function.
+  x0: n=>Float,                       --Initial point.
+  H0: n=>n=>Float,                    --Initial inverse Hessian approximation.
+  linesearch: ((Float)->Float)->Float,  --Line search that returns a step size.
+  tol: Float,                         --Convergence tolerance (of the gradient L2 norm).
+  maxiter: Nat                        --Maximum number of BFGS iterations.
+  ) -> BFGSresults n given (n|Ix) =             
   -- Algorithm 6.1 in Nocedal and Wright (2006).
 
   xref <- with_state x0 
@@ -123,10 +129,10 @@ def bfgs_minimize {n}
   iter \i.
     x = get xref
     g = get gref
-    grad_norm = sqrt $ sum $ for i. g.i * g.i
+    grad_norm = sqrt $ sum $ for i. g[i] * g[i]
 
     if grad_norm < tol || i >= maxiter
-      then Done {fval = f x, x_opt = x, error = grad_norm, num_iter = i}
+      then Done BFGSresults(f x, x, grad_norm, i)
       else
         H = get Href
         search_direction = -H**.g
@@ -150,40 +156,45 @@ def bfgs_minimize {n}
         Continue
 
 
-def rosenbrock (coord:(Fin 2)=>Float) : Float =
+def rosenbrock(coord:(Fin 2)=>Float) -> Float =
   --A standard optimization test case; the optimum is (1, 1).
-  x = coord.(0@_)
-  y = coord.(1@_)
+  x = coord[0@_]
+  y = coord[1@_]
   pow (1 - x) 2 + 100 * pow (y - x * x) 2
 
 -- %bench "rosenbrock"
-bfgs_minimize rosenbrock [10., 10.] eye (backtracking_line_search 15) 0.001 100
+bfgs_minimize rosenbrock [10., 10.] eye (\f. backtracking_line_search 15 f) 0.001 100
 
-def multiclass_logistic_loss {n m d} [Ix m] (xs: n=>d=>Float) (ys: n=>Nat) (w: (d&m)=>Float): Float =
-  w_arr = for i. for j. w.(i, j)
+def multiclass_logistic_loss(xs: n=>d=>Float, ys: n=>Nat, w: (d, m)=>Float) -> Float given (n|Ix, d|Ix, m|Ix) =
+  w_arr = for i:d. for j:m. w[(i, j)]
   logits = xs ** w_arr
-  logit_at_label = for i. logits.i.(ys.i@_)
-  logits = for i. for j. logits.i.j - logit_at_label.i
-  logsumexp $ for i. logsumexp logits.i
+  logit_at_label = for i. logits[i, ys[i]@_]
+  logits = for i. for j. logits[i, j] - logit_at_label[i]
+  logsumexp $ for i. logsumexp logits[i]
 
--- May need to convert Nat to int
-def multiclass_logreg {n d} (xs:n=>d=>Float) (ys:n=>Nat) (num_classes:Nat) : Float =
+def multiclass_logreg(
+  xs:n=>d=>Float,
+  ys:n=>Nat,
+  num_classes:Nat) -> Float given (n|Ix, d|Ix)=
   m = Fin num_classes
-  w0 = for i:(d & m). 0.
-  ob_fun = multiclass_logistic_loss xs ys
-  res = bfgs_minimize ob_fun w0 eye (zoom_line_search 500) 0.001 100
-  get_at #fval res
+  w0 = for i:(d, m). 0.
+  ob_fun = \v. multiclass_logistic_loss xs ys v
+  res = bfgs_minimize ob_fun w0 eye (\f. zoom_line_search 500 f) 0.001 100
+  res.fval
 
-def multiclass_fin {n d} (xs:(Fin n)=>(Fin d)=>Float) (ys:(Fin n)=>Int) (num_classes:Int) : Float =
-  multiclass_logreg xs (for i. i32_to_n ys.i) (i32_to_n num_classes)
+def multiclass_fin(
+  xs:(Fin n)=>(Fin d)=>Float,
+  ys:(Fin n)=>Int,
+  num_classes:Int) -> Float given (n, d) =
+  multiclass_logreg xs (for i. i32_to_n ys[i]) (i32_to_n num_classes)
 
 N = Fin 10
 D = Fin 5
 
-def run_logreg (x:Int) : Float =
+def run_logreg(x:Int) -> Float =
   xs:N=>D=>Float = for i:N. for j:D. rand (ixkey (new_key 0) (i, j))
   ys:N=>Nat = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
   multiclass_logreg xs ys 3
 
---%bench "log reg"
---run_logreg 0
+%bench "log reg"
+run_logreg 0

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -1,0 +1,159 @@
+'# BFGS optimizer
+
+def print_array {n a} [Ix n] [Show a] (prefix:String) (x:n=>a) : {IO} _ =
+  stream = get_output_stream ()
+  fwrite stream $ prefix <> " ["
+  for i:n.
+    if (ordinal i + 1) == size n
+      then fwrite stream $ show x.i
+      else fwrite stream $ show x.i <> ", "
+  fwrite stream "] \n"
+  ()
+
+def outer_product {n m} (x:n=>Float) (y:m=>Float) : (n=>m=>Float) =
+  for i:n. for j:m. x.i * y.j
+
+def zoom (f_line:Float->Float) (a_lo_init:Float) (a_hi_init:Float): Float =
+  c1 = 0.0001
+  c2 = 0.9
+  interp = \x y. 0.5 * (x + y)
+
+  f0 = f_line 0.
+  g0 = grad f_line 0.
+
+  a_hi_ref <- with_state a_hi_init
+  a_lo_ref <- with_state a_lo_init
+  iter \i.
+    a_lo = get a_lo_ref
+    a_hi = get a_hi_ref
+    a_i = interp a_lo a_hi
+    if i > 100
+      then Done a_i
+      else
+        if f_line a_i > (f0 + c1 * a_i * g0) || f_line a_i >= f_line a_lo
+          then 
+            a_hi_ref := a_i
+            Continue
+          else
+            g_i = grad f_line a_i
+            if abs g_i <= (-c2 * g0)
+              then Done a_i
+              else
+                if g_i * (a_hi - a_lo) >= 0.
+                  then a_hi_ref := a_lo
+                a_lo_ref := a_i
+                Continue
+
+def zoom_line_search (f:Float->Float) : Float =
+  c1 = 0.0001
+  c2 = 0.9
+
+  a_max = 1.
+  a_ref <- with_state 0.
+  a_ref_last <- with_state 0.
+  f_0 = f 0.
+  g_0 = grad f 0.
+  max_iter = 10
+
+  iter \i.
+    a_i = get a_ref
+    a_last = get a_ref_last
+    f_i = f a_i
+    if i > max_iter || f_i > (f_0 + c1 * a_i * g_0) || (f_i >= f a_last && i > 1)
+      then Done (zoom f a_last a_i)
+      else
+        g_i = grad f a_i
+        if abs g_i <= (-c2 * g_0)
+          then Done a_i
+          else
+            if g_i >= 0.
+              then Done (zoom f a_i a_last)
+              else 
+                a_ref_last := a_i
+                a_ref := 0.5 * (a_i + a_max)
+                Continue
+
+def line_search (f:Float->Float) : Float =
+  init_step_size = 1. 
+  f_init = f(0.)
+  g = grad f 0.
+  step_size_adjustment = 0.5
+  tol = 0.0001
+
+  step_size_ref <- with_state init_step_size
+  iter \i.
+    step_size = get step_size_ref
+    f_next = f step_size
+    f_wolfe = f_init + tol * step_size * g
+
+    if f_next < f_wolfe || i > 100
+      then Done step_size
+      else
+        step_size_ref := step_size * step_size_adjustment
+        Continue
+  
+def run_lbfgs {n} 
+    (f:n=>Float->Float)
+    (x0:n=>Float)
+    (H0:n=>n=>Float) --dense for now
+    (tol:Float)
+    :{IO} (Float & (n=>Float)) =
+  xref <- with_state x0 
+  H <- with_state H0
+  gref <- with_state (grad f x0)
+  iter \i.
+    print $ "iter " <> show i
+    x = get xref
+    g = get gref
+    print_array "x" x
+    print_array "g" g
+    print $ "f: " <> (show $ f x)
+
+    grad_norm = sqrt $ sum $ for i. g.i * g.i
+    if grad_norm < tol || i > 100
+      then Done (f x, x)
+      else
+        search_direction = -(get H)**.g
+        print_array "search_dir" search_direction
+        H_i = get H
+        print_array "Hessian" (for (i, j). H_i.i.j)
+        f_line = \s:Float. f (x + s .* search_direction)
+        step_size = zoom_line_search f_line 
+        x_diff = step_size .* search_direction
+        print_array "x diff" x_diff
+        print $ "step size: " <> (show step_size)
+        x_next = x + x_diff
+        g_next = grad f x_next
+        grad_diff = g_next - g
+        print_array "grad diff" grad_diff
+
+        rho_inv = vdot grad_diff x_diff
+        if not (rho_inv == 0.)
+            then
+                rho = 1. / rho_inv
+                print $ "rho " <> show rho
+                y = (eye - rho .* outer_product x_diff grad_diff)
+                print_array "y " (for (i, j). y.i.j)
+                z = (eye - rho .* outer_product grad_diff x_diff)
+                print_array "z " (for (i, j). z.i.j)
+                -- Improve low rank update (avoid dense matmuls)
+                H := y ** get H ** z + rho .* outer_product x_diff x_diff
+                print_array "outer prod x_diff" (for (i, j). (outer_product x_diff x_diff).i.j)
+        print_array "new Hessian" (for (i, j). (get H).i.j)
+        
+        xref := x_next
+        gref := g_next
+        Continue
+
+
+def bowl {n} (x:n=>Float) : Float =
+  sum $ for i. x.i * x.i
+
+def rosenbrock (coord:(Fin 2)=>Float) : Float =
+  x = coord.(0@_)
+  y = coord.(1@_)
+  bowl [(1. - x), (10. * (y - x * x))]
+
+%bench "bowl"
+bowl [1., 2.]
+--unsafe_io do run_lbfgs rosenbrock [10., 10.] eye 0.0001

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -1,22 +1,27 @@
 '# BFGS optimizer
+The BFGS method is a quasi-Newton algorithm for solving unconstrained nonlinear 
+optimization problems. A BFGS iteration entails computing a line search 
+direction based on the gradient and Hessian approximation, finding a new point
+in the line search direction that satisfies the Wolfe conditions, and updating
+the Hessian approximation at the new point. This implementation is based on
+BFGS as described in Nocedal, Jorge; Wright, Stephen J. (2006), Numerical 
+Optimization (2nd ed).
 
-def print_array {n a} [Ix n] [Show a] (prefix:String) (x:n=>a) : {IO} _ =
-  stream = get_output_stream ()
-  fwrite stream $ prefix <> " ["
-  for i:n.
-    if (ordinal i + 1) == size n
-      then fwrite stream $ show x.i
-      else fwrite stream $ show x.i <> ", "
-  fwrite stream "] \n"
-  ()
+'This example demonstrates Dex's ability to do fast, stateful loops with a 
+statically unknown number of iterations. See `benchmarks/bfgs.py` for a 
+comparison with Jaxopt BFGS on a multiclass logistic regression problem.
 
 def outer_product {n m} (x:n=>Float) (y:m=>Float) : (n=>m=>Float) =
   for i:n. for j:m. x.i * y.j
 
-def zoom (f_line:Float->Float) (a_lo_init:Float) (a_hi_init:Float): Float =
-  c1 = 0.0001
-  c2 = 0.9
-  interp = \x y. 0.5 * (x + y)
+def zoom 
+    (f_line:Float->Float) 
+    (a_lo_init:Float) 
+    (a_hi_init:Float)
+    (c1:Float)
+    (c2:Float)
+    : Float =
+  -- Zoom line search helper; Algorithm 3.6 from Nocedal and Wright (2006).
 
   f0 = f_line 0.
   g0 = grad f_line 0.
@@ -26,11 +31,15 @@ def zoom (f_line:Float->Float) (a_lo_init:Float) (a_hi_init:Float): Float =
   iter \i.
     a_lo = get a_lo_ref
     a_hi = get a_hi_ref
-    a_i = interp a_lo a_hi
-    if i > 100
+
+    --Find a trial step length between a_lo and a_hi.
+    a_i = 0.5 * (a_lo + a_hi)
+
+    if (a_hi - a_lo) < 0.000001  -- The line search failed.
       then Done a_i
       else
-        if f_line a_i > (f0 + c1 * a_i * g0) || f_line a_i >= f_line a_lo
+        f_ai = f_line a_i
+        if f_ai > (f0 + c1 * a_i * g0) || f_ai >= f_line a_lo
           then 
             a_hi_ref := a_i
             Continue
@@ -44,116 +53,133 @@ def zoom (f_line:Float->Float) (a_lo_init:Float) (a_hi_init:Float): Float =
                 a_lo_ref := a_i
                 Continue
 
-def zoom_line_search (f:Float->Float) : Float =
+def zoom_line_search (maxiter:Nat) (f:Float->Float): Float =
+  --Algorithm 3.5 from Nocedal and Wright (2006).
   c1 = 0.0001
   c2 = 0.9
-
   a_max = 1.
-  a_ref <- with_state 0.
-  a_ref_last <- with_state 0.
+
   f_0 = f 0.
   g_0 = grad f 0.
-  max_iter = 10
+
+  a_ref <- with_state 0.5
+  a_ref_last <- with_state 0.
 
   iter \i.
     a_i = get a_ref
     a_last = get a_ref_last
     f_i = f a_i
-    if i > max_iter || f_i > (f_0 + c1 * a_i * g_0) || (f_i >= f a_last && i > 1)
-      then Done (zoom f a_last a_i)
+    if i >= maxiter || f_i > (f_0 + c1 * a_i * g_0) || (f_i >= f a_last && i > 0)
+      then Done (zoom f a_last a_i c1 c2)
       else
         g_i = grad f a_i
         if abs g_i <= (-c2 * g_0)
           then Done a_i
           else
             if g_i >= 0.
-              then Done (zoom f a_i a_last)
+              then Done (zoom f a_i a_last c1 c2)
               else 
                 a_ref_last := a_i
                 a_ref := 0.5 * (a_i + a_max)
                 Continue
 
-def line_search (f:Float->Float) : Float =
-  init_step_size = 1. 
-  f_init = f(0.)
-  g = grad f 0.
-  step_size_adjustment = 0.5
-  tol = 0.0001
+def backtracking_line_search (maxiter:Nat) (f:Float->Float) : Float =
+  -- Algorithm 3.1 in Nocedal and Wright (2006).
+  a_init = 1. 
+  f_0 = f 0.
+  g_0 = grad f 0.
+  rho = 0.5
+  c = 0.0001
 
-  step_size_ref <- with_state init_step_size
+  a_ref <- with_state a_init
   iter \i.
-    step_size = get step_size_ref
-    f_next = f step_size
-    f_wolfe = f_init + tol * step_size * g
-
-    if f_next < f_wolfe || i > 100
-      then Done step_size
+    a_i = get a_ref
+    if f a_i <= (f_0 + c * a_i * g_0) || i >= maxiter
+      then Done a_i
       else
-        step_size_ref := step_size * step_size_adjustment
+        a_ref := a_i * rho
         Continue
+
+def BFGSresults (n:Type) [Ix n] = {
+  fval : Float & 
+  x_opt: (n=>Float) &
+  error: Float &
+  num_iter: Nat}
   
-def run_lbfgs {n} 
-    (f:n=>Float->Float)
-    (x0:n=>Float)
-    (H0:n=>n=>Float) --dense for now
-    (tol:Float)
-    :{IO} (Float & (n=>Float)) =
+def bfgs_minimize {n} 
+    (f:n=>Float->Float)                 --Objective function.
+    (x0:n=>Float)                       --Initial point.
+    (H0:n=>n=>Float)                    --Initial inverse Hessian approximation.
+    (linesearch:(Float->Float)->Float)  --Line search that returns a step size.
+    (tol:Float)                         --Convergence tolerance (of the gradient L2 norm).
+    (maxiter:Nat)                       --Maximum number of BFGS iterations.
+    :BFGSresults n =             
+  -- Algorithm 6.1 in Nocedal and Wright (2006).
+
   xref <- with_state x0 
-  H <- with_state H0
+  Href <- with_state H0
   gref <- with_state (grad f x0)
+
   iter \i.
-    print $ "iter " <> show i
     x = get xref
     g = get gref
-    print_array "x" x
-    print_array "g" g
-    print $ "f: " <> (show $ f x)
-
     grad_norm = sqrt $ sum $ for i. g.i * g.i
-    if grad_norm < tol || i > 100
-      then Done (f x, x)
+
+    if grad_norm < tol || i >= maxiter
+      then Done {fval = f x, x_opt = x, error = grad_norm, num_iter = i}
       else
-        search_direction = -(get H)**.g
-        print_array "search_dir" search_direction
-        H_i = get H
-        print_array "Hessian" (for (i, j). H_i.i.j)
+        H = get Href
+        search_direction = -H**.g
         f_line = \s:Float. f (x + s .* search_direction)
-        step_size = zoom_line_search f_line 
+        step_size = linesearch f_line 
         x_diff = step_size .* search_direction
-        print_array "x diff" x_diff
-        print $ "step size: " <> (show step_size)
         x_next = x + x_diff
         g_next = grad f x_next
         grad_diff = g_next - g
-        print_array "grad diff" grad_diff
 
+        -- Update the inverse Hessian approximation.
         rho_inv = vdot grad_diff x_diff
         if not (rho_inv == 0.)
             then
                 rho = 1. / rho_inv
-                print $ "rho " <> show rho
                 y = (eye - rho .* outer_product x_diff grad_diff)
-                print_array "y " (for (i, j). y.i.j)
-                z = (eye - rho .* outer_product grad_diff x_diff)
-                print_array "z " (for (i, j). z.i.j)
-                -- Improve low rank update (avoid dense matmuls)
-                H := y ** get H ** z + rho .* outer_product x_diff x_diff
-                print_array "outer prod x_diff" (for (i, j). (outer_product x_diff x_diff).i.j)
-        print_array "new Hessian" (for (i, j). (get H).i.j)
+                Href := y ** H ** (transpose y) + rho .* outer_product x_diff x_diff
         
         xref := x_next
         gref := g_next
         Continue
 
 
-def bowl {n} (x:n=>Float) : Float =
-  sum $ for i. x.i * x.i
-
 def rosenbrock (coord:(Fin 2)=>Float) : Float =
+  --A standard optimization test case; the optimum is (1, 1).
   x = coord.(0@_)
   y = coord.(1@_)
-  bowl [(1. - x), (10. * (y - x * x))]
+  pow (1 - x) 2 + 100 * pow (y - x * x) 2
 
-%bench "bowl"
-bowl [1., 2.]
---unsafe_io do run_lbfgs rosenbrock [10., 10.] eye 0.0001
+-- %bench "rosenbrock"
+bfgs_minimize rosenbrock [10., 10.] eye (backtracking_line_search 15) 0.001 100
+
+def multiclass_logistic_loss {n m d} [Ix m] (xs: n=>d=>Float) (ys: n=>Nat) (w: (d&m)=>Float): Float =
+  w_arr = for i. for j. w.(i, j)
+  logits = xs ** w_arr
+  logit_at_label = for i. logits.i.(ys.i@_)
+  logits = for i. for j. logits.i.j - logit_at_label.i
+  logsumexp $ for i. logsumexp logits.i
+
+def multiclass_logreg {n d} (xs:n=>d=>Float) (ys:n=>Nat) (num_classes:Nat) : Float =
+  m = Fin num_classes
+  w0 = for i:(d & m). 0.
+  ob_fun = multiclass_logistic_loss xs ys
+  res = bfgs_minimize ob_fun w0 eye (zoom_line_search 20) 0.001 100
+  get_at #fval res
+
+N = Fin 10
+D = Fin 5
+
+def run_logreg (x:Int) : Float =
+  xs:N=>D=>Float = for i:N. for j:D. rand (ixkey (new_key 0) (i, j))
+  ys:N=>Nat = [0, 1, 2, 0, 1, 2, 0, 1, 2, 0]
+  multiclass_logreg xs ys 3
+
+--%bench "log reg"
+--run_logreg 0

--- a/examples/bfgs.dx
+++ b/examples/bfgs.dx
@@ -166,12 +166,16 @@ def multiclass_logistic_loss {n m d} [Ix m] (xs: n=>d=>Float) (ys: n=>Nat) (w: (
   logits = for i. for j. logits.i.j - logit_at_label.i
   logsumexp $ for i. logsumexp logits.i
 
+-- May need to convert Nat to int
 def multiclass_logreg {n d} (xs:n=>d=>Float) (ys:n=>Nat) (num_classes:Nat) : Float =
   m = Fin num_classes
   w0 = for i:(d & m). 0.
   ob_fun = multiclass_logistic_loss xs ys
-  res = bfgs_minimize ob_fun w0 eye (zoom_line_search 20) 0.001 100
+  res = bfgs_minimize ob_fun w0 eye (zoom_line_search 500) 0.001 100
   get_at #fval res
+
+def multiclass_fin {n d} (xs:(Fin n)=>(Fin d)=>Float) (ys:(Fin n)=>Int) (num_classes:Int) : Float =
+  multiclass_logreg xs (for i. i32_to_n ys.i) (i32_to_n num_classes)
 
 N = Fin 10
 D = Fin 5

--- a/makefile
+++ b/makefile
@@ -209,7 +209,7 @@ example-names := \
   fluidsim \
   sgd psd kernelregression nn \
   quaternions manifold-gradients schrodinger tutorial \
-  latex linear-maps dither mcts md
+  latex linear-maps dither mcts md bfgs
 # TODO: re-enable
 # fft vega-plotting
 


### PR DESCRIPTION
Pair programmed with @axch . 

Run time of the Dex logistic regression example went from ~240 s to 26 s following 289a43e922666114795cdef8c32d8f2a9026a5a9.