### PR TITLE
Fix debug build by adding a missing conditional import

### DIFF
--- a/src/lib/Err.hs
+++ b/src/lib/Err.hs
@@ -32,6 +32,10 @@ import Data.Store (Store (..))
 import GHC.Stack
 import GHC.Generics
 
+#ifdef DEX_DEBUG
+import System.IO.Unsafe
+#endif
+
 import PPrint
 
 -- === source info ===


### PR DESCRIPTION
`src/lib/Err.hs` conditionally uses `unsafePerfomIO` when `DEX_DEBUG` is defined, but it doesn't `import System.IO.Unsafe`, so `unsafePerformIO` is not defined. This can be fixed by importing that module when `DEX_DEBUG` is defined.