### PR TITLE
Fix sqrt for complex numbers when x.im == 0

### DIFF
--- a/lib/complex.dx
+++ b/lib/complex.dx
@@ -58,7 +58,8 @@ def complex_pow(base:Complex, power:Complex) -> Complex = complex_exp(power * co
 
 def complex_sqrt(x:Complex) -> Complex =
   m = complex_mag x
-  Complex (sqrt ((x.re + m) / 2.0)) (sign x.im * sqrt ((m - x.re) / 2.0))
+  sgn = if x.im >= 0 then 1.0 else -1.0
+  Complex (sqrt ((x.re + m) / 2.0)) (sgn * sqrt ((m - x.re) / 2.0))
 
 def complex_sin( x:Complex) -> Complex = Complex(sin  x.re * cosh x.im, cos  x.re * sinh x.im)
 def complex_sinh(x:Complex) -> Complex = Complex(sinh x.re *  cos x.im, cosh x.re * sin  x.im)

--- a/tests/complex-tests.dx
+++ b/tests/complex-tests.dx
@@ -34,6 +34,8 @@ b = Complex (-1.1) 1.3
 > True
 :p sqrt (sq a) ~~ a
 > True
+:p sqrt (Complex (-1.0) 0.0) ~~ (Complex 0.0 1.0)
+> True
 :p log ((Complex 1.0 0.0) + a) ~~ log1p a
 > True
 :p sin (-a) ~~ (-(sin a))


### PR DESCRIPTION
Currently, if the imaginary part of a complex number is zero, then the imaginary part of the result of `sqrt` is always zero (because sign(0) = 0):
```
import complex
sqrt Complex(-1., 0.)
> Complex(0., 0.)
```

After the fix, `sqrt` returns the correct values:
```
import complex
sqrt Complex(-1., 0.)
> Complex(0., 1.)
```