### PR TITLE
Cache type and effect parameters to HOFs.

### DIFF
--- a/src/lib/CheapReduction.hs
+++ b/src/lib/CheapReduction.hs
@@ -645,6 +645,9 @@ instance IRRep r => VisitGeneric (PrimOp r) r where
     UserEffectOp op -> UserEffectOp <$> visitGeneric op
     RefOp r op  -> RefOp <$> visitGeneric r <*> traverseOp op visitGeneric visitGeneric visitGeneric
 
+instance IRRep r => VisitGeneric (TypedHof r) r where
+  visitGeneric (TypedHof eff hof) = TypedHof <$> visitGeneric eff <*> visitGeneric hof
+
 instance IRRep r => VisitGeneric (Hof r) r where
   visitGeneric = \case
     For ann d lam -> For ann <$> visitGeneric d <*> visitGeneric lam
@@ -663,8 +666,8 @@ instance IRRep r => VisitGeneric (BaseMonoid r) r where
 
 instance IRRep r => VisitGeneric (DAMOp r) r where
   visitGeneric = \case
-    Seq dir d x lam -> Seq dir <$> visitGeneric d <*> visitGeneric x <*> visitGeneric lam
-    RememberDest x lam -> RememberDest <$> visitGeneric x <*> visitGeneric lam
+    Seq eff dir d x lam -> Seq <$> visitGeneric eff <*> pure dir <*> visitGeneric d <*> visitGeneric x <*> visitGeneric lam
+    RememberDest eff x lam -> RememberDest <$> visitGeneric eff <*> visitGeneric x <*> visitGeneric lam
     AllocDest t -> AllocDest <$> visitGeneric t
     Place x y -> Place  <$> visitGeneric x <*> visitGeneric y
     Freeze x  -> Freeze <$> visitGeneric x
@@ -723,6 +726,9 @@ instance IRRep r => VisitGeneric (IxDict r) r where
     IxDictAtom   x -> IxDictAtom   <$> visitGeneric x
     IxDictRawFin x -> IxDictRawFin <$> visitGeneric x
     IxDictSpecialized t v xs -> IxDictSpecialized <$> visitGeneric t <*> renameN v <*> mapM visitGeneric xs
+
+instance IRRep r => VisitGeneric (IxType r) r where
+  visitGeneric (IxType t d) = IxType <$> visitType t <*> visitGeneric d
 
 instance VisitGeneric DictType CoreIR where
   visitGeneric (DictType n v xs) = DictType n <$> renameN v <*> mapM visitGeneric xs
@@ -872,6 +878,7 @@ instance SubstE AtomSubstVal DataConDef
 instance IRRep r => SubstE AtomSubstVal (BaseMonoid r)
 instance SubstE AtomSubstVal UserEffectOp
 instance IRRep r => SubstE AtomSubstVal (DAMOp r)
+instance IRRep r => SubstE AtomSubstVal (TypedHof r)
 instance IRRep r => SubstE AtomSubstVal (Hof r)
 instance IRRep r => SubstE AtomSubstVal (TC r)
 instance IRRep r => SubstE AtomSubstVal (Con r)

--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -430,7 +430,7 @@ liftLamExpr f (LamExpr bs body) = liftEnvReaderM $
 fromNaryForExpr :: IRRep r => Int -> Expr r n -> Maybe (Int, LamExpr r n)
 fromNaryForExpr maxDepth | maxDepth <= 0 = error "expected non-negative number of args"
 fromNaryForExpr maxDepth = \case
-  PrimOp (Hof (For _ _ (UnaryLamExpr b body))) ->
+  PrimOp (Hof (TypedHof _ (For _ _ (UnaryLamExpr b body)))) ->
     extend <|> (Just $ (1, LamExpr (Nest b Empty) body))
     where
       extend = do

--- a/src/lib/Inline.hs
+++ b/src/lib/Inline.hs
@@ -216,7 +216,7 @@ inlineDeclsSubst = \case
     -- since their main purpose is to force inlining in the simplifier, and if
     -- one just stuck like this it has become equivalent to a `for` anyway.
     ixDepthExpr :: Expr SimpIR n -> Int
-    ixDepthExpr (PrimOp (Hof (For _ _ (UnaryLamExpr _ body)))) = 1 + ixDepthBlock body
+    ixDepthExpr (PrimOp (Hof (TypedHof _ (For _ _ (UnaryLamExpr _ body))))) = 1 + ixDepthBlock body
     ixDepthExpr _ = 0
     ixDepthBlock :: Block SimpIR n -> Int
     ixDepthBlock (exprBlock -> (Just expr)) = ixDepthExpr expr

--- a/src/lib/JAX/ToSimp.hs
+++ b/src/lib/JAX/ToSimp.hs
@@ -62,7 +62,7 @@ simplifyJTy JArrayName{shape, dtype} = go shape $ simplifyDType dtype where
   go [] ty = return ty
   go ((DimSize sz):rest) ty = do
     rest' <- go rest ty
-    return $ finIxTy sz ==> rest'
+    return $ litFinIxTy sz ==> rest'
 
 simplifyDType :: DType -> Type r n
 simplifyDType = \case
@@ -123,6 +123,6 @@ unaryExpandRank op arg JArrayName{shape} = go arg shape where
   go :: Emits l => SAtom l -> [DimSizeName] -> JaxSimpM i l (SAtom l)
   go arg' = \case
     [] -> emitExprToAtom $ PrimOp (UnOp op arg')
-    (DimSize sz:rest) -> buildFor noHint P.Fwd (finIxTy sz) \i -> do
+    (DimSize sz:rest) -> buildFor noHint P.Fwd (litFinIxTy sz) \i -> do
       ixed <- mkTabApp (sink arg') [Var i] >>= emitExprToAtom
       go ixed rest

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -928,7 +928,7 @@ instance IRRep r => PrettyPrec (PrimOp r n) where
     VectorOp op -> prettyPrec op
     DAMOp op -> prettyPrec op
     UserEffectOp op -> prettyPrec op
-    Hof hof -> prettyPrec hof
+    Hof (TypedHof _ hof) -> prettyPrec hof
     RefOp ref eff -> atPrec LowestPrec case eff of
       MAsk        -> "ask" <+> pApp ref
       MExtend _ x -> "extend" <+> pApp ref <+> pApp x
@@ -987,14 +987,14 @@ instance IRRep r => PrettyPrec (Hof r n) where
 instance IRRep r => Pretty (DAMOp r n) where pretty = prettyFromPrettyPrec
 instance IRRep r => PrettyPrec (DAMOp r n) where
   prettyPrec op = atPrec LowestPrec case op of
-    Seq ann d c lamExpr -> case lamExpr of
+    Seq _ ann d c lamExpr -> case lamExpr of
       UnaryLamExpr b body -> do
         let rawFinPretty = case d of
-              IxDictRawFin n -> parens $ "RawFin" <+> p n
+              IxType _ (IxDictRawFin n) -> parens $ "RawFin" <+> p n
               _ -> mempty
         "seq" <+> rawFinPretty <+> pApp ann <+> pApp c <+> prettyLam (p b <> ".") body
       _ -> p (show op) -- shouldn't happen, but crashing pretty printers make debugging hard
-    RememberDest x y    -> "rememberDest" <+> pArg x <+> pArg y
+    RememberDest _ x y    -> "rememberDest" <+> pArg x <+> pArg y
     Place r v -> pApp r <+> "r:=" <+> pApp v
     Freeze r  -> "freeze" <+> pApp r
     AllocDest ty -> "alloc" <+> pApp ty

--- a/tests/unit/OccAnalysisSpec.hs
+++ b/tests/unit/OccAnalysisSpec.hs
@@ -50,7 +50,7 @@ uExprToBlock expr = do
 findRunIOAnnotation :: SBlock n -> LetAnn
 findRunIOAnnotation (Block _ decls _) = go decls where
   go :: Nest SDecl n l -> LetAnn
-  go (Nest (Let _ (DeclBinding ann (PrimOp (Hof (RunIO _))))) _) = ann
+  go (Nest (Let _ (DeclBinding ann (PrimOp (Hof (TypedHof _ (RunIO _)))))) _) = ann
   go (Nest _ rest) = go rest
   go Empty = error "RunIO not found"
 


### PR DESCRIPTION
To figure out the relevant types for HOFs like `For` and `RunState` we used to query the binders on their lambda parameters. That sometimes involved some awkward partiality due to assumed-successful hoisting. But more importantly it will become harder to do once we have type blocks. Querying the type of a lambda binder will give us some decls that we have to emit or go under. And hoisting a type that we expect to not dependent on a binder might fail because of spurious decls rather than true dependence. With this change, the HOFs just take extra type parameters for their relevant types, just as they would if they were regular library-level Dex functions, and there's never a need to query the lambda binders.