### PR TITLE
Make `buildScoped` take a second continuation to consume the decls from below.

### DIFF
--- a/src/lib/Simplify.hs
+++ b/src/lib/Simplify.hs
@@ -236,12 +236,7 @@ liftDoubleBuilderToSimplifyM :: DoubleBuilder SimpIR o a -> SimplifyM i o a
 liftDoubleBuilderToSimplifyM cont = SimplifyM $ liftSubstReaderT cont
 
 instance Simplifier SimplifyM
-
--- TODO: figure out why we can't derive this one (here and elsewhere)
-instance ScopableBuilder SimpIR (SimplifyM i) where
-  buildScoped cont = SimplifyM $ SubstReaderT $ ReaderT \env ->
-    buildScoped $ runSubstReaderT (sink env) (runSimplifyM' cont)
-  {-# INLINE buildScoped #-}
+deriving instance ScopableBuilder SimpIR (SimplifyM i)
 
 -- === Top-level API ===
 


### PR DESCRIPTION
That is, instead of returning an `Abs decls result`, it accepts a continuation that takes `decls` and `e` as arguments, with the decls in scope in the env. This avoids having to use `refreshAbs`. It wasn't a problem previously because decls only appeared in blocks, so there was only an Atom beneath them. But that will change when we add decls to binders.