### PR TITLE
I did not mean to do this

### DIFF
--- a/benchmarks/parboil/mriq.dx
+++ b/benchmarks/parboil/mriq.dx
@@ -1,13 +1,13 @@
--- def mriq
---       (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
---       (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
---       (phiR : ks=>Float) (phiI : ks=>Float)
---       : (cs=>Float & cs=>Float) =
---   phiMags = for i. phiR.i * phiR.i + phiI.i * phiI.i
---   expArgs = for i:cs j:ks.  2.0 * pi * (kx.j * x.i + ky.j * y.i + kz.j * z.i)
---   qr = for i. sum $ for j. cos $ expArgs.i.j * phiMags.j
---   qi = for i. sum $ for j. sin $ expArgs.i.j * phiMags.j
---   (qr, qi)
+# def mriq
+#       (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)
+#       (x : cs=>Float)  (y : cs=>Float)  (z : cs=>Float)
+#       (phiR : ks=>Float) (phiI : ks=>Float)
+#       : (cs=>Float & cs=>Float) =
+#   phiMags = for i. phiR.i * phiR.i + phiI.i * phiI.i
+#   expArgs = for i:cs j:ks.  2.0 * pi * (kx.j * x.i + ky.j * y.i + kz.j * z.i)
+#   qr = for i. sum $ for j. cos $ expArgs.i.j * phiMags.j
+#   qi = for i. sum $ for j. sin $ expArgs.i.j * phiMags.j
+#   (qr, qi)
 
 def mriq
       (kx : ks=>Float) (ky : ks=>Float) (kz : ks=>Float)

--- a/benchmarks/parboil/stencil.dx
+++ b/benchmarks/parboil/stencil.dx
@@ -1,11 +1,11 @@
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
     True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of

--- a/benchmarks/rodinia/hotspot.dx
+++ b/benchmarks/rodinia/hotspot.dx
@@ -11,14 +11,14 @@ chipWidth = 0.016
 
 tAmb = 80.0
 
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
     True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of

--- a/benchmarks/rodinia/pathfinder.dx
+++ b/benchmarks/rodinia/pathfinder.dx
@@ -1,11 +1,11 @@
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (+|) (i:n) (off:Int) : n =
   newOrd = ordinal i + off
   case newOrd < size n of
     True  -> unsafe_from_ordinal _ newOrd
     False -> i
 
--- Assumes that off >= 0
+# Assumes that off >= 0
 def (-|) (i:n) (off:Int) : n =
   newOrd = ordinal i - off
   case 0 <= newOrd of

--- a/doc/conditionals.dx
+++ b/doc/conditionals.dx
@@ -43,7 +43,7 @@ To wit:
 
 :p
   yield_accum (AddMonoid Float) \ref.
-    -- Two-armed `if` with `then` and the consequent both inline.
+    # Two-armed `if` with `then` and the consequent both inline.
     x = if False then 1. else 3.
     if False then ref += 100. else
       ref += 1.
@@ -55,7 +55,7 @@ To wit:
         ref += 1.
         ref += 2.
 
-    -- Two-armed `if` with `then` indented but the consequent inline.
+    # Two-armed `if` with `then` indented but the consequent inline.
     y = if False
           then 1. else 3.
     if False
@@ -71,7 +71,7 @@ To wit:
         ref += 1.
         ref += 2.
 
-    -- Two-armed `if` with `then` and the consequent both indented.
+    # Two-armed `if` with `then` and the consequent both indented.
     if False
       then
         ref += 100.

--- a/examples/ctc.dx
+++ b/examples/ctc.dx
@@ -23,7 +23,7 @@ Here we create a custom datatype and index set
 that interleaves the elements of a table with another set
 of values representing all the spaces in between those elements.
 
-data FenceAndPosts(n|Ix) =
+enum FenceAndPosts(n|Ix) =
   Fence(n)
   Posts(Post n)
 

--- a/examples/data-frames.dx
+++ b/examples/data-frames.dx
@@ -1,6 +1,6 @@
 '# Example tables
 
--- TODO: Index those tables by the string elements or by integers?
+# TODO: Index those tables by the string elements or by integers?
 
 def students : (Fin 3)=>{name: String & age: Int & favColor: String} =
   [ {name="Bob"  , age=12, favColor="blue" }
@@ -16,100 +16,100 @@ def studentsMissing : (Fin 3)=>{name: String & age:(Maybe Int) & favColor:(Maybe
 
 '## TODO: employees
 
--- | Last Name    | Department ID |
--- | ------------ | ------------- |
--- | "Rafferty"   | 31            |
--- | "Jones"      | 32            |
--- | "Heisenberg" | 33            |
--- | "Robinson"   | 34            |
--- | "Smith"      | 34            |
--- | "Williams"   |               |
+# | Last Name    | Department ID |
+# | ------------ | ------------- |
+# | "Rafferty"   | 31            |
+# | "Jones"      | 32            |
+# | "Heisenberg" | 33            |
+# | "Robinson"   | 34            |
+# | "Smith"      | 34            |
+# | "Williams"   |               |
 
 '## TODO: departments
 
--- | Department ID | Department Name |
--- | ------------- | --------------- |
--- | 31            | "Sales"         |
--- | 33            | "Engineering"   |
--- | 34            | "Clerical"      |
--- | 35            | "Marketing"     |
+# | Department ID | Department Name |
+# | ------------- | --------------- |
+# | 31            | "Sales"         |
+# | 33            | "Engineering"   |
+# | 34            | "Clerical"      |
+# | 35            | "Marketing"     |
 
 '## TODO: jellyAnon
 
--- | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple |
--- | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ |
--- | true     | false | false | false | true  | false  | false | true   | false | false  |
--- | true     | false | true  | false | true  | true   | false | false  | false | false  |
--- | false    | false | false | false | true  | false  | false | false  | true  | false  |
--- | false    | false | false | false | false | true   | false | false  | false | false  |
--- | false    | false | false | false | false | true   | false | false  | true  | false  |
--- | true     | false | true  | false | false | false  | false | true   | true  | false  |
--- | false    | false | true  | false | false | false  | false | false  | true  | false  |
--- | true     | false | false | false | false | false  | true  | true   | false | false  |
--- | true     | false | false | false | false | false  | false | true   | false | false  |
--- | false    | true  | false | false | false | true   | true  | false  | true  | false  |
+# | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple |
+# | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ |
+# | true     | false | false | false | true  | false  | false | true   | false | false  |
+# | true     | false | true  | false | true  | true   | false | false  | false | false  |
+# | false    | false | false | false | true  | false  | false | false  | true  | false  |
+# | false    | false | false | false | false | true   | false | false  | false | false  |
+# | false    | false | false | false | false | true   | false | false  | true  | false  |
+# | true     | false | true  | false | false | false  | false | true   | true  | false  |
+# | false    | false | true  | false | false | false  | false | false  | true  | false  |
+# | true     | false | false | false | false | false  | true  | true   | false | false  |
+# | true     | false | false | false | false | false  | false | true   | false | false  |
+# | false    | true  | false | false | false | true   | true  | false  | true  | false  |
 
 '## TODO: jellyNamed
 
--- | name       | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple |
--- | ---------- | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ |
--- | "Emily"    | true     | false | false | false | true  | false  | false | true   | false | false  |
--- | "Jacob"    | true     | false | true  | false | true  | true   | false | false  | false | false  |
--- | "Emma"     | false    | false | false | false | true  | false  | false | false  | true  | false  |
--- | "Aidan"    | false    | false | false | false | false | true   | false | false  | false | false  |
--- | "Madison"  | false    | false | false | false | false | true   | false | false  | true  | false  |
--- | "Ethan"    | true     | false | true  | false | false | false  | false | true   | true  | false  |
--- | "Hannah"   | false    | false | true  | false | false | false  | false | false  | true  | false  |
--- | "Matthew"  | true     | false | false | false | false | false  | true  | true   | false | false  |
--- | "Hailey"   | true     | false | false | false | false | false  | false | true   | false | false  |
--- | "Nicholas" | false    | true  | false | false | false | true   | true  | false  | true  | false  |
+# | name       | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple |
+# | ---------- | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ |
+# | "Emily"    | true     | false | false | false | true  | false  | false | true   | false | false  |
+# | "Jacob"    | true     | false | true  | false | true  | true   | false | false  | false | false  |
+# | "Emma"     | false    | false | false | false | true  | false  | false | false  | true  | false  |
+# | "Aidan"    | false    | false | false | false | false | true   | false | false  | false | false  |
+# | "Madison"  | false    | false | false | false | false | true   | false | false  | true  | false  |
+# | "Ethan"    | true     | false | true  | false | false | false  | false | true   | true  | false  |
+# | "Hannah"   | false    | false | true  | false | false | false  | false | false  | true  | false  |
+# | "Matthew"  | true     | false | false | false | false | false  | true  | true   | false | false  |
+# | "Hailey"   | true     | false | false | false | false | false  | false | true   | false | false  |
+# | "Nicholas" | false    | true  | false | false | false | true   | true  | false  | true  | false  |
 
 '## TODO: gradebook
 
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
 
 '## TODO: gradebookMissing
 
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      |       | 7     | 85    |
--- | "Eve"   | 13  |       | 9     | 84      | 8     | 8     | 77    |
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      |       | 7     | 85    |
+# | "Eve"   | 13  |       | 9     | 84      | 8     | 8     | 77    |
 
 '## TODO: gradebookSeq
 
--- | name    | age | quizzes      | midterm | final |
--- | ------- | --- | ------------ | ------- | ----- |
--- | "Bob"   | 12  | [8, 9, 7, 9] | 77      | 87    |
--- | "Alice" | 17  | [6, 8, 8, 7] | 88      | 85    |
--- | "Eve"   | 13  | [7, 9, 8, 8] | 84      | 77    |
+# | name    | age | quizzes      | midterm | final |
+# | ------- | --- | ------------ | ------- | ----- |
+# | "Bob"   | 12  | [8, 9, 7, 9] | 77      | 87    |
+# | "Alice" | 17  | [6, 8, 8, 7] | 88      | 85    |
+# | "Eve"   | 13  | [7, 9, 8, 8] | 84      | 77    |
 
 '## TODO: gradebookTable
 
--- | name    | age | quizzes           | midterm | final |
--- | ------- | --- | ----------------- | ------- | ----- |
--- | "Bob"   | 12  | | quiz# | grade | | 77      | 87    |
--- |         |     | | ----- | ----- | |         |       |
--- |         |     | | 1     | 8     | |         |       |
--- |         |     | | 2     | 9     | |         |       |
--- |         |     | | 3     | 7     | |         |       |
--- |         |     | | 4     | 9     | |         |       |
--- | "Alice" | 17  | | quiz# | grade | | 88      | 85    |
--- |         |     | | ----- | ----- | |         |       |
--- |         |     | | 1     | 6     | |         |       |
--- |         |     | | 2     | 8     | |         |       |
--- |         |     | | 3     | 8     | |         |       |
--- |         |     | | 4     | 7     | |         |       |
--- | "Eve"   | 13  | | quiz# | grade | | 84      | 77    |
--- |         |     | | ----- | ----- | |         |       |
--- |         |     | | 1     | 7     | |         |       |
--- |         |     | | 2     | 9     | |         |       |
--- |         |     | | 3     | 8     | |         |       |
--- |         |     | | 4     | 8     | |         |       |
+# | name    | age | quizzes           | midterm | final |
+# | ------- | --- | ----------------- | ------- | ----- |
+# | "Bob"   | 12  | | quiz# | grade | | 77      | 87    |
+# |         |     | | ----- | ----- | |         |       |
+# |         |     | | 1     | 8     | |         |       |
+# |         |     | | 2     | 9     | |         |       |
+# |         |     | | 3     | 7     | |         |       |
+# |         |     | | 4     | 9     | |         |       |
+# | "Alice" | 17  | | quiz# | grade | | 88      | 85    |
+# |         |     | | ----- | ----- | |         |       |
+# |         |     | | 1     | 6     | |         |       |
+# |         |     | | 2     | 8     | |         |       |
+# |         |     | | 3     | 8     | |         |       |
+# |         |     | | 4     | 7     | |         |       |
+# | "Eve"   | 13  | | quiz# | grade | | 84      | 77    |
+# |         |     | | ----- | ----- | |         |       |
+# |         |     | | 1     | 7     | |         |       |
+# |         |     | | 2     | 9     | |         |       |
+# |         |     | | 3     | 8     | |         |       |
+# |         |     | | 4     | 8     | |         |       |
 
 '# Table API
 
@@ -123,185 +123,185 @@ def addRows {n m a} (t:n=>a) (t':m=>a) : (n|m)=>a =
     Left ni  -> t.ni
     Right mi -> t'.mi
 
--- > addRows(
---     students,
---     [
---       [row:
---         ("name", "Colton"), ("age", 19),
---         ("favorite color", "blue")]
---     ])
--- | name     | age | favorite color |
--- | -------- | --- | -------------- |
--- | "Bob"    | 12  | "blue"         |
--- | "Alice"  | 17  | "green"        |
--- | "Eve"    | 13  | "red"          |
--- | "Colton" | 19  | "blue"         |
--- > addRows(gradebook, [])
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# > addRows(
+#     students,
+#     [
+#       [row:
+#         ("name", "Colton"), ("age", 19),
+#         ("favorite color", "blue")]
+#     ])
+# | name     | age | favorite color |
+# | -------- | --- | -------------- |
+# | "Bob"    | 12  | "blue"         |
+# | "Alice"  | 17  | "green"        |
+# | "Eve"    | 13  | "red"          |
+# | "Colton" | 19  | "blue"         |
+# > addRows(gradebook, [])
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
 
 
--- ### `addColumn :: t1:Table * c:ColName * vs:Seq<Value> -> t2:Table`
+# ### `addColumn :: t1:Table * c:ColName * vs:Seq<Value> -> t2:Table`
 def addColumn {n f a} (t:n=>{&...f}) (c:Label) (vs:n=>a) : n=>{@c:a & ...f} =
   for i. {@c=vs.i, ...t.i}
 
--- > hairColor = ["brown", "red", "blonde"]
--- > addColumn(students, "hair-color", hairColor)
--- | name    | age | favorite color | hair-color |
--- | ------- | --- | -------------- | ---------- |
--- | "Bob"   | 12  | "blue"         | "brown"    |
--- | "Alice" | 17  | "green"        | "red"      |
--- | "Eve"   | 13  | "red"          | "blonde"   |
--- > presentation = [9, 9, 6]
--- > addColumn(gradebook, "presentation", presentation)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final | presentation |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- | ------------ |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    | 9            |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    | 9            |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    | 6            |
+# > hairColor = ["brown", "red", "blonde"]
+# > addColumn(students, "hair-color", hairColor)
+# | name    | age | favorite color | hair-color |
+# | ------- | --- | -------------- | ---------- |
+# | "Bob"   | 12  | "blue"         | "brown"    |
+# | "Alice" | 17  | "green"        | "red"      |
+# | "Eve"   | 13  | "red"          | "blonde"   |
+# > presentation = [9, 9, 6]
+# > addColumn(gradebook, "presentation", presentation)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final | presentation |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- | ------------ |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    | 9            |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    | 9            |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    | 6            |
 
--- ### `buildColumn :: t1:Table * c:ColName * f:(r:Row -> v:Value) -> t2:Table`
+# ### `buildColumn :: t1:Table * c:ColName * f:(r:Row -> v:Value) -> t2:Table`
 def buildColumn {n f a} (t:n=>{&...f}) (c:Label) (fn: {&...f} -> a) : n=>{@c:a & ...f} =
   for i. {@c=fn t.i, ...t.i}
 
--- > isTeenagerBuilder =
---     function(r):
---       12 < getValue(r, "age") and getValue(r, "age") < 20
---     end
--- > buildColumn(students, "is-teenager", isTeenagerBuilder)
--- | name    | age | favorite color | is-teenager |
--- | ------- | --- | -------------- | ----------- |
--- | "Bob"   | 12  | "blue"         | false       |
--- | "Alice" | 17  | "green"        | true        |
--- | "Eve"   | 13  | "red"          | true        |
--- > didWellInFinal =
---     function(r):
---       85 <= getValue(r, "final")
---     end
--- > buildColumn(gradebook, "did-well-in-final", didWellInFinal)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final | did-well-in-final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- | ----------------- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    | true              |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    | true              |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    | false             |
+# > isTeenagerBuilder =
+#     function(r):
+#       12 < getValue(r, "age") and getValue(r, "age") < 20
+#     end
+# > buildColumn(students, "is-teenager", isTeenagerBuilder)
+# | name    | age | favorite color | is-teenager |
+# | ------- | --- | -------------- | ----------- |
+# | "Bob"   | 12  | "blue"         | false       |
+# | "Alice" | 17  | "green"        | true        |
+# | "Eve"   | 13  | "red"          | true        |
+# > didWellInFinal =
+#     function(r):
+#       85 <= getValue(r, "final")
+#     end
+# > buildColumn(gradebook, "did-well-in-final", didWellInFinal)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final | did-well-in-final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- | ----------------- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    | true              |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    | true              |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    | false             |
 
--- ### `vcat :: t1:Table * t2:Table -> t3:Table`
+# ### `vcat :: t1:Table * t2:Table -> t3:Table`
 def vcat {n m a} (t:n=>a) (t':m=>a) : (n|m)=>a = addRows t t'
 
--- > increaseAge =
---     function(r):
---       [row: ("age", 1 + getValue(r, "age"))]
---     end
--- > vcat(students, update(students, increaseAge))
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- | "Alice" | 17  | "green"        |
--- | "Eve"   | 13  | "red"          |
--- | "Bob"   | 13  | "blue"         |
--- | "Alice" | 18  | "green"        |
--- | "Eve"   | 14  | "red"          |
--- > curveMidtermAndFinal =
---     function(r):
---       curve =
---         function(n):
---           n + 5
---         end
---       [row:
---         ("midterm", curve(getValue("midterm"))),
---         ("final", curve(getValue("final")))]
---     end
--- > vcat(gradebook, update(gradebook, curveMidtermAndFinal))
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
--- | "Bob"   | 12  | 8     | 9     | 82      | 7     | 9     | 92    |
--- | "Alice" | 17  | 6     | 8     | 93      | 8     | 7     | 90    |
--- | "Eve"   | 13  | 7     | 9     | 89      | 8     | 8     | 82    |
+# > increaseAge =
+#     function(r):
+#       [row: ("age", 1 + getValue(r, "age"))]
+#     end
+# > vcat(students, update(students, increaseAge))
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# | "Alice" | 17  | "green"        |
+# | "Eve"   | 13  | "red"          |
+# | "Bob"   | 13  | "blue"         |
+# | "Alice" | 18  | "green"        |
+# | "Eve"   | 14  | "red"          |
+# > curveMidtermAndFinal =
+#     function(r):
+#       curve =
+#         function(n):
+#           n + 5
+#         end
+#       [row:
+#         ("midterm", curve(getValue("midterm"))),
+#         ("final", curve(getValue("final")))]
+#     end
+# > vcat(gradebook, update(gradebook, curveMidtermAndFinal))
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# | "Bob"   | 12  | 8     | 9     | 82      | 7     | 9     | 92    |
+# | "Alice" | 17  | 6     | 8     | 93      | 8     | 7     | 90    |
+# | "Eve"   | 13  | 7     | 9     | 89      | 8     | 8     | 82    |
 
 def hcat {n f f'} (t:n=>{&...f}) (t':n=>{&...f'}) : n=>{...f & ...f'} =
   for i. {...(t.i), ...(t'.i)}
 
--- > hcat(students, dropColumns(gradebook, ["name", "age"]))
--- | name    | age | favorite color | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | -------------- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | "blue"         | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | "green"        | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | "red"          | 7     | 9     | 84      | 8     | 8     | 77    |
--- > hcat(dropColumns(students, ["name", "age"]), gradebook)
--- | favorite color | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | -------------- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "blue"         | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "green"        | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "red"          | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# > hcat(students, dropColumns(gradebook, ["name", "age"]))
+# | name    | age | favorite color | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | -------------- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | "blue"         | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | "green"        | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | "red"          | 7     | 9     | 84      | 8     | 8     | 77    |
+# > hcat(dropColumns(students, ["name", "age"]), gradebook)
+# | favorite color | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | -------------- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "blue"         | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "green"        | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "red"          | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
 
 def values {n a} : n=>a -> n=>a = id
--- > values([
---     [row: ("name", "Alice")],
---     [row: ("name", "Bob")]])
--- | name    |
--- | ------- |
--- | "Alice" |
--- | "Bob"   |
--- > values([
---     [row: ("name", "Alice"), ("age", 12)],
---     [row: ("name", "Bob"), ("age", 13)]])
--- | name    | age |
--- | ------- | --- |
--- | "Alice" | 12  |
--- | "Bob"   | 13  |
+# > values([
+#     [row: ("name", "Alice")],
+#     [row: ("name", "Bob")]])
+# | name    |
+# | ------- |
+# | "Alice" |
+# | "Bob"   |
+# > values([
+#     [row: ("name", "Alice"), ("age", 12)],
+#     [row: ("name", "Bob"), ("age", 13)]])
+# | name    | age |
+# | ------- | --- |
+# | "Alice" | 12  |
+# | "Bob"   | 13  |
 
--- ### `crossJoin :: t1:Table * t2:Table -> t3:Table`
+# ### `crossJoin :: t1:Table * t2:Table -> t3:Table`
 def crossJoin {n m f f'} (t:n=>{&...f}) (t':m=>{&...f'}) : (n & m)=>{...f & ...f'} =
   for (i, j). {...(t.i), ...(t'.j)}
 
--- > petiteJelly = subTable(jellyAnon, [0, 1], [0, 1, 2])
--- > petiteJelly
--- | get acne | red   | black |
--- | -------- | ----- | ----- |
--- | true     | false | false |
--- | true     | false | true  |
--- > crossJoin(students, petiteJelly)
--- | name    | age | favorite color | get acne | red   | black |
--- | ------- | --- | -------------- | -------- | ----- | ----- |
--- | "Bob"   | 12  | "blue"         | true     | false | false |
--- | "Bob"   | 12  | "blue"         | true     | false | true  |
--- | "Alice" | 17  | "green"        | true     | false | false |
--- | "Alice" | 17  | "green"        | true     | false | true  |
--- | "Eve"   | 13  | "red"          | true     | false | false |
--- | "Eve"   | 13  | "red"          | true     | false | true  |
--- > crossJoin(emptyTable, petiteJelly)
--- | get acne | red   | black |
--- | -------- | ----- | ----- |
+# > petiteJelly = subTable(jellyAnon, [0, 1], [0, 1, 2])
+# > petiteJelly
+# | get acne | red   | black |
+# | -------- | ----- | ----- |
+# | true     | false | false |
+# | true     | false | true  |
+# > crossJoin(students, petiteJelly)
+# | name    | age | favorite color | get acne | red   | black |
+# | ------- | --- | -------------- | -------- | ----- | ----- |
+# | "Bob"   | 12  | "blue"         | true     | false | false |
+# | "Bob"   | 12  | "blue"         | true     | false | true  |
+# | "Alice" | 17  | "green"        | true     | false | false |
+# | "Alice" | 17  | "green"        | true     | false | true  |
+# | "Eve"   | 13  | "red"          | true     | false | false |
+# | "Eve"   | 13  | "red"          | true     | false | true  |
+# > crossJoin(emptyTable, petiteJelly)
+# | get acne | red   | black |
+# | -------- | ----- | ----- |
 
 '### TODO: `leftJoin` (lists of labels)
 
--- It should be sufficient to do the join on a single column. One can always
--- restructure the table so that the join happens on a tuple of values from
--- the flattened columns.
+# It should be sufficient to do the join on a single column. One can always
+# restructure the table so that the join happens on a tuple of values from
+# the flattened columns.
 def leftJoin = todo
--- def leftJoin (c:Label) (l:n=>{@c: a & ...f}) (r:m=>{@c: a & ...f'})
---       : n=>{extra: Maybe {...f'} & ...f} = todo
--- > leftJoin(students, gradebook, ["name", "age"])
--- | name    | age | favorite color | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | -------------- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | "blue"         | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | "green"        | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | "red"          | 7     | 9     | 84      | 8     | 8     | 77    |
--- > leftJoin(employees, departments, ["Department ID"])
--- | Last Name    | Department ID | Department Name |
--- | ------------ | ------------- | --------------- |
--- | "Rafferty"   | 31            | "Sales"         |
--- | "Jones"      | 32            |                 |
--- | "Heisenberg" | 33            | "Engineering"   |
--- | "Robinson"   | 34            | "Clerical"      |
--- | "Smith"      | 34            | "Clerical"      |
--- | "Williams"   |               |                 |
+# def leftJoin (c:Label) (l:n=>{@c: a & ...f}) (r:m=>{@c: a & ...f'})
+#       : n=>{extra: Maybe {...f'} & ...f} = todo
+# > leftJoin(students, gradebook, ["name", "age"])
+# | name    | age | favorite color | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | -------------- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | "blue"         | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | "green"        | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | "red"          | 7     | 9     | 84      | 8     | 8     | 77    |
+# > leftJoin(employees, departments, ["Department ID"])
+# | Last Name    | Department ID | Department Name |
+# | ------------ | ------------- | --------------- |
+# | "Rafferty"   | 31            | "Sales"         |
+# | "Jones"      | 32            |                 |
+# | "Heisenberg" | 33            | "Engineering"   |
+# | "Robinson"   | 34            | "Clerical"      |
+# | "Smith"      | 34            | "Clerical"      |
+# | "Williams"   |               |                 |
 
 '## Properties
 
@@ -312,8 +312,8 @@ nrows studentsMissing
 
 '### TODO: `ncols` (type-classes over records)
 
--- TODO: Is this even expressible? Perhaps through type classes?
--- If we can do Eq of records in user space then we can count fields too.
+# TODO: Is this even expressible? Perhaps through type classes?
+# If we can do Eq of records in user space then we can count fields too.
 def ncols {n f} (t:n=>{&...f}) : Int = todo
 
 ncols students
@@ -321,12 +321,12 @@ ncols studentsMissing
 
 '### TODO: `header` (type-classes over records)
 
--- TODO: Is this even expressible? Perhaps through type classes again.
+# TODO: Is this even expressible? Perhaps through type classes again.
 def header {n f} (t:n=>{...f}) : List Label = todo
--- > header(students)
--- ["name", "age", "favorite color"]
--- > header(gradebook)
--- ["name", "age", "quiz1", "quiz2", "midterm", "quiz3", "quiz4", "final"]
+# > header(students)
+# ["name", "age", "favorite color"]
+# > header(gradebook)
+# ["name", "age", "quiz1", "quiz2", "midterm", "quiz3", "quiz4", "final"]
 
 '## Access Subcomponents
 
@@ -338,377 +338,377 @@ getRow gradebook (1@_)
 def getValue {f a} (c:Label) (r:{@c:a & ...f}) : a =
   {@c=v, ...} = r
   v
--- > getValue([row: ("name", "Bob"),  ("age", 12)], "name")
--- "Bob"
--- > getValue([row: ("name", "Bob"),  ("age", 12)], "age")
--- 12
+# > getValue([row: ("name", "Bob"),  ("age", 12)], "name")
+# "Bob"
+# > getValue([row: ("name", "Bob"),  ("age", 12)], "age")
+# 12
 
--- INEXPRESSIBLE: Columns are unordered
--- ### (overloading 1/2) `getColumn :: t:Table * n:Number -> vs:Seq<Value>`
+# INEXPRESSIBLE: Columns are unordered
+# ### (overloading 1/2) `getColumn :: t:Table * n:Number -> vs:Seq<Value>`
 
--- ### (overloading 2/2) `getColumn :: t:Table * c:ColName -> vs:Seq<Value>`
+# ### (overloading 2/2) `getColumn :: t:Table * c:ColName -> vs:Seq<Value>`
 def getColumn {f n a} (c:Label) (t:n=>{@c:a & ...f}) : n=>a = todo
--- > getColumn(students, "age")
--- [12, 17, 13]
--- > getColumn(gradebook, "name")
--- ["Bob", "Alice", "Eve"]
+# > getColumn(students, "age")
+# [12, 17, 13]
+# > getColumn(gradebook, "name")
+# ["Bob", "Alice", "Eve"]
 
 '## Subtable
 
 def selectRows {n m a} (t:n=>a) (is:m=>n) : m=>a = for i:m. t.(is.i)
--- > selectRows(students, [2, 0, 2, 1])
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Eve"   | 13  | "red"          |
--- | "Bob"   | 12  | "blue"         |
--- | "Eve"   | 13  | "red"          |
--- | "Alice" | 17  | "green"        |
--- > selectRows(gradebooks, [2, 1])
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- ```
+# > selectRows(students, [2, 0, 2, 1])
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Eve"   | 13  | "red"          |
+# | "Bob"   | 12  | "blue"         |
+# | "Eve"   | 13  | "red"          |
+# | "Alice" | 17  | "green"        |
+# > selectRows(gradebooks, [2, 1])
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# ```
 
 def selectRowsMask (t:n=>a) (shouldTake:n=>Bool) : List a =
   concat $ for i.
     case shouldTake.i of
       True  -> AsList _ [t.i]
       False -> mempty
--- > selectRows(students, [true, false, true])
--- | name  | age | favorite color |
--- | ----- | --- | -------------- |
--- | "Bob" | 12  | "blue"         |
--- | "Eve" | 13  | "red"          |
--- > selectRows(gradebook, [false, false, true])
--- | name  | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ----- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Eve" | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# > selectRows(students, [true, false, true])
+# | name  | age | favorite color |
+# | ----- | --- | -------------- |
+# | "Bob" | 12  | "blue"         |
+# | "Eve" | 13  | "red"          |
+# > selectRows(gradebook, [false, false, true])
+# | name  | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ----- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Eve" | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
 
--- INEXPRESSIBLE: Columns are unordered
--- ### (overload 1/3) `selectColumns :: t1:Table * bs:Seq<Boolean> -> t2:Table`
+# INEXPRESSIBLE: Columns are unordered
+# ### (overload 1/3) `selectColumns :: t1:Table * bs:Seq<Boolean> -> t2:Table`
 
--- INEXPRESSIBLE: Columns are unordered
--- ### (overload 2/3) `selectColumns :: t1:Table * ns:Seq<Number> -> t2:Table`
+# INEXPRESSIBLE: Columns are unordered
+# ### (overload 2/3) `selectColumns :: t1:Table * ns:Seq<Number> -> t2:Table`
 
--- ### (overload 3/3) `selectColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
+# ### (overload 3/3) `selectColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
 def selectColumns {n f'} (f: Fields) (t: n=>{...f & ...f'}) : n=>{&...f} =
   for i.
     {@...f=v, ...} = t.i
     v
--- > selectColumns(students, ["favorite color", "age"])
--- | favorite color | age |
--- | -------------- | --- |
--- | "blue"         | 12  |
--- | "green"        | 17  |
--- | "red"          | 13  |
--- > selectColumns(gradebook, ["final", "name", "midterm"])
--- | final | name    | midterm |
--- | ----- | ------- | ------- |
--- | 87    | "Bob"   | 77      |
--- | 85    | "Alice" | 88      |
--- | 77    | "Eve"   | 84      |
+# > selectColumns(students, ["favorite color", "age"])
+# | favorite color | age |
+# | -------------- | --- |
+# | "blue"         | 12  |
+# | "green"        | 17  |
+# | "red"          | 13  |
+# > selectColumns(gradebook, ["final", "name", "midterm"])
+# | final | name    | midterm |
+# | ----- | ------- | ------- |
+# | 87    | "Bob"   | 77      |
+# | 85    | "Alice" | 88      |
+# | 77    | "Eve"   | 84      |
 
 def head = todo
--- > head(students, 1)
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- > head(students, -2)
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
+# > head(students, 1)
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# > head(students, -2)
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
 
 '### TODO: `distinct` (type-classes for records)
 
 def distinct = todo
--- > distinct(students)
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- | "Alice" | 17  | "green"        |
--- | "Eve"   | 13  | "red"          |
--- > distinct(selectColumns(gradebook, ["quiz3"]))
--- | quiz3 |
--- | ----- |
--- | 7     |
--- | 8     |
+# > distinct(students)
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# | "Alice" | 17  | "green"        |
+# | "Eve"   | 13  | "red"          |
+# > distinct(selectColumns(gradebook, ["quiz3"]))
+# | quiz3 |
+# | ----- |
+# | 7     |
+# | 8     |
 
 def dropColumn {n f a} (c:Label) (t:n=>{@c:a & ...f}) : n=>{&...f} =
   for i.
     {@c=_, ...r} = t.i
     r
 
--- > dropColumn(students, "age")
--- | name    | favorite color |
--- | ------- | -------------- |
--- | "Bob"   | "blue"         |
--- | "Alice" | "green"        |
--- | "Eve"   | "red"          |
--- > dropColumn(gradebook, "final")
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     |
+# > dropColumn(students, "age")
+# | name    | favorite color |
+# | ------- | -------------- |
+# | "Bob"   | "blue"         |
+# | "Alice" | "green"        |
+# | "Eve"   | "red"          |
+# > dropColumn(gradebook, "final")
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     |
 
 def dropColumns {n f'} (f: Fields) (t:n=>{...f & ...f'}) : n=>{&...f'} =
   for i.
     {@...f=_, ...r} = t.i
     r
 
--- ### `dropColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
---
--- > dropColumns(students, ["age"])
--- | name    | favorite color |
--- | ------- | -------------- |
--- | "Bob"   | "blue"         |
--- | "Alice" | "green"        |
--- | "Eve"   | "red"          |
--- > dropColumns(gradebook, ["final", "midterm"])
--- | name    | age | quiz1 | quiz2 | quiz3 | quiz4 |
--- | ------- | --- | ----- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 7     | 9     |
--- | "Alice" | 17  | 6     | 8     | 8     | 7     |
--- | "Eve"   | 13  | 7     | 9     | 8     | 8     |
+# ### `dropColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
+#
+# > dropColumns(students, ["age"])
+# | name    | favorite color |
+# | ------- | -------------- |
+# | "Bob"   | "blue"         |
+# | "Alice" | "green"        |
+# | "Eve"   | "red"          |
+# > dropColumns(gradebook, ["final", "midterm"])
+# | name    | age | quiz1 | quiz2 | quiz3 | quiz4 |
+# | ------- | --- | ----- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 7     | 9     |
+# | "Alice" | 17  | 6     | 8     | 8     | 7     |
+# | "Eve"   | 13  | 7     | 9     | 8     | 8     |
 
 def tfilter (t:n=>a) (keep:a -> Bool) : List a =
  selectRowsMask t $ for i. keep t.i
--- > ageUnderFifteen =
---     function(r):
---       getValue(r, "age") < 15
---     end
--- > tfilter(students, ageUnderFifteen)
--- | name  | age | favorite color |
--- | ----- | --- | -------------- |
--- | "Bob" | 12  | "blue"         |
--- | "Eve" | 13  | "red"          |
--- > nameLongerThan3Letters =
---     function(r):
---       length(getValue(r, "name")) > 3
---     end
--- > tfilter(gradebook, nameLongerThan3Letters)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# > ageUnderFifteen =
+#     function(r):
+#       getValue(r, "age") < 15
+#     end
+# > tfilter(students, ageUnderFifteen)
+# | name  | age | favorite color |
+# | ----- | --- | -------------- |
+# | "Bob" | 12  | "blue"         |
+# | "Eve" | 13  | "red"          |
+# > nameLongerThan3Letters =
+#     function(r):
+#       length(getValue(r, "name")) > 3
+#     end
+# > tfilter(gradebook, nameLongerThan3Letters)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
 
 '## Ordering
 
 import sort
 
--- TODO: We could the sort on the full data, with an Ord instance that only looks at the column
--- ### `tsort :: t1:Table * c:ColName * b:Boolean -> t2:Table`
+# TODO: We could the sort on the full data, with an Ord instance that only looks at the column
+# ### `tsort :: t1:Table * c:ColName * b:Boolean -> t2:Table`
 def tsort {n f a} [Ord a] (c:Label) (t:n=>{@c: a & ...f}) : n=>{@c: a & ...f} =
   ixs = argsort $ getColumn c t
   for i. t.(ixs.i)
 
--- > tsort(students, "age", true)
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- | "Eve"   | 13  | "red"          |
--- | "Alice" | 17  | "green"        |
--- > tsort(gradebook, "final", false)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# > tsort(students, "age", true)
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# | "Eve"   | 13  | "red"          |
+# | "Alice" | 17  | "green"        |
+# > tsort(gradebook, "final", false)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
 
 '### TODO: `sortByColumns` (lists of labels)
 
--- ### `sortByColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
--- > sortByColumns(students, ["age"])
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- | "Eve"   | 13  | "red"          |
--- | "Alice" | 17  | "green"        |
--- > sortByColumns(gradebook, ["quiz2", "quiz1"])
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# ### `sortByColumns :: t1:Table * cs:Seq<ColName> -> t2:Table`
+# > sortByColumns(students, ["age"])
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# | "Eve"   | 13  | "red"          |
+# | "Alice" | 17  | "green"        |
+# > sortByColumns(gradebook, ["quiz2", "quiz1"])
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
 
 
--- ### `orderBy :: t1:Table * Seq<Exists K . getKey:(r:Row -> k:K) * compare:(k1:K * k2:K -> Boolean)> -> t2:Table`
+# ### `orderBy :: t1:Table * Seq<Exists K . getKey:(r:Row -> k:K) * compare:(k1:K * k2:K -> Boolean)> -> t2:Table`
 def orderBy = todo
--- > nameLength =
---     function(r):
---       length(getValue(r, "name"))
---     end
--- > le =
---     function(n1, n2):
---       n1 <= n2
---     end
--- > orderBy(students, [(nameLength, le)])
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   | 12  | "blue"         |
--- | "Eve"   | 13  | "red"          |
--- | "Alice" | 17  | "green"        |
--- > midtermAndFinal =
---     function(r):
---       [getValue(r, "midterm"), getValue(r, "final")]
---     end
--- > compareGrade =
---     function(g1, g2):
---       le(average(g1), average(g2))
---     end
--- > orderBy(gradebook, [(nameLength, ge), (midtermAndFinal, compareGrade)])
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# > nameLength =
+#     function(r):
+#       length(getValue(r, "name"))
+#     end
+# > le =
+#     function(n1, n2):
+#       n1 <= n2
+#     end
+# > orderBy(students, [(nameLength, le)])
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   | 12  | "blue"         |
+# | "Eve"   | 13  | "red"          |
+# | "Alice" | 17  | "green"        |
+# > midtermAndFinal =
+#     function(r):
+#       [getValue(r, "midterm"), getValue(r, "final")]
+#     end
+# > compareGrade =
+#     function(g1, g2):
+#       le(average(g1), average(g2))
+#     end
+# > orderBy(gradebook, [(nameLength, ge), (midtermAndFinal, compareGrade)])
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Alice" | 17  | 6     | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | 7     | 9     | 84      | 8     | 8     | 77    |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
 
 '## Aggregate
 
 '### TODO: `count` (groupBy)
 
 def count = todo
--- Takes a `Table` and a `ColName` representing the name of a column in that `Table`. Produces a `Table` that summarizes how many rows have each value in the given column.
---
--- > count(students, "favorite color")
--- | value   | count |
--- | ------- | ----- |
--- | "blue"  | 1     |
--- | "green" | 1     |
--- | "red"   | 1     |
--- > count(gradebook, "age")
--- | value | count |
--- | ----- | ----- |
--- | 12    | 1     |
--- | 17    | 1     |
--- | 13    | 1     |
+# Takes a `Table` and a `ColName` representing the name of a column in that `Table`. Produces a `Table` that summarizes how many rows have each value in the given column.
+#
+# > count(students, "favorite color")
+# | value   | count |
+# | ------- | ----- |
+# | "blue"  | 1     |
+# | "green" | 1     |
+# | "red"   | 1     |
+# > count(gradebook, "age")
+# | value | count |
+# | ----- | ----- |
+# | 12    | 1     |
+# | 17    | 1     |
+# | 13    | 1     |
 
 '### TODO: `bin` (groupBy)
 
--- ### `bin :: t1:Table * c:ColName * n:Number -> t2:Table`
+# ### `bin :: t1:Table * c:ColName * n:Number -> t2:Table`
 def bin = todo
--- Groups the values of a numeric column into bins. The parameter `n` specifies the bin width. This function is useful in creating histograms and converting continuous random variables to categorical ones.
---
--- > bin(students, "age", 5)
--- | group            | count |
--- | ---------------- | ----- |
--- | "10 <= age < 15" | 2     |
--- | "15 <= age < 20" | 1     |
--- > bin(gradebook, "final", 5)
--- | group            | count |
--- | ---------------- | ----- |
--- | "75 <= age < 80" | 1     |
--- | "80 <= age < 85" | 0     |
--- | "85 <= age < 90" | 2     |
+# Groups the values of a numeric column into bins. The parameter `n` specifies the bin width. This function is useful in creating histograms and converting continuous random variables to categorical ones.
+#
+# > bin(students, "age", 5)
+# | group            | count |
+# | ---------------- | ----- |
+# | "10 <= age < 15" | 2     |
+# | "15 <= age < 20" | 1     |
+# > bin(gradebook, "final", 5)
+# | group            | count |
+# | ---------------- | ----- |
+# | "75 <= age < 80" | 1     |
+# | "80 <= age < 85" | 0     |
+# | "85 <= age < 90" | 2     |
 
 '### TODO: `pivotTable` (groupBy)
 
--- ### `pivotTable :: t1:Table * cs:Seq<ColName> * aggs:Seq<ColName * ColName * Function> -> t2:Table`
+# ### `pivotTable :: t1:Table * cs:Seq<ColName> * aggs:Seq<ColName * ColName * Function> -> t2:Table`
 def pivotTable (c:Label) (t:n=>{@c:a & ...f}) (agg: List {&...f} -> {&...f'}) : n=>{@c:a & ...f'} = todo
--- Partitions rows into groups and summarize each group with the functions in `agg`. Each element of `agg` specifies the output column, the input column, and the function that compute the summarizing value (e.g. average, sum, and count).
---
--- ```lua
--- > pivotTable(students, ["favorite color"], [("age-average", "age", average)])
--- | favorite color | age-average |
--- | -------------- | ----------- |
--- | "blue"         | 12          |
--- | "green"        | 17          |
--- | "red"          | 13          |
--- > proportion =
---     function(bs):
---       n = length(filter(bs, function(b): b end))
---       n / length(bs)
---     end
--- > pivotTable(
---     jellyNamed,
---     ["get acne", "brown"],
---     [
---       ("red proportion", "red", proportion),
---       ("pink proportion", "pink", proportion)
---     ])
--- | get acne | brown | red proportion | pink proportion |
--- | -------- | ----- | -------------- | --------------- |
--- | false    | false | 0              | 3/4             |
--- | false    | true  | 1              | 1               |
--- | true     | false | 0              | 1/4             |
--- | true     | true  | 0              | 0               |
+# Partitions rows into groups and summarize each group with the functions in `agg`. Each element of `agg` specifies the output column, the input column, and the function that compute the summarizing value (e.g. average, sum, and count).
+#
+# ```lua
+# > pivotTable(students, ["favorite color"], [("age-average", "age", average)])
+# | favorite color | age-average |
+# | -------------- | ----------- |
+# | "blue"         | 12          |
+# | "green"        | 17          |
+# | "red"          | 13          |
+# > proportion =
+#     function(bs):
+#       n = length(filter(bs, function(b): b end))
+#       n / length(bs)
+#     end
+# > pivotTable(
+#     jellyNamed,
+#     ["get acne", "brown"],
+#     [
+#       ("red proportion", "red", proportion),
+#       ("pink proportion", "pink", proportion)
+#     ])
+# | get acne | brown | red proportion | pink proportion |
+# | -------- | ----- | -------------- | --------------- |
+# | false    | false | 0              | 3/4             |
+# | false    | true  | 1              | 1               |
+# | true     | false | 0              | 1/4             |
+# | true     | true  | 0              | 0               |
 
 '### TODO: `groupBy` (groupBy)
 
--- TODO: Write this out to flatten out key and row' as records in the output
+# TODO: Write this out to flatten out key and row' as records in the output
 def groupBy (t:n=>row)
             (getKey:row -> key)
             (project:row -> value)
             (aggregate:key -> List value -> row')
             : List (key & row') = todo
 
--- Groups the rows of a table according to a specified key selector function and creates a result value from each group and its key. The rows of each group are projected by using a specified function.
---
--- > colorTemp =
---     function(r):
---       if getValue(r, "favorite color") == "red":
---         "warm"
---       else:
---         "cool"
---       end
---     end
--- > nameLength =
---     function(r):
---       length(getValue(r, "name"))
---     end
--- > aggregate =
---     function(k, vs):
---       [row: ("key", k), ("average", average(vs))]
---     end
--- > groupBy(students, colorTemp, nameLength, aggregate)
--- | key    | average |
--- | ------ | ------- |
--- | "warm" | 3       |
--- | "cool" | 4       |
--- > abstractAge =
---     function(r):
---       if (getValue(r, "age") <= 12):
---         "kid"
---       else if (getValue(r, "age") <= 19):
---         "teenager"
---       else:
---         "adult"
---       end
---     end
--- > finalGrade =
---     function(r):
---       getValue(r, "final")
---     end
--- > groupBy(gradebook, abstractAge, finalGrade, aggregate)
--- | key        | average |
--- | ---------- | ------- |
--- | "kid"      | 87      |
--- | "teenager" | 81      |
+# Groups the rows of a table according to a specified key selector function and creates a result value from each group and its key. The rows of each group are projected by using a specified function.
+#
+# > colorTemp =
+#     function(r):
+#       if getValue(r, "favorite color") == "red":
+#         "warm"
+#       else:
+#         "cool"
+#       end
+#     end
+# > nameLength =
+#     function(r):
+#       length(getValue(r, "name"))
+#     end
+# > aggregate =
+#     function(k, vs):
+#       [row: ("key", k), ("average", average(vs))]
+#     end
+# > groupBy(students, colorTemp, nameLength, aggregate)
+# | key    | average |
+# | ------ | ------- |
+# | "warm" | 3       |
+# | "cool" | 4       |
+# > abstractAge =
+#     function(r):
+#       if (getValue(r, "age") <= 12):
+#         "kid"
+#       else if (getValue(r, "age") <= 19):
+#         "teenager"
+#       else:
+#         "adult"
+#       end
+#     end
+# > finalGrade =
+#     function(r):
+#       getValue(r, "final")
+#     end
+# > groupBy(gradebook, abstractAge, finalGrade, aggregate)
+# | key        | average |
+# | ---------- | ------- |
+# | "kid"      | 87      |
+# | "teenager" | 81      |
 
 '## Missing values
 
 '### TODO: `completeCases` (type-classes over records)
 
--- Return a `Seq<Boolean>` with `true` entries indicating rows without missing values (complete cases) in table `t`.
---
--- > completeCases(students, "age")
--- [true, true, true]
--- > completeCases(studentsMissing, "age")
--- [false, true, true]
+# Return a `Seq<Boolean>` with `true` entries indicating rows without missing values (complete cases) in table `t`.
+#
+# > completeCases(students, "age")
+# [true, true, true]
+# > completeCases(studentsMissing, "age")
+# [false, true, true]
 
 '### TODO: `dropna` (type-classes over records)
 
--- ### `dropna :: t1:Table -> t2:Table`
--- Removes rows that have some values missing
---
--- > dropna(studentsMissing)
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Alice" | 17  | "green"        |
--- > dropna(gradebookMissing)
--- | name  | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ----- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob" | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# ### `dropna :: t1:Table -> t2:Table`
+# Removes rows that have some values missing
+#
+# > dropna(studentsMissing)
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Alice" | 17  | "green"        |
+# > dropna(gradebookMissing)
+# | name  | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ----- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob" | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
 
 def fillna {n f a} (c:Label) (t:n=>{@c:(Maybe a) & ...f}) (v:a) : n=>{@c:a & ...f} =
   for i.
@@ -717,174 +717,174 @@ def fillna {n f a} (c:Label) (t:n=>{@c:(Maybe a) & ...f}) (v:a) : n=>{@c:a & ...
       Nothing -> {@c=v, ...rest}
       Just v  -> {@c=v, ...rest}
 
--- > fillna(studentsMissing, "favorite color", "white")
--- | name    | age | favorite color |
--- | ------- | --- | -------------- |
--- | "Bob"   |     | "blue"         |
--- | "Alice" | 17  | "green"        |
--- | "Eve"   | 13  | "white"        |
--- > fillna(gradebookMissing, "quiz1", 0)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | 6     | 8     | 88      |       | 7     | 85    |
--- | "Eve"   | 13  | 0     | 9     | 84      | 8     | 8     | 77    |
+# > fillna(studentsMissing, "favorite color", "white")
+# | name    | age | favorite color |
+# | ------- | --- | -------------- |
+# | "Bob"   |     | "blue"         |
+# | "Alice" | 17  | "green"        |
+# | "Eve"   | 13  | "white"        |
+# > fillna(gradebookMissing, "quiz1", 0)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | 6     | 8     | 88      |       | 7     | 85    |
+# | "Eve"   | 13  | 0     | 9     | 84      | 8     | 8     | 77    |
 
 '## Data Cleaning
 
 '### TODO: `pivotLonger` (??)
 
--- This is a little difficult, because we'd need to reflect the labels as strings
+# This is a little difficult, because we'd need to reflect the labels as strings
 
--- ### `pivotLonger :: t1:Table * cs:Seq<ColName> * c1:ColName * c2:ColName -> t2:Table`
---
--- Reshapes the input table and make it longer. The data kept in the named columns are moved to two new columns, one for the column names and the other for the cell values.
---
--- > pivotLonger(gradebook, ["midterm", "final"], "exam", "score")
--- | name    | age | quiz1 | quiz2 | quiz3 | quiz4 | exam      | score |
--- | ------- | --- | ----- | ----- | ----- | ----- | --------- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 7     | 9     | "midterm" | 77    |
--- | "Bob"   | 12  | 8     | 9     | 7     | 9     | "final"   | 87    |
--- | "Alice" | 17  | 6     | 8     | 8     | 7     | "midterm" | 88    |
--- | "Alice" | 17  | 6     | 8     | 8     | 7     | "final"   | 85    |
--- | "Eve"   | 13  | 7     | 9     | 8     | 8     | "midterm" | 84    |
--- | "Eve"   | 13  | 7     | 9     | 8     | 8     | "final"   | 77    |
--- > pivotLonger(gradebook, ["quiz1", "quiz2", "quiz3", "quiz4", "midterm", "final"], "test", "score")
--- | name    | age | test      | score |
--- | ------- | --- | --------- | ----- |
--- | "Bob"   | 12  | "quiz1"   | 8     |
--- | "Bob"   | 12  | "quiz2"   | 9     |
--- | "Bob"   | 12  | "quiz3"   | 7     |
--- | "Bob"   | 12  | "quiz4"   | 9     |
--- | "Bob"   | 12  | "midterm" | 77    |
--- | "Bob"   | 12  | "final"   | 87    |
--- | "Alice" | 17  | "quiz1"   | 6     |
--- | "Alice" | 17  | "quiz2"   | 8     |
--- | "Alice" | 17  | "quiz3"   | 8     |
--- | "Alice" | 17  | "quiz4"   | 7     |
--- | "Alice" | 17  | "midterm" | 88    |
--- | "Alice" | 17  | "final"   | 85    |
--- | "Eve"   | 13  | "quiz1"   | 7     |
--- | "Eve"   | 13  | "quiz2"   | 9     |
--- | "Eve"   | 13  | "quiz3"   | 8     |
--- | "Eve"   | 13  | "quiz4"   | 8     |
--- | "Eve"   | 13  | "midterm" | 84    |
--- | "Eve"   | 13  | "final"   | 77    |
+# ### `pivotLonger :: t1:Table * cs:Seq<ColName> * c1:ColName * c2:ColName -> t2:Table`
+#
+# Reshapes the input table and make it longer. The data kept in the named columns are moved to two new columns, one for the column names and the other for the cell values.
+#
+# > pivotLonger(gradebook, ["midterm", "final"], "exam", "score")
+# | name    | age | quiz1 | quiz2 | quiz3 | quiz4 | exam      | score |
+# | ------- | --- | ----- | ----- | ----- | ----- | --------- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 7     | 9     | "midterm" | 77    |
+# | "Bob"   | 12  | 8     | 9     | 7     | 9     | "final"   | 87    |
+# | "Alice" | 17  | 6     | 8     | 8     | 7     | "midterm" | 88    |
+# | "Alice" | 17  | 6     | 8     | 8     | 7     | "final"   | 85    |
+# | "Eve"   | 13  | 7     | 9     | 8     | 8     | "midterm" | 84    |
+# | "Eve"   | 13  | 7     | 9     | 8     | 8     | "final"   | 77    |
+# > pivotLonger(gradebook, ["quiz1", "quiz2", "quiz3", "quiz4", "midterm", "final"], "test", "score")
+# | name    | age | test      | score |
+# | ------- | --- | --------- | ----- |
+# | "Bob"   | 12  | "quiz1"   | 8     |
+# | "Bob"   | 12  | "quiz2"   | 9     |
+# | "Bob"   | 12  | "quiz3"   | 7     |
+# | "Bob"   | 12  | "quiz4"   | 9     |
+# | "Bob"   | 12  | "midterm" | 77    |
+# | "Bob"   | 12  | "final"   | 87    |
+# | "Alice" | 17  | "quiz1"   | 6     |
+# | "Alice" | 17  | "quiz2"   | 8     |
+# | "Alice" | 17  | "quiz3"   | 8     |
+# | "Alice" | 17  | "quiz4"   | 7     |
+# | "Alice" | 17  | "midterm" | 88    |
+# | "Alice" | 17  | "final"   | 85    |
+# | "Eve"   | 13  | "quiz1"   | 7     |
+# | "Eve"   | 13  | "quiz2"   | 9     |
+# | "Eve"   | 13  | "quiz3"   | 8     |
+# | "Eve"   | 13  | "quiz4"   | 8     |
+# | "Eve"   | 13  | "midterm" | 84    |
+# | "Eve"   | 13  | "final"   | 77    |
 
 '### TODO: `pivotWider` (lists of labels)
 
--- Note that this time the list of labels is in the table column
--- Not sure how to deal with that...
+# Note that this time the list of labels is in the table column
+# Not sure how to deal with that...
 
--- ### `pivotWider :: t1:Table * c1:ColName * c2:ColName -> t2:Table`
---
--- The inverse of `pivotLonger`.
---
--- > pivotWider(students, "name", "age")
--- | favorite color | Bob | Alice | Eve |
--- | -------------- | --- | ----- | --- |
--- | "blue"         | 12  |       |     |
--- | "green"        |     | 17    |     |
--- | "red"          |     |       | 13  |
--- > longerTable =
---     pivotLonger(
---       gradebook,
---       ["quiz1", "quiz2", "quiz3", "quiz4", "midterm", "final"],
---       "test",
---       "score")
--- > pivotWider(longerTable, "test", "score")
--- | name    | age | quiz1 | quiz2 | quiz3 | quiz4 | midterm | final |
--- | ------- | --- | ----- | ----- | ----- | ----- | ------- | ----- |
--- | "Bob"   | 12  | 8     | 9     | 7     | 9     | 77      | 87    |
--- | "Alice" | 17  | 6     | 8     | 8     | 7     | 88      | 85    |
--- | "Eve"   | 13  | 7     | 9     | 8     | 8     | 84      | 77    |
+# ### `pivotWider :: t1:Table * c1:ColName * c2:ColName -> t2:Table`
+#
+# The inverse of `pivotLonger`.
+#
+# > pivotWider(students, "name", "age")
+# | favorite color | Bob | Alice | Eve |
+# | -------------- | --- | ----- | --- |
+# | "blue"         | 12  |       |     |
+# | "green"        |     | 17    |     |
+# | "red"          |     |       | 13  |
+# > longerTable =
+#     pivotLonger(
+#       gradebook,
+#       ["quiz1", "quiz2", "quiz3", "quiz4", "midterm", "final"],
+#       "test",
+#       "score")
+# > pivotWider(longerTable, "test", "score")
+# | name    | age | quiz1 | quiz2 | quiz3 | quiz4 | midterm | final |
+# | ------- | --- | ----- | ----- | ----- | ----- | ------- | ----- |
+# | "Bob"   | 12  | 8     | 9     | 7     | 9     | 77      | 87    |
+# | "Alice" | 17  | 6     | 8     | 8     | 7     | 88      | 85    |
+# | "Eve"   | 13  | 7     | 9     | 8     | 8     | 84      | 77    |
 
 '## Utilities
 
 '### TODO: `flatten` (fields map)
 
--- Can't zip multiple columns together... A typeclass could help.
+# Can't zip multiple columns together... A typeclass could help.
 
 def flatten (c:Label) (t:n=>{@c:m=>a & ...f}) : (n&m)=>{@c:a & ...f} = todo
 
--- ### `flatten :: t1:Table * cs:Seq<ColName> -> t2:Table`
---
--- When columns `cs` of table `t` have sequences, returns a `Table` where each element of each `c` in `cs` is flattened, meaning the column corresponding to `c` becomes a longer column where the original entries are concatenated. Elements of row `i` of `t` in columns other than `cs` will be repeated according to the length of `getValue(getRow(t1, i), c1)`. These lengths must therefore be the same for each `c` in `cs`.
---
--- > flatten(gradebookSeq, ["quizzes"])
--- | name    | age | quizzes | midterm | final |
--- | ------- | --- | ------- | ------- | ----- |
--- | "Bob"   | 12  | 8       | 77      | 87    |
--- | "Bob"   | 12  | 9       | 77      | 87    |
--- | "Bob"   | 12  | 7       | 77      | 87    |
--- | "Bob"   | 12  | 9       | 77      | 87    |
--- | "Alice" | 17  | 6       | 88      | 85    |
--- | "Alice" | 17  | 8       | 88      | 85    |
--- | "Alice" | 17  | 8       | 88      | 85    |
--- | "Alice" | 17  | 7       | 88      | 85    |
--- | "Eve"   | 13  | 7       | 84      | 77    |
--- | "Eve"   | 13  | 9       | 84      | 77    |
--- | "Eve"   | 13  | 8       | 84      | 77    |
--- | "Eve"   | 13  | 8       | 84      | 77    |
--- > t = buildColumn(gradebookSeq, "quiz-pass?",
---     function(r):
---       isPass =
---         function(n):
---           n >= 8
---         end
---       map(getValue(r, "quizzes"), isPass)
---     end)
--- > t
--- | name    | age | quizzes      | midterm | final | quiz-pass?                 |
--- | ------- | --- | ------------ | ------- | ----- | -------------------------- |
--- | "Bob"   | 12  | [8, 9, 7, 9] | 77      | 87    | [true, true, false, true]  |
--- | "Alice" | 17  | [6, 8, 8, 7] | 88      | 85    | [false, true, true, false] |
--- | "Eve"   | 13  | [7, 9, 8, 8] | 84      | 77    | [false, true, true, true]  |
--- > flatten(t, ["quiz-pass?", "quizzes"])
--- | name    | age | quizzes | midterm | final | quiz-pass? |
--- | ------- | --- | ------- | ------- | ----- | ---------- |
--- | "Bob"   | 12  | 8       | 77      | 87    | true       |
--- | "Bob"   | 12  | 9       | 77      | 87    | true       |
--- | "Bob"   | 12  | 7       | 77      | 87    | false      |
--- | "Bob"   | 12  | 9       | 77      | 87    | true       |
--- | "Alice" | 17  | 6       | 88      | 85    | false      |
--- | "Alice" | 17  | 8       | 88      | 85    | true       |
--- | "Alice" | 17  | 8       | 88      | 85    | true       |
--- | "Alice" | 17  | 7       | 88      | 85    | false      |
--- | "Eve"   | 13  | 7       | 84      | 77    | false      |
--- | "Eve"   | 13  | 9       | 84      | 77    | true       |
--- | "Eve"   | 13  | 8       | 84      | 77    | true       |
--- | "Eve"   | 13  | 8       | 84      | 77    | true       |
+# ### `flatten :: t1:Table * cs:Seq<ColName> -> t2:Table`
+#
+# When columns `cs` of table `t` have sequences, returns a `Table` where each element of each `c` in `cs` is flattened, meaning the column corresponding to `c` becomes a longer column where the original entries are concatenated. Elements of row `i` of `t` in columns other than `cs` will be repeated according to the length of `getValue(getRow(t1, i), c1)`. These lengths must therefore be the same for each `c` in `cs`.
+#
+# > flatten(gradebookSeq, ["quizzes"])
+# | name    | age | quizzes | midterm | final |
+# | ------- | --- | ------- | ------- | ----- |
+# | "Bob"   | 12  | 8       | 77      | 87    |
+# | "Bob"   | 12  | 9       | 77      | 87    |
+# | "Bob"   | 12  | 7       | 77      | 87    |
+# | "Bob"   | 12  | 9       | 77      | 87    |
+# | "Alice" | 17  | 6       | 88      | 85    |
+# | "Alice" | 17  | 8       | 88      | 85    |
+# | "Alice" | 17  | 8       | 88      | 85    |
+# | "Alice" | 17  | 7       | 88      | 85    |
+# | "Eve"   | 13  | 7       | 84      | 77    |
+# | "Eve"   | 13  | 9       | 84      | 77    |
+# | "Eve"   | 13  | 8       | 84      | 77    |
+# | "Eve"   | 13  | 8       | 84      | 77    |
+# > t = buildColumn(gradebookSeq, "quiz-pass?",
+#     function(r):
+#       isPass =
+#         function(n):
+#           n >= 8
+#         end
+#       map(getValue(r, "quizzes"), isPass)
+#     end)
+# > t
+# | name    | age | quizzes      | midterm | final | quiz-pass?                 |
+# | ------- | --- | ------------ | ------- | ----- | -------------------------- |
+# | "Bob"   | 12  | [8, 9, 7, 9] | 77      | 87    | [true, true, false, true]  |
+# | "Alice" | 17  | [6, 8, 8, 7] | 88      | 85    | [false, true, true, false] |
+# | "Eve"   | 13  | [7, 9, 8, 8] | 84      | 77    | [false, true, true, true]  |
+# > flatten(t, ["quiz-pass?", "quizzes"])
+# | name    | age | quizzes | midterm | final | quiz-pass? |
+# | ------- | --- | ------- | ------- | ----- | ---------- |
+# | "Bob"   | 12  | 8       | 77      | 87    | true       |
+# | "Bob"   | 12  | 9       | 77      | 87    | true       |
+# | "Bob"   | 12  | 7       | 77      | 87    | false      |
+# | "Bob"   | 12  | 9       | 77      | 87    | true       |
+# | "Alice" | 17  | 6       | 88      | 85    | false      |
+# | "Alice" | 17  | 8       | 88      | 85    | true       |
+# | "Alice" | 17  | 8       | 88      | 85    | true       |
+# | "Alice" | 17  | 7       | 88      | 85    | false      |
+# | "Eve"   | 13  | 7       | 84      | 77    | false      |
+# | "Eve"   | 13  | 9       | 84      | 77    | true       |
+# | "Eve"   | 13  | 8       | 84      | 77    | true       |
+# | "Eve"   | 13  | 8       | 84      | 77    | true       |
 
 def transformColumn {n f a b} (c:Label) (t:n=>{@c:a & ...f}) (fn:a -> b) : n=>{@c:b & ...f} =
   for i.
     {@c=v, ...r} = t.i
     {@c=fn v, ...r}
 
--- > addLastName =
---     function(name):
---       concat(name, " Smith")
---     end
--- > transformColumn(students, "name", addLastName)
--- | name          | age | favorite color |
--- | ------------- | --- | -------------- |
--- | "Bob Smith"   | 12  | "blue"         |
--- | "Alice Smith" | 17  | "green"        |
--- | "Eve Smith"   | 13  | "red"          |
--- > quizScoreToPassFail =
---     function(score):
---       if score <= 6:
---         "fail"
---       else:
---         "pass"
---       end
---     end
--- > transformColumn(gradebook, "quiz1", quizScoreToPassFail)
--- | name    | age | quiz1  | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ------ | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | "pass" | 9     | 77      | 7     | 9     | 87    |
--- | "Alice" | 17  | "fail" | 8     | 88      | 8     | 7     | 85    |
--- | "Eve"   | 13  | "pass" | 9     | 84      | 8     | 8     | 77    |
+# > addLastName =
+#     function(name):
+#       concat(name, " Smith")
+#     end
+# > transformColumn(students, "name", addLastName)
+# | name          | age | favorite color |
+# | ------------- | --- | -------------- |
+# | "Bob Smith"   | 12  | "blue"         |
+# | "Alice Smith" | 17  | "green"        |
+# | "Eve Smith"   | 13  | "red"          |
+# > quizScoreToPassFail =
+#     function(score):
+#       if score <= 6:
+#         "fail"
+#       else:
+#         "pass"
+#       end
+#     end
+# > transformColumn(gradebook, "quiz1", quizScoreToPassFail)
+# | name    | age | quiz1  | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ------ | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | "pass" | 9     | 77      | 7     | 9     | 87    |
+# | "Alice" | 17  | "fail" | 8     | 88      | 8     | 7     | 85    |
+# | "Eve"   | 13  | "pass" | 9     | 84      | 8     | 8     | 77    |
 
 '### TODO: `renameColumns` (fields map)
 
@@ -893,250 +893,250 @@ def renameColumn (c:Label) (c':Label) (t:n=>{@c:a & ...f}) : n=>{@c':a & ...f} =
     {@c=v, ...rest} = t.i
     {@c'=v, ...rest}
 
--- ### `renameColumns :: t1:Table * ccs:Seq<ColName * ColName> -> t2:Table`
--- > renameColumns(students, [("favorite color", "preferred color"), ("name", "first name")])
--- | first name | age | preferred color |
--- | ---------- | --- | --------------- |
--- | "Bob"      | 12  | "blue"          |
--- | "Alice"    | 17  | "green"         |
--- | "Eve"      | 13  | "red"           |
--- > renameColumns(gradebook, [("midterm", "final"), ("final", "midterm")])
--- | name    | age | quiz1 | quiz2 | final | quiz3 | quiz4 | midterm |
--- | ------- | --- | ----- | ----- | ----- | ----- | ----- | ------- |
--- | "Bob"   | 12  | 8     | 9     | 77    | 7     | 9     | 87      |
--- | "Alice" | 17  | 6     | 8     | 88    | 8     | 7     | 85      |
--- | "Eve"   | 13  | 7     | 9     | 84    | 8     | 8     | 77      |
+# ### `renameColumns :: t1:Table * ccs:Seq<ColName * ColName> -> t2:Table`
+# > renameColumns(students, [("favorite color", "preferred color"), ("name", "first name")])
+# | first name | age | preferred color |
+# | ---------- | --- | --------------- |
+# | "Bob"      | 12  | "blue"          |
+# | "Alice"    | 17  | "green"         |
+# | "Eve"      | 13  | "red"           |
+# > renameColumns(gradebook, [("midterm", "final"), ("final", "midterm")])
+# | name    | age | quiz1 | quiz2 | final | quiz3 | quiz4 | midterm |
+# | ------- | --- | ----- | ----- | ----- | ----- | ----- | ------- |
+# | "Bob"   | 12  | 8     | 9     | 77    | 7     | 9     | 87      |
+# | "Alice" | 17  | 6     | 8     | 88    | 8     | 7     | 85      |
+# | "Eve"   | 13  | 7     | 9     | 84    | 8     | 8     | 77      |
 
 def find [Eq a] (t:n=>a) (x:a) : Maybe n = todo
 
--- ### `find :: t:Table * r:Row -> n:Error<Number>`
--- > find(students, [row: ("age", 13)])
--- 2
--- > find(students, [row: ("age", 14)])
--- error("not found")
+# ### `find :: t:Table * r:Row -> n:Error<Number>`
+# > find(students, [row: ("age", 13)])
+# 2
+# > find(students, [row: ("age", 14)])
+# error("not found")
 
 '### TODO: `groupByRetentive` (groupBy)
 
 def groupByRetentive {n f a} (c:Label) (t:n=>{@c:a & ...f}) : List {key: a & groups:(List {@c:a & ...f})} = todo
 
--- ### `groupByRetentive :: t1:Table * c:ColName -> t2:Table`
--- > groupByRetentive(students, "favorite color")
--- | key     | groups                             |
--- | ------- | ---------------------------------- |
--- | "blue"  | | name    | age | favorite color | |
--- |         | | ------- | --- | -------------- | |
--- |         | | "Bob"   | 12  | "blue"         | |
--- | "green" | | name    | age | favorite color | |
--- |         | | ------- | --- | -------------- | |
--- |         | | "Alice" | 17  | "green"        | |
--- | "red"   | | name    | age | favorite color | |
--- |         | | ------- | --- | -------------- | |
--- |         | | "Eve"   | 13  | "red"          | |
--- > groupByRetentive(jellyAnon, "brown")
--- | key   | groups                                                                                  |
--- | ----- | --------------------------------------------------------------------------------------- |
--- | false | | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple | |
--- |       | | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ | |
--- |       | | true     | false | false | false | true  | false  | false | true   | false | false  | |
--- |       | | true     | false | true  | false | true  | true   | false | false  | false | false  | |
--- |       | | false    | false | false | false | true  | false  | false | false  | true  | false  | |
--- |       | | false    | false | false | false | false | true   | false | false  | false | false  | |
--- |       | | false    | false | false | false | false | true   | false | false  | true  | false  | |
--- |       | | true     | false | true  | false | false | false  | false | true   | true  | false  | |
--- |       | | false    | false | true  | false | false | false  | false | false  | true  | false  | |
--- |       | | true     | false | false | false | false | false  | false | true   | false | false  | |
--- | true  | | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple | |
--- |       | | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ | |
--- |       | | true     | false | false | false | false | false  | true  | true   | false | false  | |
--- |       | | false    | true  | false | false | false | true   | true  | false  | true  | false  | |
+# ### `groupByRetentive :: t1:Table * c:ColName -> t2:Table`
+# > groupByRetentive(students, "favorite color")
+# | key     | groups                             |
+# | ------- | ---------------------------------- |
+# | "blue"  | | name    | age | favorite color | |
+# |         | | ------- | --- | -------------- | |
+# |         | | "Bob"   | 12  | "blue"         | |
+# | "green" | | name    | age | favorite color | |
+# |         | | ------- | --- | -------------- | |
+# |         | | "Alice" | 17  | "green"        | |
+# | "red"   | | name    | age | favorite color | |
+# |         | | ------- | --- | -------------- | |
+# |         | | "Eve"   | 13  | "red"          | |
+# > groupByRetentive(jellyAnon, "brown")
+# | key   | groups                                                                                  |
+# | ----- | --------------------------------------------------------------------------------------- |
+# | false | | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple | |
+# |       | | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ | |
+# |       | | true     | false | false | false | true  | false  | false | true   | false | false  | |
+# |       | | true     | false | true  | false | true  | true   | false | false  | false | false  | |
+# |       | | false    | false | false | false | true  | false  | false | false  | true  | false  | |
+# |       | | false    | false | false | false | false | true   | false | false  | false | false  | |
+# |       | | false    | false | false | false | false | true   | false | false  | true  | false  | |
+# |       | | true     | false | true  | false | false | false  | false | true   | true  | false  | |
+# |       | | false    | false | true  | false | false | false  | false | false  | true  | false  | |
+# |       | | true     | false | false | false | false | false  | false | true   | false | false  | |
+# | true  | | get acne | red   | black | white | green | yellow | brown | orange | pink  | purple | |
+# |       | | -------- | ----- | ----- | ----- | ----- | ------ | ----- | ------ | ----- | ------ | |
+# |       | | true     | false | false | false | false | false  | true  | true   | false | false  | |
+# |       | | false    | true  | false | false | false | true   | true  | false  | true  | false  | |
 
 '### TODO: `groupBySubtractive` (groupBy)
 
 def groupBySubtractive {n f a} (c:Label) (t:n=>{@c:a & ...f}) : List {key: a & groups:(List {&...f})} = todo
--- ### `groupBySubtractive :: t1:Table * c:ColName -> t2:Table`
---
--- Similar to `groupByRetentive` but the named column is removed in the output.
---
--- > groupBySubtractive(students, "favorite color")
--- | key     | groups            |
--- | ------- | ----------------- |
--- | "blue"  | | name    | age | |
--- |         | | ------- | --- | |
--- |         | | "Bob"   | 12  | |
--- | "green" | | name    | age | |
--- |         | | ------- | --- | |
--- |         | | "Alice" | 17  | |
--- | "red"   | | name    | age | |
--- |         | | ------- | --- | |
--- |         | | "Eve"   | 13  | |
--- > groupBySubtractive(jellyAnon, "brown")
--- | key   | groups                                                                          |
--- | ----- | ------------------------------------------------------------------------------- |
--- | false | | get acne | red   | black | white | green | yellow | orange | pink  | purple | |
--- |       | | -------- | ----- | ----- | ----- | ----- | ------ | ------ | ----- | ------ | |
--- |       | | true     | false | false | false | true  | false  | true   | false | false  | |
--- |       | | true     | false | true  | false | true  | true   | false  | false | false  | |
--- |       | | false    | false | false | false | true  | false  | false  | true  | false  | |
--- |       | | false    | false | false | false | false | true   | false  | false | false  | |
--- |       | | false    | false | false | false | false | true   | false  | true  | false  | |
--- |       | | true     | false | true  | false | false | false  | true   | true  | false  | |
--- |       | | false    | false | true  | false | false | false  | false  | true  | false  | |
--- |       | | true     | false | false | false | false | false  | true   | false | false  | |
--- | true  | | get acne | red   | black | white | green | yellow | orange | pink  | purple | |
--- |       | | -------- | ----- | ----- | ----- | ----- | ------ | ------ | ----- | ------ | |
--- |       | | true     | false | false | false | false | false  | true   | false | false  | |
--- |       | | false    | true  | false | false | false | true   | false  | true  | false  | |
+# ### `groupBySubtractive :: t1:Table * c:ColName -> t2:Table`
+#
+# Similar to `groupByRetentive` but the named column is removed in the output.
+#
+# > groupBySubtractive(students, "favorite color")
+# | key     | groups            |
+# | ------- | ----------------- |
+# | "blue"  | | name    | age | |
+# |         | | ------- | --- | |
+# |         | | "Bob"   | 12  | |
+# | "green" | | name    | age | |
+# |         | | ------- | --- | |
+# |         | | "Alice" | 17  | |
+# | "red"   | | name    | age | |
+# |         | | ------- | --- | |
+# |         | | "Eve"   | 13  | |
+# > groupBySubtractive(jellyAnon, "brown")
+# | key   | groups                                                                          |
+# | ----- | ------------------------------------------------------------------------------- |
+# | false | | get acne | red   | black | white | green | yellow | orange | pink  | purple | |
+# |       | | -------- | ----- | ----- | ----- | ----- | ------ | ------ | ----- | ------ | |
+# |       | | true     | false | false | false | true  | false  | true   | false | false  | |
+# |       | | true     | false | true  | false | true  | true   | false  | false | false  | |
+# |       | | false    | false | false | false | true  | false  | false  | true  | false  | |
+# |       | | false    | false | false | false | false | true   | false  | false | false  | |
+# |       | | false    | false | false | false | false | true   | false  | true  | false  | |
+# |       | | true     | false | true  | false | false | false  | true   | true  | false  | |
+# |       | | false    | false | true  | false | false | false  | false  | true  | false  | |
+# |       | | true     | false | false | false | false | false  | true   | false | false  | |
+# | true  | | get acne | red   | black | white | green | yellow | orange | pink  | purple | |
+# |       | | -------- | ----- | ----- | ----- | ----- | ------ | ------ | ----- | ------ | |
+# |       | | true     | false | false | false | false | false  | true   | false | false  | |
+# |       | | false    | true  | false | false | false | true   | false  | true  | false  | |
 
 '### TODO: `update` (???)
 
--- ### `update :: t1:Table * f:(r1:Row -> r2:Row) -> t2:Table`
---
--- Consumes an existing `Table` and produces a new `Table` with the named columns updated, using `f` to produce the values for those columns, once for each row.
---
--- > abstractAge =
---     function(r):
---       if (getValue(r, "age") <= 12):
---         [row: ("age", "kid")]
---       else if (getValue(r, "age") <= 19):
---         [row: ("age", "teenager")]
---       else:
---         [row: ("age", "adult")]
---       end
---     end
--- > update(students, abstractAge)
--- | name    | age        | favorite color |
--- | ------- | ---------- | -------------- |
--- | "Bob"   | "kid"      | "blue"         |
--- | "Alice" | "teenager" | "green"        |
--- | "Eve"   | "teenager" | "red"          |
--- > didWellInFinal =
---     function(r):
---       [row:
---         ("midterm", 85 <= getValue(r, "midterm"))
---         ("final", 85 <= getValue(r, "final"))]
---     end
--- > update(gradebook, didWellInFinal)
--- | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
--- | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
--- | "Bob"   | 12  | 8     | 9     | false   | 7     | 9     | true  |
--- | "Alice" | 17  | 6     | 8     | true    | 8     | 7     | true  |
--- | "Eve"   | 13  | 7     | 9     | false   | 8     | 8     | false |
+# ### `update :: t1:Table * f:(r1:Row -> r2:Row) -> t2:Table`
+#
+# Consumes an existing `Table` and produces a new `Table` with the named columns updated, using `f` to produce the values for those columns, once for each row.
+#
+# > abstractAge =
+#     function(r):
+#       if (getValue(r, "age") <= 12):
+#         [row: ("age", "kid")]
+#       else if (getValue(r, "age") <= 19):
+#         [row: ("age", "teenager")]
+#       else:
+#         [row: ("age", "adult")]
+#       end
+#     end
+# > update(students, abstractAge)
+# | name    | age        | favorite color |
+# | ------- | ---------- | -------------- |
+# | "Bob"   | "kid"      | "blue"         |
+# | "Alice" | "teenager" | "green"        |
+# | "Eve"   | "teenager" | "red"          |
+# > didWellInFinal =
+#     function(r):
+#       [row:
+#         ("midterm", 85 <= getValue(r, "midterm"))
+#         ("final", 85 <= getValue(r, "final"))]
+#     end
+# > update(gradebook, didWellInFinal)
+# | name    | age | quiz1 | quiz2 | midterm | quiz3 | quiz4 | final |
+# | ------- | --- | ----- | ----- | ------- | ----- | ----- | ----- |
+# | "Bob"   | 12  | 8     | 9     | false   | 7     | 9     | true  |
+# | "Alice" | 17  | 6     | 8     | true    | 8     | 7     | true  |
+# | "Eve"   | 13  | 7     | 9     | false   | 8     | 8     | false |
 
 def select (t:n=>a) (f:a -> n -> b) : n=>b = for i. f t.i i
 
--- > select(
---     students,
---     function(r, n):
---       [row:
---         ("ID", n),
---         ("COLOR", getValue(r, "favorite color")),
---         ("AGE", getValue(r, "age"))]
---     end)
--- | ID | COLOR   | AGE |
--- | -- | ------- | --- |
--- | 0  | "blue"  | 12  |
--- | 1  | "green" | 17  |
--- | 2  | "red"   | 13  |
--- > select(
---     gradebook,
---     function(r, n):
---       [row:
---         ("full name", concat(getValue(r, "name"), " Smith")),
---         ("(midterm + final) / 2", (getValue(r, "midterm") + getValue(r, "final")) / 2)]
---     end)
--- | full name     | (midterm + final) / 2 |
--- | ------------- | --------------------- |
--- | "Bob Smith"   | 82                    |
--- | "Alice Smith" | 86.5                  |
--- | "Eve Smith"   | 80.5                  |
+# > select(
+#     students,
+#     function(r, n):
+#       [row:
+#         ("ID", n),
+#         ("COLOR", getValue(r, "favorite color")),
+#         ("AGE", getValue(r, "age"))]
+#     end)
+# | ID | COLOR   | AGE |
+# | -- | ------- | --- |
+# | 0  | "blue"  | 12  |
+# | 1  | "green" | 17  |
+# | 2  | "red"   | 13  |
+# > select(
+#     gradebook,
+#     function(r, n):
+#       [row:
+#         ("full name", concat(getValue(r, "name"), " Smith")),
+#         ("(midterm + final) / 2", (getValue(r, "midterm") + getValue(r, "final")) / 2)]
+#     end)
+# | full name     | (midterm + final) / 2 |
+# | ------------- | --------------------- |
+# | "Bob Smith"   | 82                    |
+# | "Alice Smith" | 86.5                  |
+# | "Eve Smith"   | 80.5                  |
 
 def selectMany (t:n=>a) (project:a -> n -> List b) (result:a -> b -> c) : List a =
   todo $ for i.
     AsList _ els = project t.i i
     for j. result t.i els.j
 
--- Projects each row of a table to a new table, flattens the resulting tables into one table, and invokes a result selector function on each row therein. The index of each source row is used in the intermediate projected form of that row.
---
--- > selectMany(
---     students,
---     function(r, n):
---       if even(n):
---         r
---       else:
---         head(r, 0)
---       end
---     end,
---     function(r1, r2):
---       r2
---     end)
--- | name  | age | favorite color |
--- | ----- | --- | -------------- |
--- | "Bob" | 12  | "blue"         |
--- | "Eve" | 13  | "red"          |
--- > repeatRow =
---     function(r, n):
---       if n == 0:
---         r
---       else:
---         addRows(repeatRow(r, n - 1), [r])
---       end
---     end
--- > selectMany(
---     gradebook,
---     repeatRow,
---     function(r1, r2):
---       selectColumns(r2, ["midterm"])
---     end)
--- | midterm |
--- | ------- |
--- | 77      |
--- | 88      |
--- | 88      |
--- | 84      |
--- | 84      |
--- | 84      |
+# Projects each row of a table to a new table, flattens the resulting tables into one table, and invokes a result selector function on each row therein. The index of each source row is used in the intermediate projected form of that row.
+#
+# > selectMany(
+#     students,
+#     function(r, n):
+#       if even(n):
+#         r
+#       else:
+#         head(r, 0)
+#       end
+#     end,
+#     function(r1, r2):
+#       r2
+#     end)
+# | name  | age | favorite color |
+# | ----- | --- | -------------- |
+# | "Bob" | 12  | "blue"         |
+# | "Eve" | 13  | "red"          |
+# > repeatRow =
+#     function(r, n):
+#       if n == 0:
+#         r
+#       else:
+#         addRows(repeatRow(r, n - 1), [r])
+#       end
+#     end
+# > selectMany(
+#     gradebook,
+#     repeatRow,
+#     function(r1, r2):
+#       selectColumns(r2, ["midterm"])
+#     end)
+# | midterm |
+# | ------- |
+# | 77      |
+# | 88      |
+# | 88      |
+# | 84      |
+# | 84      |
+# | 84      |
 
 '### TODO: `groupJoin` (groupBy)
 
--- ### `groupJoin<K> :: t1:Table * t2:Table * getKey1:(r1:Row -> k1:K) * getKey2:(r2:Row -> k2:K) * aggregate:(r3:Row * t3:Table -> r4:Row) -> t4:Table`
---
--- - `schema(r1)` is equal to `schema(t1)`
--- - `schema(r2)` is equal to `schema(t2)`
--- - `schema(r3)` is equal to `schema(t1)`
--- - `schema(t3)` is equal to `schema(t2)`
--- - `schema(t4)` is equal to `schema(r4)`
--- - `nrows(t4)` is equal to `nrows(t1)`
---
--- Correlates the rows of two tables based on equality of keys and groups the results.
---
--- > getName =
---     function(r):
---       getValue(r, "name")
---     end
--- > averageFinal =
---     function(r, t):
---       addColumn(r, "final", [average(getColumn(t, "final"))])
---     end
--- > groupJoin(students, gradebook, getName, getName, averageFinal)
--- | name    | age | favorite color | final |
--- | ------- | --- | -------------- | ----- |
--- | "Bob"   | 12  | "blue"         | 87    |
--- | "Alice" | 17  | "green"        | 85    |
--- | "Eve"   | 13  | "red"          | 77    |
--- > nameLength =
---     function(r):
---       length(getValue(r, "name"))
---     end
--- > tableNRows =
---     function(r, t):
---       addColumn(r, "nrows", [nrows(t)])
---     end
--- > groupJoin(students, gradebook, nameLength, nameLength, tableNRows)
--- | name    | age | favorite color | nrows |
--- | ------- | --- | -------------- | ----- |
--- | "Bob"   | 12  | "blue"         | 2     |
--- | "Alice" | 17  | "green"        | 1     |
--- | "Eve"   | 13  | "red"          | 2     |
+# ### `groupJoin<K> :: t1:Table * t2:Table * getKey1:(r1:Row -> k1:K) * getKey2:(r2:Row -> k2:K) * aggregate:(r3:Row * t3:Table -> r4:Row) -> t4:Table`
+#
+# - `schema(r1)` is equal to `schema(t1)`
+# - `schema(r2)` is equal to `schema(t2)`
+# - `schema(r3)` is equal to `schema(t1)`
+# - `schema(t3)` is equal to `schema(t2)`
+# - `schema(t4)` is equal to `schema(r4)`
+# - `nrows(t4)` is equal to `nrows(t1)`
+#
+# Correlates the rows of two tables based on equality of keys and groups the results.
+#
+# > getName =
+#     function(r):
+#       getValue(r, "name")
+#     end
+# > averageFinal =
+#     function(r, t):
+#       addColumn(r, "final", [average(getColumn(t, "final"))])
+#     end
+# > groupJoin(students, gradebook, getName, getName, averageFinal)
+# | name    | age | favorite color | final |
+# | ------- | --- | -------------- | ----- |
+# | "Bob"   | 12  | "blue"         | 87    |
+# | "Alice" | 17  | "green"        | 85    |
+# | "Eve"   | 13  | "red"          | 77    |
+# > nameLength =
+#     function(r):
+#       length(getValue(r, "name"))
+#     end
+# > tableNRows =
+#     function(r, t):
+#       addColumn(r, "nrows", [nrows(t)])
+#     end
+# > groupJoin(students, gradebook, nameLength, nameLength, tableNRows)
+# | name    | age | favorite color | nrows |
+# | ------- | --- | -------------- | ----- |
+# | "Bob"   | 12  | "blue"         | 2     |
+# | "Alice" | 17  | "green"        | 1     |
+# | "Eve"   | 13  | "red"          | 2     |
 
 def join [Eq key] (t1:n=>a) (t2:m=>b) (getKey1:a -> key) (getKey2:b -> key)
          (combine:a -> b -> c) : List c =
@@ -1145,32 +1145,32 @@ def join [Eq key] (t1:n=>a) (t2:m=>b) (getKey1:a -> key) (getKey2:b -> key)
       True  -> AsList _ [combine t1.i t2.j]
       False -> mempty
 
--- > getName =
---     function(r):
---       getValue(r, "name")
---     end
--- > addGradeColumn =
---     function(r1, r2):
---       addColumn(r1, "grade", [getValue(r2, "final")])
---     end
--- > join(students, gradebook, getName, getName, addGradeColumn)
--- | name    | age | favorite color | grade |
--- | ------- | --- | -------------- | ----- |
--- | "Bob"   | 12  | "blue"         | 87    |
--- | "Alice" | 17  | "green"        | 85    |
--- | "Eve"   | 13  | "red"          | 77    |
--- > nameLength =
---     function(r):
---       length(getValue(r, "name"))
---     end
--- > join(students, gradebook, nameLength, nameLength, addGradeColumn)
--- | name    | age | favorite color | grade |
--- | ------- | --- | -------------- | ----- |
--- | "Bob"   | 12  | "blue"         | 87    |
--- | "Bob"   | 12  | "blue"         | 77    |
--- | "Alice" | 17  | "green"        | 85    |
--- | "Eve"   | 13  | "red"          | 87    |
--- | "Eve"   | 13  | "red"          | 77    |
+# > getName =
+#     function(r):
+#       getValue(r, "name")
+#     end
+# > addGradeColumn =
+#     function(r1, r2):
+#       addColumn(r1, "grade", [getValue(r2, "final")])
+#     end
+# > join(students, gradebook, getName, getName, addGradeColumn)
+# | name    | age | favorite color | grade |
+# | ------- | --- | -------------- | ----- |
+# | "Bob"   | 12  | "blue"         | 87    |
+# | "Alice" | 17  | "green"        | 85    |
+# | "Eve"   | 13  | "red"          | 77    |
+# > nameLength =
+#     function(r):
+#       length(getValue(r, "name"))
+#     end
+# > join(students, gradebook, nameLength, nameLength, addGradeColumn)
+# | name    | age | favorite color | grade |
+# | ------- | --- | -------------- | ----- |
+# | "Bob"   | 12  | "blue"         | 87    |
+# | "Bob"   | 12  | "blue"         | 77    |
+# | "Alice" | 17  | "green"        | 85    |
+# | "Eve"   | 13  | "red"          | 87    |
+# | "Eve"   | 13  | "red"          | 77    |
 
 '# Buggy programs
 
@@ -1178,24 +1178,24 @@ def join [Eq key] (t1:n=>a) (t2:m=>b) (getKey1:a -> key) (getKey2:b -> key)
 Many comments in this file are derived from the [B2T2](https://github.com/brownplt/B2T2)
 benchmark, which is licensed under MIT, so we reproduce the license.
 
--- MIT License
---
--- Copyright (c) 2022 Brown University PLT
---
--- Permission is hereby granted, free of charge, to any person obtaining a copy
--- of this software and associated documentation files (the "Software"), to deal
--- in the Software without restriction, including without limitation the rights
--- to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
--- copies of the Software, and to permit persons to whom the Software is
--- furnished to do so, subject to the following conditions:
---
--- The above copyright notice and this permission notice shall be included in all
--- copies or substantial portions of the Software.
---
--- THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
--- IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
--- FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
--- AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
--- LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
--- OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
--- SOFTWARE.
+# MIT License
+#
+# Copyright (c) 2022 Brown University PLT
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.

--- a/examples/mcts.dx
+++ b/examples/mcts.dx
@@ -18,7 +18,7 @@ ROLLOUTS_PER_SAMPLE:Nat = 10
 
 ' ## Tree types
 
-data Node(node_ix, a) =
+enum Node(node_ix, a) =
   Branch(content:a, parent:(Maybe node_ix), children:(List (node_ix)))
 
 def Tree(node_ix|Ix, a:Type) -> Type =

--- a/examples/mnist-nearest-neighbors.dx
+++ b/examples/mnist-nearest-neighbors.dx
@@ -1,15 +1,16 @@
 '# THIS FILE IS STALE
 
-'(But we plan to update it at some point)
+'(Syntax has been updated, but the `load dxbo` mechanism no longer exists,
+so this example cannot currently run without a data loading alternative.)
 
-load dxbo "scratch/mnist.dxbo" as mnist
-
-:t mnist
+# load dxbo "scratch/mnist.dxbo" as mnist
+#
+# :t mnist
 
 # TODO: these should come from the data set itself
-type Img = 28=>28=>Float
-type NTrain = 60000
-type NTest  = 10000
+Img = 28=>28=>Float
+NTrain = Fin 60000
+NTest  = Fin 10000
 
 (xsTrain, ysTrain, xsTest, ysTest) = mnist
 
@@ -22,7 +23,7 @@ imgDistance : Img -> Img -> Float
 imgDistance x y = sum for (i,j). sq (x.i.j - y.i.j)
 
 fracTrue : n=>Bool -> Float
-fracTrue xs = mean for i. float (b2i xs.i)
+fracTrue xs = mean for i. b_to_f xs.i
 
 example = asidx @NTest 123
 :plotmat xsTest.example
@@ -32,7 +33,7 @@ closest = findNearestNeighbor imgDistance xsTrain (xsTest.example)
 :plotmat xsTrain.closest
 
 # Make a subset of the test set (evaluating a single test example takes ~80ms)
-type NTestSmall = 1000
+NTestSmall = Fin 1000
 xsTest' = slice @NTestSmall xsTest 0
 ysTest' = slice @NTestSmall ysTest 0
 

--- a/examples/quaternions.dx
+++ b/examples/quaternions.dx
@@ -122,7 +122,7 @@ q = \begin{bmatrix}
 \end{bmatrix}
 $$
 
-data Euler = E(Fin 3=>Float)
+enum Euler = E(Fin 3=>Float)
 
 def euler_to_quat(e:Euler) -> Quaternion =
     (E v) = e

--- a/examples/simplex.dx
+++ b/examples/simplex.dx
@@ -86,17 +86,17 @@ def argmax_suchthat_table [Ord o] (xs:n=>o) (cond:n=>Bool): n =
 
 '### Simplex data types
 
-data SimplexResult n:Type =
+enum SimplexResult n:Type =
   Infeasible
   Unbounded
   Solution (n=>Float)
 
-data ConstraintType =
+enum ConstraintType =
   LessThan
   GreaterThan
   # Todo: Add equality constraints
 
-data ObjectiveType =
+enum ObjectiveType =
   Maximize
   Minimize
 

--- a/examples/vega-plotting.dx
+++ b/examples/vega-plotting.dx
@@ -18,11 +18,11 @@ def join (joiner: List a) (lists:n=>(List a)) : List a =
 ' A serialized JSON Value
 
 # TODO - once Dex supports recursive ADT JValue becomes Value.
-data JValue = AsJValue String
+enum JValue = AsJValue String
 
 ' Simple JSON Data Type
 
-data Value =
+enum Value =
      AsObject (List (String & JValue))
      AsArray (List JValue)
      AsString String
@@ -110,7 +110,7 @@ layout based on a grammar.
 Header = String
 
 
-data EncodingType =
+enum EncodingType =
      Quantitative
      Nominal
      Ordinal
@@ -123,7 +123,7 @@ instance Show EncodingType
          Ordinal -> "ordinal")
 
 
-data Channel =
+enum Channel =
      Y
      X
      Color
@@ -153,7 +153,7 @@ instance Show Channel
   derived from the spec.
 
 
-data Mark =
+enum Mark =
      Area
      Bar
      Circle
@@ -182,7 +182,7 @@ instance Show Mark
   To avoid specifying these, we will take in as
   JSON.
 
-data Opts a =
+enum Opts a =
      WithOpts a Value
 
 def pure (x:a) : Opts a =
@@ -200,7 +200,7 @@ def mergeOpts [ToJSON a, ToJSON b] (x : a) (y : b) : Value =
 
 
 
-data VLChart row col v =
+enum VLChart row col v =
      AsVLDescriptor (Opts Mark) v (col => ({title: Header &
                               encType: EncodingType &
                               encodings: List (Opts Channel) &
@@ -278,7 +278,7 @@ chart1 = (AsVLDescriptor (pure Bar) [("title", "Bar Graph")]
 
 ' First we will construct a Nominal variable for a class.
 
-data Class =
+enum Class =
      A
      B
      C

--- a/makefile
+++ b/makefile
@@ -220,8 +220,10 @@ example-names := \
   latex dither mcts md bfgs
 
 # TODO: re-enable
-# fft vega-plotting
+# fft
 # examples depending on linalg: linear-maps, psd, kernelregression
+
+example-names += vega-plotting
 
 # Only test levenshtein-distance on Linux, because MacOS ships with a
 # different (apparently _very_ different) word list.

--- a/tests/ad-tests.dx
+++ b/tests/ad-tests.dx
@@ -1,5 +1,5 @@
 
--- TODO: use prelude sum instead once we can differentiate state effect
+# TODO: use prelude sum instead once we can differentiate state effect
 def sum'(xs:n=>Float) -> Float given (n|Ix) =
   yield_accum (AddMonoid Float) \ref. for i. ref += xs[i]
 
@@ -133,17 +133,17 @@ def sum'(xs:n=>Float) -> Float given (n|Ix) =
 :p check_deriv sqrt 4.0
 > True
 
--- badDerivFun : Float -> Float
--- badDerivFun x = x
+# badDerivFun : Float -> Float
+# badDerivFun x = x
 
--- badDerivFun#lin : Float -> (Float, Float -> Float)
--- badDerivFun#lin x = (x, llam t. 2. * t)
+# badDerivFun#lin : Float -> (Float, Float -> Float)
+# badDerivFun#lin x = (x, llam t. 2. * t)
 
--- :p checkDeriv badDerivFun 1.0
--- > False
+# :p checkDeriv badDerivFun 1.0
+# > False
 
--- Perturbation confusion test suggested by Barak Pearlmutter
--- https://github.com/HIPS/autograd/issues/4
+# Perturbation confusion test suggested by Barak Pearlmutter
+# https://github.com/HIPS/autograd/issues/4
 :p deriv (\x. x * deriv (\y. x * y) 2.0) 1.0
 > 2.
 
@@ -256,28 +256,28 @@ vec = [1.]
   check_deriv f 2.0
 > True
 
--- :p
---   f = \rec.
---     ({x=x, y=y, z=z}) = rec
---     x * y * i_to_f z
---   (check_deriv (\x. f {x=x, y=4.0, z=5}) 2.0, check_deriv (\y. f {x=2.0, y=y, z=5}) 4.0)
--- > (True, True)
+# :p
+#   f = \rec.
+#     ({x=x, y=y, z=z}) = rec
+#     x * y * i_to_f z
+#   (check_deriv (\x. f {x=x, y=4.0, z=5}) 2.0, check_deriv (\y. f {x=2.0, y=y, z=5}) 4.0)
+# > (True, True)
 
--- TODO: Re-enable once the big PR is merged
--- :p
---   f = \x.
---     y = for i:(Fin 10). { x=x * (IToF $ ordinal i) }
---     z = for i.
---       ({ x=x, ... }) = y.i
---       x
---     sum' z
---   checkDeriv f 1.0
--- > True
+# TODO: Re-enable once the big PR is merged
+# :p
+#   f = \x.
+#     y = for i:(Fin 10). { x=x * (IToF $ ordinal i) }
+#     z = for i.
+#       ({ x=x, ... }) = y.i
+#       x
+#     sum' z
+#   checkDeriv f 1.0
+# > True
 
--- :p
---   f = \x. for i:(Fin 4). { x=x * x * (n_to_f $ ordinal i) }
---   jvp f 2.0 1.0
--- > [{x = 0.}, {x = 4.}, {x = 8.}, {x = 12.}]
+# :p
+#   f = \x. for i:(Fin 4). { x=x * x * (n_to_f $ ordinal i) }
+#   jvp f 2.0 1.0
+# > [{x = 0.}, {x = 4.}, {x = 8.}, {x = 12.}]
 
 :p
   f = \x. max(0.0, x)
@@ -300,7 +300,7 @@ vec = [1.]
   check_deriv f 1.0
 > True
 
--- Test reference indexing
+# Test reference indexing
 :p
   f = \x.
     i = unsafe_from_ordinal(n=Fin 3, 0)
@@ -310,7 +310,7 @@ vec = [1.]
   check_deriv f 1.0
 > True
 
--- Regression test for bug #841, linearization through triangular table
+# Regression test for bug #841, linearization through triangular table
 func = \x:Float.
   table = for i:(Fin 2). for j:(..i). x
   tmp = (0 @ (Fin 2))
@@ -319,7 +319,7 @@ func = \x:Float.
 snd(linearize func 1.0)(2.0)
 > 2.
 
--- Nested AD, examples from #713
+# Nested AD, examples from #713
 def func2(x:m=>Float) -> Float given (m|Ix) =
     exp (0.5 * sum for i. sq x[i])
 
@@ -331,29 +331,29 @@ v = [0.2, 0.3, 0.4]
 func2 x ~~ 1.072508
 > True
 
--- analytic
+# analytic
 result = hvpf x v
 result ~~ [0.235952, 0.364653, 0.493354]
 > True
 
--- finite diff over reverse
+# finite diff over reverse
 eps = 0.0001
 (grad func2 (x + eps .* v) - grad func2 x) / eps ~~ [0.235885, 0.364631, 0.493228]
 > True
 
--- reverse over forward
+# reverse over forward
 grad (\x. jvp func2 x v) x ~~ result
 > True
 
--- reverse over reverse
+# reverse over reverse
 grad (\x. dot (grad func2 x) v) x ~~ result
 > True
 
--- forward over reverse
+# forward over reverse
 jvp (\x. grad func2 x) x v ~~ result
 > True
 
--- Regression test for bug #848, AD through state effect over case
+# Regression test for bug #848, AD through state effect over case
 def min'(a:Float, b:Float) -> Float =
   yield_state a \s.
     best = get s
@@ -366,7 +366,7 @@ grad (\x . (min' x (x+1))) 1.0
 grad (\x . [x][argmin [x]]) 1.0
 > 1.
 
--------------------- Custom linearization --------------------
+#------------------ Custom linearization --------------------
 
 @noinline
 f = \x:Float. x * 2
@@ -380,7 +380,7 @@ deriv (\x. f (x * 2) * 5) 1.0
 deriv f 1.0
 > 4.
 
--- Custom derivative is preserved even when we defunctionalize for
+# Custom derivative is preserved even when we defunctionalize for
 flip deriv 1.0 \x:Float.
   farr = for i:(Fin 5). f
   farr[unsafe_from_ordinal 1] x
@@ -389,7 +389,7 @@ flip deriv 1.0 \x:Float.
 > flip deriv 1.0 \x:Float.
 > ^^^^^
 
--- Custom derivative is preserved even when we defunctionalize case
+# Custom derivative is preserved even when we defunctionalize case
 (\x f. deriv f x) 1.0 \x:Float.
   total = sum $ for i:(Fin 10). ordinal i
   f2 = case total > 10 of
@@ -412,7 +412,7 @@ custom-linearization g \x. (g x, g x)
 >
 > ((x.1:(Float32, Float32)) -> ((Float32, Float32), (Float32, Float32)))
 
-data IHaveNoTangentType = MkIHaveNoTangentType
+enum IHaveNoTangentType = MkIHaveNoTangentType
 
 @noinline
 noInputTangent = \x:IHaveNoTangentType. 2.0
@@ -426,7 +426,7 @@ noOutputTangent = \x:Float. MkIHaveNoTangentType
 custom-linearization noOutputTangent \x. (noOutputTangent x, 0.0)
 > Type error:No tangent type for: IHaveNoTangentType
 
--- Functions of multiple arguments should be supported
+# Functions of multiple arguments should be supported
 @noinline
 h = \x:Float y:Float. x * 2 + y
 hLin = \x y. (h x y, \xt:Float yt:Float. xt + yt)
@@ -436,7 +436,7 @@ custom-linearization h hLin
 deriv (\x. h x x) 1.0 == deriv (\x. x + x) 1.0
 > True
 
--- Index-polymorphic custom linearization
+# Index-polymorphic custom linearization
 @noinline
 def w(x:n=>Float) -> n=>Float given (n|Ix) = 2 .* x
 def wLin(x:n=>Float) -> (n=>Float, (n=>Float) -> n=>Float) given (n|Ix) =
@@ -450,7 +450,7 @@ jvp (\x. w x) [1.0, 1.0] [1.0, 0.0]
 jvp w [1.0, 1.0] [1.0, 0.0]
 > [4., 0.]
 
------- standalone functions ------
+#---- standalone functions ------
 
 @noinline
 def xy2(x:Float, y:Float) -> Float =
@@ -465,7 +465,7 @@ def xy2(x:Float, y:Float) -> Float =
 :p check_deriv (\x. xy2 5.0 x) 2.0
 > True
 
------- Symbolic tangents ------
+#---- Symbolic tangents ------
 
 def ST(a) = SymbolicTangent(a)
 
@@ -491,20 +491,20 @@ custom-linearization q qLin
 
 custom-linearization-symbolic q qLin
 
--- Incorrect derivative, based on the ZeroTangent branch
+# Incorrect derivative, based on the ZeroTangent branch
 deriv (\x. q x 1.0) 1.0
 > 4.
 
--- Correct derivative, based on the SomeTangent branch
+# Correct derivative, based on the SomeTangent branch
 deriv (\x. q x x) 1.0
 > 3.
 
------- Check custom linearization of matmul ------
+#---- Check custom linearization of matmul ------
 
 amat = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
 
--- The derivative of matmul should give the same answers as a direct
--- matmul (this checks that the custom derivative is not too busted).
+# The derivative of matmul should give the same answers as a direct
+# matmul (this checks that the custom derivative is not too busted).
 
 def mmp'(m1:l=>m=>Float, m2:m=>n=>Float) -> l=>n=>Float given (l|Ix, m|Ix, n|Ix) =
   jvp (\m. m1 ** m) m2 m2
@@ -512,7 +512,7 @@ def mmp'(m1:l=>m=>Float, m2:m=>n=>Float) -> l=>n=>Float given (l|Ix, m|Ix, n|Ix)
 :p mmp'(amat, amat) ~~ naive_matmul(amat, amat)
 > True
 
--- Let's check the other orientation too
+# Let's check the other orientation too
 
 def mmp''(m1:l=>m=>Float, m2:m=>n=>Float) -> l=>n=>Float given (l|Ix, m|Ix, n|Ix) =
   jvp (\m. m ** m2) m1 m1

--- a/tests/adt-tests.dx
+++ b/tests/adt-tests.dx
@@ -1,5 +1,5 @@
 
-data IntFloat =
+enum IntFloat =
   MkIntFloat(Int, Float)
 
 :p
@@ -7,7 +7,7 @@ data IntFloat =
     MkIntFloat(x, y) -> (x, y)
 > (1, 2.3)
 
-data MyPair(a:Type, b:Type) =
+enum MyPair(a:Type, b:Type) =
    MkMyPair(a, b)
 
 z = MkMyPair (+1) 2.3
@@ -23,7 +23,7 @@ z = MkMyPair (+1) 2.3
     MkMyPair(x, y) -> (x, y)
 > (1, 2.3)
 
-data Dual(a:Type) =
+enum Dual(a:Type) =
    MkDual(a, a)
 
 :p
@@ -46,11 +46,11 @@ MkMyPair(z1, MkMyPair(z2, z3)) = zz
   tabOfPairs = for i:(Fin 3). MkMyPair (ordinal i) (ordinal i + 1)
   for i.
    case tabOfPairs[i] of
-     -- TODO: investigate shadowing bug if we call these a and b
+     # TODO: investigate shadowing bug if we call these a and b
      MkMyPair(x, y) -> (x + y, y)
 > [(1, 1), (3, 2), (5, 3)]
 
-data MyEither(a:Type, b:Type) =
+enum MyEither(a:Type, b:Type) =
   MyLeft(a)
   MyRight(b)
 
@@ -73,7 +73,7 @@ x : MyEither Int Float = MyLeft 1
     MyRight val -> f_to_i $ floor val
 > 1
 
--- %passes imp
+# %passes imp
 myTab = [MyLeft (+1), MyRight 3.5, MyLeft 123, MyLeft 456]
 
 :p myTab
@@ -84,13 +84,13 @@ myTab = [MyLeft (+1), MyRight 3.5, MyLeft 123, MyLeft 456]
   MyRight(val) -> f_to_i $ floor val
 > [1, 3, 123, 456]
 
--- check order independence
+# check order independence
 :p for i. case myTab[i] of
   MyRight(val) -> f_to_i $ floor val
   MyLeft( val) -> val
 > [1, 3, 123, 456]
 
--- test non-exhaustive patterns
+# test non-exhaustive patterns
 :p for i. case myTab[i] of
   MyLeft  val -> val
 > Runtime error
@@ -109,14 +109,14 @@ myTab = [MyLeft (+1), MyRight 3.5, MyLeft 123, MyLeft 456]
 > 4.5
 
 :p
-  -- check that the order of the case alternatives doesn't matter
+  # check that the order of the case alternatives doesn't matter
   yield_accum (AddMonoid Float) \ref.
     for i. case myTab[i] of
       MyRight val -> ref += 1.0 + val
       MyLeft tmp -> ()
 > 4.5
 
-data ThreeCases =
+enum ThreeCases =
   TheEmptyCase
   TheIntCase(Int)
   ThePairCase(Int, Float)
@@ -135,7 +135,7 @@ threeCaseTab : (Fin 4)=>ThreeCases =
       TheIntCase x      -> ref +=   10.0 + i_to_f (x * 2)
 > 2118.1
 
-data MyIntish = MkIntish(Int)
+enum MyIntish = MkIntish(Int)
 
 :p case MkIntish 1 of MkIntish x -> x
 > 1
@@ -237,7 +237,7 @@ def zerosLikeList(l: List a) -> (Fin (list_length l))=>Float given (a) =
 :p zerosLikeList l2
 > [0., 0., 0.]
 
-data Graph(n|Ix, a:Type) =
+enum Graph(n|Ix, a:Type) =
   MkGraph(nodes:(n=>a), edges:(List (n, n)))
 
 def graphToAdjacencyMatrix(g:Graph n a) -> n=>n=>Bool given (n|Ix, a) =
@@ -256,11 +256,11 @@ def graphToAdjacencyMatrix(g:Graph n a) -> n=>n=>Bool given (n|Ix, a) =
   graphToAdjacencyMatrix g
 > [[False, True, True], [False, True, False], [True, False, False]]
 
-data MySum =
+enum MySum =
   Foo(Float)
   Bar(String)
 
--- bug #348
+# bug #348
 :p
   xs = for i:(Fin 3).
     if ordinal i < 2
@@ -269,14 +269,14 @@ data MySum =
   (xs, xs)
 > ([(Foo 2.), (Foo 2.), (Foo 1.)], [(Foo 2.), (Foo 2.), (Foo 1.)])
 
-data MySum2 =
+enum MySum2 =
   Foo2
   Bar2(Fin 3 => Int)
 
--- bug #348
+# bug #348
 :p concat for i:(Fin 4). AsList _ [(Foo2, Foo2)]
 > (AsList 4 [(Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2), (Foo2, Foo2)])
 
--- reproducer for a shadowing bug (PR #440)
+# reproducer for a shadowing bug (PR #440)
 :p concat $ for i:(Fin 2). to_list [(Just [0,0,0], Just [0,0,0]), (Just [0,0,0], Just [0,0,0])]
 > (AsList 4 [((Just [0, 0, 0]), (Just [0, 0, 0])), ((Just [0, 0, 0]), (Just [0, 0, 0])), ((Just [0, 0, 0]), (Just [0, 0, 0])), ((Just [0, 0, 0]), (Just [0, 0, 0]))])

--- a/tests/algeff-tests.dx
+++ b/tests/algeff-tests.dx
@@ -7,22 +7,22 @@ handler catch_ of Exn r : Maybe r
 
 handler bad_catch_1 of Exn r : Maybe r
   ctl raise = \_. Nothing
-  ctl raise = \_. Nothing -- duplicate!
+  ctl raise = \_. Nothing # duplicate!
   return = \x. Just x
 > Type error:Duplicate operation: raise
 
 handler bad_catch_2 of Exn r : Maybe r
   ctl raise = \_. Nothing
 > Type error:missing return
-  -- return = \x. Just x -- missing!
+  # return = \x. Just x -- missing!
 
 handler bad_catch_3 of Exn r : Maybe r
-  -- ctl raise = \_. Nothing -- missing!
+  # ctl raise = \_. Nothing -- missing!
   return = \x. Just x
 > Type error:Missing operation: raise
 
 handler bad_catch_4 of Exn r : Maybe r
-  ctl raise = \_. 42.0 -- definitely not Maybe
+  ctl raise = \_. 42.0 # definitely not Maybe
   return = \x. Just x
 > Type error:
 > Expected: (Maybe r)
@@ -33,7 +33,7 @@ handler bad_catch_4 of Exn r : Maybe r
 
 handler bad_catch_5 of Exn r : Maybe r
   ctl raise = \_. Nothing
-  return = \x. 42.0 -- definitely not Maybe
+  return = \x. 42.0 # definitely not Maybe
 > Type error:
 > Expected: (Maybe r)
 >   Actual: Float32
@@ -42,7 +42,7 @@ handler bad_catch_5 of Exn r : Maybe r
 >                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 handler bad_catch_6 of Exn r : Maybe r
-  def raise = \_. Nothing -- wrong policy!
+  def raise = \_. Nothing # wrong policy!
   return = \x. Just x
 > Type error:operation raise was declared with def but defined with ctl
 
@@ -53,23 +53,23 @@ def checkFloatNonNegative (x:Float) : {Exn} Float =
   check $ x >= 0.0
   x
 
--- catch_ \_.
---   checkFloatNonNegative (3.14)
--- > Compiler bug!
--- > Please report this at github.com/google-research/dex-lang/issues
--- >
--- > Not implemented
--- > CallStack (from HasCallStack):
--- >   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
+# catch_ \_.
+#   checkFloatNonNegative (3.14)
+# > Compiler bug!
+# > Please report this at github.com/google-research/dex-lang/issues
+# >
+# > Not implemented
+# > CallStack (from HasCallStack):
+# >   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
 
--- catch_ \_.
---   checkFloatNonNegative (-1.0)
--- > Compiler bug!
--- > Please report this at github.com/google-research/dex-lang/issues
--- >
--- > Not implemented
--- > CallStack (from HasCallStack):
--- >   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
+# catch_ \_.
+#   checkFloatNonNegative (-1.0)
+# > Compiler bug!
+# > Please report this at github.com/google-research/dex-lang/issues
+# >
+# > Not implemented
+# > CallStack (from HasCallStack):
+# >   error, called at src/lib/Simplify.hs:214:19 in dex-0.1.0.0-8hDfthyGTXmzhkTo2ydOn:Simplify
 
 effect Counter
   def inc : Unit -> Unit

--- a/tests/cast-tests.dx
+++ b/tests/cast-tests.dx
@@ -1,23 +1,23 @@
--- ==== Integral casts ====
---
--- Semantics of internal_cast on integral types are based on the bit representation
--- of the values in question. All WordX types have a bit representation equal to their
--- value in standard binary format. All IntX types use two's complement representation.
---
--- The cast is always performed by taking the source value to its bit representation,
--- resizing that representation (depending on the target signedness), and interpreting
--- the resulting bit pattern in the target type.
---
--- The rules for resizing the bit pattern are as follows:
---   1. If the target bitwidth is smaller than source bitwidth, the maximum number of
---      least significant bits are preserved.
---   2. If the target bitwidth is equal to the source bitwidth, nothing happens.
---   3. If the target bitwidth is greater than the source bitwidth, and:
---     3a. the target type is signed, the representation is sign-extended (the
---         MSB is used to pad the value up to the desired width).
---     3b. the target type is unsigned, the representation is zero-extended.
+# ==== Integral casts ====
+#
+# Semantics of internal_cast on integral types are based on the bit representation
+# of the values in question. All WordX types have a bit representation equal to their
+# value in standard binary format. All IntX types use two's complement representation.
+#
+# The cast is always performed by taking the source value to its bit representation,
+# resizing that representation (depending on the target signedness), and interpreting
+# the resulting bit pattern in the target type.
+#
+# The rules for resizing the bit pattern are as follows:
+#   1. If the target bitwidth is smaller than source bitwidth, the maximum number of
+#      least significant bits are preserved.
+#   2. If the target bitwidth is equal to the source bitwidth, nothing happens.
+#   3. If the target bitwidth is greater than the source bitwidth, and:
+#     3a. the target type is signed, the representation is sign-extended (the
+#         MSB is used to pad the value up to the desired width).
+#     3b. the target type is unsigned, the representation is zero-extended.
 
--- Casts to Int32
+# Casts to Int32
 
 internal_cast(to=Int32, 2147483647 :: Int64)
 > 2147483647
@@ -25,7 +25,7 @@ internal_cast(to=Int32, 2147483647 :: Int64)
 internal_cast(to=Int32, 2147483648 :: Int64)
 > -2147483648
 
-internal_cast(to=Int32, 8589935826 :: Int64)  -- 2^33 + 1234
+internal_cast(to=Int32, 8589935826 :: Int64) # 2^33 + 1234
 > 1234
 
 internal_cast(to=Int32, 123 :: Word8)
@@ -49,7 +49,7 @@ internal_cast(to=Int32, 4294967296 :: Word64)
 internal_cast(to=Int32, 5000000000 :: Word64)
 > 705032704
 
--- Casts to Int64
+# Casts to Int64
 
 internal_cast(to=Int64, 123 :: Int32)
 > 123
@@ -63,10 +63,10 @@ internal_cast(to=Int64, 123 :: Word8)
 internal_cast(to=Int64, 1234 :: Word32)
 > 1234
 
-internal_cast(to=Int64, 4294967296 :: Word64) -- 2^32
+internal_cast(to=Int64, 4294967296 :: Word64) # 2^32
 > 4294967296
 
--- Casts to Word8
+# Casts to Word8
 
 internal_cast(to=Word8, 1234 :: Int32)
 > 0xd2
@@ -80,7 +80,7 @@ internal_cast(to=Word8, 1234 :: Word32)
 internal_cast(to=Word8, 1234 :: Word64)
 > 0xd2
 
--- Casts to Word32
+# Casts to Word32
 
 internal_cast(to=Word32, 1234 :: Int32)
 > 0x4d2
@@ -91,7 +91,7 @@ internal_cast(to=Word32, -2147483648 :: Int32)
 internal_cast(to=Word32, 1234 :: Int64)
 > 0x4d2
 
-internal_cast(to=Word32, 4294968530 :: Int64)  -- 2^32 + 1234
+internal_cast(to=Word32, 4294968530 :: Int64) # 2^32 + 1234
 > 0x4d2
 
 internal_cast(to=Word32, -1 :: Int64)
@@ -106,7 +106,7 @@ internal_cast(to=Word32, 1234 :: Word64)
 internal_cast(to=Word32, 4294967296 :: Word64)
 > 0x0
 
--- Casts to Word64
+# Casts to Word64
 
 internal_cast(to=Word64, 1234 :: Int32)
 > 0x4d2

--- a/tests/complex-tests.dx
+++ b/tests/complex-tests.dx
@@ -17,9 +17,9 @@ b = Complex (-1.1) 1.3
 > True
 :p divide (a * b) a ~~ b
 > True
--- This next test can be added once we parameterize the field in the VSpace typeclass.
---:p ((a * b) / a) ~~ b
---> True
+# This next test can be added once we parameterize the field in the VSpace typeclass.
+#:p ((a * b) / a) ~~ b
+#> True
 :p a == b
 > False
 :p a == a
@@ -44,7 +44,7 @@ b = Complex (-1.1) 1.3
 > True
 :p tan (-a) ~~ (- (tan a))
 > True
-:p exp (pi .* (Complex 0.0 1.0)) ~~ (Complex (-1.0) 0.0)  -- Euler's identity
+:p exp (pi .* (Complex 0.0 1.0)) ~~ (Complex (-1.0) 0.0) # Euler's identity
 > True
 :p ((sq (sin a)) + (sq (cos a))) ~~ (Complex 1.0 0.0)
 > True

--- a/tests/eval-tests.dx
+++ b/tests/eval-tests.dx
@@ -37,9 +37,9 @@
 :p rand_int (new_key 0)
 > 431640317
 
--- :p let x = unpack range 10000
---        key = hash 0
---    in sum (for i: randint (key x[i]) 10)
+# :p let x = unpack range 10000
+#        key = hash 0
+#    in sum (for i: randint (key x[i]) 10)
 NArr = Fin 7
 
 arr = iota NArr
@@ -84,9 +84,9 @@ fun = \y. sum (map n_to_f arr) + y
    y + z
 > 3.
 
--- :p let f (x, y) = x + 2 * y;
---        z[i] = (x[i], x[i] * x[i])
---    in sum (for i. f z[i])
+# :p let f (x, y) = x + 2 * y;
+#        z[i] = (x[i], x[i] * x[i])
+#    in sum (for i. f z[i])
 :p exp 1.0
 > 2.718282
 
@@ -154,7 +154,7 @@ sum (sum xs) ~~ (cumsum2d xs)[3@_,2@_]
 :p [False, False, True]
 > [False, False, True]
 
-:p [False, True, True, False]  -- testing again because it's been flaky
+:p [False, True, True, False] # testing again because it's been flaky
 > [False, True, True, False]
 
 :p (True, False)
@@ -199,8 +199,8 @@ N4 = Fin 4
 
 mat = for i:N3 j:N4. (iota _)[i] + (10 * (iota _)[j])
 
--- :p sum for (i,j). mat[i][j]
--- > 192
+# :p sum for (i,j). mat[i][j]
+# > 192
 
 litArr = [10, 5, 3]
 
@@ -229,8 +229,8 @@ litArr = [10, 5, 3]
 :p hash (i_to_w64 123) 456
 > 0x500945c565c98701
 
-key = (w32_to_w64 (i_to_w32 320440878) .<<. 32) .|. (w32_to_w64 (i_to_w32 57701188)) -- 0x13198a2e03707344
-count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242054355)) -- 0x243f6a8885a308d3
+key = (w32_to_w64 (i_to_w32 320440878) .<<. 32) .|. (w32_to_w64 (i_to_w32 57701188)) # 0x13198a2e03707344
+count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242054355)) # 0x243f6a8885a308d3
 :p threefry_2x32 key count
 > 0xc4923a9c483df7a0
 
@@ -326,9 +326,9 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 :p [(for i:(Fin 1). (False, for j:(Fin 2). 1.0)), [(True, for k:(Fin 2) . 2.0)]]
 > [[(False, [1., 1.])], [(True, [2., 2.])]]
 
--- TODO: parse negative integer literals
--- :p (mod 5 3, mod 7 3, mod (-1) 3, mod -5 3)
--- > (2, 1, 2, 1)
+# TODO: parse negative integer literals
+# :p (mod 5 3, mod 7 3, mod (-1) 3, mod -5 3)
+# > (2, 1, 2, 1)
 
 :p [[1,2], for i. 3]
 > [[1, 2], [3, 3]]
@@ -415,15 +415,15 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 :p slice([1,2,3,4,5], 2, Fin 3)
 > [3, 4, 5]
 
--- TODO: test file specifically for parse errors (including testing error messages)
+# TODO: test file specifically for parse errors (including testing error messages)
 :p
    f : (Float)->Float = \x.
-     -- line comment should be ok here
+     # line comment should be ok here
      2.0 * x
    f 1.0
 > 2.
 
--- Not sure why the ordinary `sum/for` version doesn't work anymore
+# Not sure why the ordinary `sum/for` version doesn't work anymore
 :p
     n = 3 + 7
     fsum for i:(Fin n). 1.0
@@ -492,19 +492,19 @@ count = (w32_to_w64 (i_to_w32 608135816) .<<. 32) .|. (w32_to_w64 (i_to_w32 2242
 :p select(True, from_ordinal(n=Fin 2, 0), from_ordinal(n=Fin 2, 1))
 > 0
 
--- TODO: printing (also parsing) tables with alternative index sets
--- :p
---   xs = [[1],[2]]
---   for (i,j). xs[i][j]
--- > [1, 2]@(2, 1)
+# TODO: printing (also parsing) tables with alternative index sets
+# :p
+#   xs = [[1],[2]]
+#   for (i,j). xs[i][j]
+# > [1, 2]@(2, 1)
 
 
--- TODO: injections
--- :p
---   xs = for i:5. 1.0
---   two = fromOrdinal (Fin 5) 2
---   for i:3. sum for j:(two<..). xs.(%inject(j))
--- > [2.0, 2.0, 2.0]
+# TODO: injections
+# :p
+#   xs = for i:5. 1.0
+#   two = fromOrdinal (Fin 5) 2
+#   for i:3. sum for j:(two<..). xs.(%inject(j))
+# > [2.0, 2.0, 2.0]
 
 :p
   run_state 0.0 \ref. for i:(Fin 4).
@@ -566,21 +566,21 @@ Just 1 == Just 0
 > False
 
 
--- Userspace-Bool breaks these
+# Userspace-Bool breaks these
 
--- -- Needed to avoid ambiguous type variables if both sides use the same constructor
--- def cmpEither(x:Int|Int) (y:Int|Int) : Bool = x == y
+# -- Needed to avoid ambiguous type variables if both sides use the same constructor
+# def cmpEither(x:Int|Int) (y:Int|Int) : Bool = x == y
 
--- :p cmpEither (Left 1) (Left 1)
--- > True
+# :p cmpEither (Left 1) (Left 1)
+# > True
 
--- :p cmpEither (Left 1) (Left 2)
--- > False
+# :p cmpEither (Left 1) (Left 2)
+# > False
 
--- :p cmpEither (Left 1) (Right 1)
--- > False
+# :p cmpEither (Left 1) (Right 1)
+# > False
 
--- TODO: within-module version of this (currently fails in Imp checking)
+# TODO: within-module version of this (currently fails in Imp checking)
 upperBound = sum $ for i:(Fin 4). (1::Nat)
 :p for j:(Fin upperBound). 1.0
 > [1., 1., 1., 1.]
@@ -601,7 +601,7 @@ for i:(Fin 4).
   (x, z)
 > (2, [(2, 5), (2, 5), (2, 5), (2, 5)])
 
--- TODO: re-enable these once we prevent (`(-3):Nat` occurring
+# TODO: re-enable these once we prevent (`(-3):Nat` occurring
 for i:(Fin (-3)). 1.0
 > Type error:Can't reduce type expression: (Fin -3 [])
 >
@@ -614,7 +614,7 @@ x = 2 - 4
 > x = 2 - 4
 >     ^^^^^
 
--- Make sure that we can construct and print an array using a pair index set
+# Make sure that we can construct and print an array using a pair index set
 for i:(Fin 2, Fin 2). 1.0
 > [1., 1., 1., 1.]
 
@@ -627,13 +627,13 @@ for i:(Fin 5). for j:(..i).
   ir * (ir + 1.0) / 2.0 + jr
 > [[0.], [1., 2.], [3., 4., 5.], [6., 7., 8., 9.], [10., 11., 12., 13., 14.]]
 
--- TODO: fix!
--- -- Exercise the use of free variables in the sum solver
--- :p
---   n = 2 + 2
---   x = for i:(Fin n). for j:(..i). 1.0
---   sum $ for i. sum x.i
--- > 10.0
+# TODO: fix!
+# -- Exercise the use of free variables in the sum solver
+# :p
+#   n = 2 + 2
+#   x = for i:(Fin n). for j:(..i). 1.0
+#   sum $ for i. sum x.i
+# > 10.0
 
 
 :p 1 + 2
@@ -657,32 +657,32 @@ def newtonSolve(tol:Float, f: (Float)->Float, x0:Float) -> Float =
           x := newtonIter f $ get x
           Continue
 
--- :p newtonSolve 0.001 (\x. sq x - 2.0) 1.0
--- > 1.414216
+# :p newtonSolve 0.001 (\x. sq x - 2.0) 1.0
+# > 1.414216
 
--- :p
---   x = for i:(Fin 3). for j:(Fin 200). 1.0
---   -- Last dimension split to allow for vector loads
---   y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). IToF $ (iota _).(i,j,h)
---   z = yield_accum \acc.
---         for l.
---           for i.
---             xil = (broadcastVector x.i.l)
---             for j.
---               acc!i!j += xil * (loadVector y.l[j])
---   for i:(Fin 3). for j:(Fin 4). storeVector z.i[j]
--- > [ [ [318400.0, 318600.0, 318800.0, 319000.0]
--- > , [319200.0, 319400.0, 319600.0, 319800.0]
--- > , [320000.0, 320200.0, 320400.0, 320600.0]
--- > , [320800.0, 321000.0, 321200.0, 321400.0] ]
--- > , [ [318400.0, 318600.0, 318800.0, 319000.0]
--- > , [319200.0, 319400.0, 319600.0, 319800.0]
--- > , [320000.0, 320200.0, 320400.0, 320600.0]
--- > , [320800.0, 321000.0, 321200.0, 321400.0] ]
--- > , [ [318400.0, 318600.0, 318800.0, 319000.0]
--- > , [319200.0, 319400.0, 319600.0, 319800.0]
--- > , [320000.0, 320200.0, 320400.0, 320600.0]
--- > , [320800.0, 321000.0, 321200.0, 321400.0] ] ]
+# :p
+#   x = for i:(Fin 3). for j:(Fin 200). 1.0
+#   -- Last dimension split to allow for vector loads
+#   y = for i:(Fin 200). for j:(Fin 4). for h:(Fin VectorWidth). IToF $ (iota _).(i,j,h)
+#   z = yield_accum \acc.
+#         for l.
+#           for i.
+#             xil = (broadcastVector x.i.l)
+#             for j.
+#               acc!i!j += xil * (loadVector y.l[j])
+#   for i:(Fin 3). for j:(Fin 4). storeVector z.i[j]
+# > [ [ [318400.0, 318600.0, 318800.0, 319000.0]
+# > , [319200.0, 319400.0, 319600.0, 319800.0]
+# > , [320000.0, 320200.0, 320400.0, 320600.0]
+# > , [320800.0, 321000.0, 321200.0, 321400.0] ]
+# > , [ [318400.0, 318600.0, 318800.0, 319000.0]
+# > , [319200.0, 319400.0, 319600.0, 319800.0]
+# > , [320000.0, 320200.0, 320400.0, 320600.0]
+# > , [320800.0, 321000.0, 321200.0, 321400.0] ]
+# > , [ [318400.0, 318600.0, 318800.0, 319000.0]
+# > , [319200.0, 319400.0, 319600.0, 319800.0]
+# > , [320000.0, 320200.0, 320400.0, 320600.0]
+# > , [320800.0, 321000.0, 321200.0, 321400.0] ] ]
 
 :p
   fs = for i:(Fin 4).
@@ -708,12 +708,12 @@ def newtonSolve(tol:Float, f: (Float)->Float, x0:Float) -> Float =
   (f 5, w)
 > (7, 2.)
 
--- def add(n : Type) ?-> (a : n=>Float) (b : n=>Float) : n=>Float =
---   (tile (\t:(Tile n (Fin VectorWidth)). storeVector $ loadTile t a + loadTile t b)
---         (\i:n. a.i + b.i))
--- toAdd = for _:(Fin 10). 1.0
--- add toAdd toAdd
--- > [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
+# def add(n : Type) ?-> (a : n=>Float) (b : n=>Float) : n=>Float =
+#   (tile (\t:(Tile n (Fin VectorWidth)). storeVector $ loadTile t a + loadTile t b)
+#         (\i:n. a.i + b.i))
+# toAdd = for _:(Fin 10). 1.0
+# add toAdd toAdd
+# > [2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0, 2.0]
 
 arr2d = for i:(Fin 2). for j:(Fin 2). (iota _)[(i,j)]
 arr2d[1@_]
@@ -800,15 +800,15 @@ s1 = "hello world"
   sum zs + sum zs
 > 12
 
--- triLit : (i:Fin 4)=>(..i)=>Int =
---   [ coerce_table _ [0]
---   , coerce_table _ [1, 2]
---   , coerce_table _ [3, 4, 5]
---   , coerce_table _ [6, 7, 8, 9] ]
--- triLit
--- > [[0], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
+# triLit : (i:Fin 4)=>(..i)=>Int =
+#   [ coerce_table _ [0]
+#   , coerce_table _ [1, 2]
+#   , coerce_table _ [3, 4, 5]
+#   , coerce_table _ [6, 7, 8, 9] ]
+# triLit
+# > [[0], [1, 2], [3, 4, 5], [6, 7, 8, 9]]
 
--- @noinline
+# @noinline
 def fromLeftFloat(x:(Float `Either` Int)) -> Float =
   case x of
     Left x' -> x'
@@ -840,7 +840,7 @@ def f5(x:Int) -> Int = f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ f4 $ x
 def f6(x:Int) -> Int = f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ f5 $ x
 
 
--- regression test for #1229 - checks that constraints and data args can be interleaved
+# regression test for #1229 - checks that constraints and data args can be interleaved
 @noinline
 def interleave_args(x:Float, xs:n=>Float) -> Float given (n|Ix) =
   x + sum xs
@@ -849,11 +849,11 @@ interleave_args(1.0, [2.0, 3.0])
 > 6.
 
 
--- This will compile extremely slowly if non-inlining is broken
+# This will compile extremely slowly if non-inlining is broken
 :p f6 0
 > 100000
 
--- Testing integer powers
+# Testing integer powers
 
 :p intpow 10 2
 > 100
@@ -882,7 +882,7 @@ f x2
 grad f x2
 > 6.2
 
--- Integer utility tests
+# Integer utility tests
 
 :p map is_power_of_2 [0, 1, 2, 3, 256, 1023, 1024, 1024*1024, 1024*1024 + 1]
 > [False, True, True, False, True, False, True, True, False]
@@ -910,8 +910,8 @@ interface AssociatedWithTwo(a:Type, c:Type)
 instance AssociatedWithTwo(Int, Float)
   def value2() = 8
 
--- TODO: the source location for this error message is a bit off since we added
--- n-ary applications.
+# TODO: the source location for this error message is a bit off since we added
+# n-ary applications.
 value2(a=Int, c=Float)
 > 8
 value2(a=Float, c=Int)
@@ -920,17 +920,17 @@ value2(a=Float, c=Int)
 > value2(a=Float, c=Int)
 > ^^^^^^^^^^^^^^^^^^^^^^
 
--- XXX: Disabled because we now compile expressions like these to blocks, which
--- need a type that makes sense in the top scope. We may revisit that choice.
--- -- checks that mixing non-data values into the results of case expressions don't
--- -- prevent them from later being used in types.
--- :p
---   x = 1 + 1
---   (n, _) = case x > 1 of
---     True  -> (x, \x:Int. x)
---     False -> (x, \x:Int. x)
---   for i:(Fin n). 1.0
--- > [1., 1.]
+# XXX: Disabled because we now compile expressions like these to blocks, which
+# need a type that makes sense in the top scope. We may revisit that choice.
+# -- checks that mixing non-data values into the results of case expressions don't
+# -- prevent them from later being used in types.
+# :p
+#   x = 1 + 1
+#   (n, _) = case x > 1 of
+#     True  -> (x, \x:Int. x)
+#     False -> (x, \x:Int. x)
+#   for i:(Fin n). 1.0
+# > [1., 1.]
 
 1.0e-4
 > 0.0001
@@ -966,7 +966,7 @@ def all_prefixes(s:String)  -> List String =
 :p all_prefixes "fence"
 > (AsList 6 ["", "f", "fe", "fen", "fenc", "fence"])
 
--- NonEmpty tests
+# NonEmpty tests
 
 first_ix :: ()
 > ()
@@ -987,7 +987,7 @@ first_ix :: ((() `Either` Fin 2) `Either` Fin 3)
 > (Left (Left ()))
 
 
--- Check that empty sets can't satisfy NonEmpty
+# Check that empty sets can't satisfy NonEmpty
 
 first_ix :: (Fin 0)
 > Type error:Couldn't synthesize a class dictionary for: (NonEmpty (Fin 0))
@@ -1008,7 +1008,7 @@ first_ix :: (Fin 0, ())
 > ^^^^^^^^^
 
 
--- Subset tests
+# Subset tests
 
 project(to=(), inject(to=(() `Either` Fin 2), ()))
 > (Just ())
@@ -1025,7 +1025,7 @@ unsafe_project(to=(), inject(to=(Fin 2 `Either` ()), ()))
 :p unsafe_coerce(to=Fin 1 => (Nat, Nat), ([1], [2]))
 > [(1, 2)]
 
--- Stack tests
+# Stack tests
 
 :p
   with_stack Float \stack.
@@ -1043,7 +1043,7 @@ unsafe_project(to=(), inject(to=(Fin 2 `Either` ()), ()))
     stack.read()
 > (AsList 3 [(1., [1., 2.]), (10., [10., 20.]), (100., [100., 200.])])
 
--- Checks for O(N^2) behavior
+# Checks for O(N^2) behavior
 :p
   n = 1000000
   with_stack Float \stack.
@@ -1054,15 +1054,15 @@ unsafe_project(to=(), inject(to=(Fin 2 `Either` ()), ()))
     sum xs
 > 9000000.
 
--- Non-data case scrutinee tests
+# Non-data case scrutinee tests
 
--- Check that we can print out a sum-typed non-data value
+# Check that we can print out a sum-typed non-data value
 Just f64_to_f
 > (Just <function of type ((x:Float64) -> Float32)>)
 
--- Check that we can print out a sum-typed non-data value that came
--- from a case (this tickles ACase colliding with the code generated
--- to print).  The @noinline defeats case-of-known-constructor.
+# Check that we can print out a sum-typed non-data value that came
+# from a case (this tickles ACase colliding with the code generated
+# to print).  The @noinline defeats case-of-known-constructor.
 @noinline
 def id_bool(x:Bool) -> Bool = x
 
@@ -1071,8 +1071,8 @@ case (id_bool True) of
   False -> Nothing
 > (Just <function of type ((x:Float64) -> Float32)>)
 
--- Check that we can later scrutinize a sum-typed non-data value that
--- came from a case.
+# Check that we can later scrutinize a sum-typed non-data value that
+# came from a case.
 foo = case (id_bool True) of
   True -> Just f64_to_f
   False -> Nothing
@@ -1082,14 +1082,14 @@ case foo of
   Nothing -> 2.0
 > 1.
 
--- Non-data catch tests
+# Non-data catch tests
 
--- Should be able to catch a function
--- This is a regression test for Issue #1193.
+# Should be able to catch a function
+# This is a regression test for Issue #1193.
 catch \. f64_to_f
 > (Just <function of type ((x:Float64) -> Float32)>)
 
--- Should be able to catch a function-valued computation that fails
+# Should be able to catch a function-valued computation that fails
 catch \.
   x = if True
     then throw()
@@ -1097,7 +1097,7 @@ catch \.
   \y. x + y
 > Nothing
 
--- Should be able to apply a function that came out of a catch
+# Should be able to apply a function that came out of a catch
 frob : (Maybe ((Float) -> Float)) = catch \. \x. x + x
 
 case frob of
@@ -1106,9 +1106,9 @@ case frob of
 > 4.
 
 
--- regression tests for #1212
-data Rectangle(a) = AsRectangle(n:Nat, m:Nat, elts:(Fin n => Fin m => a))
-data Brick(a) = AsBrick(n:Nat, m:Nat, l:Nat, elts:(Fin n => Fin m => Fin l => a))
+# regression tests for #1212
+enum Rectangle(a) = AsRectangle(n:Nat, m:Nat, elts:(Fin n => Fin m => a))
+enum Brick(a) = AsBrick(n:Nat, m:Nat, l:Nat, elts:(Fin n => Fin m => Fin l => a))
 
 def mk_rect(n:Nat) -> Rectangle Nat =
   AsRectangle _ _ $ for i:(Fin n) j:(Fin n). ordinal i

--- a/tests/exception-tests.dx
+++ b/tests/exception-tests.dx
@@ -41,7 +41,7 @@ def checkFloatInUnitInterval(x:Float) -> {Except} Float =
       else 23
 > (Just [23, 23, 23])
 
--- Is this the result we want?
+# Is this the result we want?
 :p yield_state zero \ref.
      catch \.
        for i:(Fin 6).
@@ -58,7 +58,7 @@ def checkFloatInUnitInterval(x:Float) -> {Except} Float =
        ref := 2
 > Nothing
 
--- https://github.com/google-research/dex-lang/issues/612
+# https://github.com/google-research/dex-lang/issues/612
 def sashabug(h: ()) -> {Except} List Int =
   yield_state mempty \results.
       results := (get results) <> AsList 1 [2]

--- a/tests/gpu-tests.dx
+++ b/tests/gpu-tests.dx
@@ -6,7 +6,7 @@ x
 x + x
 > [0., 2., 4., 6., 8.]
 
--- TODO: Make it a FileCheck test
+# TODO: Make it a FileCheck test
 testNestedParallelism =
   for i:(Fin 10).
     x = ordinal i
@@ -15,7 +15,7 @@ testNestedParallelism =
 (fst testNestedParallelism.(2@_)).(5@_)
 > 20.
 
--- TODO: Make it a FileCheck test
+# TODO: Make it a FileCheck test
 testNestedLoops =
   for i:(Fin 10).
     for j:(Fin 20).
@@ -23,11 +23,11 @@ testNestedLoops =
 testNestedLoops.(4@_).(5@_)
 > 20
 
--- The state is large enough such that it shouldn't fit on the stack of a
--- single GPU thread. It should get lifted to a top-level allocation instead.
--- allocationLiftingTest =
---   for i:(Fin 100).
---     yieldState (for j:(Fin 1000). ordinal i) $ \s.
---       s!(0@_) := get s!(0@_) + 1
--- (allocationLiftingTest.(4@_).(0@_), allocationLiftingTest.(4@_).(1@_))
--- > (5, 4)
+# The state is large enough such that it shouldn't fit on the stack of a
+# single GPU thread. It should get lifted to a top-level allocation instead.
+# allocationLiftingTest =
+#   for i:(Fin 100).
+#     yieldState (for j:(Fin 1000). ordinal i) $ \s.
+#       s!(0@_) := get s!(0@_) + 1
+# (allocationLiftingTest.(4@_).(0@_), allocationLiftingTest.(4@_).(1@_))
+# > (5, 4)

--- a/tests/inline-tests.dx
+++ b/tests/inline-tests.dx
@@ -1,52 +1,52 @@
--- The "=== inline ===" strings below are a hack around the fact that
--- Dex currently does two passes of inlining and prints the results of
--- both.  Surrounding the CHECK block with these commands constrains
--- the body to occur in the output from the first inlining pass.
+# The "=== inline ===" strings below are a hack around the fact that
+# Dex currently does two passes of inlining and prints the results of
+# both.  Surrounding the CHECK block with these commands constrains
+# the body to occur in the output from the first inlining pass.
 
 @noinline
 def id'(x:Nat) -> Nat = x
 
--- CHECK-LABEL: Inline for into for
+# CHECK-LABEL: Inline for into for
 "Inline for into for"
 
 %passes inline
 :pp
   xs = for i:(Fin 10). ordinal i
   for j. xs[j] + 2
--- CHECK: === inline ===
--- CHECK: for
--- CHECK-NOT: for
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: for
+# CHECK-NOT: for
+# CHECK: === inline ===
 
--- CHECK-LABEL: Inline for into sum
+# CHECK-LABEL: Inline for into sum
 "Inline for into sum"
 
 %passes inline
 :pp sum for i:(Fin 10). ordinal i
--- CHECK: === inline ===
--- CHECK: for
--- CHECK-NOT: for
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: for
+# CHECK-NOT: for
+# CHECK: === inline ===
 
--- CHECK-LABEL: Inline nested for into for
+# CHECK-LABEL: Inline nested for into for
 "Inline nested for into for"
 
 %passes inline
 :pp
   xs = for i:(Fin 10). for j:(Fin 20). ordinal i * ordinal j
   for j i. xs[i, j] + 2
--- CHECK: === inline ===
--- CHECK: for
--- CHECK: for
--- CHECK-NOT: for
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: for
+# CHECK: for
+# CHECK-NOT: for
+# CHECK: === inline ===
 
--- CHECK-LABEL: Inlining does not reorder effects
+# CHECK-LABEL: Inlining does not reorder effects
 "Inlining does not reorder effects"
 
--- Note that it _would be_ legal to reorder independent effects, but
--- the inliner currently does not do that.  But the effect in this
--- example is not legal to reorder in any case.
+# Note that it _would be_ legal to reorder independent effects, but
+# the inliner currently does not do that.  But the effect in this
+# example is not legal to reorder in any case.
 
 %passes inline
 :pp run_state 0 \ct.
@@ -56,45 +56,45 @@ def id'(x:Nat) -> Nat = x
   for j.
     ct := (get ct) * 2
     xs[j] + 2
--- CHECK: === inline ===
--- CHECK: for
--- CHECK: for
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: for
+# CHECK: for
+# CHECK: === inline ===
 
--- CHECK-LABEL: Inlining does not duplicate the inlinee through beta reduction
+# CHECK-LABEL: Inlining does not duplicate the inlinee through beta reduction
 "Inlining does not duplicate the inlinee through beta reduction"
 
--- The check is for the error call in the dynamic check that `ix` has
--- type `Fin 100`.
+# The check is for the error call in the dynamic check that `ix` has
+# type `Fin 100`.
 %passes inline
 :pp
   ix = (id' 20)@(Fin 100)
   (for i:(Fin 100). ordinal i + ordinal i)[ix]
--- CHECK: === inline ===
--- CHECK: error
--- CHECK-NOT: error
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: error
+# CHECK-NOT: error
+# CHECK: === inline ===
 
--- CHECK-LABEL: Inlining does not violate type IR through beta reduction
+# CHECK-LABEL: Inlining does not violate type IR through beta reduction
 "Inlining does not violate type IR through beta reduction"
 
--- Beta reducing this ix into the `i` index of the `for` should stop
--- before it produces anything a type expression can't handle, and
--- thus execute.
+# Beta reducing this ix into the `i` index of the `for` should stop
+# before it produces anything a type expression can't handle, and
+# thus execute.
 
 :p
   ix = (1@(Fin 2))
   sum (for i:(Fin 2) j:(..i). ordinal j)[ix]
--- CHECK: 1
--- CHECK-NOT: Compiler bug
+# CHECK: 1
+# CHECK-NOT: Compiler bug
 
--- CHECK-LABEL: Inlining simplifies case-of-known-constructor
+# CHECK-LABEL: Inlining simplifies case-of-known-constructor
 "Inlining simplifies case-of-known-constructor"
 
--- Inlining xs exposes a case-of-known-constructor opportunity here;
--- the first inlining pass doesn't take it (yet) because it's
--- conservative about inlining `i` into the body of `xs`, but the
--- second pass does.
+# Inlining xs exposes a case-of-known-constructor opportunity here;
+# the first inlining pass doesn't take it (yet) because it's
+# conservative about inlining `i` into the body of `xs`, but the
+# second pass does.
 %passes inline
 :pp
   xs = for i:(Either (Fin 3) (Fin 4)).
@@ -102,20 +102,20 @@ def id'(x:Nat) -> Nat = x
       Left k -> 1
       Right k -> 2
   for j:(Fin 3). xs[Left j]
--- CHECK: === inline ===
--- CHECK: for
--- CHECK: case
--- CHECK: === inline ===
--- CHECK: for
--- CHECK-NOT: case
+# CHECK: === inline ===
+# CHECK: for
+# CHECK: case
+# CHECK: === inline ===
+# CHECK: for
+# CHECK-NOT: case
 
--- CHECK-LABEL: Inlining carries out the case-of-case optimization
+# CHECK-LABEL: Inlining carries out the case-of-case optimization
 "Inlining carries out the case-of-case optimization"
 
--- Before inlining there are two cases, but attempting to inline `x`
--- reveals a case-of-case opprtunity, which in turn exposes
--- case-of-known-constructor in each branch, leading to just one case
--- in the end.
+# Before inlining there are two cases, but attempting to inline `x`
+# reveals a case-of-case opprtunity, which in turn exposes
+# case-of-known-constructor in each branch, leading to just one case
+# in the end.
 %passes inline
 :pp
   x = if id'(3) > 2
@@ -124,7 +124,7 @@ def id'(x:Nat) -> Nat = x
   case x of
     Just a -> a * a
     Nothing -> 0
--- CHECK: === inline ===
--- CHECK: case
--- CHECK-NOT: case
--- CHECK: === inline ===
+# CHECK: === inline ===
+# CHECK: case
+# CHECK-NOT: case
+# CHECK: === inline ===

--- a/tests/instance-interface-syntax-tests.dx
+++ b/tests/instance-interface-syntax-tests.dx
@@ -1,33 +1,33 @@
 
 interface Empty(a:Type)
   pass
--- CHECK-NOT: Parse error
+# CHECK-NOT: Parse error
 
 instance Empty(Int)
   pass
--- CHECK-NOT: Parse error
+# CHECK-NOT: Parse error
 
 instance Empty(Float32)
   def witness() = 0.0
--- CHECK-NOT: Parse error
--- CHECK: Error: variable not in scope: witness
+# CHECK-NOT: Parse error
+# CHECK: Error: variable not in scope: witness
 
 interface Inhabited(a)
   witness : a
--- CHECK-NOT: Parse error
+# CHECK-NOT: Parse error
 
 instance Inhabited(Int)
   witness = 0
--- CHECK-NOT: Parse error
+# CHECK-NOT: Parse error
 
 instance Inhabited(Float64)
   witness = f_to_f64(0.0)
  pass
--- CHECK: Parse error
--- CHECK: unexpected "pa"
--- CHECK: expecting end of line
+# CHECK: Parse error
+# CHECK: unexpected "pa"
+# CHECK: expecting end of line
 
 instance Inhabited(Word32)
   witness = 0
    pass
--- CHECK: Parse error
+# CHECK: Parse error

--- a/tests/instance-methods-tests.dx
+++ b/tests/instance-methods-tests.dx
@@ -9,11 +9,11 @@ instance FooBar0(Int)
 
 w : Int = 42
 
--- CHECK: 43
+# CHECK: 43
 foo0 w
 > 43
 
--- CHECK: 44
+# CHECK: 44
 bar0 w
 > 44
 
@@ -24,17 +24,17 @@ interface FooBar1(a)
 
 instance FooBar1(Int)
   foo1 = \x. x + 1
-  -- Fails: Definition of `bar1` uses the class method `bar1` (with index 1);
-  -- but the instance `FooBar1 Int` is currently still being defined and, at
-  -- this point, can only grant access to method `foo1` (with index 0).
+  # Fails: Definition of `bar1` uses the class method `bar1` (with index 1);
+  # but the instance `FooBar1 Int` is currently still being defined and, at
+  # this point, can only grant access to method `foo1` (with index 0).
   bar1 = \x. bar1 x + 1
 > Type error:Wrong number of positional arguments provided. Expected 1 but got 0
 >
 >   foo1 = \x. x + 1
 >   ^^^^^^^^^^^^^^^^
--- CHECK: Type error:Couldn't synthesize a class dictionary for: (FooBar1 Int32)
--- CHECK:   bar1 = \x. bar1 x + 1
--- CHECK:              ^^^^^
+# CHECK: Type error:Couldn't synthesize a class dictionary for: (FooBar1 Int32)
+# CHECK:   bar1 = \x. bar1 x + 1
+# CHECK:              ^^^^^
 
 
 interface FooBar2(a)
@@ -42,34 +42,34 @@ interface FooBar2(a)
   bar2 : (a) -> Int
 
 def f2(x:a) given (a|FooBar2) = (\y. foo2 y + 1) x
--- The defintion of `f2` is OK because argument `d : FooBar2 a` grants access to
--- all methods of class `FooBar2 a`. (Only one method of `FooBar2` is actually
--- used in the body of `f2`.)
+# The defintion of `f2` is OK because argument `d : FooBar2 a` grants access to
+# all methods of class `FooBar2 a`. (Only one method of `FooBar2` is actually
+# used in the body of `f2`.)
 
 def g2(x:a) given (a|FooBar2) = (\y z. foo2 y + z) x (bar2 x)
--- The defintion of `g2` is OK because argument `d : FooBar2 a` grants access to
--- all methods of class `FooBar2 a`.
+# The defintion of `g2` is OK because argument `d : FooBar2 a` grants access to
+# all methods of class `FooBar2 a`.
 
 
 instance FooBar2(Int)
   def foo2(x) = x + 1
-  -- Fails: The definition of `bar2` uses `f2`, which requires a dictionary
-  -- `d : FooBar2 Int` that has access to all methods of `FooBar2 Int`.
+  # Fails: The definition of `bar2` uses `f2`, which requires a dictionary
+  # `d : FooBar2 Int` that has access to all methods of `FooBar2 Int`.
   def bar2(x) = f2 x + 1
 > Type error:Couldn't synthesize a class dictionary for: (FooBar2 Int32)
 >
 >   def bar2(x) = f2 x + 1
 >                 ^^^^^
--- CHECK: Type error:Couldn't synthesize a class dictionary for: (FooBar2 Int32)
--- CHECK:   bar2 = \x. f2 x + 1
--- CHECK:              ^^^
+# CHECK: Type error:Couldn't synthesize a class dictionary for: (FooBar2 Int32)
+# CHECK:   bar2 = \x. f2 x + 1
+# CHECK:              ^^^
 
 
 interface Shows0(a)
   shows0 : (a) -> String
   showsList0 : (List a) -> String
 
--- The body of method `showsList0` uses method `shows0` from the same instance.
+# The body of method `showsList0` uses method `shows0` from the same instance.
 instance Shows0(Nat)
   def shows0(x) = show x
   def showsList0(xs) =
@@ -79,7 +79,7 @@ instance Shows0(Nat)
 
 showsList0 (AsList 3 [0, 1, 2])
 > "012"
--- CHECK: "012"
+# CHECK: "012"
 
 interface Shows1(a)
   shows1 : (a) -> String
@@ -87,10 +87,10 @@ interface Shows1(a)
 
 instance Shows1(Nat)
   def shows1(x) = showsList1 (AsList 1 [x])
-  -- Methods `shows1` and `showsList1` refer to each other in a mutually recursive
-  -- fashion: the body of method `showsList1` uses method `shows1` from the same
-  -- instance, and the body of method `showsList1` uses method `shows1` also from
-  -- this instance.
+  # Methods `shows1` and `showsList1` refer to each other in a mutually recursive
+  # fashion: the body of method `showsList1` uses method `shows1` from the same
+  # instance, and the body of method `showsList1` uses method `shows1` also from
+  # this instance.
   def showsList1(xs) =
     AsList(n, ys) = xs
     strings = map shows1 ys
@@ -99,6 +99,6 @@ instance Shows1(Nat)
 >
 >   def shows1(x) = showsList1 (AsList 1 [x])
 >                   ^^^^^^^^^^^^^^^^^^^^^^^^^
--- CHECK: Type error:Couldn't synthesize a class dictionary for: (Shows1 Nat)
--- CHECK:   shows1 = \x. showsList1 (AsList 1 [x])
--- CHECK:                ^^^^^^^^^^^
+# CHECK: Type error:Couldn't synthesize a class dictionary for: (Shows1 Nat)
+# CHECK:   shows1 = \x. showsList1 (AsList 1 [x])
+# CHECK:                ^^^^^^^^^^^

--- a/tests/io-tests.dx
+++ b/tests/io-tests.dx
@@ -17,7 +17,7 @@
 
 unsafe_io \.
   print "testing log"
-  1.0 -- prevent DCE
+  1.0 # prevent DCE
 > testing log
 > 1.
 
@@ -27,7 +27,7 @@ unsafe_io \.
     if rem i 2 == 0
       then print $ show i <> " is even"
       else print $ show i <> " is odd"
-  1.0 -- prevent DCE
+  1.0 # prevent DCE
 > 0 is even
 > 1 is odd
 > 2 is even

--- a/tests/linalg-tests.dx
+++ b/tests/linalg-tests.dx
@@ -1,27 +1,27 @@
 import linalg
 
--- Check that the optimized matmul gives the same answers as the naive one
+# Check that the optimized matmul gives the same answers as the naive one
 amat = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
 
 :p tiled_matmul(amat, amat) ~~ naive_matmul amat amat
 > True
 
--- Check that the inverse of the inverse is identity.
+# Check that the inverse of the inverse is identity.
 mat = [[11.,9.,24.,2.],[1.,5.,2.,6.],[3.,17.,18.,1.],[2.,5.,7.,1.]]
 :p mat ~~ (invert (invert mat))
 > True
 
--- Check that solving gives the inverse.
+# Check that solving gives the inverse.
 v = [1., 2., 3., 4.]
 :p v ~~ (mat **. (solve mat v))
 > True
 
--- Check that det and exp(logdet) are the same.
+# Check that det and exp(logdet) are the same.
 (s, logdet) = sign_and_log_determinant mat
 :p (determinant mat) ~~ (s * (exp logdet))
 > True
 
--- Matrix integer powers.
+# Matrix integer powers.
 :p matrix_power mat 0 ~~ eye
 > True
 :p matrix_power mat 1 ~~ mat
@@ -34,21 +34,21 @@ v = [1., 2., 3., 4.]
 :p trace mat == (11. + 5. + 18. + 1.)
 > True
 
--- Check that we can linearize LU decomposition
--- This is a regression test for Issue #842.
+# Check that we can linearize LU decomposition
+# This is a regression test for Issue #842.
 snd(linearize (\x. snd $ sign_and_log_determinant [[x]]) 1.0)(2.0)
 > 2.
 
--- Check that we can differentiate through LU decomposition
--- This is a regression test for Issue #848.
+# Check that we can differentiate through LU decomposition
+# This is a regression test for Issue #848.
 grad (\x. (pivotize [[x]]).sign) 1.0
 > 0.
 
 grad (\x. snd $ sign_and_log_determinant [[x]]) 2.0
 > 0.5
 
--- Check forward_substitute solve by comparing
--- against zero-padding and doing the full solve.
+# Check forward_substitute solve by comparing
+# against zero-padding and doing the full solve.
 def padLowerTriMat(mat:LowerTriMat n v) -> n=>n=>v given (n|Ix, v|Add) =
   for i j.
     if (ordinal j)<=(ordinal i)

--- a/tests/linear-tests.dx
+++ b/tests/linear-tests.dx
@@ -187,7 +187,7 @@ linFstArg x y = x / y
 linUnary : Float --o Float
 linUnary x = linFstArg x 1.0
 
--- Nonlinear because of defaulting rules
+# Nonlinear because of defaulting rules
 :t
    f x = x + x
    f

--- a/tests/monad-tests.dx
+++ b/tests/monad-tests.dx
@@ -94,41 +94,41 @@ def foom(s:Ref h ((Fin 3)=>Int)) -> {State h} () given (h:Heap) =
 :p run_state [0,0,0] foom
 > ((), [1, 0, 2])
 
--- TODO: handle effects returning functions
--- :p
---   def foo(x:Float) : Float =
---      f = withReader x \r.
---            y = ask r
---            \z. 100.0 * x + 10.0 * y + z
---      f 1.0
+# TODO: handle effects returning functions
+# :p
+#   def foo(x:Float) : Float =
+#      f = withReader x \r.
+#            y = ask r
+#            \z. 100.0 * x + 10.0 * y + z
+#      f 1.0
 
---   foo 3.0
--- > 331.0
+#   foo 3.0
+# > 331.0
 
--- :p
---   foo : Float -> (Float, Float)
---   foo x =
---      (f, ans) = runState x \s.
---          y = get s
---          \z. 100.0 * x + 10.0 * y + z
---      (f 1.0, ans)
+# :p
+#   foo : Float -> (Float, Float)
+#   foo x =
+#      (f, ans) = runState x \s.
+#          y = get s
+#          \z. 100.0 * x + 10.0 * y + z
+#      (f 1.0, ans)
 
---   foo 3.0
--- > (331.0, 3.0)
+#   foo 3.0
+# > (331.0, 3.0)
 
--- :p
---   foo : Float -> (Float, Float)
---   foo x =
---      (f, ans) = runAccumulator \s.
---         s += x
---         \y. 10.0 * x + y
---      (f 1.0, ans)
+# :p
+#   foo : Float -> (Float, Float)
+#   foo x =
+#      (f, ans) = runAccumulator \s.
+#         s += x
+#         \y. 10.0 * x + y
+#      (f 1.0, ans)
 
---   foo 3.0
--- > (31.0, 3.0)
+#   foo 3.0
+# > (31.0, 3.0)
 
--- TODO: some way to explicitly give type to `runAccum`
---       (maybe just explicit implicit args)
+# TODO: some way to explicitly give type to `runAccum`
+#       (maybe just explicit implicit args)
 :p
   with_reader 2.0 \r.
     run_accum (AddMonoid Float) \w.
@@ -187,7 +187,7 @@ def effectsAtZero(f: (Int)->{|eff} ()) -> {|eff} () given (eff:Effects) =
 :p arg_filter([0, 7, -1, 6]) \x. x > 5
 > (AsList 2 [1, 3])
 
--- Test list equality
+# Test list equality
 (AsList _ [1, 2]) == (AsList _ [1, 2])
 > True
 
@@ -197,7 +197,7 @@ def effectsAtZero(f: (Int)->{|eff} ()) -> {|eff} () given (eff:Effects) =
 (AsList _ [1, 2]) == (AsList _ [2, 2])
 > False
 
--- Test custom list monoid with accum
+# Test custom list monoid with accum
 def adjacencyMatrixToEdgeList(mat: n=>n=>Bool) -> List (n, n) given (n|Ix) =
   yield_accum(ListMonoid((n,n))) \list.
     for idxs.

--- a/tests/opt-tests.dx
+++ b/tests/opt-tests.dx
@@ -1,198 +1,198 @@
 @noinline
 def id'(x:Int) -> Int = x
 
--- CHECK-LABEL: dce-dead-app
+# CHECK-LABEL: dce-dead-app
 "dce-dead-app"
 
 %passes opt
 :pp
   x = id' 1
   5 + 1
--- First Result is from optimizing id'
--- CHECK: === Result ===
--- CHECK: === Result ===
--- CHECK-NEXT: 0x6
+# First Result is from optimizing id'
+# CHECK: === Result ===
+# CHECK: === Result ===
+# CHECK-NEXT: 0x6
 
 def arange_f(off:Nat) -> (Fin n)=>Int given (n) =
   for i. id' $ (n_to_i $ ordinal i + off)
 
--- CHECK-LABEL: matmul-single-alloc
+# CHECK-LABEL: matmul-single-alloc
 "matmul-single-alloc"
 m = for i:(Fin 100) j:(Fin 100). n_to_f $ ordinal (i, j)
 
 %passes imp
 m' = naive_matmul(m, m)
--- CHECK: alloc Float32[10000]
--- CHECK-NOT: alloc
+# CHECK: alloc Float32[10000]
+# CHECK-NOT: alloc
 
 "basic destination passing for scalar array literals"
--- CHECK-LABEL: basic destination passing for scalar array literals
+# CHECK-LABEL: basic destination passing for scalar array literals
 
 %passes lower
 _ = for i:(Fin 50). [ordinal i, 2, 3]
--- CHECK-NOT: alloc
+# CHECK-NOT: alloc
 
 "no destinations for singleton values"
--- CHECK-LABEL: no destinations for singleton values
+# CHECK-LABEL: no destinations for singleton values
 
 %passes lower
 :pp yield_state 0 \ref.
   for i:(Fin 10). ref := get ref + 1
--- CHECK-NOT: alloc
+# CHECK-NOT: alloc
 
--- === Loop unrolling ===
+# === Loop unrolling ===
 
--- CHECK-LABEL: unroll-eliminate-table
+# CHECK-LABEL: unroll-eliminate-table
 "unroll-eliminate-table"
 
 %passes opt
 :pp
   [x0, x1, x2] = arange_f 2
   (x0, x2)
--- CHECK: === Result ===
--- CHECK: [[x0:[^ ]*]]:Int32 = id{{.*}} 2
--- CHECK-NEXT: [[x2:[^ ]*]]:Int32 = id{{.*}} 4
--- CHECK-NEXT: ([[x0]], [[x2]])
+# CHECK: === Result ===
+# CHECK: [[x0:[^ ]*]]:Int32 = id{{.*}} 2
+# CHECK-NEXT: [[x2:[^ ]*]]:Int32 = id{{.*}} 4
+# CHECK-NEXT: ([[x0]], [[x2]])
 
 "don't unroll large table literals"
--- CHECK-LABEL: don't unroll large table literals
+# CHECK-LABEL: don't unroll large table literals
 
 %passes opt
 x = for i:(Fin 4). [0, 0, 0, ordinal i, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0]
--- CHECK: [ 0x0
--- CHECK: , 0x0 ]
--- CHECK-NOT: [0x0
+# CHECK: [ 0x0
+# CHECK: , 0x0 ]
+# CHECK-NOT: [0x0
 
 "no excessive nested unrolling"
--- CHECK-LABEL: no excessive nested unrolling
+# CHECK-LABEL: no excessive nested unrolling
 
 %passes opt
 _ = for i:(Fin 20) j:(Fin 4). ordinal j
--- CHECK: [0x0, 0x1, 0x2, 0x3]
--- CHECK-NOT: [0x0, 0x1, 0x2, 0x3]
+# CHECK: [0x0, 0x1, 0x2, 0x3]
+# CHECK-NOT: [0x0, 0x1, 0x2, 0x3]
 
 "no excessive atom body unrolling"
--- CHECK-LABEL: no excessive atom body unrolling
+# CHECK-LABEL: no excessive atom body unrolling
 
 one_f32 : Float32 = 1.0
 
 %passes simp
 _ = for i:(Fin 100). one_f32
--- CHECK: 1.
--- CHECK-NOT: 1.
+# CHECK: 1.
+# CHECK-NOT: 1.
 
--- === Loop invariant code motion ===
+# === Loop invariant code motion ===
 
 "alloc hoisting"
--- CHECK-LABEL: alloc hoisting
+# CHECK-LABEL: alloc hoisting
 
 %passes lower-opt
 _ = for i:(Fin 10).
   n = ordinal i + 2
   for j:(Fin 4).
     xs = for k:(Fin n). ordinal j
-    (sum xs, sum xs)  -- Two uses of xs to defeat the inliner
--- The alloc for the (ordinal i + 2)-sized array should happen in the i loop,
--- not in the j loop
--- CHECK: [[n:v#[0-9]+]]:Word32 = %iadd {{.*}} 0x2
--- CHECK-NOT: seq
--- CHECK: alloc {{.*}}RawFin{{.*}}[[n]]
--- CHECK: seq
--- CHECK: seq
+    (sum xs, sum xs) # Two uses of xs to defeat the inliner
+# The alloc for the (ordinal i + 2)-sized array should happen in the i loop,
+# not in the j loop
+# CHECK: [[n:v#[0-9]+]]:Word32 = %iadd {{.*}} 0x2
+# CHECK-NOT: seq
+# CHECK: alloc {{.*}}RawFin{{.*}}[[n]]
+# CHECK: seq
+# CHECK: seq
 
 "loop hoisting"
--- CHECK-LABEL: loop hoisting
+# CHECK-LABEL: loop hoisting
 
 %passes opt
 _ = for i:(Fin 20) j:(Fin 4). ordinal j
--- CHECK-NOT: for
--- CHECK: [[x:v#[0-9]+]]:{{.*}} = [0x0, 0x1, 0x2, 0x3]
--- CHECK: for {{.*}}:{{.*}}. [[x]]
+# CHECK-NOT: for
+# CHECK: [[x:v#[0-9]+]]:{{.*}} = [0x0, 0x1, 0x2, 0x3]
+# CHECK: for {{.*}}:{{.*}}. [[x]]
 
--- === Peephole optimization ===
+# === Peephole optimization ===
 
 "constant fold boolean expressions"
--- CHECK-LABEL: constant fold boolean expressions
+# CHECK-LABEL: constant fold boolean expressions
 
 %passes opt
 :pp (2 > 1 || 4 < 5) && 6 == 6
--- CHECK: (1| () |)
+# CHECK: (1| () |)
 
--- === Vectorization ===
+# === Vectorization ===
 
 "vectorization"
--- CHECK-LABEL: vectorization
+# CHECK-LABEL: vectorization
 
 "vectorizing int binary op"
--- CHECK-LABEL: vectorizing int binary op
+# CHECK-LABEL: vectorizing int binary op
 %passes vect
 _ = for i:(Fin 256). (n_to_i32 (ordinal i)) * 2
--- CHECK: seq (RawFin 0x10)
--- CHECK: [[i0:v#[0-9]+]]:<16xInt32> = vbroadcast
--- CHECK: [[i1:v#[0-9]+]]:<16xInt32> = viota
--- CHECK: [[i2:v#[0-9]+]]:<16xInt32> = %iadd [[i0]] [[i1]]
--- CHECK: [[twos:v#[0-9]+]]:<16xInt32> = vbroadcast 2
--- CHECK: %imul [[i2]] [[twos]]
+# CHECK: seq (RawFin 0x10)
+# CHECK: [[i0:v#[0-9]+]]:<16xInt32> = vbroadcast
+# CHECK: [[i1:v#[0-9]+]]:<16xInt32> = viota
+# CHECK: [[i2:v#[0-9]+]]:<16xInt32> = %iadd [[i0]] [[i1]]
+# CHECK: [[twos:v#[0-9]+]]:<16xInt32> = vbroadcast 2
+# CHECK: %imul [[i2]] [[twos]]
 
 "vectorizing float binary op"
--- CHECK-LABEL: vectorizing float binary op
+# CHECK-LABEL: vectorizing float binary op
 %passes vect
 _ = for i:(Fin 256). (n_to_f32 (ordinal i)) + 1
--- CHECK: seq (RawFin 0x10)
--- CHECK: [[i0:v#[0-9]+]]:<16xFloat32> = vbroadcast
--- CHECK: [[i1:v#[0-9]+]]:<16xFloat32> = viota
--- CHECK: [[i2:v#[0-9]+]]:<16xFloat32> = %fadd [[i0]] [[i1]]
--- CHECK: [[ones:v#[0-9]+]]:<16xFloat32> = vbroadcast 1.
--- CHECK: %fadd [[i2]] [[ones]]
+# CHECK: seq (RawFin 0x10)
+# CHECK: [[i0:v#[0-9]+]]:<16xFloat32> = vbroadcast
+# CHECK: [[i1:v#[0-9]+]]:<16xFloat32> = viota
+# CHECK: [[i2:v#[0-9]+]]:<16xFloat32> = %fadd [[i0]] [[i1]]
+# CHECK: [[ones:v#[0-9]+]]:<16xFloat32> = vbroadcast 1.
+# CHECK: %fadd [[i2]] [[ones]]
 
 "vectorizing float64 binary op, implies different width"
--- CHECK-LABEL: vectorizing float64 binary op, implies different width
+# CHECK-LABEL: vectorizing float64 binary op, implies different width
 %passes vect
 _ = for i:(Fin 256). (n_to_f64 (ordinal i)) + 1
--- CHECK: seq (RawFin 0x20)
--- CHECK: [[i0:v#[0-9]+]]:<8xFloat64> = vbroadcast
--- CHECK: [[i1:v#[0-9]+]]:<8xFloat64> = viota
--- CHECK: [[i2:v#[0-9]+]]:<8xFloat64> = %fadd [[i0]] [[i1]]
--- CHECK: [[ones:v#[0-9]+]]:<8xFloat64> = vbroadcast 1.
--- CHECK: %fadd [[i2]] [[ones]]
+# CHECK: seq (RawFin 0x20)
+# CHECK: [[i0:v#[0-9]+]]:<8xFloat64> = vbroadcast
+# CHECK: [[i1:v#[0-9]+]]:<8xFloat64> = viota
+# CHECK: [[i2:v#[0-9]+]]:<8xFloat64> = %fadd [[i0]] [[i1]]
+# CHECK: [[ones:v#[0-9]+]]:<8xFloat64> = vbroadcast 1.
+# CHECK: %fadd [[i2]] [[ones]]
 
 "vectorizing array reference"
--- CHECK-LABEL: vectorizing array reference
+# CHECK-LABEL: vectorizing array reference
 xs = for i:(Fin 256). (n_to_i32 (ordinal i)) + 1
 
 %passes vect
 _ = for i:(Fin 256). xs[i] + 1
--- CHECK: seq (RawFin 0x10)
--- CHECK: [[i:v#[0-9]+]]:<16xInt32> =
--- CHECK-NEXT: vslice
--- CHECK: [[ones:v#[0-9]+]]:<16xInt32> = vbroadcast 1
--- CHECK: %iadd [[i]] [[ones]]
+# CHECK: seq (RawFin 0x10)
+# CHECK: [[i:v#[0-9]+]]:<16xInt32> =
+# CHECK-NEXT: vslice
+# CHECK: [[ones:v#[0-9]+]]:<16xInt32> = vbroadcast 1
+# CHECK: %iadd [[i]] [[ones]]
 
 "vectorizing reader effect"
--- CHECK-LABEL: vectorizing reader effect
+# CHECK-LABEL: vectorizing reader effect
 %passes vect
 _ = with_reader 2 \ref.
   for i:(Fin 256). xs[i] + ask(ref)
--- CHECK: seq (RawFin 0x10)
--- CHECK: [[ref:v#[0-9]+]]:Int32 = ask
--- CHECK: [[xi:v#[0-9]+]]:<16xInt32> =
--- CHECK-NEXT: vslice
--- CHECK: [[bcast:v#[0-9]+]]:<16xInt32> = vbroadcast [[ref]]
--- CHECK: %iadd [[xi]] [[bcast]]
+# CHECK: seq (RawFin 0x10)
+# CHECK: [[ref:v#[0-9]+]]:Int32 = ask
+# CHECK: [[xi:v#[0-9]+]]:<16xInt32> =
+# CHECK-NEXT: vslice
+# CHECK: [[bcast:v#[0-9]+]]:<16xInt32> = vbroadcast [[ref]]
+# CHECK: %iadd [[xi]] [[bcast]]
 
 "vectorizing independent writer effect"
--- CHECK-LABEL: vectorizing independent writer effect
+# CHECK-LABEL: vectorizing independent writer effect
 %passes vect
 _ = yield_accum (AddMonoid Int32) \ref.
   for i:(Fin 256). ref!i += xs[i]
--- CHECK: seq (RawFin 0x10)
--- CHECK: [[refi:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
--- CHECK: [[xi:v#[0-9]+]]:<16xInt32> =
--- CHECK-NEXT: vslice
--- CHECK: extend [[refi]] [[xi]]
+# CHECK: seq (RawFin 0x10)
+# CHECK: [[refi:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
+# CHECK: [[xi:v#[0-9]+]]:<16xInt32> =
+# CHECK-NEXT: vslice
+# CHECK: extend [[refi]] [[xi]]
 
 "vectorizing under an outer loop, like matmul"
--- CHECK-LABEL: vectorizing under an outer loop, like matmul
+# CHECK-LABEL: vectorizing under an outer loop, like matmul
 
 mat1 = for i:(Fin 32). for j:(Fin 32).
   (n_to_i32 (ordinal i)) * (n_to_i32 (ordinal j)) + 1
@@ -205,15 +205,15 @@ _ = yield_accum (AddMonoid Int32) \result.
   for k:(Fin 32).
     for j:(Fin 32).
       result!(3@(Fin 32))!j += mat1[3@_][k] * mat2[k][j]
--- CHECK: seq (RawFin 0x2)
--- CHECK: [[refj:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
--- CHECK: [[mat2j:v#[0-9]+]]:<16xInt32> = vslice
--- CHECK: [[mat1:v#[0-9]+]]:<16xInt32> = vbroadcast
--- CHECK: [[prodj:v#[0-9]+]]:<16xInt32> = %imul [[mat1]] [[mat2j]]
--- CHECK: extend [[refj]] [[prodj]]
+# CHECK: seq (RawFin 0x2)
+# CHECK: [[refj:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
+# CHECK: [[mat2j:v#[0-9]+]]:<16xInt32> = vslice
+# CHECK: [[mat1:v#[0-9]+]]:<16xInt32> = vbroadcast
+# CHECK: [[prodj:v#[0-9]+]]:<16xInt32> = %imul [[mat1]] [[mat2j]]
+# CHECK: extend [[refj]] [[prodj]]
 
 "vectorizing through the `tile` combinator and its funny index set"
--- CHECK-LABEL: vectorizing through the `tile` combinator and its funny index set
+# CHECK-LABEL: vectorizing through the `tile` combinator and its funny index set
 
 %passes vect
 _ = yield_accum (AddMonoid Int32) \result.
@@ -221,20 +221,20 @@ _ = yield_accum (AddMonoid Int32) \result.
     for_ i:set.
       ix = inject(i, to=(Fin 256))
       result!ix += xs[ix]
--- CHECK: seq (RawFin 0x8)
--- CHECK: seq (RawFin 0x2)
--- CHECK: [[refix:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
--- CHECK: [[xsix:v#[0-9]+]]:<16xInt32> =
--- CHECK-NEXT: vslice
--- CHECK: extend [[refix]] [[xsix]]
+# CHECK: seq (RawFin 0x8)
+# CHECK: seq (RawFin 0x2)
+# CHECK: [[refix:v#[0-9]+]]:(Ref {{v#[0-9]+}} <16xInt32>) = vrefslice
+# CHECK: [[xsix:v#[0-9]+]]:<16xInt32> =
+# CHECK-NEXT: vslice
+# CHECK: extend [[refix]] [[xsix]]
 
 "Non-aligned"
--- CHECK-LABEL: Non-aligned
+# CHECK-LABEL: Non-aligned
 
--- This is a regression test.  We are checking that Dex-side
--- vectorization does not end up assuming that arrays are aligned on
--- the size of the vectors, only on the size of the underlying
--- scalars.
+# This is a regression test.  We are checking that Dex-side
+# vectorization does not end up assuming that arrays are aligned on
+# the size of the vectors, only on the size of the underlying
+# scalars.
 
 non_aligned = for i:(Fin 7). for j:(Fin 257). +0
 
@@ -244,5 +244,5 @@ _ = yield_accum (AddMonoid Int32) \result.
     for_ i:set.
       ix = inject(i, to=(Fin 257))
       result!(6@(Fin 7))!ix += non_aligned[6@_][ix]
--- CHECK: load <16 x i32>, <16 x i32>* %"v#{{[0-9]+}}", align 4
--- CHECK: store <16 x i32> %"v#{{[0-9]+}}", <16 x i32>* %"v#{{[0-9]+}}", align 4
+# CHECK: load <16 x i32>, <16 x i32>* %"v#{{[0-9]+}}", align 4
+# CHECK: store <16 x i32> %"v#{{[0-9]+}}", <16 x i32>* %"v#{{[0-9]+}}", align 4

--- a/tests/parser-tests.dx
+++ b/tests/parser-tests.dx
@@ -28,7 +28,7 @@
 
 f = \x. x + 10.
 
-:p f -1.0   -- parses as (-) f (-1.0)
+:p f -1.0 # parses as (-) f (-1.0)
 > Type error:
 > Expected: ((x:Float32) -> Float32)
 >   Actual: Float32
@@ -61,8 +61,8 @@ f = \x. x + 10.
       ref := get ref + 1
 > ((), 10)
 
--- Check that a syntax error in a funDefLet doesn't try to reparse the
--- whole definition as something it's not.
+# Check that a syntax error in a funDefLet doesn't try to reparse the
+# whole definition as something it's not.
 def frob(x:Int, y:Int) -> + =
 
 > Parse error:66:29:
@@ -72,7 +72,7 @@ def frob(x:Int, y:Int) -> + =
 > unexpected '='
 > expecting name or symbol name
 
--- Check that indented blocks have to actually be indented.
+# Check that indented blocks have to actually be indented.
 for i.
 i
 
@@ -93,15 +93,15 @@ def (foo + bar) : Int = 6
 
 'Data definitions allow but do not require type / kind annotations
 
-data MyPair1(a, b) = MkPair1(a, b)
+enum MyPair1(a, b) = MkPair1(a, b)
 
-data MyPair2(a:Type, b:Type) = MkPair2(x:a, y:b)
+enum MyPair2(a:Type, b:Type) = MkPair2(x:a, y:b)
 
 'Data definitions allow interleaving arguments and class constraints
 (regression test for Issue 1015)
 
-data TableInType(n|Ix, a, table:(n=>a)) =
-  MkTableInType              -- Doesn't store any data except in the type!
+enum TableInType(n|Ix, a, table:(n=>a)) =
+  MkTableInType # Doesn't store any data except in the type!
 
 'Left arrow <- desugars to a continuation lambda
 (feature test for Issue 1137)
@@ -116,7 +116,7 @@ data TableInType(n|Ix, a, table:(n=>a)) =
 without parens or with whitespace before the parens.
 
 
-data MyMaybe a =
+enum MyMaybe a =
   MyNothing
 
 > Parse error:119:14:
@@ -125,7 +125,7 @@ data MyMaybe a =
 >     |              ^
 > unexpected 'a'
 > expecting '=' or parameter list in parentheses (without preceding whitespace)
-data MyMaybe (a) =
+enum MyMaybe (a) =
   MyNothing
 
 > Parse error:128:14:
@@ -134,7 +134,7 @@ data MyMaybe (a) =
 >     |              ^
 > unexpected '('
 > expecting '=' or parameter list in parentheses (without preceding whitespace)
-data MyMaybe(a) =
+enum MyMaybe(a) =
   MyNothing
   MyJust a
 
@@ -144,7 +144,7 @@ data MyMaybe(a) =
 >     |          ^^
 > unexpected "a<newline>"
 > expecting end of input, end of line, or optional parameter list
-data MyMaybe(a) =
+enum MyMaybe(a) =
   MyNothing
   MyJust (a)
 

--- a/tests/print-tests.dx
+++ b/tests/print-tests.dx
@@ -2,8 +2,8 @@
 :pcodegen [(),(),()]
 > [(), (), ()]
 
--- :pcodegen {x = 1.0, y = 2}
--- > {x = 1., y = 2}
+# :pcodegen {x = 1.0, y = 2}
+# > {x = 1., y = 2}
 
 :pcodegen (the Nat 60, the Int 60, the Float 60, the Int64 60, the Float64 60)
 > (60, 60, 60., 60, 60.)
@@ -14,7 +14,7 @@
 :pcodegen [Just (Just 1.0), Just Nothing, Nothing]
 > [(Just (Just 1.)), (Just Nothing), Nothing]
 
-data MyType = MyValue(Nat)
+enum MyType = MyValue(Nat)
 
 :pcodegen MyValue 1
 > (MyValue 1)

--- a/tests/repl-multiline-test.dx
+++ b/tests/repl-multiline-test.dx
@@ -1,5 +1,5 @@
 
--- comment
+# comment
 
 'Single-line multiline comment
 

--- a/tests/set-tests.dx
+++ b/tests/set-tests.dx
@@ -1,10 +1,10 @@
 import set
 
--- check order invariance.
+# check order invariance.
 :p (to_set ["Bob", "Alice", "Charlie"]) == (to_set ["Charlie", "Bob", "Alice"])
 > True
 
--- check uniqueness.
+# check uniqueness.
 :p (to_set ["Bob", "Alice", "Alice", "Charlie"]) == (to_set ["Charlie", "Charlie", "Bob", "Alice"])
 > True
 
@@ -57,13 +57,13 @@ Person : Type = Element names2
 :p size Person
 > 3
 
--- Check that ordinal and unsafeFromOrdinal are inverses.
+# Check that ordinal and unsafeFromOrdinal are inverses.
 roundTrip = for i:Person.
   i == (unsafe_from_ordinal (ordinal i))
 :p all roundTrip
 > True
 
--- Check that member and value are inverses.
+# Check that member and value are inverses.
 roundTrip2 = for i:Person.
   s = value i
   ix = member s names2

--- a/tests/shadow-tests.dx
+++ b/tests/shadow-tests.dx
@@ -1,5 +1,5 @@
 
--- repeated vars in patterns not allowed
+# repeated vars in patterns not allowed
 :p
   (x, x) = (1, 1)
   x
@@ -18,19 +18,19 @@
 >     (x, x) = p
 >         ^
 
--- TODO: re-enable if we choose to allow non-peer shadowing
--- -- shouldn't cause error even though it shadows x elsewhere
--- x = 50
+# TODO: re-enable if we choose to allow non-peer shadowing
+# -- shouldn't cause error even though it shadows x elsewhere
+# x = 50
 
--- :p let x = 100 in (let x = 200 in x)
+# :p let x = 100 in (let x = 200 in x)
 
--- > [200]
+# > [200]
 
 arr = 10
 
--- TODO: enable when we handle this case
--- _ = 10
--- _ = 10 -- underscore shadows allowed
+# TODO: enable when we handle this case
+# _ = 10
+# _ = 10 -- underscore shadows allowed
 
 arr = 20
 > Error: variable already defined: arr
@@ -47,7 +47,7 @@ arr = 20
 > :p arr
 >    ^^^
 
--- testing top-level shadowing
+# testing top-level shadowing
 f : (given (a:Type), a) -> a = \x. x
 
 x = 1
@@ -71,20 +71,20 @@ x = 1
    w
 > 4
 
--- Testing data shadowing
-data Shadow = Shadow
+# Testing data shadowing
+enum Shadow = Shadow
 > Error: variable already defined: Shadow
 
-data Shadow2 =
+enum Shadow2 =
   Shadow1(Int)
   Shadow1
 > Error: variable already defined: Shadow1
 
 ShadowCon = 1
-data Shadow3 = ShadowCon
+enum Shadow3 = ShadowCon
 > Error: variable already defined: ShadowCon
 
-data Shadow4 = ShadowCon'
+enum Shadow4 = ShadowCon'
 ShadowCon' = 1
 > Error: variable already defined: ShadowCon'
 >

--- a/tests/show-tests.dx
+++ b/tests/show-tests.dx
@@ -1,10 +1,10 @@
 '# `Show` instances
--- String
+# String
 
 :p show "abc"
 > "abc"
 
--- Int32
+# Int32
 
 :p show (1234 :: Int32)
 > "1234"
@@ -15,7 +15,7 @@
 :p show ((f_to_i (-(pow 2. 31.))) :: Int32)
 > "-2147483648"
 
--- Int64
+# Int64
 
 :p show (i_to_i64 1234 :: Int64)
 > "1234"
@@ -23,7 +23,7 @@
 :p show (i_to_i64 (-1234) :: Int64)
 > "-1234"
 
--- Float32
+# Float32
 
 :p show (123.456789 :: Float32)
 > "123.456787"
@@ -31,27 +31,27 @@
 :p show ((pow 2. 16.) :: Float32)
 > "65536"
 
--- FIXME(https://github.com/google-research/dex-lang/issues/316):
--- Unparenthesized expression with type ascription does not parse.
--- :p show (nan: Float32)
+# FIXME(https://github.com/google-research/dex-lang/issues/316):
+# Unparenthesized expression with type ascription does not parse.
+# :p show (nan: Float32)
 
 :p show (nan :: Float32)
 > "nan"
 
--- Note: `show nan` (Dex runtime dtoa implementation) appears different from
--- `:p nan` (Dex interpreter implementation).
+# Note: `show nan` (Dex runtime dtoa implementation) appears different from
+# `:p nan` (Dex interpreter implementation).
 :p nan
 > nan
 
 :p show (infinity :: Float32)
 > "inf"
 
--- Note: `show infinity` (Dex runtime dtoa implementation) appears different from
--- `:p nan` (Dex interpreter implementation).
+# Note: `show infinity` (Dex runtime dtoa implementation) appears different from
+# `:p nan` (Dex interpreter implementation).
 :p infinity
 > inf
 
--- Float64
+# Float64
 
 :p show (f_to_f64 123.456789:: Float64)
 > "123.456787109375"
@@ -62,20 +62,20 @@
 :p show ((f_to_f64 nan):: Float64)
 > "nan"
 
--- Note: `show nan` (Dex runtime dtoa implementation) appears different from
--- `:p nan` (Dex interpreter implementation).
+# Note: `show nan` (Dex runtime dtoa implementation) appears different from
+# `:p nan` (Dex interpreter implementation).
 :p (f_to_f64 nan)
 > nan
 
 :p show ((f_to_f64 infinity):: Float64)
 > "inf"
 
--- Note: `show infinity` (Dex runtime dtoa implementation) appears different from
--- `:p nan` (Dex interpreter implementation).
+# Note: `show infinity` (Dex runtime dtoa implementation) appears different from
+# `:p nan` (Dex interpreter implementation).
 :p (f_to_f64 infinity)
 > inf
 
--- Tuples
+# Tuples
 
 :p show (123, 456)
 > "(123, 456)"

--- a/tests/stack-tests.dx
+++ b/tests/stack-tests.dx
@@ -11,7 +11,7 @@ with_stack Nat \stack.
   stack.push 11
   stack.pop()
   stack.pop()
-  stack.pop()     -- Check that popping an empty stack is OK.
+  stack.pop() # Check that popping an empty stack is OK.
   stack.push 20
   stack.push 21
   stack.pop()

--- a/tests/standalone-function-tests.dx
+++ b/tests/standalone-function-tests.dx
@@ -6,8 +6,8 @@ def standalone_sum(xs:n=>v) -> v given (n|Ix, v|Add) =
 vec3 = [1,2,3]
 vec2 = [4,5]
 
--- TODO: test that we only get one copy inlined (hard to without dumping IR
--- until we have logging for that sort of thing)
+# TODO: test that we only get one copy inlined (hard to without dumping IR
+# until we have logging for that sort of thing)
 :p standalone_sum vec2 + standalone_sum vec3
 > 15
 

--- a/tests/stats-tests.dx
+++ b/tests/stats-tests.dx
@@ -1,8 +1,8 @@
--- stats-tests.dx
+# stats-tests.dx
 
 import stats
 
--- LogSpace Float
+# LogSpace Float
 
 rp = [0.1, 0.3, 0.2, 0.1]
 nnp = map f_to_ls rp
@@ -37,7 +37,7 @@ ls_to_f (divide (f_to_ls 0.4) (f_to_ls 0.5)) ~~ 0.8
 > True
 
 
--- Log-sum-exp
+# Log-sum-exp
 
 Exp (-infinity) + Exp (-infinity)
 > LogSpace(-inf)
@@ -73,9 +73,9 @@ is_infinite nan
 > False
 
 
--- mainly cross-checking against results from R
+# mainly cross-checking against results from R
 
--- bernoulli
+# bernoulli
 
 ln (density (Bernoulli 0.6) True) ~~ -0.5108256
 > True
@@ -98,7 +98,7 @@ quantile (Bernoulli 0.6) 0.41 == True
 rand_vec 5 (\k. draw (Bernoulli 0.6) k) (new_key 0) :: Fin 5=>Bool
 > [False, True, True, True, True]
 
--- binomial
+# binomial
 
 ln (density (Binomial 10 0.4) 8) ~~ -4.545315
 > True
@@ -127,7 +127,7 @@ quantile (Binomial 10 0.4) 0.5 == 4
 rand_vec 5 (\k. draw (Binomial 10 0.4) k) (new_key 0) :: Fin 5=>Nat
 > [1, 0, 7, 6, 7]
 
--- exponential
+# exponential
 
 ln (density (Exponential 2.0) 3.0) ~~ -5.306853
 > True
@@ -150,7 +150,7 @@ quantile (Exponential 2.0) 0.5 ~~ 0.3465736
 rand_vec 5 (\k. draw (Exponential 2.0) k) (new_key 0) :: Fin 5=>Float
 > [1.021143, 0.1418202, 0.09321166, 0.2130168, 0.4305491]
 
--- geometric
+# geometric
 
 ln (density (Geometric 0.1) 10) ~~ -3.25083
 > True
@@ -191,7 +191,7 @@ ln (density (Geometric 1) 2) == -infinity
 rand_vec 5 (\k. draw (Geometric 0.1) k) (new_key 0) :: Fin 5=>Nat
 > [20, 3, 2, 5, 9]
 
--- normal
+# normal
 
 ln (density (Normal 1.0 2.0) 3.0) ~~ -2.112086
 > True
@@ -205,7 +205,7 @@ ln (cumulative (Normal 1.0 2.0) 0.5) ~~ -0.9130617
 ln (survivor (Normal 1.0 2.0) 0.1) ~~ -0.3950523
 > True
 
--- poisson
+# poisson
 
 ln (density (Poisson 5.0) 8) ~~ -2.7291
 > True
@@ -228,7 +228,7 @@ quantile (Poisson 5.0) 0.7 == 6
 rand_vec 5 (\k. draw (Poisson 5.0) k) (new_key 0) :: Fin 5=>Nat
 > [4, 4, 2, 2, 7]
 
--- uniform
+# uniform
 
 ln (density (Uniform 2.0 5.0) 3.5) ~~ -1.098612
 > True
@@ -246,7 +246,7 @@ rand_vec 5 (\k. draw (Uniform 2.0 5.0) k) (new_key 0) :: Fin 5=>Float
 > [4.610805, 2.740888, 2.510233, 3.040717, 3.731907]
 
 
--- data summaries
+# data summaries
 
 mean_and_variance [2.0,3.0,4.0] ~~ (3,1)
 > True

--- a/tests/struct-tests.dx
+++ b/tests/struct-tests.dx
@@ -85,7 +85,7 @@ struct MissingConstraint(n) =
 >   thing : n=>Float
 >           ^^^^^^^^
 
-data AnotherMissingConstraint(n) =
+enum AnotherMissingConstraint(n) =
   MkAnotherMissingConstraint(n=>Float)
 > Type error:Couldn't synthesize a class dictionary for: (Ix n)
 >

--- a/tests/trig-tests.dx
+++ b/tests/trig-tests.dx
@@ -23,7 +23,7 @@
 :p atan2 (-1.0) (-1.0) ~~ (-3.0/4.0*pi)
 > True
 
--- Test all the way around the circle.
+# Test all the way around the circle.
 angles = linspace (Fin 11) (-pi + 0.001) (pi)
 :p all for i:(Fin 11).
   angles[i] ~~ atan2 (sin angles[i]) (cos angles[i])

--- a/tests/type-tests.dx
+++ b/tests/type-tests.dx
@@ -5,50 +5,50 @@ improve things by recording source information when we create fresh inference
 variables. Solving fully (insisting on no ambiguity) at each decl might also
 help make the errors more local.
 
--- :t \x. x
--- > Type error:Ambiguous type variables: [?]
--- >
--- > ((_ans_ @> _ans_), [_ans_:(?->?) = \x:?. x])
+# :t \x. x
+# > Type error:Ambiguous type variables: [?]
+# >
+# > ((_ans_ @> _ans_), [_ans_:(?->?) = \x:?. x])
 
--- :t \x. sum for i. x.i
--- > Type error:Ambiguous type variables: [?3]
--- >
--- > ( (_ans_ @> _ans_)
--- > , [ _ans_:((?3=>Float)->Float) = \x:(?3=>Float).
--- >   tmp:((?3=>Float)->Float) = (sum) (?3)
--- >   tmp1:(?3=>Float) = for \i:?3. (x) (i)
--- >   (tmp) (tmp1) ] )
+# :t \x. sum for i. x.i
+# > Type error:Ambiguous type variables: [?3]
+# >
+# > ( (_ans_ @> _ans_)
+# > , [ _ans_:((?3=>Float)->Float) = \x:(?3=>Float).
+# >   tmp:((?3=>Float)->Float) = (sum) (?3)
+# >   tmp1:(?3=>Float) = for \i:?3. (x) (i)
+# >   (tmp) (tmp1) ] )
 
--- :t \f x y. f y x
--- > Type error:Ambiguous type variables: [?3, ?6, ?7]
--- >
--- > ( (_ans_ @> _ans_)
--- > , [ _ans_:((?3->(?6->?7))->(?6->(?3->?7))) = \f:(?3->(?6->?7)). \x:?6. \y:?3.
--- >   tmp:(?6->?7) = (f) (y)
--- >   (tmp) (x) ] )
+# :t \f x y. f y x
+# > Type error:Ambiguous type variables: [?3, ?6, ?7]
+# >
+# > ( (_ans_ @> _ans_)
+# > , [ _ans_:((?3->(?6->?7))->(?6->(?3->?7))) = \f:(?3->(?6->?7)). \x:?6. \y:?3.
+# >   tmp:(?6->?7) = (f) (y)
+# >   (tmp) (x) ] )
 
--- :t \x. for i j. x.j.i
--- > Type error:Ambiguous type variables: [?3, ?6, ?7]
--- >
--- > ( (_ans_ @> _ans_)
--- > , [ _ans_:((?3=>(?6=>?7))->(?6=>(?3=>?7))) = \x:(?3=>(?6=>?7)). for \i:?6. for \j:?3.
--- >   tmp1:(?6=>?7) = (x) (j)
--- >   (tmp1) (i) ] )
+# :t \x. for i j. x.j.i
+# > Type error:Ambiguous type variables: [?3, ?6, ?7]
+# >
+# > ( (_ans_ @> _ans_)
+# > , [ _ans_:((?3=>(?6=>?7))->(?6=>(?3=>?7))) = \x:(?3=>(?6=>?7)). for \i:?6. for \j:?3.
+# >   tmp1:(?6=>?7) = (x) (j)
+# >   (tmp1) (i) ] )
 
--- :t \f x. f x
--- > Type error:Ambiguous type variables: [?2, ?3]
--- >
--- > ((_ans_ @> _ans_), [_ans_:((?2->?3)->(?2->?3)) = \f:(?2->?3). \x:?2. (f) (x)])
+# :t \f x. f x
+# > Type error:Ambiguous type variables: [?2, ?3]
+# >
+# > ((_ans_ @> _ans_), [_ans_:((?2->?3)->(?2->?3)) = \f:(?2->?3). \x:?2. (f) (x)])
 
--- :t \x. for (i,j). x.i.j
--- > Type error:Ambiguous type variables: [?4, ?7, ?8]
--- >
--- > ( (_ans_ @> _ans_)
--- > , [ _ans_:((?4=>(?7=>?8))->((?4 & ?7)=>?8)) = \x:(?4=>(?7=>?8)). for \pat:(?4 & ?7).
--- >   tmp1:?4 = %fst pat
--- >   tmp2:?7 = %snd pat
--- >   tmp3:(?7=>?8) = (x) (tmp1)
--- >   (tmp3) (tmp2) ] )
+# :t \x. for (i,j). x.i.j
+# > Type error:Ambiguous type variables: [?4, ?7, ?8]
+# >
+# > ( (_ans_ @> _ans_)
+# > , [ _ans_:((?4=>(?7=>?8))->((?4 & ?7)=>?8)) = \x:(?4=>(?7=>?8)). for \pat:(?4 & ?7).
+# >   tmp1:?4 = %fst pat
+# >   tmp2:?7 = %snd pat
+# >   tmp3:(?7=>?8) = (x) (tmp1)
+# >   (tmp3) (tmp2) ] )
 
 :t
    myid : (given (a:Type), a) -> a = \x. x
@@ -152,7 +152,7 @@ MyPair : (Type) -> Type =
 > ((1, 2), (1., 2.))
 
 
--- TODO: put source annotation on effect for a better message here
+# TODO: put source annotation on effect for a better message here
 def fEff() -> {|a} a given (a) = todo
 > Type error:
 > Expected: Type
@@ -168,39 +168,39 @@ def fEff() -> {|a} a given (a) = todo
 >     for i:(Fin 7). sum for j:(Fin unboundName). 1.0
 >                                   ^^^^^^^^^^^
 
--- differentCaseResultTypes : Either Int Float -> Float
--- differentCaseResultTypes x = case x
---   Left f -> f
---   Right i -> i
--- > Type error:
--- > Expected: Int
--- >   Actual: Float
--- > In: i
--- >
--- >   Right i -> i
--- >              ^
+# differentCaseResultTypes : Either Int Float -> Float
+# differentCaseResultTypes x = case x
+#   Left f -> f
+#   Right i -> i
+# > Type error:
+# > Expected: Int
+# >   Actual: Float
+# > In: i
+# >
+# >   Right i -> i
+# >              ^
 
--- inferEither x = case x
---     Left i -> i + 1
---     Right f -> floor f
+# inferEither x = case x
+#     Left i -> i + 1
+#     Right f -> floor f
 
--- caseEffects : wRef:(Ref Float) -> (Either Int Float) -> {Writer wRef} ()
--- caseEffects ref x = case x
---     Left  i -> ()
---     Right r -> ref := r
--- > Type error:
--- > Expected: { }
--- >   Actual: {State ref | ?_28}
--- > In: (ref := r)
--- >
--- >     Right r -> ref := r
--- >                    ^^^
+# caseEffects : wRef:(Ref Float) -> (Either Int Float) -> {Writer wRef} ()
+# caseEffects ref x = case x
+#     Left  i -> ()
+#     Right r -> ref := r
+# > Type error:
+# > Expected: { }
+# >   Actual: {State ref | ?_28}
+# > In: (ref := r)
+# >
+# >     Right r -> ref := r
+# >                    ^^^
 
--- :p (\(u,v). for i:0...u. 1.0) (2, 3)
--- > Type error:Function's result type cannot depend on a variable bound in an argument pattern
--- >
--- > :p (\(u,v). for i:0...u. 1.0) (2, 3)
--- >     ^^^^^^^^^^^^^^^^^^^^^^^^
+# :p (\(u,v). for i:0...u. 1.0) (2, 3)
+# > Type error:Function's result type cannot depend on a variable bound in an argument pattern
+# >
+# > :p (\(u,v). for i:0...u. 1.0) (2, 3)
+# >     ^^^^^^^^^^^^^^^^^^^^^^^^
 
 g : (given (a:Type), a) -> a = \x. x
 
@@ -239,7 +239,7 @@ fun : (given (aaa:Type), aaa) -> aaa = \x. sin x
 > fun : (given (aaa:Type), aaa) -> aaa = \x. sin x
 >                                            ^^^^^
 
-data NewPair(aa:Type, bb:Type) = MkNewPair(aa, bb)
+enum NewPair(aa:Type, bb:Type) = MkNewPair(aa, bb)
 
 fromNewPair : (given (a, b), NewPair a b) -> (a, b) = \p.
   MkNewPair(x, y) = p
@@ -262,25 +262,25 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 :p NewPair
 > <function of type ((aa:Type,bb:Type) -> Type)>
 
--- TODO: these are broken since switching from newtype mechanism to ADTs
+# TODO: these are broken since switching from newtype mechanism to ADTs
 
--- :p NewPair Int
--- > NewPair Int
+# :p NewPair Int
+# > NewPair Int
 
--- :p NewPair Int Float
--- > NewPair Int Float
+# :p NewPair Int Float
+# > NewPair Int Float
 
--- NewPairIntFloat = NewPair Int Float
+# NewPairIntFloat = NewPair Int Float
 
--- :p NewPairIntFloat
--- > NewPair Int Float
+# :p NewPairIntFloat
+# > NewPair Int Float
 
--- newPair2 : NewPairIntFloat = MkNewPair 1 2.0
+# newPair2 : NewPairIntFloat = MkNewPair 1 2.0
 
--- :p fst $ fromNewPair newPair
--- > 1
+# :p fst $ fromNewPair newPair
+# > 1
 
--- Tests for the Unit index set
+# Tests for the Unit index set
 
 () == ()
 > True
@@ -304,7 +304,7 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 > ()
 
 
--- Test for pairs
+# Test for pairs
 
 ((2.0, 3.0) + (4.0, 1.1)) ~~ (6.0, 4.1)
 > True
@@ -316,7 +316,7 @@ newPair : NewPair Int Float = MkNewPair 1 2.0
 > True
 
 
--- Tests for Bool
+# Tests for Bool
 :p True == True
 > True
 :p False == True
@@ -356,15 +356,15 @@ def triRefIndex(ref:Ref h ((i':n)=>(..i')=>Float), i:n) -> Ref h ((..i)=>Float)
 > (for i:(Fin 5). for j:(i..). 0.0)[0@_]
 >                                   ^^^
 
--- Type inference of arguments always happens in checking mode, but
--- the checking doesn't provide any insight into what the argument is
--- in this case. This checks that type inference is able to realize
--- that and switch to inference mode, so that it can correctly infer
--- the full dependent type.
---
--- There was a time when this wasn't possible, because checking mode
--- would unify the input type with a non-dependent function type,
--- leading to a later unification errors.
+# Type inference of arguments always happens in checking mode, but
+# the checking doesn't provide any insight into what the argument is
+# in this case. This checks that type inference is able to realize
+# that and switch to inference mode, so that it can correctly infer
+# the full dependent type.
+#
+# There was a time when this wasn't possible, because checking mode
+# would unify the input type with a non-dependent function type,
+# leading to a later unification errors.
 
 id (for i:(Fin 2). for j:(..i). 1.0)
 > [[1.], [1., 1.]]
@@ -377,16 +377,16 @@ def weakerInferenceReduction(l: (i:n)=>(..i)=>Float, j:n) -> ()  given (n|Ix) =
     ()
   ()
 
--- Regression test for
--- https://github.com/google-research/dex-lang/issues/833,
--- simplification of a table of functions whose type mentions
--- the table index.
+# Regression test for
+# https://github.com/google-research/dex-lang/issues/833,
+# simplification of a table of functions whose type mentions
+# the table index.
 val = for i:(Fin 2). \x:Float . for j:(..i). 1
 
 :t val
 > ((i:(Fin 2)) => (x:Float32) -> ((RangeTo (Fin 2) i) => Nat))
 
--- Tests for table
+# Tests for table
 
 a = [0, 1]
 b = [0, 1]
@@ -406,7 +406,7 @@ c = [1, 2]
   f (1,2)
 > 2
 
--- Tests for type inference of table literals
+# Tests for type inference of table literals
 
 def mkEmpty(a|Data) -> (Fin 0)=>a = []
 
@@ -422,15 +422,15 @@ def mkEmpty(a|Data) -> (Fin 0)=>a = []
 def uncurryTable(x: (Fin 2, Fin 2)=>a) -> (Fin 2)=>(Fin 2)=>a  given (a) =
   for i j. x[(i, j)]
 
--- We should be able to infer the tuple type here
+# We should be able to infer the tuple type here
 :t uncurryTable (coerce_table _ [0.0, 1.0, 2.0, 3.0])
 > ((Fin 2) => (Fin 2) => Float32)
 
--- Extra difficulty: need to default the integer type
+# Extra difficulty: need to default the integer type
 :t uncurryTable (coerce_table _ [0, 1, 2, 3])
 > ((Fin 2) => (Fin 2) => Nat)
 
--- Make sure that the local type alias is unifiable with Int
+# Make sure that the local type alias is unifiable with Int
 def GetInt(n: Int) -> Type = Int
 def ff(n : Int) -> Int =
   i = GetInt n
@@ -439,7 +439,7 @@ def ff(n : Int) -> Int =
 ff 0
 > 2
 
--- The two local aliases for Fin n should be unifiable with each other and Fin n
+# The two local aliases for Fin n should be unifiable with each other and Fin n
 def q(n: Nat) -> (Fin n)=>Nat =
   ix1 = Fin n
   x1 = for i:ix1. ordinal i
@@ -450,16 +450,16 @@ def q(n: Nat) -> (Fin n)=>Nat =
 q 5
 > [0, 2, 4, 6, 8]
 
--- Dereference variable names when resolving table type annotations
--- This is a regression test for
--- https://github.com/google-research/dex-lang/issues/563
+# Dereference variable names when resolving table type annotations
+# This is a regression test for
+# https://github.com/google-research/dex-lang/issues/563
 :t coerce_table Bool [0.0, 1.0]
 > (Bool => Float32)
 
--- Regression test for
--- https://github.com/google-research/dex-lang/issues/912.
--- This should not take a long time, because we should compare sizes
--- before constructing the indices of the annotated index set.
+# Regression test for
+# https://github.com/google-research/dex-lang/issues/912.
+# This should not take a long time, because we should compare sizes
+# before constructing the indices of the annotated index set.
 :t [0.0, 1.0]::((Fin 100000000)=>Float)
 > Type error:
 > Expected: (Fin 100000000)
@@ -476,8 +476,8 @@ q 5
 > :t [0.0, 1.0]::((i: Fin 100000000)=>(..i)=>Float)
 >    ^^^^^^^^^^
 
--- Make sure we fail gracefully when the annotated index set doesn't
--- have a static size.
+# Make sure we fail gracefully when the annotated index set doesn't
+# have a static size.
 def frob(_:()) -> () given (n) =
   [0.0, 1.0]::((Fin n)=>Float)
   ()
@@ -490,29 +490,29 @@ def frob(_:()) -> () given (n) =
 
 '### Parser disambiguation of type annotations
 
--- Regression tests for https://github.com/google-research/dex-lang/issues/933
+# Regression tests for https://github.com/google-research/dex-lang/issues/933
 
--- foo is a function with all-implicit arguments (whether that's a
--- good idea or not).
+# foo is a function with all-implicit arguments (whether that's a
+# good idea or not).
 def foo() ->> a=>Float given (a|Ix) =
   for z:a. 1.0
 
 :t foo
 > ({a:Type}[d:(Ix a)] ->> (a => Float32))
 
--- Reference foo with a type annotation (no parens needed)
+# Reference foo with a type annotation (no parens needed)
 foo :: (Fin 3) => Float
 > [1., 1., 1.]
 
--- Type annotation is an operator
+# Type annotation is an operator
 sum $ foo :: (Fin 3) => Float
 > 3.
 
--- A pi type that locally binds foo to the index
+# A pi type that locally binds foo to the index
 (foo : (Fin 3)) => Float
 > ((Fin 3) => Float32)
 
--- The equals sign makes it a type-annotated top-level binding for foo
+# The equals sign makes it a type-annotated top-level binding for foo
 foo : Fin 3 => Float = [1.0, 2.0, 3.0]
 > Error: variable already defined: foo
 >
@@ -547,30 +547,30 @@ def transpose_ix(i:n, j:(i..)) -> (i:n &> ..i) given (n|Ix) =
   i' = unsafe_project i
   (j' ,> i')
 
--- TODO: re-enable when we have a better story for explicitly constructing dependent tables
--- def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
---   for i j.
---     (j' ,> i') = transpose_ix i j
---     lower.j'.i'
+# TODO: re-enable when we have a better story for explicitly constructing dependent tables
+# def transpose_lower_to_upper {n v} (lower:LowerTriMat n v) : UpperTriMat n v =
+#   for i j.
+#     (j' ,> i') = transpose_ix i j
+#     lower.j'.i'
 
--- dpair : ((i:Fin 3)=>(..i)=>Int) =
---   coerce_table _ [ coerce_table _ [1]
---                  , coerce_table _ [2,3]
---                  , coerce_table _ [4,5,6]]
+# dpair : ((i:Fin 3)=>(..i)=>Int) =
+#   coerce_table _ [ coerce_table _ [1]
+#                  , coerce_table _ [2,3]
+#                  , coerce_table _ [4,5,6]]
 
--- :p transpose_lower_to_upper dpair
--- > [[1, 2, 4], [3, 5], [6]]
+# :p transpose_lower_to_upper dpair
+# > [[1, 2, 4], [3, 5], [6]]
 
--- '### Tests for function VSpace
--- that we could restore if we choose to:
--- https://github.com/google-research/dex-lang/issues/1230
+# '### Tests for function VSpace
+# that we could restore if we choose to:
+# https://github.com/google-research/dex-lang/issues/1230
 
--- :p (sin + cos) 5.0 ~~ (\x. sin x + cos x) 5.0
--- > True
--- :p (sin * cos) 5.0 ~~ (\x. sin x * cos x) 5.0
--- > True
--- :p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
--- > True
+# :p (sin + cos) 5.0 ~~ (\x. sin x + cos x) 5.0
+# > True
+# :p (sin * cos) 5.0 ~~ (\x. sin x * cos x) 5.0
+# > True
+# :p (2.8 .* sin) 5.0 ~~ (\x. 2.8 * sin x) 5.0
+# > True
 
 '### Miscellany
 
@@ -578,17 +578,17 @@ xbool : Bool = arb $ new_key 0
 :p xbool
 > True
 
--- This is to ensure we don't accidentally implement `Sub Word32` while we
--- have `Nat` as an alias for `Word32`.
+# This is to ensure we don't accidentally implement `Sub Word32` while we
+# have `Nat` as an alias for `Word32`.
 :p for i:(Fin 4). ordinal i - 1
 > Type error:Couldn't synthesize a class dictionary for: (Sub Nat)
 >
 > :p for i:(Fin 4). ordinal i - 1
 >                   ^^^^^^^^^^^^^
 
--- Check that the result passed to :html has type `String`.  This is
--- also a regression test for
--- https://github.com/google-research/dex-lang/issues/934
+# Check that the result passed to :html has type `String`.  This is
+# also a regression test for
+# https://github.com/google-research/dex-lang/issues/934
 
 table = [1.0, 2.0]
 
@@ -600,14 +600,14 @@ table = [1.0, 2.0]
 > :html table
 >       ^^^^^
 
--- We can't have table literals of non-data
+# We can't have table literals of non-data
 :p [\x:Float. x, \x:Float. x + x]
 > Type error:Couldn't synthesize a class dictionary for: (Data ((x.1:Float32) -> Float32))
 >
 > :p [\x:Float. x, \x:Float. x + x]
 >    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-data A = MkA
+enum A = MkA
 
 interface I(param:Type)
   m : ()
@@ -620,25 +620,25 @@ instance I()
   m = todo
 > Type error:Wrong number of positional arguments provided. Expected 1 but got 0
 
--- This example shows that constraints that we learn from the body of a function
--- can be used outside the function.
+# This example shows that constraints that we learn from the body of a function
+# can be used outside the function.
 :p
-  -- u1 = <fresh_unif>
-  z = zero -- zero(at=u1)
+  # u1 = <fresh_unif>
+  z = zero # zero(at=u1)
   def foo(aa:Type, x:Int) =
-     x + z -- implies `u1->Int`. We can hoist this constraint outside of `foo`
-           -- and use it to zonk the `z = zero(at=u1)` decl.
+     x + z # implies `u1->Int`. We can hoist this constraint outside of `foo`
+           # and use it to zonk the `z = zero(at=u1)` decl.
   z
 > 0
 
--- This example shows that we *have to* use the constraints outside the function
--- (i.e. `u1->Int`) even if `u1` is sufficiently constrained elsewhere because
--- the constraints might conflict.
+# This example shows that we *have to* use the constraints outside the function
+# (i.e. `u1->Int`) even if `u1` is sufficiently constrained elsewhere because
+# the constraints might conflict.
 :p
-  -- u1 = <fresh_unif>
+  # u1 = <fresh_unif>
   z = zero
   def foo(aa:Type, x:Int) =
-     -- solved! u1->Int
+     # solved! u1->Int
      x + z
   1.0 + z
 > Type error:
@@ -648,14 +648,14 @@ instance I()
 >   1.0 + z
 >         ^
 
--- But sometimes the solution can't be hoisted because it refers to local
--- variables. In that case we have to throw an error about leaked variables.
+# But sometimes the solution can't be hoisted because it refers to local
+# variables. In that case we have to throw an error about leaked variables.
 :p
-  -- u1 = <fresh_unif>
-  z = zero -- zero(at=u1)
+  # u1 = <fresh_unif>
+  z = zero # zero(at=u1)
   def foo(aa:Type, x:aa) =
-     x + z -- implies `u1->aa`, but we can't hoist solution above `aa`
-           -- Also, we can't ignore this solution because ...
+     x + z # implies `u1->aa`, but we can't hoist solution above `aa`
+           # Also, we can't ignore this solution because ...
   1 + z
 > Leaked local variables:[aa]
 > Failed to exchange binders in buildAbsInf
@@ -667,18 +667,18 @@ instance I()
 >   ^^^^^^^^^^^^^^^^^^^^^^^^^
 
 
--- We don't need to throw a leaked variable here. We know that `u1` can't be
--- used outside because we introduced it underneath the `a` binder. So we can
--- happily delete the `u1` binder and its solution once we've applied the
--- solution,`u1 -> a`, to all the occurrences of `u1`.
+# We don't need to throw a leaked variable here. We know that `u1` can't be
+# used outside because we introduced it underneath the `a` binder. So we can
+# happily delete the `u1` binder and its solution once we've applied the
+# solution,`u1 -> a`, to all the occurrences of `u1`.
 :p
   def should_be_fine(
       a:Type,
-      -- u1 = <fresh_unif>
-      x  -- x:u1
-      ) -> a = x  -- solved! u1 -> a This solution won't hoist outside of a's
-                  -- scope but that's ok. We know there are no other use sites
-                  -- of `u1` because it goes out of scope before `a` does.
+      # u1 = <fresh_unif>
+      x # x:u1
+      ) -> a = x # solved! u1 -> a This solution won't hoist outside of a's
+                  # scope but that's ok. We know there are no other use sites
+                  # of `u1` because it goes out of scope before `a` does.
   1
 > 1
 

--- a/tests/typeclass-tests.dx
+++ b/tests/typeclass-tests.dx
@@ -54,7 +54,7 @@ instance InterfaceTest4(Float)
   foo = 1
   def bar(_) = 1
 
--------------------- Diamond superclasses --------------------
+#------------------ Diamond superclasses --------------------
 
 interface A(a)
   a_ : (a) -> Int
@@ -63,12 +63,12 @@ interface B(a|A)
 interface C(a|A)
   c_ : (Int)
 
--- Diamond superclasses should be ok
+# Diamond superclasses should be ok
 def f1(x: a) -> Int given (a|B|C) = a_ x
--- Multiple binders are ok too
+# Multiple binders are ok too
 def f2(x: a) -> Int given (a|A|A) = a_ x
 
--------------------- Transitive superclasses --------------------
+#------------------ Transitive superclasses --------------------
 
 interface D(a)
   d_ : (a) -> Int
@@ -86,9 +86,9 @@ instance F(Int)
 def deriveDFromE(x:a) -> Int given (a|E) = d_ x
 def deriveDFromF(x:a) -> Int given (a|F) = d_ x
 
--------------------- Overlapping instances --------------------
+#------------------ Overlapping instances --------------------
 
--- Overlapping instances
+# Overlapping instances
 instance A(Int)
   def a_(x) = 1
 instance A(n=>a) given (a|A, n|Ix)
@@ -96,22 +96,22 @@ instance A(n=>a) given (a|A, n|Ix)
 instance A(n=>Int) given (n|Ix)
   def a_(x) = 0
 
--- There are two derivations for n=>Int
+# There are two derivations for n=>Int
 def f3(x: n=>Int) -> Int given (n|Ix) = a_ x
 > Type error:Multiple candidate class dictionaries for: (A (n => Int32))
 >
 > def f3(x: n=>Int) -> Int given (n|Ix) = a_ x
 >                                         ^^^^
--- Adding an explicit binder shouldn't change anything
+# Adding an explicit binder shouldn't change anything
 def f4(x: n=>Int) -> Int given (n|Ix) (A (n=>Int)) = a_ x
 > Type error:Multiple candidate class dictionaries for: (A (n => Int32))
 >
 > def f4(x: n=>Int) -> Int given (n|Ix) (A (n=>Int)) = a_ x
 >                                                      ^^^^
 
--- TODO: This should fail! The choice of dictionary depends on instantiation
---       of a (there's a generic one and a specific one for n=>Int)!
---       This is reported in #669.
+# TODO: This should fail! The choice of dictionary depends on instantiation
+#       of a (there's a generic one and a specific one for n=>Int)!
+#       This is reported in #669.
 def f5(x : n=>a) -> Int given (n|Ix, a|A) = a_ x
 
 interface Eq'(a)
@@ -126,12 +126,12 @@ instance Eq'(n=>a) given (n|Ix, a|Eq')
 instance Ord'(n=>a) given (n|Ix, a|Ord')
   def ord(_) = 4
 
--- Simplifiable constraints should be accepted
+# Simplifiable constraints should be accepted
 def f6(x : n=>Int) -> Int given (n|Ix) (Eq'  (n=>Int))= eq x
 def f7(x : n=>Int) -> Int given (n|Ix) (Ord' (n=>Int)) = eq x
 
--- This additional instance makes f7 ambiguous. Note that there's an easy way out
--- in the form of the superclass of Ord', but we still check that there's no overlap.
+# This additional instance makes f7 ambiguous. Note that there's an easy way out
+# in the form of the superclass of Ord', but we still check that there's no overlap.
 instance Eq'(Int)
   def eq(_) = 0
 def f8(x : n=>Int) -> Int given (n|Ix) (Ord' (n=>Int))  = eq x
@@ -140,25 +140,25 @@ def f8(x : n=>Int) -> Int given (n|Ix) (Ord' (n=>Int))  = eq x
 > def f8(x : n=>Int) -> Int given (n|Ix) (Ord' (n=>Int))  = eq x
 >                                                           ^^^^
 
--- XXX: In Haskell overlap is determined entirely by instance heads, making it
---      independent of other instances in scope. In Dex an instance might be ruled out,
---      because at some point its constraints are unsatisfiable, but later on it
---      might become viable. How big of an issue is that??
+# XXX: In Haskell overlap is determined entirely by instance heads, making it
+#      independent of other instances in scope. In Dex an instance might be ruled out,
+#      because at some point its constraints are unsatisfiable, but later on it
+#      might become viable. How big of an issue is that??
 
--------------------- Multi-parameter interfaces --------------------
+#------------------ Multi-parameter interfaces --------------------
 
--- Adapted from PR 1039
+# Adapted from PR 1039
 interface MyDist(d, a)
   log_pdf : (d, a) -> Float
 
 interface MyOrderedDist(d, a, given () (MyDist d a))
   log_cdf : (d, a) -> Float
 
--- TODO: Test actually using it.
+# TODO: Test actually using it.
 
--------------------- User-defined Ix --------------------
+#------------------ User-defined Ix --------------------
 
-data TwoPoints =
+enum TwoPoints =
   FirstPoint
   SecondPoint
 
@@ -174,11 +174,11 @@ instance Ix(TwoPoints)
 :p for i:TwoPoints. i
 > [FirstPoint, SecondPoint]
 
------------------ User-defined Ix referencing toplevel data -----------------
+#--------------- User-defined Ix referencing toplevel data -----------------
 
--- This is a regression test for Issue #930.
+# This is a regression test for Issue #930.
 
-data TwoMorePoints =
+enum TwoMorePoints =
   APoint
   AnotherPoint
 
@@ -194,7 +194,7 @@ instance Ix(TwoMorePoints)
 :p for i:TwoMorePoints. ordinal i
 > [0, 1]
 
------------------ Data constraint synthesis -----------------
+#--------------- Data constraint synthesis -----------------
 
 def data_id(x:a) -> a given (a|Data) = x
 
@@ -222,7 +222,7 @@ data_id [4, 5, 6]
 data_id (the (n:Nat &> (Fin n) => Nat) (3 ,> [5, 6, 7]))
 > (3 ,> [5, 6, 7])
 
------------------ Lambda function taking class arguments -----------------
+#--------------- Lambda function taking class arguments -----------------
 
 :t \(given (a|Ix, b|Ix) (Subset a b)) (xs:a=>Float). xs[0@_]
 > ({a:Type}[d:(Ix a)]{b:Type}[d.1:(Ix b),v#0:(Subset a b)](xs:(a

--- a/tests/uexpr-tests.dx
+++ b/tests/uexpr-tests.dx
@@ -76,7 +76,7 @@ def TyId(a:Type) -> Type = a
 
 def tabId(x:n=>Int) -> n=>Int given (n|Ix) = for i. x[i]
 
--- bug: this doesn't work if we split it across top-level decls
+# bug: this doesn't work if we split it across top-level decls
 :p
   xs = for i:(Fin 3) . 1
   tabId xs
@@ -139,36 +139,36 @@ myPair = (1, 2.3)
   (x,y,z)
 > (1, 2, 3)
 
--- XXX: This is an ambiguous type error with overloaded literals
--- TODO: Reenable once we have reasonable error messages for ambiguous types
--- :p
---   ((x,y),z) = (1,2,3)
---   ((x,y),z)
--- > Type error:
--- > Expected: (a & b)
--- >   Actual: Int32
--- > (Solving for: [a:Type, b:Type])
--- >
--- >   ((x,y),z) = (1,2,3)
--- >     ^^^
+# XXX: This is an ambiguous type error with overloaded literals
+# TODO: Reenable once we have reasonable error messages for ambiguous types
+# :p
+#   ((x,y),z) = (1,2,3)
+#   ((x,y),z)
+# > Type error:
+# > Expected: (a & b)
+# >   Actual: Int32
+# > (Solving for: [a:Type, b:Type])
+# >
+# >   ((x,y),z) = (1,2,3)
+# >     ^^^
 
 :p
   (x,y,z) = (1,2,3)
   (x,y,z)
 > (1, 2, 3)
 
--- XXX: This is an ambiguous type error with overloaded literals
--- TODO: Reenable once we have reasonable error messages for ambiguous types
--- :p
---   (x,y) = 1
---   (x,y)
--- > Type error:
--- > Expected: (a & b)
--- >   Actual: Int32
--- > (Solving for: [a:Type, b:Type])
--- >
--- >   (x,y) = 1
--- >    ^^^
+# XXX: This is an ambiguous type error with overloaded literals
+# TODO: Reenable once we have reasonable error messages for ambiguous types
+# :p
+#   (x,y) = 1
+#   (x,y)
+# > Type error:
+# > Expected: (a & b)
+# >   Actual: Int32
+# > (Solving for: [a:Type, b:Type])
+# >
+# >   (x,y) = 1
+# >    ^^^
 
 :p
   yield_state [1,2,3] \xsRef.
@@ -239,11 +239,11 @@ def myOtherFst(pair:(a,b)) -> a given (a, b) =
    transpose_linear(f)(1.0)
 > 4.
 
--- FIXME: This fails due to shadowing!
---def transpose' (x:n=>m=>Float) --o : m=>n=>Float = for i j. x.j.i
---
---:p transpose_linear transpose' [[1.0, 2.0, 3.0]]
---> [[1.0], [2.0], [3.0]]
+# FIXME: This fails due to shadowing!
+#def transpose' (x:n=>m=>Float) --o : m=>n=>Float = for i j. x.j.i
+#
+#:p transpose_linear transpose' [[1.0, 2.0, 3.0]]
+#> [[1.0], [2.0], [3.0]]
 
 :p
    f : (Float) -> (Fin 3=>Float) =
@@ -260,16 +260,16 @@ def eitherFloor(x:(Either Int Float)) -> Int = case x of
 :p (eitherFloor (Left 1), eitherFloor (Right 2.3))
 > (1, 2)
 
--- Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
--- :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
--- > Type error:
--- > Expected: ((Fin a & Fin 2) => Int32)
--- >   Actual: ((Fin 4) => b)
--- > (Solving for: [a, b])
--- > If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
--- >
--- > :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
--- >    ^^^^^^^^^^^^^
+# Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
+# :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+# > Type error:
+# > Expected: ((Fin a & Fin 2) => Int32)
+# >   Actual: ((Fin 4) => b)
+# > (Solving for: [a, b])
+# > If attempting to construct a fixed-size table not indexed by 'Fin n' for some n, this error may indicate there was not enough information to infer a concrete index set; try adding an explicit annotation.
+# >
+# > :p [1, 2, 3, 4] : ((Fin _ & Fin 2) => Int)
+# >    ^^^^^^^^^^^^^
 
 :p
   [(a, b), c] = [(1, 2), (3, 4)]
@@ -292,7 +292,7 @@ def eitherFloor(x:(Either Int Float)) -> Int = case x of
   a + d
 > 5
 
--- Can only unpack tables indexed by `Fin n`
+# Can only unpack tables indexed by `Fin n`
 :p
   [a, b, c, d] = coerce_table (Fin 2, Fin 2) [1, 2, 3, 4]
   (a, b, c, d)
@@ -304,11 +304,11 @@ def eitherFloor(x:(Either Int Float)) -> Int = case x of
 >   [a, b, c, d] = coerce_table (Fin 2, Fin 2) [1, 2, 3, 4]
 >   ^^^^^^^^^^^^^
 
--- Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
--- :p
---   [a, b, c, d] = zero :: (_ => Int)
---   (a, b, c, d)
--- > (0, (0, (0, 0)))
+# Needs delayed inference (can't verify Ix and reduce the type before we infer the hole).
+# :p
+#   [a, b, c, d] = zero :: (_ => Int)
+#   (a, b, c, d)
+# > (0, (0, (0, 0)))
 
 def bug(n|Data) -> () =
   for w':n.


### PR DESCRIPTION
- Change `data` to `enum` keyword in examples (vega-plotting, simplex, mcts, quaternions, ctc) and all test files that still used the old syntax
- Change `--` comment syntax to `#` across all .dx files in tests/, examples/, benchmarks/, and doc/ that hadn't been updated
- Fix `type` keyword to plain assignment in mnist-nearest-neighbors.dx and update deprecated function names (b2i -> b_to_f)
- Re-enable vega-plotting example in makefile

https://claude.ai/code/session_01ExtSL62sjtN3DfW4bnDYQ8