### PR TITLE
`make install` was failing after transition to TypeScript last week

### DIFF
--- a/dex.cabal
+++ b/dex.cabal
@@ -16,7 +16,7 @@ build-type:          Simple
 data-files:          lib/*.dx
                    , static/*.css
                    , static/*.html
-                   , static/*.js
+                   , static/*.ts
                    , src/lib/dexrt.bc
 
 flag cuda


### PR DESCRIPTION
Updated *dex.cabal* to look for `.ts` files