### PR TITLE
Initial support for tooltips: parse tree visualizations.

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -84,9 +84,11 @@ library
                      , Serialize
                      , Simplify
                      , Subst
+                     , SourceInfo
                      , SourceRename
                      , TopLevel
                      , Transpose
+                     , TraverseSourceInfo
                      , Types.Core
                      , Types.Imp
                      , Types.Misc
@@ -323,12 +325,14 @@ test-suite spec
                      , aeson
                      , aeson-pretty
                      , bytestring
+                     , blaze-html
                      , dex
   other-modules:       ConstantCastingSpec
                      , JaxADTSpec
                      , OccAnalysisSpec
                      , OccurrenceSpec
                      , RawNameSpec
+                     , SourceInfoSpec
   default-language:    Haskell2010
   build-tool-depends:  hspec-discover:hspec-discover
                        -- Mimicking -XGHC2021 in GHC 8.10.1

--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -4,8 +4,8 @@
 -- license that can be found in the LICENSE file or at
 -- https://developers.google.com/open-source/licenses/bsd
 
-module Err (Err (..), Errs (..), ErrType (..), Except (..), ErrCtx (..),
-            SrcPosCtx, SrcTextCtx, SrcPos,
+module Err (Err (..), Errs (..), ErrType (..), Except (..),
+            ErrCtx (..), SrcTextCtx,
             Fallible (..), Catchable (..), catchErrExcept,
             FallibleM (..), HardFailM (..), CtxReader (..),
             runFallibleM, runHardFail, throw, throwErr,
@@ -30,9 +30,11 @@ import Data.Text (Text)
 import Data.Text qualified as T
 import Data.Text.Prettyprint.Doc.Render.Text
 import Data.Text.Prettyprint.Doc
+import GHC.Generics (Generic (..))
 import GHC.Stack
 import System.Environment
 import System.IO.Unsafe
+import SourceInfo
 
 -- === core API ===
 
@@ -63,16 +65,13 @@ data ErrType = NoErr
              | MonadFailErr
                deriving (Show, Eq)
 
-type SrcPosCtx  = Maybe SrcPos
 type SrcTextCtx = Maybe (Int, Text) -- Int is the offset in the source file
 data ErrCtx = ErrCtx
   { srcTextCtx :: SrcTextCtx
   , srcPosCtx  :: SrcPosCtx
   , messageCtx :: [String]
   , stackCtx   :: Maybe [String] }
-    deriving (Show, Eq)
-
-type SrcPos = (Int, Int)
+    deriving (Show, Eq, Generic)
 
 class MonadFail m => Fallible m where
   throwErrs :: Errs -> m a
@@ -441,7 +440,7 @@ instance Pretty Err where
   pretty (Err e ctx s) = pretty e <> pretty s <> prettyCtx
     -- TODO: figure out a more uniform way to newlines
     where prettyCtx = case ctx of
-            ErrCtx _ Nothing [] Nothing -> mempty
+            ErrCtx _ (SrcPosCtx Nothing _) [] Nothing -> mempty
             _ -> hardline <> pretty ctx
 
 instance Pretty ErrCtx where
@@ -452,7 +451,7 @@ instance Pretty ErrCtx where
     prettyLines (reverse messages) <> highlightedSource <> prettyStack
     where
       highlightedSource = case (maybeTextCtx, maybePosCtx) of
-        (Just (offset, text), Just (start, stop)) ->
+        (Just (offset, text), SrcPosCtx (Just (start, stop)) _) ->
            hardline <> pretty (highlightRegion (start - offset, stop - offset) text)
         _ -> mempty
       prettyStack = case stack of
@@ -531,13 +530,14 @@ instance CtxReader m => CtxReader (StateT s m) where
   {-# INLINE getErrCtx #-}
 
 instance Semigroup ErrCtx where
-  ErrCtx text pos ctxStrs stk <> ErrCtx text' pos' ctxStrs' stk' =
+  ErrCtx text (SrcPosCtx p spanId) ctxStrs stk <> ErrCtx text' (SrcPosCtx p' spanId') ctxStrs' stk' =
     ErrCtx (leftmostJust  text text')
-           (rightmostJust pos  pos' )
+           (SrcPosCtx (rightmostJust p p') (rightmostJust spanId spanId'))
            (ctxStrs <> ctxStrs')
            (leftmostJust stk stk')  -- We usually extend errors form the right
+
 instance Monoid ErrCtx where
-  mempty = ErrCtx Nothing Nothing [] Nothing
+  mempty = ErrCtx Nothing emptySrcPosCtx [] Nothing
 
 -- === misc util stuff ===
 

--- a/src/lib/Lexing.hs
+++ b/src/lib/Lexing.hs
@@ -23,6 +23,7 @@ import qualified Text.Megaparsec.Char.Lexer as L
 import Text.Megaparsec.Debug
 
 import Err
+import SourceInfo
 import Types.Primitives
 
 data ParseCtx = ParseCtx

--- a/src/lib/PPrint.hs
+++ b/src/lib/PPrint.hs
@@ -560,9 +560,9 @@ instance Pretty Result where
 instance Pretty (UBinder c n l) where pretty = prettyFromPrettyPrec
 instance PrettyPrec (UBinder c n l) where
   prettyPrec b = atPrec ArgPrec case b of
-    UBindSource v -> p v
-    UIgnore       -> "_"
-    UBind v _     -> p v
+    UBindSource _ v -> p v
+    UIgnore         -> "_"
+    UBind _ v _     -> p v
 
 instance PrettyE e => Pretty (WithSrcE e n) where
   pretty (WithSrcE _ x) = p x
@@ -577,8 +577,8 @@ instance PrettyPrecB b => PrettyPrec (WithSrcB b n l) where
   prettyPrec (WithSrcB _ x) = prettyPrec x
 
 instance PrettyE e => Pretty (SourceNameOr e n) where
-  pretty (SourceName   v) = p v
-  pretty (InternalName v _) = p v
+  pretty (SourceName _ v) = p v
+  pretty (InternalName _ v _) = p v
 
 instance Pretty (SourceOrInternalName c n) where
   pretty (SourceOrInternalName sn) = p sn

--- a/src/lib/SourceInfo.hs
+++ b/src/lib/SourceInfo.hs
@@ -32,7 +32,7 @@ type SrcPos = (Int, Int)
 type SpanId = Int
 
 data SrcPosCtx = SrcPosCtx (Maybe SrcPos) (Maybe SpanId)
-  deriving (Show, Eq, Generic, Data, Typeable)
+  deriving (Show, Eq, Generic, Data)
 instance Hashable SrcPosCtx
 instance Store SrcPosCtx
 

--- a/src/lib/SourceInfo.hs
+++ b/src/lib/SourceInfo.hs
@@ -1,0 +1,226 @@
+-- Copyright 2021 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module SourceInfo (
+  SrcPos, SpanId, SrcPosCtx (..), emptySrcPosCtx, fromPos,
+  pattern EmptySrcPosCtx,
+  sliceText, SpanTree (..), SpanTreeM (..), SpanPayload, SpanPos,
+  evalSpanTree, makeSpanTree, makeEmptySpanTree, makeSpanTreeRec,
+  fixSpanPayloads,
+  fillTreeAndAddTrivialLeaves
+  ) where
+
+import Data.Data
+import Data.Hashable
+import Data.Char (isSpace)
+import Data.List (findIndex)
+import Data.Maybe (listToMaybe, maybeToList)
+import Data.Store (Store (..))
+import qualified Data.Text as T
+import GHC.Generics (Generic (..))
+import Control.Applicative
+import Control.Monad.State.Strict
+
+-- === Core API ===
+
+type SrcPos = (Int, Int)
+type SpanId = Int
+
+data SrcPosCtx = SrcPosCtx (Maybe SrcPos) (Maybe SpanId)
+  deriving (Show, Eq, Generic, Data, Typeable)
+instance Hashable SrcPosCtx
+instance Store SrcPosCtx
+
+instance Ord SrcPosCtx where
+  compare (SrcPosCtx pos spanId) (SrcPosCtx pos' spanId') =
+    case (pos, pos') of
+      (Just (l, r), Just (l', r')) -> compare (l, r', spanId) (l', r, spanId')
+      (Just _, _) -> GT
+      (_, Just _) -> LT
+      (_, _) -> compare spanId spanId'
+
+emptySrcPosCtx :: SrcPosCtx
+emptySrcPosCtx = SrcPosCtx Nothing Nothing
+
+pattern EmptySrcPosCtx :: SrcPosCtx
+pattern EmptySrcPosCtx = SrcPosCtx Nothing Nothing
+
+fromPos :: SrcPos -> SrcPosCtx
+fromPos pos = SrcPosCtx (Just pos) Nothing
+
+-- === Span utilities ===
+
+type SpanPayload = (Int, Int, SpanId)
+type SpanPos = (Int, Int)
+
+data SpanTree =
+  Span SpanPayload [SpanTree] |
+  LeafSpan SpanPayload |
+  Trivia SpanPos
+  deriving (Show, Eq)
+
+newtype SpanTreeM a = SpanTreeM
+  { runSpanTree' :: StateT [SpanPayload] Maybe a }
+  deriving (Functor, Applicative, Monad, MonadState [SpanPayload], Alternative)
+
+evalSpanTree :: SpanTreeM a -> [SpanPayload] -> Maybe a
+evalSpanTree m spans = evalStateT (runSpanTree' m) spans
+
+getNextSpanPayload :: SpanTreeM (Maybe SpanPayload)
+getNextSpanPayload = SpanTreeM $ do
+  infos <- get
+  case infos of
+    [] -> return Nothing
+    x:xs -> put xs >> return (Just x)
+
+data SpanContained = Contained | NotContained | PartialOverlap
+  deriving (Show, Eq)
+
+-- | @contained x y@ returns whether @y@ is contained in @x@.
+spanContained :: SpanPayload -> SpanPayload -> SpanContained
+spanContained (lpos, rpos, _) (lpos', rpos', _) =
+  case (lpos <= lpos', rpos >= rpos') of
+    (True, True) -> Contained
+    (False, False) -> NotContained
+    (_, _) -> if rpos <= lpos'
+      then NotContained
+      else PartialOverlap
+
+-- | @makeSpanTreeRec x@ returns a @[SpanTree]@ with the children of @x@.
+getSpanChildren :: SpanPayload -> SpanTreeM (Maybe [SpanTree])
+getSpanChildren root = do
+  getNextSpanPayload >>= \case
+    Just child -> do
+      case spanContained root child of
+        -- If `child` is contained in `root`, then we add it as a child.
+        Contained -> do
+          childTree <- makeSpanTreeRec child
+          remainingChildren <- getSpanChildren root
+          return $ Just (maybeToList childTree ++ concat (maybeToList remainingChildren))
+        NotContained -> do infos <- get; put (child : infos); return $ Just []
+        PartialOverlap -> do infos <- get; put (child : infos); return $ Just []
+    Nothing -> return $ Just []
+
+-- | @makeSpanTreeRec x@ returns a @SpanTree@ with the @x@ as the root.
+makeSpanTreeRec :: SpanPayload -> SpanTreeM (Maybe SpanTree)
+makeSpanTreeRec root = do
+  children <- getSpanChildren root
+  case children of
+    Nothing -> return Nothing
+    Just [] -> return $ Just (LeafSpan root)
+    Just xs -> return $ Just (Span root xs)
+
+makeEmptySpanTree :: [SpanPayload] -> Maybe SpanTree
+makeEmptySpanTree [] = Nothing
+makeEmptySpanTree (root:children) = join $ evalSpanTree (makeSpanTreeRec root) children
+
+makeSpanTree :: (Show a, IsTrivia a) => [a] -> [SpanPayload] -> Maybe SpanTree
+makeSpanTree xs infos = case makeEmptySpanTree infos of
+  Nothing -> Nothing
+  Just posTree -> Just (fillTreeAndAddTrivialLeaves xs posTree)
+
+slice :: Int -> Int -> [a] -> [a]
+slice left right xs = take (right - left) (drop left xs)
+
+sliceText :: Int -> Int -> T.Text -> T.Text
+sliceText left right xs = T.take (right - left) (T.drop left xs)
+
+getSpanPos :: SpanTree -> SpanPos
+getSpanPos tree = case tree of
+  Span (l, r, _) _ -> (l, r)
+  LeafSpan (l, r, _) -> (l, r)
+  Trivia pos -> pos
+
+fillTrivia :: SpanPayload -> [SpanTree] -> [SpanTree]
+fillTrivia (l, r, _) offsets =
+  let (before, after) = case offsets of
+                [] -> ([], [])
+                _ ->
+                  let (headL, _) = getSpanPos (head offsets) in
+                  let (_, tailR) = getSpanPos (last offsets) in
+                  let before' = [Trivia (l, headL) | l /= headL] in
+                  let after' = [Trivia (tailR, r) | r /= tailR] in
+                  (before', after') in
+  let offsets' = before ++ offsets ++ after in
+  let pairs = zip offsets' (drop 1 offsets') in
+  let unzipped = pairs >>= getOffsetAndTrivia in
+  maybeToList (listToMaybe offsets') ++ unzipped
+  where getOffsetAndTrivia :: (SpanTree, SpanTree) -> [SpanTree]
+        getOffsetAndTrivia (t, t') =
+          let (_, r') = endpoints t in
+          let (l', _) = endpoints t' in
+          let diff = l' - r' in
+          if diff == 0 then
+            [t']
+          else
+            [Trivia (r', l'), t']
+
+fixSpanPayloads :: [SpanPayload] -> [SpanPayload]
+fixSpanPayloads spans =
+  let pairs = zip spans (drop 1 spans) in
+  let unzipped = pairs >>= mergeSpans in
+  unzipped ++ [last spans]
+  where mergeSpans :: (SpanPayload, SpanPayload) -> [SpanPayload]
+        mergeSpans (s, s') = case spanContained s s' of
+          Contained -> [s]
+          NotContained -> [s]
+          -- Note: currently, overlapping spans are simply dropped.
+          -- Consider replacing with approach that preserves partial span info.
+          PartialOverlap -> []
+
+rebalanceTrivia :: Show a => (a -> Bool) -> [a] -> [SpanTree] -> [SpanTree]
+rebalanceTrivia trivia xs trees =
+  let whitespaceSeparated = trees >>= createTrivia in
+  whitespaceSeparated
+  where
+    createTrivia :: SpanTree -> [SpanTree]
+    createTrivia t = case t of
+      Span _ _ -> [t]
+      LeafSpan _ -> blah
+      Trivia _ -> blah
+      where blah :: [SpanTree]
+            blah =
+              let (l, r) = endpoints t in
+              let s' = slice l r xs in
+              let firstNonTrivia = findIndex (not . trivia) s' in
+              let lastNonTrivia = fmap (length s' -) (findIndex (not . trivia) (reverse s')) in
+              case (firstNonTrivia, lastNonTrivia) of
+                (Just l', Nothing) | l' > 0 -> [Trivia (l, l + l'), shiftTree (l + l', r) t]
+                (Nothing, Just r') | r' < length s' -> [shiftTree (l, l + r') t, Trivia (l + r', r)]
+                (Just l', Just r') | l' > 0 || r' < length s' ->
+                  [Trivia (l, l + l'), shiftTree (l + l', l + r') t, Trivia (l + r', r)]
+                (_, _) -> [t]
+
+    --
+    shiftTree :: SpanPos -> SpanTree -> SpanTree
+    shiftTree (l', r') t = case t of
+      Span (_, _, i) children -> Span (l', r', i) children
+      LeafSpan (_, _, i) -> LeafSpan (l', r', i)
+      Trivia _ -> Trivia (l', r')
+
+endpoints :: SpanTree -> (Int, Int)
+endpoints (Span (l, r, _) _) = (l, r)
+endpoints (LeafSpan (l, r, _)) = (l, r)
+endpoints (Trivia (l, r)) = (l, r)
+
+class IsTrivia a where
+  isTrivia :: a -> Bool
+
+instance IsTrivia Char where
+  isTrivia = isSpace
+
+-- | Fills a @SpanTree@ with @Trivia@ in span gaps.
+fillTreeAndAddTrivialLeaves :: Show a => IsTrivia a => [a] -> SpanTree -> SpanTree
+fillTreeAndAddTrivialLeaves xs tree = case tree of
+  Span info children ->
+    let children' = fillTrivia info children in
+    let children'' = rebalanceTrivia isTrivia xs children' in
+    let filled = map (fillTreeAndAddTrivialLeaves xs) children'' in
+    Span info filled
+  LeafSpan _ -> tree
+  Trivia _ -> tree

--- a/src/lib/SourceRename.hs
+++ b/src/lib/SourceRename.hs
@@ -99,8 +99,8 @@ class SourceRenamableB (b :: B) where
                 -> m o a
 
 instance SourceRenamableE (SourceNameOr UVar) where
-  sourceRenameE (SourceName sourceName) =
-    InternalName sourceName <$> lookupSourceName sourceName
+  sourceRenameE (SourceName pos sourceName) =
+    InternalName pos sourceName <$> lookupSourceName sourceName
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 lookupSourceName :: Renamer m => SourceName -> m n (UVar n)
@@ -128,30 +128,30 @@ ambiguousVarErrMsg v defs =
       error "shouldn't be possible because module vars can't shadow local ones"
 
 instance SourceRenamableE (SourceNameOr (Name (AtomNameC CoreIR))) where
-  sourceRenameE (SourceName sourceName) = do
+  sourceRenameE (SourceName pos sourceName) = do
     lookupSourceName sourceName >>= \case
-      UAtomVar v -> return $ InternalName sourceName v
+      UAtomVar v -> return $ InternalName pos sourceName v
       _ -> throw TypeErr $ "Not an ordinary variable: " ++ pprint sourceName
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 instance SourceRenamableE (SourceNameOr (Name DataConNameC)) where
-  sourceRenameE (SourceName sourceName) = do
+  sourceRenameE (SourceName pos sourceName) = do
     lookupSourceName sourceName >>= \case
-      UDataConVar v -> return $ InternalName sourceName v
+      UDataConVar v -> return $ InternalName pos sourceName v
       _ -> throw TypeErr $ "Not a data constructor: " ++ pprint sourceName
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 instance SourceRenamableE (SourceNameOr (Name ClassNameC)) where
-  sourceRenameE (SourceName sourceName) = do
+  sourceRenameE (SourceName pos sourceName) = do
     lookupSourceName sourceName >>= \case
-      UClassVar v -> return $ InternalName sourceName v
+      UClassVar v -> return $ InternalName pos sourceName v
       _ -> throw TypeErr $ "Not a class name: " ++ pprint sourceName
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
 instance SourceRenamableE (SourceNameOr (Name EffectNameC)) where
-  sourceRenameE (SourceName sourceName) = do
+  sourceRenameE (SourceName pos sourceName) = do
     lookupSourceName sourceName >>= \case
-      UEffectVar v -> return $ InternalName sourceName v
+      UEffectVar v -> return $ InternalName pos sourceName v
       _ -> throw TypeErr $ "Not an effect name: " ++ pprint sourceName
   sourceRenameE _ = error "Shouldn't be source-renaming internal names"
 
@@ -326,7 +326,7 @@ sourceRenameUBinder :: (Color c, Distinct o, Renamer m)
                     -> (forall o'. DExt o o' => UBinder c o o' -> m o' a)
                     -> m o a
 sourceRenameUBinder asUVar ubinder cont = case ubinder of
-  UBindSource b -> do
+  UBindSource pos b -> do
     SourceMap sm <- askSourceMap
     mayShadow <- askMayShadow
     let shadows = M.member b sm
@@ -335,8 +335,8 @@ sourceRenameUBinder asUVar ubinder cont = case ubinder of
     withFreshM (getNameHint b) \freshName -> do
       Distinct <- getDistinct
       extendSourceMap b (asUVar $ binderName freshName) $
-        cont $ UBind b freshName
-  UBind _ _ -> error "Shouldn't be source-renaming internal names"
+        cont $ UBind pos b freshName
+  UBind _ _ _ -> error "Shouldn't be source-renaming internal names"
   UIgnore -> cont UIgnore
 
 instance SourceRenamableE UDataDef where
@@ -376,17 +376,17 @@ instance SourceRenamableE UnitE where
   sourceRenameE UnitE = return UnitE
 
 instance SourceRenamableE UMethodDef' where
-  sourceRenameE (UMethodDef ~(SourceName v) expr) = do
+  sourceRenameE (UMethodDef ~(SourceName pos v) expr) = do
     lookupSourceName v >>= \case
-      UMethodVar v' -> UMethodDef (InternalName v v') <$> sourceRenameE expr
+      UMethodVar v' -> UMethodDef (InternalName pos v v') <$> sourceRenameE expr
       _ -> throw TypeErr $ "not a method name: " ++ pprint v
 
 instance SourceRenamableE UEffectOpDef where
   sourceRenameE (UReturnOpDef expr) = do
     UReturnOpDef <$> sourceRenameE expr
-  sourceRenameE (UEffectOpDef rp ~(SourceName v) expr) = do
+  sourceRenameE (UEffectOpDef rp ~(SourceName pos v) expr) = do
     lookupSourceName v >>= \case
-      UEffectOpVar v' -> UEffectOpDef rp (InternalName v v') <$> sourceRenameE expr
+      UEffectOpVar v' -> UEffectOpDef rp (InternalName pos v v') <$> sourceRenameE expr
       _ -> throw TypeErr $ "not an effect operation name: " ++ pprint v
 
 instance SourceRenamableB b => SourceRenamableB (Nest b) where
@@ -413,11 +413,11 @@ class SourceRenamablePat (pat::B) where
 instance SourceRenamablePat (UBinder (AtomNameC CoreIR)) where
   sourceRenamePat sibs ubinder cont = do
     newSibs <- case ubinder of
-      UBindSource b -> do
+      UBindSource _ b -> do
         when (S.member b sibs) $ throw RepeatedPatVarErr $ pprint b
         return $ S.singleton b
       UIgnore -> return mempty
-      UBind _ _ -> error "Shouldn't be source-renaming internal names"
+      UBind _ _ _ -> error "Shouldn't be source-renaming internal names"
     sourceRenameB ubinder \ubinder' ->
       cont (sibs <> newSibs) ubinder'
 
@@ -486,14 +486,14 @@ class HasSourceNames (b::B) where
 instance HasSourceNames UTopDecl where
   sourceNames decl = case decl of
     ULocalDecl d -> sourceNames d
-    UDataDefDecl _ ~(UBindSource tyConName) dataConNames -> do
+    UDataDefDecl _ ~(UBindSource _ tyConName) dataConNames -> do
       S.singleton tyConName <> sourceNames dataConNames
-    UStructDecl ~(UBindSource tyConName) _ -> do
+    UStructDecl ~(UBindSource _ tyConName) _ -> do
       S.singleton tyConName
-    UInterface _ _ ~(UBindSource className) methodNames -> do
+    UInterface _ _ ~(UBindSource _ className) methodNames -> do
       S.singleton className <> sourceNames methodNames
     UInstance _ _ _ _ instanceName _ -> sourceNames instanceName
-    UEffectDecl _ ~(UBindSource effName) opNames -> do
+    UEffectDecl _ ~(UBindSource _ effName) opNames -> do
       S.singleton effName <> sourceNames opNames
     UHandlerDecl _ _ _ _ _ _ handlerName -> sourceNames handlerName
 
@@ -530,9 +530,9 @@ instance HasSourceNames b => HasSourceNames (Nest b)where
 
 instance HasSourceNames (UBinder c) where
   sourceNames b = case b of
-    UBindSource name -> S.singleton name
+    UBindSource _ name -> S.singleton name
     UIgnore -> mempty
-    UBind _ _ -> error "Shouldn't be source-renaming internal names"
+    UBind {} -> error "Shouldn't be source-renaming internal names"
 
 -- === misc instance ===
 

--- a/src/lib/TraverseSourceInfo.hs
+++ b/src/lib/TraverseSourceInfo.hs
@@ -1,0 +1,127 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# OPTIONS_GHC -Wno-incomplete-patterns #-}
+
+module TraverseSourceInfo (HasSourceInfo, gatherSourceInfo, addSpanIds) where
+
+import qualified Data.ByteString as BS
+import Control.Monad.State
+import Control.Monad.Writer
+import GHC.Generics
+import GHC.Int
+import GHC.Word
+
+import Occurrence qualified as Occ
+import SourceInfo
+import Types.OpNames qualified as P
+import Types.Primitives
+import Types.Source
+
+class HasSourceInfo a where
+  traverseSourceInfo :: Applicative m => (SrcPosCtx -> m SrcPosCtx) -> a -> m a
+
+  default traverseSourceInfo :: (Applicative m, Generic a, HasSourceInfo (Rep a Any)) => (SrcPosCtx -> m SrcPosCtx) -> a -> m a
+  traverseSourceInfo f x = to <$> traverseSourceInfo f (from x :: Rep a Any)
+
+tc :: HasSourceInfo a => Applicative m => (SrcPosCtx -> m SrcPosCtx) -> a -> m a
+tc = traverseSourceInfo
+
+instance HasSourceInfo (V1 p) where
+  traverseSourceInfo _ x = pure x
+
+instance HasSourceInfo (U1 p) where
+  traverseSourceInfo _ x = pure x
+
+instance (HasSourceInfo c) => HasSourceInfo (K1 i c p) where
+  traverseSourceInfo f (K1 x) = K1 <$> traverseSourceInfo f x
+
+instance HasSourceInfo (f p) => HasSourceInfo (M1 i c f p) where
+  traverseSourceInfo f (M1 x) = M1 <$> traverseSourceInfo f x
+
+instance (HasSourceInfo (a p), HasSourceInfo (b p)) => HasSourceInfo ((a :+: b) p) where
+  traverseSourceInfo f (L1 x) = L1 <$> traverseSourceInfo f x
+  traverseSourceInfo f (R1 x) = R1 <$> traverseSourceInfo f x
+
+instance (HasSourceInfo (a p), HasSourceInfo (b p)) => HasSourceInfo ((a :*: b) p) where
+  traverseSourceInfo f (a :*: b) = (:*:) <$> traverseSourceInfo f a <*> traverseSourceInfo f b
+
+instance HasSourceInfo P.TC
+instance HasSourceInfo P.Con
+instance HasSourceInfo P.MemOp
+instance HasSourceInfo P.VectorOp
+instance HasSourceInfo P.MiscOp
+instance HasSourceInfo PrimName
+instance HasSourceInfo UnOp
+instance HasSourceInfo BinOp
+instance HasSourceInfo CmpOp
+instance HasSourceInfo BaseType
+instance HasSourceInfo ScalarBaseType
+instance HasSourceInfo Device
+
+instance (HasSourceInfo a, HasSourceInfo b) => HasSourceInfo (a, b)
+instance (HasSourceInfo a, HasSourceInfo b, HasSourceInfo c) => HasSourceInfo (a, b, c)
+instance (HasSourceInfo a, HasSourceInfo b) => HasSourceInfo (Either a b)
+instance HasSourceInfo a => HasSourceInfo [a]
+instance HasSourceInfo a => HasSourceInfo (Maybe a)
+
+instance HasSourceInfo Occ.Count
+instance HasSourceInfo Occ.UsageInfo
+instance HasSourceInfo LetAnn
+instance HasSourceInfo UResumePolicy
+instance HasSourceInfo CInstanceDef
+instance HasSourceInfo CTopDecl'
+
+instance HasSourceInfo AppExplicitness
+instance HasSourceInfo CDef
+instance HasSourceInfo CSDecl'
+instance HasSourceInfo CSBlock
+instance HasSourceInfo ForKind
+instance HasSourceInfo Group'
+
+instance HasSourceInfo Bin'
+
+instance HasSourceInfo a => HasSourceInfo (WithSrc a) where
+  traverseSourceInfo f (WithSrc pos x) = WithSrc <$> f pos <*> tc f x
+
+instance HasSourceInfo () where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Char where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Int where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Int32 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Int64 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Word8 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Word16 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Word32 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Word64 where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Float where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo Double where
+  traverseSourceInfo _ x = pure x
+instance HasSourceInfo BS.ByteString where
+  traverseSourceInfo _ x = pure x
+
+-- The real base case.
+instance HasSourceInfo SrcPosCtx where
+  traverseSourceInfo f x = f x
+
+gatherSourceInfo :: (HasSourceInfo a) => a -> [SrcPosCtx]
+gatherSourceInfo x = execWriter (tc (\(ctx :: SrcPosCtx) -> tell [ctx] >> return ctx) x)
+
+addSpanIds :: (HasSourceInfo a) => a -> a
+addSpanIds x = evalState (tc f x) 0
+  where f (SrcPosCtx maybeSrcPos _) = do
+          currentId <- get
+          put (currentId + 1)
+          return (SrcPosCtx maybeSrcPos (Just currentId))

--- a/src/lib/Types/Core.hs
+++ b/src/lib/Types/Core.hs
@@ -36,9 +36,9 @@ import Data.Store (Store (..))
 import Foreign.Ptr
 
 import Name
-import Err
 import Util (FileHash, SnocList (..), Tree (..))
 import IRVariants
+import SourceInfo
 
 import qualified Types.OpNames as P
 import Types.Primitives

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -20,6 +20,7 @@
 
 module Types.Source where
 
+import Data.Data
 import Data.Hashable
 import Data.Foldable
 import qualified Data.Map.Strict       as M
@@ -35,29 +36,38 @@ import Data.Store (Store (..))
 import Name
 import qualified Types.OpNames as P
 import IRVariants
-import Err
+import SourceInfo
 import Util (File (..))
 
 import Types.Primitives
 
+data SourceName' = SourceName' SrcPosCtx SourceName
+  deriving (Show, Eq, Ord, Generic)
+
+fromName :: SourceName -> SourceName'
+fromName = SourceName' emptySrcPosCtx
+
+instance HasNameHint SourceName' where
+  getNameHint (SourceName' _ name) = getNameHint name
+
 data SourceNameOr (a::E) (n::S) where
   -- Only appears before renaming pass
-  SourceName :: SourceName -> SourceNameOr a n
+  SourceName :: SrcPosCtx -> SourceName -> SourceNameOr a n
   -- Only appears after renaming pass
   -- We maintain the source name for user-facing error messages.
-  InternalName :: SourceName -> a n -> SourceNameOr a n
-deriving instance Eq (a n) => Eq (SourceNameOr (a::E) (n::S))
+  InternalName :: SrcPosCtx -> SourceName -> a n -> SourceNameOr a n
+deriving instance Eq (a n) => Eq (SourceNameOr a n)
 deriving instance Ord (a n) => Ord (SourceNameOr a n)
 deriving instance Show (a n) => Show (SourceNameOr a n)
 
 newtype SourceOrInternalName (c::C) (n::S) = SourceOrInternalName (SourceNameOr (Name c) n)
-  deriving (Eq, Ord, Show)
+  deriving (Eq, Ord, Show, Generic)
 
 pattern SISourceName :: (n ~ VoidS) => SourceName -> SourceOrInternalName c n
-pattern SISourceName n = SourceOrInternalName (SourceName n)
+pattern SISourceName n = SourceOrInternalName (SourceName EmptySrcPosCtx n)
 
-pattern SIInternalName :: SourceName -> Name c n -> SourceOrInternalName c n
-pattern SIInternalName n a = SourceOrInternalName (InternalName n a)
+pattern SIInternalName :: SourceName -> Name c n -> Maybe SrcPos -> Maybe SpanId -> SourceOrInternalName c n
+pattern SIInternalName n a srcPos spanId = SourceOrInternalName (InternalName (SrcPosCtx srcPos spanId) n a)
 
 -- === Concrete syntax ===
 -- The grouping-level syntax of the source language
@@ -192,6 +202,7 @@ data UEffect (n::S) =
  | UExceptionEffect
  | UIOEffect
  | UUserEffect (SourceOrInternalName EffectNameC n)
+ deriving (Generic)
 
 data UEffectRow (n::S) =
   UEffectRow (S.Set (UEffect n)) (Maybe (SourceOrInternalName (AtomNameC CoreIR) n))
@@ -215,13 +226,13 @@ data UVar (n::S) =
 type UAtomBinder = UBinder (AtomNameC CoreIR)
 data UBinder (c::C) (n::S) (l::S) where
   -- Only appears before renaming pass
-  UBindSource :: SourceName -> UBinder c n n
+  UBindSource :: SrcPosCtx -> SourceName -> UBinder c n n
   -- May appear before or after renaming pass
   UIgnore :: UBinder c n n
   -- The following binders only appear after the renaming pass.
   -- We maintain the source name for user-facing error messages
   -- and named arguments.
-  UBind :: SourceName -> NameBinder c n l -> UBinder c n l
+  UBind :: SrcPosCtx -> SourceName -> NameBinder c n l -> UBinder c n l
 
 type UBlock = WithSrcE UBlock'
 data UBlock' (n::S) where
@@ -255,7 +266,9 @@ data UExpr' (n::S) =
  | UNatLit   Word64
  | UIntLit   Int
  | UFloatLit Double
-   deriving (Show, Generic)
+   deriving (Show, Generic, Typeable)
+
+deriving instance (Typeable n, forall h. Data h) => Data (UExpr' n)
 
 type UNamedArg (n::S) = (SourceName, UExpr n)
 type FieldName = WithSrc FieldName'
@@ -273,11 +286,17 @@ data ULamExpr (n::S) where
     -> UBlock l                           -- body
     -> ULamExpr n
 
+deriving instance (Typeable n, forall h. Data h) => Data (ULamExpr n)
+
 data UPiExpr (n::S) where
   UPiExpr :: Nest (WithExpl UOptAnnBinder) n l -> AppExplicitness -> UEffectRow l -> UType l -> UPiExpr n
 
+deriving instance (Typeable n, forall h. Data h) => Data (UPiExpr n)
+
 data UTabPiExpr (n::S) where
   UTabPiExpr :: UOptAnnBinder n l -> UType l -> UTabPiExpr n
+
+deriving instance (Typeable n, forall h. Data h) => Data (UTabPiExpr n)
 
 data UDepPairType (n::S) where
   UDepPairType :: DepPairExplicitness -> UOptAnnBinder n l -> UType l -> UDepPairType n
@@ -290,6 +309,12 @@ data UDataDef (n::S) where
     -> Nest (WithExpl UOptAnnBinder) n l
     -> [(SourceName, UDataDefTrail l)] -- data constructor types
     -> UDataDef n
+
+deriving instance (
+    Typeable n,
+    (forall l. Data (Nest (WithExpl UOptAnnBinder) n l)),
+    (forall l. Data (UDataDefTrail l))
+  ) => Data (UDataDef n)
 
 data UStructDef (n::S) where
   UStructDef
@@ -342,6 +367,9 @@ data UTopDecl (n::S) (l::S) where
     ->   [UEffectOpDef l']                -- operation definitions
     -> UBinder HandlerNameC n l           -- handler name
     -> UTopDecl n l
+  deriving (Typeable)
+
+deriving instance (Typeable n, Typeable l, forall h. Data h) => Data (UDecl n l)
 
 type UType = UExpr
 type UConstraint = UExpr
@@ -361,6 +389,8 @@ instance Store UResumePolicy
 
 data UForExpr (n::S) where
   UForExpr :: UOptAnnBinder n l -> UBlock l -> UForExpr n
+
+deriving instance (Typeable n, forall h. Data h) => Data (UForExpr n)
 
 type UMethodDef = WithSrcE UMethodDef'
 data UMethodDef' (n::S) = UMethodDef (SourceNameOr (Name MethodNameC) n) (ULamExpr n)
@@ -396,7 +426,9 @@ data UPat' (n::S) (l::S) =
  | UPatProd (Nest UPat n l)
  | UPatDepPair (PairB UPat UPat n l)
  | UPatTable (Nest UPat n l)
-  deriving (Show)
+  deriving (Show, Generic)
+
+deriving instance (Typeable n, Typeable l, forall h. Data h) => Data (UPat' n l)
 
 pattern UPatIgnore :: UPat' (n::S) n
 pattern UPatIgnore = UPatBinder UIgnore
@@ -411,20 +443,22 @@ instance HasSourceName (UAnnBinder req n l) where
 
 instance HasSourceName (UBinder c n l) where
   getSourceName = \case
-    UBindSource sn -> sn
-    UIgnore        -> "_"
-    UBind sn _     -> sn
+    UBindSource _ sn -> sn
+    UIgnore          -> "_"
+    UBind _ sn _     -> sn
 
 -- === Source context helpers ===
 
 data WithSrc a = WithSrc SrcPosCtx a
-  deriving (Show, Functor)
+  deriving (Show, Functor, Generic)
 
 data WithSrcE (a::E) (n::S) = WithSrcE SrcPosCtx (a n)
-  deriving (Show)
+  deriving (Show, Typeable, Generic)
+
+deriving instance (Typeable a, Typeable n, Data (a n)) => Data (WithSrcE a n)
 
 data WithSrcB (binder::B) (n::S) (l::S) = WithSrcB SrcPosCtx (binder n l)
-  deriving (Show)
+  deriving (Show, Typeable, Data, Generic)
 
 class HasSrcPos a where
   srcPos :: a -> SrcPosCtx
@@ -558,7 +592,7 @@ data PrimName =
  | UIndexRef | UApplyMethod Int
  | UNat | UNatCon | UFin | UEffectRowKind
  | UTuple -- overloaded for type constructor and data constructor, resolved in inference
-   deriving (Show, Eq)
+   deriving (Show, Eq, Generic)
 
 -- === instances ===
 
@@ -672,21 +706,21 @@ instance HasNameHint ModuleSourceName where
 
 instance HasNameHint (UBinder c n l) where
   getNameHint b = case b of
-    UBindSource v -> getNameHint v
-    UIgnore       -> noHint
-    UBind v _     -> getNameHint v
+    UBindSource _ v -> getNameHint v
+    UIgnore         -> noHint
+    UBind _ v _     -> getNameHint v
 
 instance Color c => BindsNames (UBinder c) where
-  toScopeFrag (UBindSource _) = emptyOutFrag
+  toScopeFrag (UBindSource _ _) = emptyOutFrag
   toScopeFrag (UIgnore)       = emptyOutFrag
-  toScopeFrag (UBind _ b)     = toScopeFrag b
+  toScopeFrag (UBind _ _ b)     = toScopeFrag b
 
 instance Color c => ProvesExt (UBinder c) where
 instance Color c => BindsAtMostOneName (UBinder c) c where
   b @> x = case b of
-    UBindSource _ -> emptyInFrag
-    UIgnore       -> emptyInFrag
-    UBind _ b'    -> b' @> x
+    UBindSource _ _ -> emptyInFrag
+    UIgnore         -> emptyInFrag
+    UBind _ _ b'    -> b' @> x
 
 instance ProvesExt  (UAnnBinder  req) where
 instance BindsNames  (UAnnBinder req) where
@@ -730,14 +764,20 @@ instance Store (SourceMap n)
 
 instance Hashable ModuleSourceName
 
+instance Store SourceName'
+instance Hashable SourceName'
+
+instance IsString SourceName' where
+  fromString = SourceName' emptySrcPosCtx
+
 instance IsString (SourceNameOr a VoidS) where
-  fromString = SourceName
+  fromString = SourceName emptySrcPosCtx
 
 instance IsString (SourceOrInternalName c VoidS) where
   fromString = SISourceName
 
 instance IsString (UBinder s VoidS VoidS) where
-  fromString = UBindSource
+  fromString = UBindSource emptySrcPosCtx
 
 instance IsString (UPat' VoidS VoidS) where
   fromString = UPatBinder . fromString
@@ -749,10 +789,10 @@ instance IsString (UExpr' VoidS) where
   fromString = UVar . fromString
 
 instance IsString (a n) => IsString (WithSrcE a n) where
-  fromString = WithSrcE Nothing . fromString
+  fromString = WithSrcE emptySrcPosCtx . fromString
 
 instance IsString (b n l) => IsString (WithSrcB b n l) where
-  fromString = WithSrcB Nothing . fromString
+  fromString = WithSrcB emptySrcPosCtx . fromString
 
 deriving instance Show (UBinder s n l)
 deriving instance Show (UDataDefTrail n)

--- a/src/lib/Types/Source.hs
+++ b/src/lib/Types/Source.hs
@@ -266,9 +266,7 @@ data UExpr' (n::S) =
  | UNatLit   Word64
  | UIntLit   Int
  | UFloatLit Double
-   deriving (Show, Generic, Typeable)
-
-deriving instance (Typeable n, forall h. Data h) => Data (UExpr' n)
+   deriving (Show, Generic)
 
 type UNamedArg (n::S) = (SourceName, UExpr n)
 type FieldName = WithSrc FieldName'
@@ -286,17 +284,11 @@ data ULamExpr (n::S) where
     -> UBlock l                           -- body
     -> ULamExpr n
 
-deriving instance (Typeable n, forall h. Data h) => Data (ULamExpr n)
-
 data UPiExpr (n::S) where
   UPiExpr :: Nest (WithExpl UOptAnnBinder) n l -> AppExplicitness -> UEffectRow l -> UType l -> UPiExpr n
 
-deriving instance (Typeable n, forall h. Data h) => Data (UPiExpr n)
-
 data UTabPiExpr (n::S) where
   UTabPiExpr :: UOptAnnBinder n l -> UType l -> UTabPiExpr n
-
-deriving instance (Typeable n, forall h. Data h) => Data (UTabPiExpr n)
 
 data UDepPairType (n::S) where
   UDepPairType :: DepPairExplicitness -> UOptAnnBinder n l -> UType l -> UDepPairType n
@@ -309,12 +301,6 @@ data UDataDef (n::S) where
     -> Nest (WithExpl UOptAnnBinder) n l
     -> [(SourceName, UDataDefTrail l)] -- data constructor types
     -> UDataDef n
-
-deriving instance (
-    Typeable n,
-    (forall l. Data (Nest (WithExpl UOptAnnBinder) n l)),
-    (forall l. Data (UDataDefTrail l))
-  ) => Data (UDataDef n)
 
 data UStructDef (n::S) where
   UStructDef
@@ -367,9 +353,6 @@ data UTopDecl (n::S) (l::S) where
     ->   [UEffectOpDef l']                -- operation definitions
     -> UBinder HandlerNameC n l           -- handler name
     -> UTopDecl n l
-  deriving (Typeable)
-
-deriving instance (Typeable n, Typeable l, forall h. Data h) => Data (UDecl n l)
 
 type UType = UExpr
 type UConstraint = UExpr
@@ -389,8 +372,6 @@ instance Store UResumePolicy
 
 data UForExpr (n::S) where
   UForExpr :: UOptAnnBinder n l -> UBlock l -> UForExpr n
-
-deriving instance (Typeable n, forall h. Data h) => Data (UForExpr n)
 
 type UMethodDef = WithSrcE UMethodDef'
 data UMethodDef' (n::S) = UMethodDef (SourceNameOr (Name MethodNameC) n) (ULamExpr n)
@@ -428,8 +409,6 @@ data UPat' (n::S) (l::S) =
  | UPatTable (Nest UPat n l)
   deriving (Show, Generic)
 
-deriving instance (Typeable n, Typeable l, forall h. Data h) => Data (UPat' n l)
-
 pattern UPatIgnore :: UPat' (n::S) n
 pattern UPatIgnore = UPatBinder UIgnore
 
@@ -453,12 +432,10 @@ data WithSrc a = WithSrc SrcPosCtx a
   deriving (Show, Functor, Generic)
 
 data WithSrcE (a::E) (n::S) = WithSrcE SrcPosCtx (a n)
-  deriving (Show, Typeable, Generic)
-
-deriving instance (Typeable a, Typeable n, Data (a n)) => Data (WithSrcE a n)
+  deriving (Show, Generic)
 
 data WithSrcB (binder::B) (n::S) (l::S) = WithSrcB SrcPosCtx (binder n l)
-  deriving (Show, Typeable, Data, Generic)
+  deriving (Show, Data, Generic)
 
 class HasSrcPos a where
   srcPos :: a -> SrcPosCtx

--- a/src/lib/Util.hs
+++ b/src/lib/Util.hs
@@ -8,25 +8,25 @@
 
 module Util where
 
-import Crypto.Hash
-import Data.Functor.Identity (Identity(..))
-import Data.List (sort)
-import Data.Maybe (catMaybes)
-import Data.Hashable (Hashable)
-import qualified Data.List.NonEmpty as NE
-import qualified Data.ByteString    as BS
-import Data.Foldable
-import Data.List.NonEmpty (NonEmpty (..))
 import Prelude
 import qualified Data.Set as Set
 import qualified Data.Map.Strict as M
 import Control.Applicative
 import Control.Monad.State.Strict
 import System.CPUTime
-import Data.Store (Store (..))
-import GHC.Generics (Generic)
 import GHC.Base (getTag)
 import GHC.Exts ((==#), tagToEnum#)
+import Crypto.Hash
+import Data.Functor.Identity (Identity(..))
+import Data.Maybe (catMaybes)
+import Data.List (sort)
+import Data.Hashable (Hashable)
+import Data.Store (Store)
+import qualified Data.List.NonEmpty as NE
+import qualified Data.ByteString    as BS
+import Data.Foldable
+import Data.List.NonEmpty (NonEmpty (..))
+import GHC.Generics (Generic)
 
 import Err
 

--- a/static/dynamic.html
+++ b/static/dynamic.html
@@ -16,6 +16,8 @@
           onload="render(RENDER_MODE.DYNAMIC);"
           onerror="render(RENDER_MODE.DYNAMIC);"
           crossorigin="anonymous"></script>
+  <!-- jQuery -->
+  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.6.3/jquery.min.js"></script>
 </head>
 
 <body>

--- a/static/style.css
+++ b/static/style.css
@@ -47,9 +47,6 @@ nav ol {
   margin: auto;
 }
 
-.cell {
-}
-
 .code-block, .err-block, .result-block {
   padding: 0em 0em 0em 2em;
   display: block;
@@ -105,4 +102,14 @@ code {
 
 .iso-sugar {
   color: #25BBA7;
+}
+
+/* Tooltips support */
+
+.code-span:hover {
+  background-color: rgb(200 200 240 / 0.4);
+}
+
+.code-span-leaf:hover {
+  background-color: rgb(255 255 0);
 }

--- a/tests/unit/SourceInfoSpec.hs
+++ b/tests/unit/SourceInfoSpec.hs
@@ -1,0 +1,237 @@
+-- Copyright 2022 Google LLC
+--
+-- Use of this source code is governed by a BSD-style
+-- license that can be found in the LICENSE file or at
+-- https://developers.google.com/open-source/licenses/bsd
+
+{-# OPTIONS_GHC -Wno-orphans #-}
+
+module SourceInfoSpec (spec) where
+
+import Data.List
+import Data.Text qualified as T
+import Text.Blaze.Html.Renderer.String
+import Test.Hspec
+
+import RenderHtml
+import SourceInfo
+
+--   [0, 1, 2, 3, 4, 5, 6, 7, 8, 9]
+-- a: ~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+-- b:    ~~~~~~~~~~~~~
+-- c:    ~~~~
+-- d:             ~~~~
+-- e:                      ~~~~~~~
+
+s :: String
+s = "def foo : Float -> Float = id"
+--   012345678901234567890123456789
+--   0         1         2
+
+posTree' :: SpanTree
+posTree' =
+  Span (0, 1000, 0) [
+    -- span(10, 25): "Float -> Float "
+    -- Fix 1: change `fillTreeAndAddTrivialLeaves` to move whitespace
+    -- Fix 2: change parsing to not include whitespace
+    Span (10, 25, 3) [
+      LeafSpan (10, 16, 5),
+      LeafSpan (19, 25, 7)
+    ],
+    LeafSpan (27, 29, 9)
+  ]
+
+posTreeFilled' :: SpanTree
+posTreeFilled' =
+  Span (0,1000,0) [
+    Trivia (0,0),
+    Trivia (0,9),
+    Trivia (9,10),
+    Span (10,25,3) [
+      Trivia (10,10),
+      LeafSpan (10,15,5),
+      Trivia (15,16),
+      Trivia (16,16),
+      Trivia (16,18),
+      Trivia (18,19),
+      Trivia (19,19),
+      LeafSpan (19,24,7),
+      Trivia (24,25)
+    ],
+    Trivia (25,25),
+    Trivia (25,26),
+    Trivia (26,27),
+    LeafSpan (27,29,9),
+    Trivia (29,1000)
+  ]
+
+xs :: String
+xs = "0123456789!"
+
+spanInfos :: [SpanPayload]
+spanInfos =
+  [ (0, 10, 0)
+  , (1, 5, 1)
+  , (1, 2, 2)
+  , (4, 5, 3)
+  , (7, 9, 4)
+  ]
+
+srcPosCtxs :: [SrcPosCtx]
+srcPosCtxs =
+  [ SrcPosCtx (Just (0, 10)) (Just 0)
+  , SrcPosCtx (Just (1, 5)) (Just 1)
+  , SrcPosCtx (Just (1, 2)) (Just 2)
+  , SrcPosCtx (Just (4, 5)) (Just 3)
+  , SrcPosCtx (Just (7, 9)) (Just 4)
+  ]
+
+positionSpanTree :: SpanTree
+positionSpanTree =
+  Span (0, 10, 0) [
+    Trivia (0, 1),
+    Span (1, 5, 1) [
+      LeafSpan (1, 2, 2),
+      LeafSpan (4, 5, 3)
+    ],
+    LeafSpan (7, 9, 4)
+  ]
+
+positionFilledSpanTree :: SpanTree
+positionFilledSpanTree =
+  Span (0, 10, 0) [
+    Trivia (0, 1),
+    Span (1, 5, 1) [
+      LeafSpan (1, 2, 2),
+      Trivia (2, 4),
+      LeafSpan (4, 5, 3)
+    ],
+    Trivia (5, 7),
+    LeafSpan (7, 9, 4),
+    Trivia (9,10)
+  ]
+
+-- Regression tests
+
+-- Note: the parser currently produces overlapping spans (`SrcPos`) for the program below.
+overlappingSpansCode :: String
+overlappingSpansCode =
+  unlines [
+    "def foo (i: Int) : Unit =",
+    "  def explicitAction (h:Int) : Int = i",
+    "  ()"
+  ]
+
+overlappingSpans :: [SpanPayload]
+overlappingSpans =
+  [ (0, 1000, 0),
+    (9, 63, 10),
+    (9, 10, 4),
+    (9, 10, 11),
+    (12, 15, 6),
+    (19, 24, 8),
+    (30, 63, 13),
+    (50, 66, 23),
+    (50, 51, 17),
+    (50, 51, 24),
+    (52, 55, 19),
+    (59, 63, 21),
+    (65, 66, 26),
+    (71, 73, 28)
+  ]
+
+overlappingSpansTree :: SpanTree
+overlappingSpansTree =
+  Span
+  (0, 1000, 0)
+  [ Trivia (0, 9),
+    Span
+      (9, 63, 10)
+      [ Span (9, 10, 4) [LeafSpan (9, 10, 11)],
+        Trivia (10, 10),
+        Trivia (10, 11),
+        Trivia (11, 12),
+        LeafSpan (12, 15, 6),
+        Trivia (15, 15),
+        Trivia (15, 18),
+        Trivia (18, 19),
+        Trivia (19, 19),
+        LeafSpan (19, 23, 8),
+        Trivia (23, 24),
+        Trivia (24, 30),
+        Trivia (30, 30),
+        LeafSpan (30, 62, 13),
+        Trivia (62, 63)
+      ],
+    Trivia (63, 50),
+    Span
+      (50, 66, 23)
+      [ Span
+          (50, 51, 17)
+          [ LeafSpan (50, 51, 24)
+          ],
+        Trivia (51, 52),
+        Trivia (52, 52),
+        LeafSpan (52, 54, 19),
+        Trivia (54, 55),
+        Trivia (55, 59),
+        Trivia (59, 59),
+        LeafSpan (59, 62, 21),
+        Trivia (62, 63),
+        Trivia (63, 63),
+        Trivia (63, 64),
+        Trivia (64, 65),
+        LeafSpan (65, 66, 26)
+      ],
+    Trivia (66, 67),
+    Trivia (67, 69),
+    Trivia (69, 71),
+    LeafSpan (71, 73, 28),
+    Trivia (73, 1000)
+  ]
+
+renderedHtml :: String
+renderedHtml =
+  concat [
+    "<span id=\"0\" class=\"code-span\"><span>0</span>",
+    "<span id=\"1\" class=\"code-span\">",
+    "<span id=\"2\" class=\"code-span-leaf\">1</span>",
+    "<span>23</span>",
+    "<span id=\"3\" class=\"code-span-leaf\">4</span>",
+    "</span>",
+    "<span>56</span>",
+    "<span id=\"4\" class=\"code-span-leaf\">78</span>",
+    "<span>9</span>",
+    "</span>"
+  ]
+
+spec :: Spec
+spec = do
+  describe "SrcPosCtxTest" do
+    it "sortedSrcPosCtx" do
+      sort srcPosCtxs `shouldBe` srcPosCtxs
+
+  describe "SpanTreeTest" do
+    it "Float -> Float" do
+      -- fillTreeAndAddTrivialLeaves xs positionSpanTree `shouldBe` contentSpanTree
+      fillTreeAndAddTrivialLeaves s posTree' `shouldBe` posTreeFilled'
+
+    it "overlapping spans" do
+      makeSpanTree overlappingSpansCode overlappingSpans `shouldBe` Just overlappingSpansTree
+
+    it "works" do
+      -- fillTreeAndAddTrivialLeaves xs positionSpanTree `shouldBe` contentSpanTree
+      fillTreeAndAddTrivialLeaves xs positionSpanTree `shouldBe` positionFilledSpanTree
+
+    -- it "works 2" do
+    --   -- runSpanTree (return 1) spanInfos `shouldBe` (1 :: Int)
+    --   evalSpanTree (makeSpanTreeRec $ head spanInfos) (tail spanInfos) `shouldBe` Just positionSpanTree
+
+    it "works 3" do
+      -- runSpanTree (return 1) spanInfos `shouldBe` (1 :: Int)
+      -- makeSpanTree xs spanInfos `shouldBe` Just contentSpanTree
+      makeSpanTree xs spanInfos `shouldBe` Just positionFilledSpanTree
+
+    it "renders properly" do
+      let htmlText = treeToHtml' (T.pack xs) positionFilledSpanTree in
+        renderHtml htmlText `shouldBe` renderedHtml

--- a/tests/unit/SourceInfoSpec.hs
+++ b/tests/unit/SourceInfoSpec.hs
@@ -233,5 +233,5 @@ spec = do
       makeSpanTree xs spanInfos `shouldBe` Just positionFilledSpanTree
 
     it "renders properly" do
-      let htmlText = treeToHtml' (T.pack xs) positionFilledSpanTree in
+      let htmlText = treeToHtml (T.pack xs) positionFilledSpanTree in
         renderHtml htmlText `shouldBe` renderedHtml


### PR DESCRIPTION
Dex has a reactive notebook and literate programming environment in `dex web`.

Tooltips add additional IDE information to the web environment, visible when hovering the cursor over code.

This initial PR adds infrastructure for tooltips, with parse tree visualizations as the first feature.
- Backend: compiler computes a `SpanTree` describing all nested expression spans, based on concrete syntax trees.
- Frontend: HTML rendering uses `SpanTree` to augment HTML elements with class attributes about span ranges. These span range attributes are highlighted on mouse hover.

First step towards https://github.com/google-research/dex-lang/issues/1304.

## Demo

### `dex web`

```bash
dex --prelude /dev/null web lib/prelude.dx 2>&/dev/null
```

<div align="center">
  <a href="https://www.youtube.com/watch?v=H-U-VJ50sKM"><img src="https://img.youtube.com/vi/H-U-VJ50sKM/0.jpg" alt="Dex tooltips demo"></a>
  <br/>
  <i>Dex tooltips demo video</i>
</div>

### Exported HTML

Created via `make docs`.

[prelude.html](https://raw.githubusercontent.com/google-research/dex-lang/gh-pages-tooltips/prelude.html) behaves exactly the same as the live demo above.