### PR TITLE
Redefine NameMapE as the primitive type

### DIFF
--- a/src/lib/Core.hs
+++ b/src/lib/Core.hs
@@ -482,5 +482,3 @@ freshNameM hint = do
   Distinct <- getDistinct
   return $ withFresh hint scope \b -> Abs b (binderName b)
 {-# INLINE freshNameM #-}
-
-type AtomNameMap r = NameMap (AtomNameC r)

--- a/src/lib/MTL1.hs
+++ b/src/lib/MTL1.hs
@@ -223,8 +223,8 @@ instance HoistableState UnitE where
   hoistState _ _ UnitE = UnitE
   {-# INLINE hoistState #-}
 
-instance HoistableState (NameMap c a) where
-  hoistState _ b m = hoistFilterNameMap b m
+instance Show a => HoistableState (NameMap c a) where
+  hoistState _ b m = hoistNameMap b m
   {-# INLINE hoistState #-}
 
 -------------------- ScopedT1 --------------------

--- a/src/lib/Occurrence.hs
+++ b/src/lib/Occurrence.hs
@@ -93,7 +93,10 @@ instance (MaxPlus a) => MaxPlus (NameMap c a n) where
   max  = unionWithNameMap max
   plus = unionWithNameMap plus
 
-deriving instance (MaxPlus (e n)) => MaxPlus (NameMapE c e n)
+instance (MaxPlus (e n)) => MaxPlus (NameMapE c e n) where
+  zero = mempty
+  max  = unionWithNameMapE max
+  plus = unionWithNameMapE plus
 
 -- === Access ===
 

--- a/src/lib/Occurrence.hs
+++ b/src/lib/Occurrence.hs
@@ -88,11 +88,6 @@ class MaxPlus a where
   max :: a -> a -> a
   plus :: a -> a -> a
 
-instance (MaxPlus a) => MaxPlus (NameMap c a n) where
-  zero = mempty
-  max  = unionWithNameMap max
-  plus = unionWithNameMap plus
-
 instance (MaxPlus (e n)) => MaxPlus (NameMapE c e n) where
   zero = mempty
   max  = unionWithNameMapE max

--- a/src/lib/Vectorize.hs
+++ b/src/lib/Vectorize.hs
@@ -131,7 +131,7 @@ askVectorByteWidth :: TopVectorizeM i o Word32
 askVectorByteWidth = TopVectorizeM $ SubstReaderT $ lift $ lift11 (fromLiftE <$> ask)
 
 extendCommuteMap :: AtomName SimpIR o -> MonoidCommutes -> TopVectorizeM i o a -> TopVectorizeM i o a
-extendCommuteMap name commutativity = local $ insertNameMap name commutativity
+extendCommuteMap name commutativity = local $ insertNameMapE name $ LiftE commutativity
 
 vectorizeLoopsDestBlock :: DestBlock i
   -> TopVectorizeM i o (DestBlock o)
@@ -309,9 +309,9 @@ vectorSafeEffect (EffectRow effs NoTail) = allM safe $ eSetToList effs where
   safe (RWSEffect Writer (Var h)) = do
     h' <- renameM $ atomVarName h
     commuteMap <- ask
-    case lookupNameMap h' commuteMap of
-      Just Commutes -> return True
-      Just DoesNotCommute -> return False
+    case lookupNameMapE h' commuteMap of
+      Just (LiftE Commutes) -> return True
+      Just (LiftE DoesNotCommute) -> return False
       Nothing -> error $ "Handle " ++ pprint h ++ " not present in commute map?"
   safe _ = return False
 


### PR DESCRIPTION
And define `NameMap` as a type alias for a `NameMapE` of a `LiftE` type.  This follows a rationale (included) for why `NameMapE` (with the type it has) is the data structure you want for bottom-up traversals.

The reason to make `NameMap` an alias is to avoid duplicating the API surface between the two maps, so that it's not such a pain to eventually cover the entire API of `Data.Map` in the `NameMapE` API.